### PR TITLE
Added a travis testing config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: perl
+
+perl:
+  - "5.22"
+  - "5.18"
+  - "5.12"
+
+install:
+  # Install conda + bioconda
+  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels bioconda
+  - conda update -q conda
+  - conda info -a
+  # Create environment with FastQC and cutadapt
+  - conda create -q -n test-environment fastqc cutadapt
+  - source activate test-environment
+
+script:
+  - ./trim_galore test_files/illumina_100K.fastq.gz
+  - ./trim_galore test_files/nextera_100K.fastq.gz
+  - ./trim_galore test_files/smallRNA_100K.fastq.gz
+  - ./trim_galore test_files/4_seqs_with_Ns.fastq.gz
+  - ./trim_galore test_files/colorspace_file.fastq
+  # These commands are supposed to fail.
+  - ./trim_galore test_files/truncated.fq.gz && return 1 || return 0
+  - ./trim_galore test_files/empty_file.fastq && return 1 || return 0


### PR DESCRIPTION
New config file that tells Travis how to run. Just a few basic commands using the test data in the repo so far, can be extended to run with different command line options etc to try to cover all running modes.

To make this run, you'll need to activate Travis for the repo. Go to https://travis-ci.org and log in, then hit the little tick box to enable testing for this account.

Once that's enabled, a test will run for every commit and PR. If you enable it before you merge this, it should run once it's merged I think.

Phil