### PR TITLE
fix incorrect argument abbreviation

### DIFF
--- a/Docs/Trim_Galore_User_Guide.md
+++ b/Docs/Trim_Galore_User_Guide.md
@@ -196,7 +196,7 @@ Following this, reads should be aligned with Bismark and deduplicated with UmiBa
 * `--max_length <INT>`
   * Discard reads that are longer than <INT> bp after trimming. This is only advised for smallRNA sequencing to remove non-small RNA sequences.
 
-* `-s/--stringency <INT>`
+* `--stringency <INT>`
   * Overlap with adapter sequence required to trim a sequence.
   * Defaults to a very stringent setting of `1`, _i.e._ even a single base pair of overlapping sequence will be trimmed of the 3' end of any read.
 


### PR DESCRIPTION
TrimGalore 0.6.5 gives me an error "Option s is ambiguous (small_rna, stringency, suppress_warn)" when I use `-s`, so I suppose it has to be the full `--stringency`