### PR TITLE
Optionally use igzip for decompression of gzipped files.

### DIFF
--- a/trim_galore
+++ b/trim_galore
@@ -35,7 +35,7 @@ my $trimmer_version = '0.6.8dev';
 my $cutadapt_version;
 my $python_version;
 
-my ($compression_path,$cores,$cutoff,$adapter,$stringency,$rrbs,$length_cutoff,$keep,$fastqc,$non_directional,$phred_encoding,$fastqc_args,$trim,$gzip,$validate,$retain,$length_read_1,$length_read_2,$a2,$error_rate,$output_dir,$no_report_file,$dont_gzip,$clip_r1,$clip_r2,$three_prime_clip_r1,$three_prime_clip_r2,$nextera,$stranded_illumina,$small_rna,$path_to_cutadapt,$illumina,$max_length,$maxn,$trim_n,$hardtrim5,$clock,$polyA,$hardtrim3,$nextseq,$basename,$consider_already_trimmed,$umi_from_r2) = process_commandline();
+my ($compression_path,$decompression_path,$cores,$cutoff,$adapter,$stringency,$rrbs,$length_cutoff,$keep,$fastqc,$non_directional,$phred_encoding,$fastqc_args,$trim,$gzip,$validate,$retain,$length_read_1,$length_read_2,$a2,$error_rate,$output_dir,$no_report_file,$dont_gzip,$clip_r1,$clip_r2,$three_prime_clip_r1,$three_prime_clip_r2,$nextera,$stranded_illumina,$small_rna,$path_to_cutadapt,$illumina,$max_length,$maxn,$trim_n,$hardtrim5,$clock,$polyA,$hardtrim3,$nextseq,$basename,$consider_already_trimmed,$umi_from_r2) = process_commandline();
 my $report_message; # stores result of adapter auto-detection
 
 my @filenames = @ARGV;
@@ -107,13 +107,13 @@ sub implicon_umi{
     ### INPUT FILES
     my ($in1,$in2,$umi_length) = @_;
     if ($in1 =~ /\.gz$/){
-		open ($in1_fh,"$compression_path -d -c $in1 |") or die "Failed to read from file $in1: $!";
+		open ($in1_fh,"$decompression_path -d -c $in1 |") or die "Failed to read from file $in1: $!";
     }
     else{
 		open ($in1_fh,$in1) or die "Failed to read from file $in1: $!";
     }
     if ($in2 =~ /\.gz$/){
-		open ($in2_fh,"$compression_path -d -c $in2 |") or die "Failed to read from file $in2: $!";
+		open ($in2_fh,"$decompression_path -d -c $in2 |") or die "Failed to read from file $in2: $!";
     }
     else{
 		open ($in2_fh,$in2) or die "Failed to read from file $in2: $!";
@@ -259,13 +259,13 @@ sub clockwork{
     ### INPUT FILES
     my ($in1,$in2) = @_;
     if ($in1 =~ /\.gz$/){
-		open ($in1_fh,"$compression_path -d -c $in1 |") or die "Failed to read from file $in1: $!";
+		open ($in1_fh,"$decompression_path -d -c $in1 |") or die "Failed to read from file $in1: $!";
     }
     else{
 		open ($in1_fh,$in1) or die "Failed to read from file $in1: $!";
     }
     if ($in2 =~ /\.gz$/){
-		open ($in2_fh,"$compression_path -d -c $in2 |") or die "Failed to read from file $in2: $!";
+		open ($in2_fh,"$decompression_path -d -c $in2 |") or die "Failed to read from file $in2: $!";
     }
     else{
 		open ($in2_fh,$in2) or die "Failed to read from file $in2: $!";
@@ -944,7 +944,7 @@ sub trim{
 		open (QUAL,"$output_dir$temp") or die $!; # quality trimmed file
       
 		if ($filename =~ /\.gz$/){
-			open (IN,"gunzip -c $filename |") or die $!; # original, untrimmed file
+			open (IN,"$decompression_path -d -c $filename |") or die $!; # original, untrimmed file
 		}
 		else{
 			open (IN,$filename) or die $!; # original, untrimmed file
@@ -1144,7 +1144,7 @@ sub trim{
 
 		# This is the Illumina adapter trimmed file
 		if ($temp =~ /\.gz$/){
-			open (QUAL,"gunzip -c $output_dir$temp |") or die $!; # quality trimmed file
+			open (QUAL,"$decompression_path -d -c $output_dir$temp |") or die $!; # quality trimmed file
 		}
 		else{
 			open (QUAL,"$output_dir$temp") or die $!; # quality trimmed file
@@ -1574,7 +1574,7 @@ sub hardtrim_to_5prime_end{
     my $hardtrim_5; # filehandle
 
     if ($filename =~ /gz$/){
-    open ($in,"$compression_path -d -c $filename |") or die "Couldn't read from file $!";
+    open ($in,"$decompression_path -d -c $filename |") or die "Couldn't read from file $!";
     }
     else{
     open ($in,$filename) or die "Couldn't read from file $!";
@@ -1652,7 +1652,7 @@ sub hardtrim_to_3prime_end{
     my $hardtrim_3; # filehandle
 
     if ($filename =~ /gz$/){
-    open ($in,"$compression_path -d -c $filename |") or die "Couldn't read from file $!";
+    open ($in,"$decompression_path -d -c $filename |") or die "Couldn't read from file $!";
     }
     else{
     open ($in,$filename) or die "Couldn't read from file $!";
@@ -1732,14 +1732,14 @@ sub validate_paired_end_files{
    
 
   if ($file_1 =~ /\.gz$/){
-      open (IN1,"$compression_path -d -c $output_dir$file_1 |") or die "Couldn't read from file $file_1: $!\n";
+      open (IN1,"$decompression_path -d -c $output_dir$file_1 |") or die "Couldn't read from file $file_1: $!\n";
   }
   else{
       open (IN1, "$output_dir$file_1") or die "Couldn't read from file $file_1: $!\n";
   }
 
   if ($file_2 =~ /\.gz$/){
-      open (IN2,"$compression_path -d -c $output_dir$file_2 |") or die "Couldn't read from file $file_2: $!\n";
+      open (IN2,"$decompression_path -d -c $output_dir$file_2 |") or die "Couldn't read from file $file_2: $!\n";
   }
   else{
       open (IN2, "$output_dir$file_2") or die "Couldn't read from file $file_2: $!\n";
@@ -2039,7 +2039,7 @@ sub file_sanity_check{
 
   my $file = shift;
   if ($file =~ /gz$/){
-      open (SANITY,"$compression_path -d -c $file |") or die "Failed to read from file '$file' to perform sanity check: $!\n";
+      open (SANITY,"$decompression_path -d -c $file |") or die "Failed to read from file '$file' to perform sanity check: $!\n";
   }
   else{
       open (SANITY,$file) or die "Failed to read from file '$file' to perform sanity check: $!\n";
@@ -2075,7 +2075,7 @@ sub autodetect_adapter_type{
   warn "Attempting to auto-detect adapter type from the first 1 million sequences of the first file (>> $ARGV[0] <<)\n\n";
 
   if ($ARGV[0] =~ /gz$/){
-    open (AUTODETECT,"$compression_path -d -c $ARGV[0] |") or die "Failed to read from file $ARGV[0]\n";
+    open (AUTODETECT,"$decompression_path -d -c $ARGV[0] |") or die "Failed to read from file $ARGV[0]\n";
   }
   else{
     open (AUTODETECT,$ARGV[0]) or die "Failed to read from file $ARGV[0]\n";
@@ -2247,7 +2247,7 @@ sub autodetect_polyA_type{
     warn "Attempting to auto-detect PolyA type from the first 1 million sequences of the first file (>> $ARGV[0] <<)\n\n";
 
     if ($ARGV[0] =~ /gz$/){
-    open (AUTODETECT,"$compression_path -d -c $ARGV[0] |") or die "Failed to read from file $ARGV[0]\n";
+    open (AUTODETECT,"$decompression_path -d -c $ARGV[0] |") or die "Failed to read from file $ARGV[0]\n";
     }
     else{
     open (AUTODETECT,$ARGV[0]) or die "Failed to read from file $ARGV[0]\n";
@@ -2578,6 +2578,16 @@ VERSION
 			if ($pigz_return == 0) {
 				warn "Parallel gzip (pigz) detected. Proceeding with multicore (de)compression using $cores cores\n\n";
 				$compression_path = "pigz -p $cores";
+
+				if ($cores > 4) {
+					# Parallel gzip (pigz) always uses a single thread (the main thread) for decompression,
+					# but will create three other threads for reading, writing, and check calculation,
+					# which can speed up decompression under some circumstances.
+					$decompression_path = "pigz -p 4";
+				}
+				else {
+                                    $decompression_path = "pigz -p $cores";
+                                }
 			} 
 			else {
 				warn "Proceeding with 'gzip' for compression. PLEASE NOTE: Using multi-cores for trimming with 'gzip' only has only very limited effect! (see here: https://github.com/FelixKrueger/TrimGalore/issues/16#issuecomment-458557103)\n";
@@ -2592,6 +2602,19 @@ VERSION
 	unless (defined $compression_path){
 		$compression_path = "gzip"; # fall-back option
 	}
+
+	### Test if igzip is installed
+	my $igzip_return = system ("igzip --version 2> /dev/null");
+	# warn "IGZIP returned: $igzip_return\n";
+	if ($igzip_return == 0) {
+		warn "igzip detected. Using igzip for decompressing\n\n";
+		$decompression_path = "igzip";
+	}
+	else {
+		warn "Proceeding with '$decompression_path' for decompression.";
+		warn "To decrease CPU usage of decompression, please install 'igzip' and run again\n\n";
+	}
+
 
 	### SUPRESS WARNINGS
 	if (defined $suppress_warn){
@@ -3000,7 +3023,7 @@ VERSION
         $umi_from_r2 = 8;
     }
 
-    return ($compression_path,$cores,$quality,$adapter,$stringency,$rrbs,$length_cutoff,$keep,$fastqc,$non_directional,$phred_encoding,$fastqc_args,$trim,$gzip,$validate,$retain,$length_read_1,$length_read_2,$adapter2,$error_rate,$output_dir,$no_report_file,$dont_gzip,$clip_r1,$clip_r2,$three_prime_clip_r1,$three_prime_clip_r2,$nextera,$stranded_illumina,$small_rna,$path_to_cutadapt,$illumina,$max_length,$maxn,$trim_n,$hardtrim5,$clock,$polyA,$hardtrim3,$nextseq,$basename,$consider_already_trimmed,$umi_from_r2);
+    return ($compression_path,$decompression_path,$cores,$quality,$adapter,$stringency,$rrbs,$length_cutoff,$keep,$fastqc,$non_directional,$phred_encoding,$fastqc_args,$trim,$gzip,$validate,$retain,$length_read_1,$length_read_2,$adapter2,$error_rate,$output_dir,$no_report_file,$dont_gzip,$clip_r1,$clip_r2,$three_prime_clip_r1,$three_prime_clip_r2,$nextera,$stranded_illumina,$small_rna,$path_to_cutadapt,$illumina,$max_length,$maxn,$trim_n,$hardtrim5,$clock,$polyA,$hardtrim3,$nextseq,$basename,$consider_already_trimmed,$umi_from_r2);
 }
 
 sub Ncounter{


### PR DESCRIPTION
igzip (https://github.com/intel/isa-l/) is quite a bit faster than standard gzip/pigz for decompressing gzipped files.

Total runtime might not be that much faster with igzip as in most cases igzip will only consume around 20% CPU as other commands in the pipeline can't keep up. But it lowers the total amount of CPU used by TrimGalore.

cutadapt also uses python-isal/igzip under the hood via xopen to read FASTQ files.