### PR TITLE
Drop macos-x86_64 from release binary matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,10 +127,6 @@ jobs:
             os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
 
-          - name: macos-x86_64
-            os: macos-13
-            target: x86_64-apple-darwin
-
           - name: macos-aarch64
             os: macos-latest
             target: aarch64-apple-darwin

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `dev` tag tracks the latest development branch; versioned tags (e.g. `v2.1.0
 
 ### Prebuilt binaries
 
-Prebuilt binaries for Linux (x86_64, aarch64) and macOS (Intel, Apple Silicon) are available on the [Releases](https://github.com/FelixKrueger/TrimGalore/releases) page.
+Prebuilt binaries for Linux (x86_64, aarch64) and macOS (Apple Silicon) are available on the [Releases](https://github.com/FelixKrueger/TrimGalore/releases) page. Intel Mac users: install via `cargo install trim-galore` (local build) or use the Docker `amd64` image.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

`macos-13` on GitHub's shared runner pool has been persistently queued — the v2.1.0-beta.1 dry-run (run 24599969886) sat at 5+ hours for the `Build macos-x86_64` job before being cancelled. Every other job in the dry-run completed successfully in under 2 minutes, so this single runner pool is the sole blocker on Beta 1.

Drop Intel macOS from the release binary matrix. Intel Mac users can still install via:
- `cargo install trim-galore` (local build from crates.io)
- Docker `ghcr.io/felixkrueger/trimgalore` (multi-arch manifest covers `linux/amd64`)

Apple Silicon macOS remains covered by the existing `macos-latest` runner.

## Changes

- `.github/workflows/release.yml`: remove `macos-x86_64` matrix row from `build-binaries`.
- `README.md`: update "Prebuilt binaries" platform list and note Intel Mac install paths.

## Test plan

- [ ] Re-dispatch release workflow with `dry_run: true` on `optimus_prime` after merge; confirm all jobs reach terminal state within ~20 min.
- [ ] Confirm `Build macos-aarch64` still runs and passes.
- [ ] Confirm `create-tag-and-release` + `upload-binaries` + `publish-crate` jobs resolve correctly (skipped on dry-run, run on real dispatch).

## Follow-up (not this PR)

If Intel Mac pre-built binaries become important again, options are (a) cross-compile `x86_64-apple-darwin` on `macos-14` with Rosetta-based smoke test, or (b) paid `macos-13-xlarge` runners. Revisit post-GA if users report friction.