### PR TITLE
Build provenance + lint/reproducibility/audit CI gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Dependabot configuration (v2) — https://docs.github.com/en/code-security/dependabot
+#
+# Tracks two ecosystems:
+#   - cargo (direct + transitive dependencies in Cargo.lock)
+#   - github-actions (pinned action versions in .github/workflows/*.yml)
+#
+# Weekly Monday cadence matches a pre-week triage flow.  `open-pull-requests-
+# limit: 5` caps the initial surge when Dependabot first activates; raise if
+# we start dropping real updates.
+#
+# No `labels:` field — Dependabot will auto-create and apply its default
+# `dependencies` label on the first PR per ecosystem.  We can move to explicit
+# labels later if we want fine-grained categorisation.
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    assignees:
+      - "FelixKrueger"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    assignees:
+      - "FelixKrueger"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,13 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-repro-
       - name: Build twice with same SOURCE_DATE_EPOCH, assert bit-identical
         run: |
-          SOURCE_DATE_EPOCH=1700000000 cargo clean && cargo build --release
+          # `export` (not `VAR=x cmd1 && cmd2`) — the shell-prefix form only
+          # scopes the var to cmd1, so `cargo build` after the `&&` would fall
+          # back to wall-clock time and break bit-identity.
+          export SOURCE_DATE_EPOCH=1700000000
+          cargo clean && cargo build --release
           sha256sum target/release/trim_galore | awk '{print $1}' > /tmp/sha_a
-          SOURCE_DATE_EPOCH=1700000000 cargo clean && cargo build --release
+          cargo clean && cargo build --release
           sha256sum target/release/trim_galore | awk '{print $1}' > /tmp/sha_b
           diff /tmp/sha_a /tmp/sha_b
       - name: Malformed SOURCE_DATE_EPOCH hard-fails build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [master, dev, optimus_prime]
   pull_request:
-    branches: [master]
+    # Trigger on PRs targeting any active integration branch — `optimus_prime`
+    # is the active dev branch for the Oxidized Edition; `master` stays listed
+    # for the Perl release line.
+    branches: [master, optimus_prime]
   # Weekly cron so the `audit` job surfaces new RustSec advisories even during
   # quiet weeks (no pushes / PRs).  Non-audit jobs skip on schedule via the
   # per-job `if: github.event_name != 'schedule'` guard below.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,16 @@ on:
     branches: [master, dev, optimus_prime]
   pull_request:
     branches: [master]
+  # Weekly cron so the `audit` job surfaces new RustSec advisories even during
+  # quiet weeks (no pushes / PRs).  Non-audit jobs skip on schedule via the
+  # per-job `if: github.event_name != 'schedule'` guard below.
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
 
 jobs:
   rust-tests:
     name: Rust Tests
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
 
     steps:
@@ -34,10 +40,98 @@ jobs:
       - name: Build release
         run: cargo build --release
 
+      - name: Verify --version carries provenance
+        run: |
+          # Content-targeted grep (not line count): the provenance line must match
+          # <git-hash> — <os>/<arch> — built <ISO-8601-UTC>. The em-dash is literal.
+          ./target/release/trim_galore --version \
+            | grep -qE '^[0-9a-f]{7,40} — [a-z0-9_]+/[a-z0-9_]+ — built [0-9T:Z-]+$'
+          # -V must NOT carry the provenance line (stays the short form).
+          ! ./target/release/trim_galore -V \
+            | grep -qE '^[0-9a-f]{7,40} — '
+
+  reproducibility:
+    name: Reproducibility (SOURCE_DATE_EPOCH)
+    # Dedicated job with its own cache — `cargo clean` inside here would trash
+    # the `rust-tests` cache if co-located. Parallel to `rust-tests` so no
+    # wall-clock cost.
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo (reproducibility job)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          # target/ intentionally excluded — this job does `cargo clean` twice.
+          key: ${{ runner.os }}-cargo-repro-${{ hashFiles('Cargo.lock') }}
+          # Narrow to the repro-specific prefix so we don't restore `target/`
+          # from the `rust-tests` cache (which would be wiped by `cargo clean`
+          # anyway — just avoids wasting restore bandwidth).
+          restore-keys: ${{ runner.os }}-cargo-repro-
+      - name: Build twice with same SOURCE_DATE_EPOCH, assert bit-identical
+        run: |
+          SOURCE_DATE_EPOCH=1700000000 cargo clean && cargo build --release
+          sha256sum target/release/trim_galore | awk '{print $1}' > /tmp/sha_a
+          SOURCE_DATE_EPOCH=1700000000 cargo clean && cargo build --release
+          sha256sum target/release/trim_galore | awk '{print $1}' > /tmp/sha_b
+          diff /tmp/sha_a /tmp/sha_b
+      - name: Malformed SOURCE_DATE_EPOCH hard-fails build
+        run: |
+          # Build script must panic with a message mentioning SOURCE_DATE_EPOCH,
+          # not silently fall back to wall-clock time.
+          set +e
+          SOURCE_DATE_EPOCH=garbage cargo clean
+          SOURCE_DATE_EPOCH=garbage cargo build --release 2>&1 | tee /tmp/sde.log
+          rc=${PIPESTATUS[0]}
+          set -e
+          test $rc -ne 0
+          grep -q "SOURCE_DATE_EPOCH" /tmp/sde.log
+
+  lint:
+    name: Lint (fmt + clippy)
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+      - name: cargo clippy (release, all targets, -D warnings)
+        run: cargo clippy --all-targets --release -- -D warnings
+
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   validation:
     name: Validate vs Perl TrimGalore
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
-    needs: [rust-tests]
+    needs: [rust-tests, lint]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,15 @@ name: Release
 #   workflow with `dry_run: true` — all destructive side effects
 #   (crates.io publish, tag push, Docker registry push, GitHub
 #   release creation) are suppressed.
+#
+# Lint-gating note:
+#   This workflow intentionally does NOT gate on the `lint` job from
+#   ci.yml.  Releases are cut from commits that have already passed
+#   ci.yml on the PR-merge path, so re-running lint here would duplicate
+#   work without adding signal.  A hotfix tag pushed outside the normal
+#   PR path could bypass the gate — mitigation is the social convention
+#   that all release-bearing merges go through a PR.  Revisit if the
+#   release automation rewires.
 # ------------------------------------------------------------------
 
 on:

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,76 @@
+use std::env;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn git_short_hash() -> String {
+    Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn build_epoch() -> u64 {
+    match env::var("SOURCE_DATE_EPOCH") {
+        // .trim() absorbs whitespace from shell expansions like
+        // `SOURCE_DATE_EPOCH="$(git log -1 --format=%ct) "`; sign/format
+        // strictness (no leading `+`, no underscores, no hex) is preserved.
+        Ok(s) => s.trim().parse::<u64>().unwrap_or_else(|_| {
+            panic!(
+                "SOURCE_DATE_EPOCH must be a non-negative decimal seconds-since-epoch integer, got {s:?}"
+            )
+        }),
+        Err(_) => SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before 1970-01-01")
+            .as_secs(),
+    }
+}
+
+fn format_iso8601_utc(epoch: u64) -> String {
+    let secs_of_day = epoch % 86_400;
+    let days = epoch / 86_400;
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day % 3600) / 60;
+    let second = secs_of_day % 60;
+
+    let (year, month, day) = civil_from_days(days as i64);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+// Howard Hinnant's days-from-civil algorithm (public domain).
+// Input: days since 1970-01-01.  Output: (year, month, day) on the proleptic Gregorian calendar.
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    let year = y + i64::from(m <= 2);
+    (year, m, d)
+}
+
+fn main() {
+    let hash = git_short_hash();
+    let timestamp = format_iso8601_utc(build_epoch());
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_else(|_| "unknown".to_string());
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "unknown".to_string());
+
+    let version_body = format!("{hash} — {target_os}/{target_arch} — built {timestamp}");
+
+    println!("cargo:rustc-env=GIT_SHORT_HASH={hash}");
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={timestamp}");
+    println!("cargo:rustc-env=VERSION_BODY={version_body}");
+
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+}

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -162,7 +162,7 @@ pub fn autodetect_adapter<P: AsRef<Path>>(
         .enumerate()
         .map(|(i, &c)| (i, adapters[i].0, c))
         .collect();
-    sorted_counts.sort_by(|a, b| b.2.cmp(&a.2));
+    sorted_counts.sort_by_key(|entry| std::cmp::Reverse(entry.2));
 
     // Check if adapter trimming should be suppressed
     let suppressed = if let Some(threshold) = consider_already_trimmed {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -3,8 +3,8 @@
 //! Provides built-in adapter sequences for common sequencing platforms
 //! and auto-detection by scanning the first 1M reads.
 
-use anyhow::{Context, Result};
 use crate::fastq::FastqReader;
+use anyhow::{Context, Result};
 use std::io::BufRead;
 use std::path::Path;
 
@@ -187,10 +187,7 @@ pub fn autodetect_adapter<P: AsRef<Path>>(
         format!(
             "Using {} adapter for trimming (count: {}). \
              Second best hit was {} (count: {}).",
-            sorted_counts[0].1,
-            sorted_counts[0].2,
-            sorted_counts[1].1,
-            sorted_counts[1].2,
+            sorted_counts[0].1, sorted_counts[0].2, sorted_counts[1].1, sorted_counts[1].2,
         )
     };
 
@@ -335,7 +332,11 @@ pub fn read_fasta_adapters<P: AsRef<Path>>(path: P) -> Result<Vec<(String, Strin
             // Flush previous entry
             if let Some(name) = current_name.take() {
                 if current_seq.is_empty() {
-                    anyhow::bail!("Empty sequence for adapter '{}' in {}", name, path.display());
+                    anyhow::bail!(
+                        "Empty sequence for adapter '{}' in {}",
+                        name,
+                        path.display()
+                    );
                 }
                 validate_adapter_sequence(&current_seq)?;
                 adapters.push((name, current_seq.clone()));
@@ -350,14 +351,21 @@ pub fn read_fasta_adapters<P: AsRef<Path>>(path: P) -> Result<Vec<(String, Strin
     // Flush last entry
     if let Some(name) = current_name {
         if current_seq.is_empty() {
-            anyhow::bail!("Empty sequence for adapter '{}' in {}", name, path.display());
+            anyhow::bail!(
+                "Empty sequence for adapter '{}' in {}",
+                name,
+                path.display()
+            );
         }
         validate_adapter_sequence(&current_seq)?;
         adapters.push((name, current_seq));
     }
 
     if adapters.is_empty() {
-        anyhow::bail!("No adapter sequences found in FASTA file: {}", path.display());
+        anyhow::bail!(
+            "No adapter sequences found in FASTA file: {}",
+            path.display()
+        );
     }
 
     Ok(adapters)
@@ -365,7 +373,10 @@ pub fn read_fasta_adapters<P: AsRef<Path>>(path: P) -> Result<Vec<(String, Strin
 
 /// Validate that an adapter sequence contains only valid DNA characters.
 fn validate_adapter_sequence(seq: &str) -> Result<()> {
-    if !seq.bytes().all(|b| matches!(b, b'A' | b'C' | b'G' | b'T' | b'N' | b'X')) {
+    if !seq
+        .bytes()
+        .all(|b| matches!(b, b'A' | b'C' | b'G' | b'T' | b'N' | b'X'))
+    {
         anyhow::bail!(
             "Adapter sequence must contain only DNA characters (A, C, G, T, N, X), got: '{}'",
             seq
@@ -380,7 +391,10 @@ mod tests {
 
     #[test]
     fn test_contains_subsequence() {
-        assert!(contains_subsequence(b"ACGTAAGAGATCGGAAGAGCTTTT", b"AGATCGGAAGAGC"));
+        assert!(contains_subsequence(
+            b"ACGTAAGAGATCGGAAGAGCTTTT",
+            b"AGATCGGAAGAGC"
+        ));
         assert!(!contains_subsequence(b"ACGTACGT", b"AGATCGGAAGAGC"));
         assert!(contains_subsequence(b"AGATCGGAAGAGC", b"AGATCGGAAGAGC"));
         assert!(!contains_subsequence(b"", b"AGATC"));
@@ -435,8 +449,14 @@ mod tests {
         let result = parse_adapter_spec(" AGCTAGCG -a TCTCTTATAT -a TTTATTCGGATTTAT").unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], ("adapter_1".to_string(), "AGCTAGCG".to_string()));
-        assert_eq!(result[1], ("adapter_2".to_string(), "TCTCTTATAT".to_string()));
-        assert_eq!(result[2], ("adapter_3".to_string(), "TTTATTCGGATTTAT".to_string()));
+        assert_eq!(
+            result[1],
+            ("adapter_2".to_string(), "TCTCTTATAT".to_string())
+        );
+        assert_eq!(
+            result[2],
+            ("adapter_3".to_string(), "TTTATTCGGATTTAT".to_string())
+        );
     }
 
     #[test]
@@ -451,8 +471,14 @@ mod tests {
 
         let result = read_fasta_adapters(&path).unwrap();
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0], ("Illumina".to_string(), "AGATCGGAAGAGC".to_string()));
-        assert_eq!(result[1], ("Nextera".to_string(), "CTGTCTCTTATA".to_string()));
+        assert_eq!(
+            result[0],
+            ("Illumina".to_string(), "AGATCGGAAGAGC".to_string())
+        );
+        assert_eq!(
+            result[1],
+            ("Nextera".to_string(), "CTGTCTCTTATA".to_string())
+        );
 
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -55,8 +55,8 @@ pub fn find_3prime_adapter(
     // First row: dp[0][j] = 0 for all j (adapter can start anywhere — free read prefix skip)
     // First column: dp[i][0] = i (aligning i adapter bases to nothing costs i deletions)
     let mut dp = vec![vec![0usize; n + 1]; m + 1];
-    for i in 1..=m {
-        dp[i][0] = i;
+    for (i, row) in dp.iter_mut().enumerate().skip(1) {
+        row[0] = i;
     }
 
     for i in 1..=m {
@@ -64,8 +64,8 @@ pub fn find_3prime_adapter(
             let cost_sub = if adapter[i - 1] == read[j - 1] { 0 } else { 1 };
 
             dp[i][j] = (dp[i - 1][j - 1] + cost_sub) // match/mismatch
-                .min(dp[i - 1][j] + 1)                // deletion (gap in read)
-                .min(dp[i][j - 1] + 1);               // insertion (gap in adapter)
+                .min(dp[i - 1][j] + 1) // deletion (gap in read)
+                .min(dp[i][j - 1] + 1); // insertion (gap in adapter)
         }
     }
 
@@ -244,7 +244,11 @@ mod tests {
         let adapter = b"AGATCGGAAGAGC";
         let m = find_3prime_adapter(read, adapter, 0.1, 1).unwrap();
         // Must find the leftmost match (position ~1), not a later perfect match
-        assert!(m.read_start <= 1, "Expected read_start <= 1, got {}", m.read_start);
+        assert!(
+            m.read_start <= 1,
+            "Expected read_start <= 1, got {}",
+            m.read_start
+        );
         assert_eq!(m.overlap, 13);
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,15 @@ use std::path::PathBuf;
 /// Drop-in replacement for Trim Galore, rewritten in Rust. Produces byte-identical
 /// output, compatible with MultiQC and existing pipelines.
 #[derive(Parser, Debug)]
-#[clap(name = "trim_galore", version = concat!(env!("CARGO_PKG_VERSION"), " (Oxidized Edition)"), about)]
+#[clap(
+    name = "trim_galore",
+    version = concat!(env!("CARGO_PKG_VERSION"), " (Oxidized Edition)"),
+    long_version = concat!(
+        env!("CARGO_PKG_VERSION"), " (Oxidized Edition)\n",
+        env!("VERSION_BODY")
+    ),
+    about
+)]
 pub struct Cli {
     /// Input FASTQ file(s). For paired-end, provide two files.
     #[clap(required = true)]
@@ -184,8 +192,12 @@ pub struct Cli {
     /// called as high-quality G. By default, poly-G trimming is auto-detected
     /// from the data. Use this flag to force-enable it.
     /// This is independent from --nextseq (quality-based G-trimming).
-    #[clap(long = "poly_g", alias = "poly-g", alias = "polyG",
-           conflicts_with = "no_poly_g")]
+    #[clap(
+        long = "poly_g",
+        alias = "poly-g",
+        alias = "polyG",
+        conflicts_with = "no_poly_g"
+    )]
     pub poly_g: bool,
 
     /// Disable poly-G auto-detection and trimming.
@@ -205,7 +217,6 @@ pub struct Cli {
     pub discard_untrimmed: bool,
 
     // --- Specialty modes (run-and-exit, bypass normal trimming) ---
-
     /// Hard-trim to keep only the first N bases from the 5' end.
     /// Bypasses adapter/quality trimming entirely.
     #[clap(long = "hardtrim5")]
@@ -238,7 +249,6 @@ pub struct Cli {
     pub demux: Option<PathBuf>,
 
     // --- Deprecated flags (accepted for backwards compatibility, no-ops) ---
-
     /// [Deprecated] Output is gzipped by default in v2.0. Use --dont_gzip to disable.
     #[clap(long = "gzip", hide = true)]
     pub gzip: bool,
@@ -306,7 +316,10 @@ impl Cli {
         }
 
         if self.error_rate < 0.0 || self.error_rate > 1.0 {
-            anyhow::bail!("Error rate must be between 0 and 1, got {}", self.error_rate);
+            anyhow::bail!(
+                "Error rate must be between 0 and 1, got {}",
+                self.error_rate
+            );
         }
 
         if self.stringency == 0 {
@@ -380,20 +393,30 @@ impl Cli {
 
         // Deprecation warnings for Perl-era flags
         if self.gzip {
-            eprintln!("WARNING: --gzip is deprecated in Trim Galore v2.0. Output is gzipped by default. Use --dont_gzip to disable. Ignoring.");
+            eprintln!(
+                "WARNING: --gzip is deprecated in Trim Galore v2.0. Output is gzipped by default. Use --dont_gzip to disable. Ignoring."
+            );
         }
         if self.path_to_cutadapt.is_some() {
-            eprintln!("WARNING: --path_to_cutadapt is deprecated in Trim Galore v2.0 (no external Cutadapt needed). Ignoring.");
+            eprintln!(
+                "WARNING: --path_to_cutadapt is deprecated in Trim Galore v2.0 (no external Cutadapt needed). Ignoring."
+            );
         }
         if self.cutadapt_args.is_some() {
-            eprintln!("WARNING: --cutadapt_args is deprecated in Trim Galore v2.0 (no external Cutadapt needed). Ignoring.");
+            eprintln!(
+                "WARNING: --cutadapt_args is deprecated in Trim Galore v2.0 (no external Cutadapt needed). Ignoring."
+            );
             eprintln!("         Note: --discard-untrimmed is now a native flag.");
         }
         if self.suppress_warn {
-            eprintln!("WARNING: --suppress_warn is deprecated in Trim Galore v2.0 (no Cutadapt subprocess). Ignoring.");
+            eprintln!(
+                "WARNING: --suppress_warn is deprecated in Trim Galore v2.0 (no Cutadapt subprocess). Ignoring."
+            );
         }
         if self.keep {
-            eprintln!("WARNING: --keep is not yet supported in Trim Galore v2.0. RRBS reads below length cutoff will be removed. Ignoring.");
+            eprintln!(
+                "WARNING: --keep is not yet supported in Trim Galore v2.0. RRBS reads below length cutoff will be removed. Ignoring."
+            );
         }
 
         Ok(())

--- a/src/demux.rs
+++ b/src/demux.rs
@@ -7,7 +7,7 @@
 //!
 //! Single-end only (matches TrimGalore behavior).
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
@@ -47,7 +47,9 @@ pub fn read_barcode_file(path: &Path) -> Result<Vec<BarcodeEntry>> {
         if parts.len() != 2 {
             bail!(
                 "Barcode file {} line {}: expected tab-separated 'sample_name\\tbarcode_sequence', got: '{}'",
-                path.display(), line_num + 1, line
+                path.display(),
+                line_num + 1,
+                line
             );
         }
 
@@ -55,10 +57,15 @@ pub fn read_barcode_file(path: &Path) -> Result<Vec<BarcodeEntry>> {
         let barcode = parts[1].to_string();
 
         // Validate barcode characters
-        if !barcode.bytes().all(|b| matches!(b, b'A' | b'C' | b'T' | b'G' | b'N')) {
+        if !barcode
+            .bytes()
+            .all(|b| matches!(b, b'A' | b'C' | b'T' | b'G' | b'N'))
+        {
             bail!(
                 "Barcode file {} line {}: barcode must contain only A, C, T, G, N. Got: '{}'",
-                path.display(), line_num + 1, barcode
+                path.display(),
+                line_num + 1,
+                barcode
             );
         }
 
@@ -68,21 +75,31 @@ pub fn read_barcode_file(path: &Path) -> Result<Vec<BarcodeEntry>> {
             Some(len) if barcode.len() != len => {
                 bail!(
                     "Barcode file {} line {}: barcode '{}' has length {} but expected {} (all barcodes must be the same length)",
-                    path.display(), line_num + 1, barcode, barcode.len(), len
+                    path.display(),
+                    line_num + 1,
+                    barcode,
+                    barcode.len(),
+                    len
                 );
             }
             _ => {}
         }
 
         eprintln!("Testing:\t{}\t{}", sample_name, barcode);
-        entries.push(BarcodeEntry { barcode, sample_name });
+        entries.push(BarcodeEntry {
+            barcode,
+            sample_name,
+        });
     }
 
     if entries.is_empty() {
         bail!("Barcode file {} is empty", path.display());
     }
 
-    eprintln!("Demultiplexing file {} seems to be in the correct format. Proceeding...", path.display());
+    eprintln!(
+        "Demultiplexing file {} seems to be in the correct format. Proceeding...",
+        path.display()
+    );
     Ok(entries)
 }
 
@@ -121,9 +138,12 @@ pub fn demultiplex(
         base_name = base_name[..base_name.len() - 3].to_string();
     }
 
-    let dir = output_dir
-        .map(|d| d.to_path_buf())
-        .unwrap_or_else(|| trimmed_file.parent().unwrap_or(Path::new(".")).to_path_buf());
+    let dir = output_dir.map(|d| d.to_path_buf()).unwrap_or_else(|| {
+        trimmed_file
+            .parent()
+            .unwrap_or(Path::new("."))
+            .to_path_buf()
+    });
 
     // Open per-sample output writers + NoCode
     let mut writers: HashMap<String, FastqWriter> = HashMap::new();
@@ -141,10 +161,8 @@ pub fn demultiplex(
     let mut nocode_writer = FastqWriter::create(&nocode_path, gzip, cores)?;
 
     // Per-barcode counts
-    let mut counts: HashMap<String, usize> = barcodes
-        .iter()
-        .map(|e| (e.barcode.clone(), 0))
-        .collect();
+    let mut counts: HashMap<String, usize> =
+        barcodes.iter().map(|e| (e.barcode.clone(), 0)).collect();
     counts.insert("NoCode".to_string(), 0);
 
     // Process the trimmed file
@@ -229,7 +247,7 @@ pub fn demultiplex(
         writeln!(w, "{}\t{}\t{}", barcode, sample, count)?;
     }
     writeln!(w, "======================")?;
-    write!(w, "      ¯\\_(ツ)_/¯\n")?;
+    writeln!(w, "      ¯\\_(ツ)_/¯")?;
     w.flush()?;
 
     Ok(())

--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -3,10 +3,10 @@
 //! Provides gzip-aware reading and writing of FASTQ records with 64KB buffers
 //! for efficient I/O throughput.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
+use flate2::Compression;
 use flate2::read::MultiGzDecoder;
 use flate2::write::GzEncoder;
-use flate2::Compression;
 use gzp::deflate::Gzip;
 use gzp::par::compress::ParCompressBuilder;
 use std::fs::File;
@@ -162,11 +162,11 @@ impl FastqReader {
         let file = File::open(path)
             .with_context(|| format!("Failed to open input file: {}", path.display()))?;
 
-        let reader: Box<dyn BufRead> = if path
-            .extension()
-            .is_some_and(|ext| ext == "gz")
-        {
-            Box::new(BufReader::with_capacity(BUF_SIZE, MultiGzDecoder::new(file)))
+        let reader: Box<dyn BufRead> = if path.extension().is_some_and(|ext| ext == "gz") {
+            Box::new(BufReader::with_capacity(
+                BUF_SIZE,
+                MultiGzDecoder::new(file),
+            ))
         } else {
             Box::new(BufReader::with_capacity(BUF_SIZE, file))
         };
@@ -250,11 +250,11 @@ impl FastqReader {
         let file = File::open(path)
             .with_context(|| format!("Failed to open input file: {}", path.display()))?;
 
-        let reader: Box<dyn BufRead + Send> = if path
-            .extension()
-            .is_some_and(|ext| ext == "gz")
-        {
-            Box::new(BufReader::with_capacity(BUF_SIZE, MultiGzDecoder::new(file)))
+        let reader: Box<dyn BufRead + Send> = if path.extension().is_some_and(|ext| ext == "gz") {
+            Box::new(BufReader::with_capacity(
+                BUF_SIZE,
+                MultiGzDecoder::new(file),
+            ))
         } else {
             Box::new(BufReader::with_capacity(BUF_SIZE, file))
         };
@@ -331,7 +331,12 @@ impl FastqReader {
 
                 Ok(Some(FastqRecord { id, seq, qual }))
             }
-            ReaderSource::Threaded { rx, buffer, buf_pos, .. } => {
+            ReaderSource::Threaded {
+                rx,
+                buffer,
+                buf_pos,
+                ..
+            } => {
                 // Return next record from current batch buffer
                 if *buf_pos < buffer.len() {
                     let idx = *buf_pos;
@@ -339,7 +344,11 @@ impl FastqReader {
                     // Take the record out, replacing with a dummy to avoid clone
                     let record = std::mem::replace(
                         &mut buffer[idx],
-                        FastqRecord { id: String::new(), seq: String::new(), qual: String::new() },
+                        FastqRecord {
+                            id: String::new(),
+                            seq: String::new(),
+                            qual: String::new(),
+                        },
                     );
                     return Ok(Some(record));
                 }
@@ -354,7 +363,11 @@ impl FastqReader {
                             // Return first record from new batch
                             let record = std::mem::replace(
                                 &mut buffer[0],
-                                FastqRecord { id: String::new(), seq: String::new(), qual: String::new() },
+                                FastqRecord {
+                                    id: String::new(),
+                                    seq: String::new(),
+                                    qual: String::new(),
+                                },
                             );
                             Ok(Some(record))
                         }
@@ -416,8 +429,9 @@ impl FastqWriter {
         // Ensure parent directory exists
         if let Some(parent) = path.parent() {
             if !parent.exists() {
-                std::fs::create_dir_all(parent)
-                    .with_context(|| format!("Failed to create output directory: {}", parent.display()))?;
+                std::fs::create_dir_all(parent).with_context(|| {
+                    format!("Failed to create output directory: {}", parent.display())
+                })?;
             }
         }
 
@@ -430,7 +444,12 @@ impl FastqWriter {
                 Box::new(
                     ParCompressBuilder::<Gzip>::new()
                         .num_threads(cores)
-                        .with_context(|| format!("Failed to create parallel compressor with {} threads", cores))?
+                        .with_context(|| {
+                            format!(
+                                "Failed to create parallel compressor with {} threads",
+                                cores
+                            )
+                        })?
                         .compression_level(Compression::new(6))
                         .from_writer(file),
                 )

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -182,23 +182,19 @@ mod tests {
     fn test_paired_n_filter_no_rescue() {
         let r1 = make_record("ACGTACGT");
         let r2 = make_record("NNNNNNNN"); // All N
-        let result = filter_paired_end(
-            &r1, &r2, 5, None, Some(MaxNFilter::Count(2)), 35, 35,
-        );
+        let result = filter_paired_end(&r1, &r2, 5, None, Some(MaxNFilter::Count(2)), 35, 35);
         assert_eq!(result, PairFilterResult::TooManyN);
     }
 
     #[test]
     fn test_paired_length_rescue() {
         let r1 = make_record("ACGTACGTACGT"); // 12bp, long enough
-        let r2 = make_record("AC");            // 2bp, too short
-        let result = filter_paired_end(
-            &r1, &r2, 5, None, None, 10, 10,
-        );
+        let r2 = make_record("AC"); // 2bp, too short
+        let result = filter_paired_end(&r1, &r2, 5, None, None, 10, 10);
         match result {
             PairFilterResult::TooShort { r1_ok, r2_ok } => {
-                assert!(r1_ok);   // R1 is rescuable (>= unpaired_length_r1)
-                assert!(!r2_ok);  // R2 is too short even for unpaired
+                assert!(r1_ok); // R1 is rescuable (>= unpaired_length_r1)
+                assert!(!r2_ok); // R2 is too short even for unpaired
             }
             _ => panic!("Expected TooShort"),
         }

--- a/src/io.rs
+++ b/src/io.rs
@@ -21,11 +21,15 @@ pub fn single_end_output_name(
     basename: Option<&str>,
     gzip: bool,
 ) -> PathBuf {
-    let stem = basename.map(|b| b.to_string()).unwrap_or_else(|| {
-        strip_fastq_extensions(input)
-    });
+    let stem = basename
+        .map(|b| b.to_string())
+        .unwrap_or_else(|| strip_fastq_extensions(input));
 
-    let ext = if gzip { "_trimmed.fq.gz" } else { "_trimmed.fq" };
+    let ext = if gzip {
+        "_trimmed.fq.gz"
+    } else {
+        "_trimmed.fq"
+    };
     let filename = format!("{}{}", stem, ext);
 
     match output_dir {
@@ -161,11 +165,17 @@ mod tests {
 
     #[test]
     fn test_strip_fastq_extensions() {
-        assert_eq!(strip_fastq_extensions(Path::new("sample.fastq.gz")), "sample");
+        assert_eq!(
+            strip_fastq_extensions(Path::new("sample.fastq.gz")),
+            "sample"
+        );
         assert_eq!(strip_fastq_extensions(Path::new("sample.fq.gz")), "sample");
         assert_eq!(strip_fastq_extensions(Path::new("sample.fastq")), "sample");
         assert_eq!(strip_fastq_extensions(Path::new("sample.fq")), "sample");
-        assert_eq!(strip_fastq_extensions(Path::new("sample_R1.fq.gz")), "sample_R1");
+        assert_eq!(
+            strip_fastq_extensions(Path::new("sample_R1.fq.gz")),
+            "sample_R1"
+        );
     }
 
     #[test]
@@ -205,9 +215,15 @@ mod tests {
     fn test_json_report_name() {
         let input = Path::new("/data/sample.fq.gz");
         let out = json_report_name(input, None);
-        assert_eq!(out, PathBuf::from("/data/sample.fq.gz_trimming_report.json"));
+        assert_eq!(
+            out,
+            PathBuf::from("/data/sample.fq.gz_trimming_report.json")
+        );
 
         let out = json_report_name(input, Some(Path::new("/output")));
-        assert_eq!(out, PathBuf::from("/output/sample.fq.gz_trimming_report.json"));
+        assert_eq!(
+            out,
+            PathBuf::from("/output/sample.fq.gz_trimming_report.json")
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,10 @@ use trim_galore::report;
 use trim_galore::specialty;
 use trim_galore::trimmer;
 
+type AdapterList = Vec<(String, String)>;
+type SetupResult = Result<(String, AdapterList, AdapterList, trimmer::TrimConfig)>;
+type ResolvedAdapter = Result<(String, AdapterList, AdapterList, Option<(usize, usize)>)>;
+
 fn main() -> Result<()> {
     env_logger::init();
 
@@ -22,7 +26,11 @@ fn main() -> Result<()> {
     cli.validate()?;
 
     // Input sanity check on first file
-    eprintln!("\nTrim Galore - Oxidized Edition v{}", env!("CARGO_PKG_VERSION"));
+    eprintln!(
+        "\nTrim Galore - Oxidized Edition v{}",
+        env!("CARGO_PKG_VERSION")
+    );
+    eprintln!("{}", env!("VERSION_BODY"));
     eprintln!("==================================================\n");
 
     FastqReader::sanity_check(&cli.input[0])?;
@@ -48,7 +56,14 @@ fn main() -> Result<()> {
         return Ok(());
     }
     if let Some(umi_len) = cli.implicon {
-        specialty::implicon(&cli.input[0], &cli.input[1], umi_len, gzip, output_dir, cli.cores)?;
+        specialty::implicon(
+            &cli.input[0],
+            &cli.input[1],
+            umi_len,
+            gzip,
+            output_dir,
+            cli.cores,
+        )?;
         return Ok(());
     }
 
@@ -57,7 +72,10 @@ fn main() -> Result<()> {
     }
 
     if cli.cores > 1 {
-        eprintln!("Using {} worker threads (parallel trim + compress)", cli.cores);
+        eprintln!(
+            "Using {} worker threads (parallel trim + compress)",
+            cli.cores
+        );
     }
 
     if cli.paired {
@@ -68,21 +86,24 @@ fn main() -> Result<()> {
         // Pragmatic trade-off: on opt-in case-sensitive APFS volumes this may
         // false-positive, but the penalty is a loud early error rather than
         // silent data loss.
-        let mut out_paths: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
-        let norm = |p: &std::path::Path| -> String {
-            p.to_string_lossy().to_ascii_lowercase()
-        };
+        let mut out_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let norm = |p: &std::path::Path| -> String { p.to_string_lossy().to_ascii_lowercase() };
         for chunk in cli.input.chunks(2) {
             let (o1, o2) = naming::paired_end_output_names(
-                &chunk[0], &chunk[1], output_dir,
-                cli.basename.as_deref(), gzip,
+                &chunk[0],
+                &chunk[1],
+                output_dir,
+                cli.basename.as_deref(),
+                gzip,
             );
             let mut candidates = vec![o1, o2];
             if cli.retain_unpaired {
                 let (u1, u2) = naming::unpaired_output_names(
-                    &chunk[0], &chunk[1], output_dir,
-                    cli.basename.as_deref(), gzip,
+                    &chunk[0],
+                    &chunk[1],
+                    output_dir,
+                    cli.basename.as_deref(),
+                    gzip,
                 );
                 candidates.push(u1);
                 candidates.push(u2);
@@ -120,20 +141,28 @@ fn main() -> Result<()> {
             }
             FastqReader::sanity_check(&chunk[1])?;
 
-            let (_label, adapters_r1, adapters_r2, config) =
-                setup_trimming(&cli, &chunk[0])?;
+            let (_label, adapters_r1, adapters_r2, config) = setup_trimming(&cli, &chunk[0])?;
 
             run_paired(
-                &cli, &chunk[0], &chunk[1],
-                &config, gzip, output_dir,
+                &cli,
+                &chunk[0],
+                &chunk[1],
+                &config,
+                gzip,
+                output_dir,
                 cli.basename.as_deref(),
-                &adapters_r1, &adapters_r2,
+                &adapters_r1,
+                &adapters_r2,
             )
-            .with_context(|| format!(
-                "processing pair {} of {} (R1={}, R2={})",
-                pair_idx + 1, total_pairs,
-                chunk[0].display(), chunk[1].display()
-            ))?;
+            .with_context(|| {
+                format!(
+                    "processing pair {} of {} (R1={}, R2={})",
+                    pair_idx + 1,
+                    total_pairs,
+                    chunk[0].display(),
+                    chunk[1].display()
+                )
+            })?;
         }
     } else {
         // Single-end: process each input file independently
@@ -156,15 +185,20 @@ fn main() -> Result<()> {
 /// When adapter is user-specified, auto-detection is skipped. When auto-detecting,
 /// the poly-G scan piggybacks on the adapter scan. Returns (adapter_label,
 /// adapters_r1, adapters_r2, TrimConfig).
-fn setup_trimming(cli: &Cli, input_file: &Path) -> Result<(String, Vec<(String, String)>, Vec<(String, String)>, trimmer::TrimConfig)> {
+fn setup_trimming(cli: &Cli, input_file: &Path) -> SetupResult {
     // Determine adapter
-    let (adapter_label, adapters_r1, adapters_r2, autodetect_poly_g) = resolve_adapter(cli, input_file)?;
+    let (adapter_label, adapters_r1, adapters_r2, autodetect_poly_g) =
+        resolve_adapter(cli, input_file)?;
 
     // Display adapter info
     if adapters_r1.len() == 1 {
         eprintln!("Adapter: {} ({})", adapter_label, adapters_r1[0].1);
     } else {
-        eprintln!("Adapters ({}, {} sequences):", adapter_label, adapters_r1.len());
+        eprintln!(
+            "Adapters ({}, {} sequences):",
+            adapter_label,
+            adapters_r1.len()
+        );
         for (name, seq) in &adapters_r1 {
             eprintln!("  {}: {}", name, seq);
         }
@@ -206,17 +240,23 @@ fn setup_trimming(cli: &Cli, input_file: &Path) -> Result<(String, Vec<(String, 
 
     // RRBS: auto-set --clip_r2 2 for directional paired-end mode
     let clip_r2 = if cli.rrbs && !cli.non_directional && cli.paired && cli.clip_r2.is_none() {
-        eprintln!("Setting the option '--clip_r2 2' (to remove methylation bias from the start of Read 2)");
+        eprintln!(
+            "Setting the option '--clip_r2 2' (to remove methylation bias from the start of Read 2)"
+        );
         Some(2)
     } else {
         cli.clip_r2
     };
 
     if cli.rrbs {
-        eprintln!("File was specified to be an MspI-digested RRBS sample. Read 1 sequences with adapter contamination will be trimmed a further 2 bp from their 3' end, and Read 2 sequences will be trimmed by 2 bp from their 5' end to remove potential methylation-biased bases from the end-repair reaction");
+        eprintln!(
+            "File was specified to be an MspI-digested RRBS sample. Read 1 sequences with adapter contamination will be trimmed a further 2 bp from their 3' end, and Read 2 sequences will be trimmed by 2 bp from their 5' end to remove potential methylation-biased bases from the end-repair reaction"
+        );
     }
     if cli.non_directional {
-        eprintln!("File was specified to be a non-directional MspI-digested RRBS sample. Sequences starting with either 'CAA' or 'CGA' will have the first 2 bp trimmed off to remove potential methylation-biased bases from the end-repair reaction");
+        eprintln!(
+            "File was specified to be a non-directional MspI-digested RRBS sample. Sequences starting with either 'CAA' or 'CGA' will have the first 2 bp trimmed off to remove potential methylation-biased bases from the end-repair reaction"
+        );
     }
 
     // Determine poly-G trimming: CLI overrides auto-detection
@@ -265,10 +305,12 @@ fn setup_trimming(cli: &Cli, input_file: &Path) -> Result<(String, Vec<(String, 
     }
 
     // Convert string adapters to bytes for the trimmer config
-    let adapters_bytes: Vec<(String, Vec<u8>)> = adapters_r1.iter()
+    let adapters_bytes: Vec<(String, Vec<u8>)> = adapters_r1
+        .iter()
         .map(|(name, seq)| (name.clone(), seq.as_bytes().to_vec()))
         .collect();
-    let adapters_r2_bytes: Vec<(String, Vec<u8>)> = adapters_r2.iter()
+    let adapters_r2_bytes: Vec<(String, Vec<u8>)> = adapters_r2
+        .iter()
         .map(|(name, seq)| (name.clone(), seq.as_bytes().to_vec()))
         .collect();
 
@@ -307,7 +349,7 @@ fn setup_trimming(cli: &Cli, input_file: &Path) -> Result<(String, Vec<(String, 
 /// The last element is Some((poly_g_count, reads_scanned)) when auto-detection ran,
 /// None when the adapter was user-specified or preset-selected (poly-G must be
 /// detected separately via `adapter::detect_poly_g()`).
-fn resolve_adapter(cli: &Cli, input_file: &Path) -> Result<(String, Vec<(String, String)>, Vec<(String, String)>, Option<(usize, usize)>)> {
+fn resolve_adapter(cli: &Cli, input_file: &Path) -> ResolvedAdapter {
     if let Some(ref spec) = cli.adapter {
         let adapters_r1 = adapter::parse_adapter_spec(spec)?;
         let adapters_r2 = match &cli.adapter2 {
@@ -320,7 +362,12 @@ fn resolve_adapter(cli: &Cli, input_file: &Path) -> Result<(String, Vec<(String,
 
     // Presets: single-adapter, use AdapterPreset methods
     if cli.nextera {
-        return Ok((adapter::NEXTERA.name.to_string(), adapter::NEXTERA.to_adapter_vec(), Vec::new(), None));
+        return Ok((
+            adapter::NEXTERA.name.to_string(),
+            adapter::NEXTERA.to_adapter_vec(),
+            Vec::new(),
+            None,
+        ));
     }
     if cli.small_rna {
         return Ok((
@@ -347,7 +394,12 @@ fn resolve_adapter(cli: &Cli, input_file: &Path) -> Result<(String, Vec<(String,
         ));
     }
     if cli.illumina {
-        return Ok((adapter::ILLUMINA.name.to_string(), adapter::ILLUMINA.to_adapter_vec(), Vec::new(), None));
+        return Ok((
+            adapter::ILLUMINA.name.to_string(),
+            adapter::ILLUMINA.to_adapter_vec(),
+            Vec::new(),
+            None,
+        ));
     }
 
     // Auto-detect (also piggybacks poly-G counting)
@@ -374,7 +426,8 @@ fn run_single_file(
     output_dir: Option<&Path>,
     adapters_r1: &[(String, String)],
 ) -> Result<()> {
-    let output_path = naming::single_end_output_name(input, output_dir, cli.basename.as_deref(), gzip);
+    let output_path =
+        naming::single_end_output_name(input, output_dir, cli.basename.as_deref(), gzip);
     let report_path = naming::report_name(input, output_dir);
 
     eprintln!("Trimming: {}", input.display());
@@ -394,40 +447,72 @@ fn run_single_file(
     // Print summary
     eprintln!("\n=== Summary ===\n");
     eprintln!("Total reads processed:           {:>10}", stats.total_reads);
-    eprintln!("Reads with adapters:             {:>10} ({:.1}%)",
+    eprintln!(
+        "Reads with adapters:             {:>10} ({:.1}%)",
         stats.total_reads_with_adapter,
-        pct(stats.total_reads_with_adapter, stats.total_reads));
+        pct(stats.total_reads_with_adapter, stats.total_reads)
+    );
     if stats.discarded_untrimmed > 0 {
-        eprintln!("Reads discarded as untrimmed:    {:>10} ({:.1}%)",
-            stats.discarded_untrimmed, pct(stats.discarded_untrimmed, stats.total_reads));
+        eprintln!(
+            "Reads discarded as untrimmed:    {:>10} ({:.1}%)",
+            stats.discarded_untrimmed,
+            pct(stats.discarded_untrimmed, stats.total_reads)
+        );
     }
-    eprintln!("Reads too short:                 {:>10} ({:.1}%)",
-        stats.too_short, pct(stats.too_short, stats.total_reads));
-    eprintln!("Reads written (passing filters): {:>10} ({:.1}%)",
-        stats.reads_written, pct(stats.reads_written, stats.total_reads));
+    eprintln!(
+        "Reads too short:                 {:>10} ({:.1}%)",
+        stats.too_short,
+        pct(stats.too_short, stats.total_reads)
+    );
+    eprintln!(
+        "Reads written (passing filters): {:>10} ({:.1}%)",
+        stats.reads_written,
+        pct(stats.reads_written, stats.total_reads)
+    );
     if stats.rrbs_trimmed_3prime > 0 {
-        eprintln!("RRBS trimmed (3' end, adapter): {:>10} ({:.1}%)",
-            stats.rrbs_trimmed_3prime, pct(stats.rrbs_trimmed_3prime, stats.total_reads));
+        eprintln!(
+            "RRBS trimmed (3' end, adapter): {:>10} ({:.1}%)",
+            stats.rrbs_trimmed_3prime,
+            pct(stats.rrbs_trimmed_3prime, stats.total_reads)
+        );
     }
     if stats.rrbs_trimmed_5prime > 0 {
-        eprintln!("RRBS trimmed (5' end, CAA/CGA): {:>10} ({:.1}%)",
-            stats.rrbs_trimmed_5prime, pct(stats.rrbs_trimmed_5prime, stats.total_reads));
+        eprintln!(
+            "RRBS trimmed (5' end, CAA/CGA): {:>10} ({:.1}%)",
+            stats.rrbs_trimmed_5prime,
+            pct(stats.rrbs_trimmed_5prime, stats.total_reads)
+        );
     }
     if stats.poly_a_trimmed > 0 {
-        eprintln!("Reads with poly-A/T trimmed:     {:>10} ({:.1}%)",
-            stats.poly_a_trimmed, pct(stats.poly_a_trimmed, stats.total_reads));
-        eprintln!("  Poly-A/T bases removed:        {:>10}", stats.poly_a_bases_trimmed);
+        eprintln!(
+            "Reads with poly-A/T trimmed:     {:>10} ({:.1}%)",
+            stats.poly_a_trimmed,
+            pct(stats.poly_a_trimmed, stats.total_reads)
+        );
+        eprintln!(
+            "  Poly-A/T bases removed:        {:>10}",
+            stats.poly_a_bases_trimmed
+        );
     }
     if stats.poly_g_trimmed > 0 {
-        eprintln!("Reads with poly-G/C trimmed:     {:>10} ({:.1}%)",
-            stats.poly_g_trimmed, pct(stats.poly_g_trimmed, stats.total_reads));
-        eprintln!("  Poly-G/C bases removed:        {:>10}", stats.poly_g_bases_trimmed);
+        eprintln!(
+            "Reads with poly-G/C trimmed:     {:>10} ({:.1}%)",
+            stats.poly_g_trimmed,
+            pct(stats.poly_g_trimmed, stats.total_reads)
+        );
+        eprintln!(
+            "  Poly-G/C bases removed:        {:>10}",
+            stats.poly_g_bases_trimmed
+        );
     }
 
     // Write report
     if !cli.no_report_file {
-        let input_filename = input.file_name()
-            .unwrap_or_default().to_string_lossy().to_string();
+        let input_filename = input
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
         let report_cfg = report::TrimConfig {
             version: env!("CARGO_PKG_VERSION").to_string(),
             quality_cutoff: cli.effective_quality_cutoff(),
@@ -485,8 +570,10 @@ fn run_single_file(
 
     // Demultiplex if requested
     if let Some(ref barcode_file) = cli.demux {
-        eprintln!("\nTrimming complete, starting demultiplexing procedure (based on 3' barcodes supplied as per file >{}<)",
-            barcode_file.display());
+        eprintln!(
+            "\nTrimming complete, starting demultiplexing procedure (based on 3' barcodes supplied as per file >{}<)",
+            barcode_file.display()
+        );
         let barcodes = demux::read_barcode_file(barcode_file)?;
         demux::demultiplex(&output_path, &barcodes, gzip, output_dir, cli.cores)?;
     }
@@ -517,7 +604,8 @@ fn run_paired(
 
     // Compute unpaired output paths (needed for both parallel and sequential paths)
     let (unpaired_r1_path, unpaired_r2_path) = if cli.retain_unpaired {
-        let (up1, up2) = naming::unpaired_output_names(input_r1, input_r2, output_dir, basename, gzip);
+        let (up1, up2) =
+            naming::unpaired_output_names(input_r1, input_r2, output_dir, basename, gzip);
         eprintln!("  Unpaired R1: {}", up1.display());
         eprintln!("  Unpaired R2: {}", up2.display());
         (Some(up1), Some(up2))
@@ -528,12 +616,17 @@ fn run_paired(
     let (stats_r1, stats_r2, pair_stats) = if cli.cores > 1 {
         // Worker-pool parallel path: N workers each handle trim + compress
         parallel::run_paired_end_parallel(
-            input_r1, input_r2,
-            &output_r1, &output_r2,
+            input_r1,
+            input_r2,
+            &output_r1,
+            &output_r2,
             unpaired_r1_path.as_deref(),
             unpaired_r2_path.as_deref(),
-            config, cli.cores, gzip,
-            cli.length_1, cli.length_2,
+            config,
+            cli.cores,
+            gzip,
+            cli.length_1,
+            cli.length_2,
         )?
     } else {
         // Sequential path (--cores 1)
@@ -551,16 +644,25 @@ fn run_paired(
         };
 
         let result = trimmer::run_paired_end(
-            &mut reader_r1, &mut reader_r2,
-            &mut writer_r1, &mut writer_r2,
-            unpaired_w1.as_mut(), unpaired_w2.as_mut(),
-            config, cli.length_1, cli.length_2,
+            &mut reader_r1,
+            &mut reader_r2,
+            &mut writer_r1,
+            &mut writer_r2,
+            unpaired_w1.as_mut(),
+            unpaired_w2.as_mut(),
+            config,
+            cli.length_1,
+            cli.length_2,
         )?;
 
         writer_r1.flush()?;
         writer_r2.flush()?;
-        if let Some(ref mut w) = unpaired_w1 { w.flush()?; }
-        if let Some(ref mut w) = unpaired_w2 { w.flush()?; }
+        if let Some(ref mut w) = unpaired_w1 {
+            w.flush()?;
+        }
+        if let Some(ref mut w) = unpaired_w2 {
+            w.flush()?;
+        }
         drop(writer_r1);
         drop(writer_r2);
         drop(unpaired_w1);
@@ -571,56 +673,107 @@ fn run_paired(
 
     // Print summary
     eprintln!("\n=== Summary (Read 1) ===\n");
-    eprintln!("Total reads processed:           {:>10}", stats_r1.total_reads);
-    eprintln!("Reads with adapters:             {:>10} ({:.1}%)",
+    eprintln!(
+        "Total reads processed:           {:>10}",
+        stats_r1.total_reads
+    );
+    eprintln!(
+        "Reads with adapters:             {:>10} ({:.1}%)",
         stats_r1.total_reads_with_adapter,
-        pct(stats_r1.total_reads_with_adapter, stats_r1.total_reads));
+        pct(stats_r1.total_reads_with_adapter, stats_r1.total_reads)
+    );
 
     eprintln!("\n=== Summary (Read 2) ===\n");
-    eprintln!("Total reads processed:           {:>10}", stats_r2.total_reads);
-    eprintln!("Reads with adapters:             {:>10} ({:.1}%)",
+    eprintln!(
+        "Total reads processed:           {:>10}",
+        stats_r2.total_reads
+    );
+    eprintln!(
+        "Reads with adapters:             {:>10} ({:.1}%)",
         stats_r2.total_reads_with_adapter,
-        pct(stats_r2.total_reads_with_adapter, stats_r2.total_reads));
+        pct(stats_r2.total_reads_with_adapter, stats_r2.total_reads)
+    );
 
     if stats_r1.poly_a_trimmed > 0 {
-        eprintln!("R1 reads with poly-A trimmed:    {:>10} ({:.1}%)",
-            stats_r1.poly_a_trimmed, pct(stats_r1.poly_a_trimmed, stats_r1.total_reads));
+        eprintln!(
+            "R1 reads with poly-A trimmed:    {:>10} ({:.1}%)",
+            stats_r1.poly_a_trimmed,
+            pct(stats_r1.poly_a_trimmed, stats_r1.total_reads)
+        );
     }
     if stats_r2.poly_a_trimmed > 0 {
-        eprintln!("R2 reads with poly-T trimmed:    {:>10} ({:.1}%)",
-            stats_r2.poly_a_trimmed, pct(stats_r2.poly_a_trimmed, stats_r2.total_reads));
+        eprintln!(
+            "R2 reads with poly-T trimmed:    {:>10} ({:.1}%)",
+            stats_r2.poly_a_trimmed,
+            pct(stats_r2.poly_a_trimmed, stats_r2.total_reads)
+        );
     }
     if stats_r1.poly_g_trimmed > 0 {
-        eprintln!("R1 reads with poly-G trimmed:    {:>10} ({:.1}%)",
-            stats_r1.poly_g_trimmed, pct(stats_r1.poly_g_trimmed, stats_r1.total_reads));
-        eprintln!("  R1 poly-G bases removed:       {:>10}", stats_r1.poly_g_bases_trimmed);
+        eprintln!(
+            "R1 reads with poly-G trimmed:    {:>10} ({:.1}%)",
+            stats_r1.poly_g_trimmed,
+            pct(stats_r1.poly_g_trimmed, stats_r1.total_reads)
+        );
+        eprintln!(
+            "  R1 poly-G bases removed:       {:>10}",
+            stats_r1.poly_g_bases_trimmed
+        );
     }
     if stats_r2.poly_g_trimmed > 0 {
-        eprintln!("R2 reads with poly-C trimmed:    {:>10} ({:.1}%)",
-            stats_r2.poly_g_trimmed, pct(stats_r2.poly_g_trimmed, stats_r2.total_reads));
-        eprintln!("  R2 poly-C bases removed:       {:>10}", stats_r2.poly_g_bases_trimmed);
+        eprintln!(
+            "R2 reads with poly-C trimmed:    {:>10} ({:.1}%)",
+            stats_r2.poly_g_trimmed,
+            pct(stats_r2.poly_g_trimmed, stats_r2.total_reads)
+        );
+        eprintln!(
+            "  R2 poly-C bases removed:       {:>10}",
+            stats_r2.poly_g_bases_trimmed
+        );
     }
 
     eprintln!("\n=== Paired-end validation ===\n");
-    eprintln!("Pairs analyzed:                  {:>10}", pair_stats.pairs_analyzed);
-    eprintln!("Pairs removed:                   {:>10} ({:.1}%)",
+    eprintln!(
+        "Pairs analyzed:                  {:>10}",
+        pair_stats.pairs_analyzed
+    );
+    eprintln!(
+        "Pairs removed:                   {:>10} ({:.1}%)",
         pair_stats.pairs_removed,
-        pct(pair_stats.pairs_removed, pair_stats.pairs_analyzed));
+        pct(pair_stats.pairs_removed, pair_stats.pairs_analyzed)
+    );
     if pair_stats.r1_unpaired > 0 || pair_stats.r2_unpaired > 0 {
-        eprintln!("Unpaired R1 kept:                {:>10}", pair_stats.r1_unpaired);
-        eprintln!("Unpaired R2 kept:                {:>10}", pair_stats.r2_unpaired);
+        eprintln!(
+            "Unpaired R1 kept:                {:>10}",
+            pair_stats.r1_unpaired
+        );
+        eprintln!(
+            "Unpaired R2 kept:                {:>10}",
+            pair_stats.r2_unpaired
+        );
     }
 
     // Write reports
     if !cli.no_report_file {
-        let all_input_filenames: Vec<String> = [input_r1, input_r2].iter()
-            .map(|p| p.file_name().unwrap_or_default().to_string_lossy().to_string())
+        let all_input_filenames: Vec<String> = [input_r1, input_r2]
+            .iter()
+            .map(|p| {
+                p.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
             .collect();
 
-        for (idx, (input, stats)) in [(input_r1, &stats_r1), (input_r2, &stats_r2)].iter().enumerate() {
+        for (idx, (input, stats)) in [(input_r1, &stats_r1), (input_r2, &stats_r2)]
+            .iter()
+            .enumerate()
+        {
             let report_path = naming::report_name(input, output_dir);
-            let input_filename = input.file_name()
-                .unwrap_or_default().to_string_lossy().to_string();
+            let input_filename = input
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
             let report_cfg = report::TrimConfig {
                 version: env!("CARGO_PKG_VERSION").to_string(),
                 quality_cutoff: cli.effective_quality_cutoff(),
@@ -671,7 +824,9 @@ fn run_paired(
             let json_file = File::create(&json_path)?;
             let mut jw = BufWriter::new(json_file);
             report::write_json_report(
-                &mut jw, &report_cfg, stats,
+                &mut jw,
+                &report_cfg,
+                stats,
                 Some(&pair_stats),
                 (idx + 1) as u8,
                 &json_extra,
@@ -690,7 +845,11 @@ fn run_paired(
     Ok(())
 }
 
-fn run_fastqc(output_path: &Path, fastqc_args: Option<&str>, output_dir: Option<&Path>) -> Result<()> {
+fn run_fastqc(
+    output_path: &Path,
+    fastqc_args: Option<&str>,
+    output_dir: Option<&Path>,
+) -> Result<()> {
     let mut cmd = std::process::Command::new("fastqc");
     if let Some(args) = fastqc_args {
         for arg in args.split_whitespace() {
@@ -716,5 +875,9 @@ fn run_fastqc(output_path: &Path, fastqc_args: Option<&str>, output_dir: Option<
 }
 
 fn pct(part: usize, total: usize) -> f64 {
-    if total == 0 { 0.0 } else { part as f64 / total as f64 * 100.0 }
+    if total == 0 {
+        0.0
+    } else {
+        part as f64 / total as f64 * 100.0
+    }
 }

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -11,9 +11,9 @@
 //! core count, because the dominant cost (gzip compression, ~60% of runtime)
 //! is distributed across workers instead of funneled through one thread.
 
-use anyhow::{bail, Result};
-use flate2::write::GzEncoder;
+use anyhow::{Result, bail};
 use flate2::Compression;
+use flate2::write::GzEncoder;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::Write;
@@ -55,6 +55,7 @@ struct PairedBatchResult {
 ///
 /// Total threads: N + 4. Each worker independently handles trim + compress,
 /// so the dominant bottleneck (gzip compression) scales linearly with N.
+#[allow(clippy::too_many_arguments)]
 pub fn run_paired_end_parallel(
     input_r1: &Path,
     input_r2: &Path,
@@ -92,8 +93,14 @@ pub fn run_paired_end_parallel(
             s.spawn(move || {
                 while let Ok(Some((seq, mut r1s, mut r2s))) = rx.recv() {
                     match process_paired_batch(
-                        seq, &mut r1s, &mut r2s, config, gzip,
-                        retain_unpaired, unpaired_length_r1, unpaired_length_r2,
+                        seq,
+                        &mut r1s,
+                        &mut r2s,
+                        config,
+                        gzip,
+                        retain_unpaired,
+                        unpaired_length_r1,
+                        unpaired_length_r2,
                     ) {
                         Ok(result) => {
                             if rtx.send(result).is_err() {
@@ -130,12 +137,10 @@ pub fn run_paired_end_parallel(
                         batch_r1.push(r1);
                         batch_r2.push(r2);
                         if batch_r1.len() >= BATCH_SIZE {
-                            let br1 = std::mem::replace(
-                                &mut batch_r1, Vec::with_capacity(BATCH_SIZE),
-                            );
-                            let br2 = std::mem::replace(
-                                &mut batch_r2, Vec::with_capacity(BATCH_SIZE),
-                            );
+                            let br1 =
+                                std::mem::replace(&mut batch_r1, Vec::with_capacity(BATCH_SIZE));
+                            let br2 =
+                                std::mem::replace(&mut batch_r2, Vec::with_capacity(BATCH_SIZE));
                             let idx = (seq as usize) % txs.len();
                             if txs[idx].send(Some((seq, br1, br2))).is_err() {
                                 break;
@@ -220,6 +225,7 @@ pub fn run_paired_end_parallel(
 }
 
 /// Process a batch of paired reads: trim, filter, compress into gzip blocks.
+#[allow(clippy::too_many_arguments)]
 fn process_paired_batch(
     batch_seq: u64,
     reads_r1: &mut [FastqRecord],
@@ -258,26 +264,51 @@ fn process_paired_batch(
             };
 
             process_pairs(
-                reads_r1, reads_r2, config,
-                &mut stats_r1, &mut stats_r2, &mut pair_stats,
-                &mut gz_r1, &mut gz_r2,
-                gz_up_r1.as_mut(), gz_up_r2.as_mut(),
-                unpaired_length_r1, unpaired_length_r2,
+                reads_r1,
+                reads_r2,
+                config,
+                &mut stats_r1,
+                &mut stats_r2,
+                &mut pair_stats,
+                &mut gz_r1,
+                &mut gz_r2,
+                gz_up_r1.as_mut(),
+                gz_up_r2.as_mut(),
+                unpaired_length_r1,
+                unpaired_length_r2,
             )?;
 
             gz_r1.finish()?;
             gz_r2.finish()?;
-            if let Some(gz) = gz_up_r1 { gz.finish()?; }
-            if let Some(gz) = gz_up_r2 { gz.finish()?; }
+            if let Some(gz) = gz_up_r1 {
+                gz.finish()?;
+            }
+            if let Some(gz) = gz_up_r2 {
+                gz.finish()?;
+            }
         }
     } else {
         process_pairs(
-            reads_r1, reads_r2, config,
-            &mut stats_r1, &mut stats_r2, &mut pair_stats,
-            &mut buf_r1, &mut buf_r2,
-            if retain_unpaired { Some(&mut buf_up_r1) } else { None },
-            if retain_unpaired { Some(&mut buf_up_r2) } else { None },
-            unpaired_length_r1, unpaired_length_r2,
+            reads_r1,
+            reads_r2,
+            config,
+            &mut stats_r1,
+            &mut stats_r2,
+            &mut pair_stats,
+            &mut buf_r1,
+            &mut buf_r2,
+            if retain_unpaired {
+                Some(&mut buf_up_r1)
+            } else {
+                None
+            },
+            if retain_unpaired {
+                Some(&mut buf_up_r2)
+            } else {
+                None
+            },
+            unpaired_length_r1,
+            unpaired_length_r2,
         )?;
     }
 
@@ -297,6 +328,7 @@ fn process_paired_batch(
 ///
 /// Generic over `W: Write` so it works with both `GzEncoder` (gzip output)
 /// and `Vec<u8>` (plain text output) without runtime dispatch.
+#[allow(clippy::too_many_arguments)]
 fn process_pairs<W: Write>(
     reads_r1: &mut [FastqRecord],
     reads_r2: &mut [FastqRecord],
@@ -325,10 +357,18 @@ fn process_pairs<W: Write>(
         stats_r2.bases_quality_trimmed += res_r2.quality_trimmed_bp;
         update_adapter_stats(stats_r1, &res_r1);
         update_adapter_stats(stats_r2, &res_r2);
-        if res_r1.rrbs_trimmed_3prime { stats_r1.rrbs_trimmed_3prime += 1; }
-        if res_r1.rrbs_trimmed_5prime { stats_r1.rrbs_trimmed_5prime += 1; }
-        if res_r2.rrbs_trimmed_3prime { stats_r2.rrbs_trimmed_3prime += 1; }
-        if res_r2.rrbs_trimmed_5prime { stats_r2.rrbs_trimmed_5prime += 1; }
+        if res_r1.rrbs_trimmed_3prime {
+            stats_r1.rrbs_trimmed_3prime += 1;
+        }
+        if res_r1.rrbs_trimmed_5prime {
+            stats_r1.rrbs_trimmed_5prime += 1;
+        }
+        if res_r2.rrbs_trimmed_3prime {
+            stats_r2.rrbs_trimmed_3prime += 1;
+        }
+        if res_r2.rrbs_trimmed_5prime {
+            stats_r2.rrbs_trimmed_5prime += 1;
+        }
         if config.rrbs && res_r2.clip_5prime_applied {
             stats_r2.rrbs_r2_clipped_5prime += 1;
         }
@@ -361,9 +401,13 @@ fn process_pairs<W: Write>(
         stats_r2.total_bp_after_trim += r2.seq.len();
 
         match filters::filter_paired_end(
-            r1, r2,
-            config.length_cutoff, config.max_length, config.max_n.clone(),
-            unpaired_length_r1, unpaired_length_r2,
+            r1,
+            r2,
+            config.length_cutoff,
+            config.max_length,
+            config.max_n.clone(),
+            unpaired_length_r1,
+            unpaired_length_r2,
         ) {
             PairFilterResult::Pass => {
                 stats_r1.total_bp_written += r1.seq.len();
@@ -443,7 +487,9 @@ pub fn run_single_end_parallel(
                 while let Ok(Some((seq, mut reads))) = rx.recv() {
                     match process_single_batch(seq, &mut reads, config, gzip) {
                         Ok(result) => {
-                            if rtx.send(result).is_err() { break; }
+                            if rtx.send(result).is_err() {
+                                break;
+                            }
                         }
                         Err(e) => {
                             eprintln!("Worker error: {}", e);
@@ -467,7 +513,9 @@ pub fn run_single_end_parallel(
                 if batch.len() >= BATCH_SIZE {
                     let full = std::mem::replace(&mut batch, Vec::with_capacity(BATCH_SIZE));
                     let idx = (seq as usize) % txs.len();
-                    if txs[idx].send(Some((seq, full))).is_err() { break; }
+                    if txs[idx].send(Some((seq, full))).is_err() {
+                        break;
+                    }
                     seq += 1;
                 }
             }
@@ -549,8 +597,12 @@ fn process_reads<W: Write>(
         let result = trimmer::trim_read(record, config, false);
         stats.bases_quality_trimmed += result.quality_trimmed_bp;
         update_adapter_stats(stats, &result);
-        if result.rrbs_trimmed_3prime { stats.rrbs_trimmed_3prime += 1; }
-        if result.rrbs_trimmed_5prime { stats.rrbs_trimmed_5prime += 1; }
+        if result.rrbs_trimmed_3prime {
+            stats.rrbs_trimmed_3prime += 1;
+        }
+        if result.rrbs_trimmed_5prime {
+            stats.rrbs_trimmed_5prime += 1;
+        }
         if result.poly_a_trimmed > 0 {
             stats.poly_a_trimmed += 1;
             stats.poly_a_bases_trimmed += result.poly_a_trimmed;
@@ -569,7 +621,10 @@ fn process_reads<W: Write>(
         stats.total_bp_after_trim += record.seq.len();
 
         match filters::filter_single_end(
-            record, config.length_cutoff, config.max_length, config.max_n.clone(),
+            record,
+            config.length_cutoff,
+            config.max_length,
+            config.max_n.clone(),
         ) {
             FilterResult::Pass => {
                 stats.total_bp_written += record.seq.len();

--- a/src/quality.rs
+++ b/src/quality.rs
@@ -132,8 +132,8 @@ pub fn homopolymer_trim_index(sequence: &[u8], target_3prime: u8, revcomp: bool)
     if revcomp {
         // Scan from 5' end for complement head (e.g. poly-T for poly-A, poly-C for poly-G)
         let mut best_index: usize = 0;
-        for i in 0..n {
-            if sequence[i] == target {
+        for (i, &base) in sequence.iter().enumerate().take(n) {
+            if base == target {
                 score += 1;
             } else {
                 score -= 2;

--- a/src/report.rs
+++ b/src/report.rs
@@ -75,8 +75,10 @@ impl TrimStats {
         // Merge per-adapter stats (element-wise addition across 2D vecs)
         // Ensure self has enough adapter slots
         if other.reads_with_adapter.len() > self.reads_with_adapter.len() {
-            self.reads_with_adapter.resize(other.reads_with_adapter.len(), 0);
-            self.adapter_length_counts.resize(other.adapter_length_counts.len(), Vec::new());
+            self.reads_with_adapter
+                .resize(other.reads_with_adapter.len(), 0);
+            self.adapter_length_counts
+                .resize(other.adapter_length_counts.len(), Vec::new());
         }
         for (i, &count) in other.reads_with_adapter.iter().enumerate() {
             self.reads_with_adapter[i] += count;
@@ -165,16 +167,40 @@ pub fn write_report_header<W: Write>(w: &mut W, config: &TrimConfig) -> std::io:
     writeln!(w, "SUMMARISING RUN PARAMETERS")?;
     writeln!(w, "=========================")?;
     writeln!(w, "Input filename: {}", config.input_filename)?;
-    writeln!(w, "Trimming mode: {}", if config.paired { "paired-end" } else { "single-end" })?;
-    writeln!(w, "Trim Galore version: {} (Oxidized Edition)", config.version)?;
+    writeln!(
+        w,
+        "Trimming mode: {}",
+        if config.paired {
+            "paired-end"
+        } else {
+            "single-end"
+        }
+    )?;
+    writeln!(
+        w,
+        "Trim Galore version: {} (Oxidized Edition)",
+        config.version
+    )?;
     if config.nextseq {
-        writeln!(w, "2-colour high quality G-trimming enabled, with quality cutoff: --nextseq-trim={}", config.quality_cutoff)?;
+        writeln!(
+            w,
+            "2-colour high quality G-trimming enabled, with quality cutoff: --nextseq-trim={}",
+            config.quality_cutoff
+        )?;
     } else {
         writeln!(w, "Quality Phred score cutoff: {}", config.quality_cutoff)?;
     }
-    writeln!(w, "Quality encoding type selected: ASCII+{}", config.phred_encoding)?;
+    writeln!(
+        w,
+        "Quality encoding type selected: ASCII+{}",
+        config.phred_encoding
+    )?;
     if config.adapters.len() == 1 {
-        writeln!(w, "Adapter sequence: '{}' (user-specified or auto-detected)", config.adapters[0].1)?;
+        writeln!(
+            w,
+            "Adapter sequence: '{}' (user-specified or auto-detected)",
+            config.adapters[0].1
+        )?;
     } else {
         write!(w, "Adapter sequence(s):")?;
         for (name, seq) in &config.adapters {
@@ -184,7 +210,11 @@ pub fn write_report_header<W: Write>(w: &mut W, config: &TrimConfig) -> std::io:
     }
     if !config.adapters_r2.is_empty() {
         if config.adapters_r2.len() == 1 {
-            writeln!(w, "Optional adapter 2 sequence (Read 2): '{}'", config.adapters_r2[0].1)?;
+            writeln!(
+                w,
+                "Optional adapter 2 sequence (Read 2): '{}'",
+                config.adapters_r2[0].1
+            )?;
         } else {
             write!(w, "Adapter 2 sequence(s) (Read 2):")?;
             for (name, seq) in &config.adapters_r2 {
@@ -197,24 +227,47 @@ pub fn write_report_header<W: Write>(w: &mut W, config: &TrimConfig) -> std::io:
         writeln!(w, "Trimming rounds per read (-n): {}", config.times)?;
     }
     writeln!(w, "Maximum trimming error rate: {}", config.error_rate)?;
-    writeln!(w, "Minimum required adapter overlap (stringency): {} bp", config.stringency)?;
-    writeln!(w, "Minimum required sequence length {}-end: {} bp",
-        if config.paired { "for both reads before a sequence pair gets removed" } else { "single" },
-        config.length_cutoff)?;
+    writeln!(
+        w,
+        "Minimum required adapter overlap (stringency): {} bp",
+        config.stringency
+    )?;
+    writeln!(
+        w,
+        "Minimum required sequence length {}-end: {} bp",
+        if config.paired {
+            "for both reads before a sequence pair gets removed"
+        } else {
+            "single"
+        },
+        config.length_cutoff
+    )?;
     if config.trim_n {
         writeln!(w, "Removing Ns from the end of reads")?;
     }
     if config.rrbs {
-        writeln!(w, "File was specified to be an MspI-digested RRBS sample. Read 1 sequences with adapter contamination will be trimmed a further 2 bp from their 3' end, and Read 2 sequences will be trimmed by 2 bp from their 5' end to remove potential methylation-biased bases from the end-repair reaction")?;
+        writeln!(
+            w,
+            "File was specified to be an MspI-digested RRBS sample. Read 1 sequences with adapter contamination will be trimmed a further 2 bp from their 3' end, and Read 2 sequences will be trimmed by 2 bp from their 5' end to remove potential methylation-biased bases from the end-repair reaction"
+        )?;
     }
     if config.non_directional {
-        writeln!(w, "File was specified to be a non-directional MspI-digested RRBS sample. Sequences starting with either 'CAA' or 'CGA' will have the first 2 bp trimmed off to remove potential methylation-biased bases from the end-repair reaction")?;
+        writeln!(
+            w,
+            "File was specified to be a non-directional MspI-digested RRBS sample. Sequences starting with either 'CAA' or 'CGA' will have the first 2 bp trimmed off to remove potential methylation-biased bases from the end-repair reaction"
+        )?;
     }
     if config.poly_a {
-        writeln!(w, "Poly-A trimming enabled: removing poly-A tails from 3' end of R1/SE reads, and poly-T heads from 5' end of R2 reads")?;
+        writeln!(
+            w,
+            "Poly-A trimming enabled: removing poly-A tails from 3' end of R1/SE reads, and poly-T heads from 5' end of R2 reads"
+        )?;
     }
     if config.poly_g {
-        writeln!(w, "Poly-G trimming enabled: removing poly-G tails from 3' end of R1/SE reads, and poly-C heads from 5' end of R2 reads")?;
+        writeln!(
+            w,
+            "Poly-G trimming enabled: removing poly-G tails from 3' end of R1/SE reads, and poly-C heads from 5' end of R2 reads"
+        )?;
     }
     if config.gzip {
         writeln!(w, "Output file will be GZIP compressed")?;
@@ -228,57 +281,97 @@ pub fn write_report_header<W: Write>(w: &mut W, config: &TrimConfig) -> std::io:
 pub fn write_run_stats<W: Write>(w: &mut W, stats: &TrimStats) -> std::io::Result<()> {
     writeln!(w, "=== Summary ===")?;
     writeln!(w)?;
-    writeln!(w, "Total reads processed:              {:>10}", format_number(stats.total_reads))?;
-    writeln!(w, "Reads with adapters:                {:>10} ({:.1}%)",
+    writeln!(
+        w,
+        "Total reads processed:              {:>10}",
+        format_number(stats.total_reads)
+    )?;
+    writeln!(
+        w,
+        "Reads with adapters:                {:>10} ({:.1}%)",
         format_number(stats.total_reads_with_adapter),
-        percentage(stats.total_reads_with_adapter, stats.total_reads))?;
+        percentage(stats.total_reads_with_adapter, stats.total_reads)
+    )?;
     writeln!(w)?;
 
     if stats.total_reads > 0 {
         if stats.discarded_untrimmed > 0 {
-            writeln!(w, "Reads discarded as untrimmed:       {:>10} ({:.1}%)",
+            writeln!(
+                w,
+                "Reads discarded as untrimmed:       {:>10} ({:.1}%)",
                 format_number(stats.discarded_untrimmed),
-                percentage(stats.discarded_untrimmed, stats.total_reads))?;
+                percentage(stats.discarded_untrimmed, stats.total_reads)
+            )?;
         }
-        writeln!(w, "Reads that were too short:          {:>10} ({:.1}%)",
+        writeln!(
+            w,
+            "Reads that were too short:          {:>10} ({:.1}%)",
             format_number(stats.too_short),
-            percentage(stats.too_short, stats.total_reads))?;
-        writeln!(w, "Reads that were too long:           {:>10} ({:.1}%)",
+            percentage(stats.too_short, stats.total_reads)
+        )?;
+        writeln!(
+            w,
+            "Reads that were too long:           {:>10} ({:.1}%)",
             format_number(stats.too_long),
-            percentage(stats.too_long, stats.total_reads))?;
-        writeln!(w, "Reads with too many N:              {:>10} ({:.1}%)",
+            percentage(stats.too_long, stats.total_reads)
+        )?;
+        writeln!(
+            w,
+            "Reads with too many N:              {:>10} ({:.1}%)",
             format_number(stats.too_many_n),
-            percentage(stats.too_many_n, stats.total_reads))?;
+            percentage(stats.too_many_n, stats.total_reads)
+        )?;
     }
 
-    writeln!(w, "Reads written (passing filters):    {:>10} ({:.1}%)",
+    writeln!(
+        w,
+        "Reads written (passing filters):    {:>10} ({:.1}%)",
         format_number(stats.reads_written),
-        percentage(stats.reads_written, stats.total_reads))?;
+        percentage(stats.reads_written, stats.total_reads)
+    )?;
     writeln!(w)?;
 
     if stats.rrbs_trimmed_3prime > 0 {
-        writeln!(w, "RRBS reads trimmed by additional 2 bp when adapter contamination was detected:\t{} ({:.1}%)",
+        writeln!(
+            w,
+            "RRBS reads trimmed by additional 2 bp when adapter contamination was detected:\t{} ({:.1}%)",
             stats.rrbs_trimmed_3prime,
-            percentage(stats.rrbs_trimmed_3prime, stats.total_reads))?;
+            percentage(stats.rrbs_trimmed_3prime, stats.total_reads)
+        )?;
     }
     if stats.rrbs_trimmed_5prime > 0 {
-        writeln!(w, "RRBS reads trimmed by 2 bp at the start when read started with CAA or CGA in total:\t{} ({:.1}%)",
+        writeln!(
+            w,
+            "RRBS reads trimmed by 2 bp at the start when read started with CAA or CGA in total:\t{} ({:.1}%)",
             stats.rrbs_trimmed_5prime,
-            percentage(stats.rrbs_trimmed_5prime, stats.total_reads))?;
+            percentage(stats.rrbs_trimmed_5prime, stats.total_reads)
+        )?;
     }
     if stats.poly_a_trimmed > 0 {
-        writeln!(w, "Reads with poly-A/T trimmed:    {:>10} ({:.1}%)",
+        writeln!(
+            w,
+            "Reads with poly-A/T trimmed:    {:>10} ({:.1}%)",
             format_number(stats.poly_a_trimmed),
-            percentage(stats.poly_a_trimmed, stats.total_reads))?;
-        writeln!(w, "  Poly-A/T bases removed:       {:>10}",
-            format_number(stats.poly_a_bases_trimmed))?;
+            percentage(stats.poly_a_trimmed, stats.total_reads)
+        )?;
+        writeln!(
+            w,
+            "  Poly-A/T bases removed:       {:>10}",
+            format_number(stats.poly_a_bases_trimmed)
+        )?;
     }
     if stats.poly_g_trimmed > 0 {
-        writeln!(w, "Reads with poly-G/C trimmed:    {:>10} ({:.1}%)",
+        writeln!(
+            w,
+            "Reads with poly-G/C trimmed:    {:>10} ({:.1}%)",
             format_number(stats.poly_g_trimmed),
-            percentage(stats.poly_g_trimmed, stats.total_reads))?;
-        writeln!(w, "  Poly-G/C bases removed:       {:>10}",
-            format_number(stats.poly_g_bases_trimmed))?;
+            percentage(stats.poly_g_trimmed, stats.total_reads)
+        )?;
+        writeln!(
+            w,
+            "  Poly-G/C bases removed:       {:>10}",
+            format_number(stats.poly_g_bases_trimmed)
+        )?;
     }
 
     Ok(())
@@ -291,22 +384,48 @@ pub fn write_pair_validation_stats<W: Write>(
 ) -> std::io::Result<()> {
     writeln!(w, "=== Paired-end validation ===")?;
     writeln!(w)?;
-    writeln!(w, "Number of sequence pairs analysed:  {:>10}", format_number(stats.pairs_analyzed))?;
+    writeln!(
+        w,
+        "Number of sequence pairs analysed:  {:>10}",
+        format_number(stats.pairs_analyzed)
+    )?;
     writeln!(w)?;
-    writeln!(w, "Number of sequence pairs removed because at least one read was shorter than the length cutoff ({:.2}%):",
-        percentage(stats.pairs_removed, stats.pairs_analyzed))?;
-    writeln!(w, "                             {:>10}", format_number(stats.pairs_removed))?;
+    writeln!(
+        w,
+        "Number of sequence pairs removed because at least one read was shorter than the length cutoff ({:.2}%):",
+        percentage(stats.pairs_removed, stats.pairs_analyzed)
+    )?;
+    writeln!(
+        w,
+        "                             {:>10}",
+        format_number(stats.pairs_removed)
+    )?;
 
     if stats.pairs_removed_n > 0 {
-        writeln!(w, "Number of pairs removed for N content ({:.2}%):",
-            percentage(stats.pairs_removed_n, stats.pairs_analyzed))?;
-        writeln!(w, "                             {:>10}", format_number(stats.pairs_removed_n))?;
+        writeln!(
+            w,
+            "Number of pairs removed for N content ({:.2}%):",
+            percentage(stats.pairs_removed_n, stats.pairs_analyzed)
+        )?;
+        writeln!(
+            w,
+            "                             {:>10}",
+            format_number(stats.pairs_removed_n)
+        )?;
     }
 
     if stats.r1_unpaired > 0 || stats.r2_unpaired > 0 {
         writeln!(w)?;
-        writeln!(w, "Unpaired read 1 kept:        {:>10}", format_number(stats.r1_unpaired))?;
-        writeln!(w, "Unpaired read 2 kept:        {:>10}", format_number(stats.r2_unpaired))?;
+        writeln!(
+            w,
+            "Unpaired read 1 kept:        {:>10}",
+            format_number(stats.r1_unpaired)
+        )?;
+        writeln!(
+            w,
+            "Unpaired read 2 kept:        {:>10}",
+            format_number(stats.r2_unpaired)
+        )?;
     }
 
     writeln!(w)?;
@@ -335,48 +454,84 @@ pub fn write_cutadapt_compatible_section<W: Write>(
 
     writeln!(w)?;
     // Native identifier for MultiQC with Trim Galore v2.0 support
-    writeln!(w, "Trim Galore {} (Oxidized Edition) — adapter trimming built in", config.version)?;
+    writeln!(
+        w,
+        "Trim Galore {} (Oxidized Edition) — adapter trimming built in",
+        config.version
+    )?;
     // Backwards compatibility: older MultiQC discovers reports via "This is cutadapt"
-    writeln!(w, "This is cutadapt 4.0 (compatible; for MultiQC backwards compatibility)")?;
+    writeln!(
+        w,
+        "This is cutadapt 4.0 (compatible; for MultiQC backwards compatibility)"
+    )?;
     // Command line — MultiQC extracts the sample name from the input filename here
     let first_adapter_seq = adapters.first().map(|(_, s)| s.as_str()).unwrap_or("");
-    writeln!(w, "Command line parameters: -j 1 -e {} -q {} -O {} -a {} {}",
-        config.error_rate, config.quality_cutoff, config.stringency,
-        first_adapter_seq, config.input_filename)?;
+    writeln!(
+        w,
+        "Command line parameters: -j 1 -e {} -q {} -O {} -a {} {}",
+        config.error_rate,
+        config.quality_cutoff,
+        config.stringency,
+        first_adapter_seq,
+        config.input_filename
+    )?;
     writeln!(w, "Processing reads on 1 core in single-end mode ...")?;
     writeln!(w)?;
 
     // Summary — regexes: "Total reads processed:\s*([\d,]+)" etc.
     writeln!(w, "=== Summary ===")?;
     writeln!(w)?;
-    writeln!(w, "Total reads processed:           {:>10}", format_number(stats.total_reads))?;
-    writeln!(w, "Reads with adapters:             {:>10} ({:.1}%)",
+    writeln!(
+        w,
+        "Total reads processed:           {:>10}",
+        format_number(stats.total_reads)
+    )?;
+    writeln!(
+        w,
+        "Reads with adapters:             {:>10} ({:.1}%)",
         format_number(stats.total_reads_with_adapter),
-        percentage(stats.total_reads_with_adapter, stats.total_reads))?;
+        percentage(stats.total_reads_with_adapter, stats.total_reads)
+    )?;
     if stats.discarded_untrimmed > 0 {
-        writeln!(w, "Reads discarded as untrimmed:    {:>10} ({:.1}%)",
+        writeln!(
+            w,
+            "Reads discarded as untrimmed:    {:>10} ({:.1}%)",
             format_number(stats.discarded_untrimmed),
-            percentage(stats.discarded_untrimmed, stats.total_reads))?;
+            percentage(stats.discarded_untrimmed, stats.total_reads)
+        )?;
     }
     // In v0.6.x, Cutadapt wrote ALL reads — length/pair filtering was a separate
     // TrimGalore step. So Cutadapt's "Reads written" was total_reads minus only
     // --discard-untrimmed. We replicate that here for MultiQC backwards compatibility.
     let cutadapt_reads_written = stats.total_reads - stats.discarded_untrimmed;
-    writeln!(w, "Reads written (passing filters): {:>10} ({:.1}%)",
+    writeln!(
+        w,
+        "Reads written (passing filters): {:>10} ({:.1}%)",
         format_number(cutadapt_reads_written),
-        percentage(cutadapt_reads_written, stats.total_reads))?;
+        percentage(cutadapt_reads_written, stats.total_reads)
+    )?;
     writeln!(w)?;
 
     // Basepair statistics — "Total basepairs processed:\s*([\d,]+) bp"
-    writeln!(w, "Total basepairs processed:   {:>12} bp", format_number(stats.total_bp_processed))?;
-    writeln!(w, "Quality-trimmed:             {:>12} bp ({:.1}%)",
+    writeln!(
+        w,
+        "Total basepairs processed:   {:>12} bp",
+        format_number(stats.total_bp_processed)
+    )?;
+    writeln!(
+        w,
+        "Quality-trimmed:             {:>12} bp ({:.1}%)",
         format_number(stats.bases_quality_trimmed),
-        percentage(stats.bases_quality_trimmed, stats.total_bp_processed))?;
+        percentage(stats.bases_quality_trimmed, stats.total_bp_processed)
+    )?;
     // Same as reads: report bp after trimming but before length/pair filtering,
     // matching what Cutadapt would have written.
-    writeln!(w, "Total written (filtered):    {:>12} bp ({:.1}%)",
+    writeln!(
+        w,
+        "Total written (filtered):    {:>12} bp ({:.1}%)",
         format_number(stats.total_bp_after_trim),
-        percentage(stats.total_bp_after_trim, stats.total_bp_processed))?;
+        percentage(stats.total_bp_after_trim, stats.total_bp_processed)
+    )?;
     writeln!(w)?;
 
     // Per-adapter sections — "=== Adapter N ===" triggers MultiQC section parsing
@@ -386,8 +541,13 @@ pub fn write_cutadapt_compatible_section<W: Write>(
 
         writeln!(w, "=== Adapter {} ===", idx + 1)?;
         writeln!(w)?;
-        writeln!(w, "Sequence: {}; Type: regular 3'; Length: {}; Trimmed: {} times.",
-            seq, seq.len(), times_trimmed)?;
+        writeln!(
+            w,
+            "Sequence: {}; Type: regular 3'; Length: {}; Trimmed: {} times.",
+            seq,
+            seq.len(),
+            times_trimmed
+        )?;
         writeln!(w)?;
 
         write_allowed_errors(w, seq.len(), config.error_rate)?;
@@ -403,7 +563,11 @@ pub fn write_cutadapt_compatible_section<W: Write>(
                 }
                 let expect = stats.total_reads as f64 / 4f64.powi(length as i32);
                 let max_err = (length as f64 * config.error_rate).floor() as usize;
-                writeln!(w, "{}\t{}\t{:.1}\t{}\t{}", length, count, expect, max_err, count)?;
+                writeln!(
+                    w,
+                    "{}\t{}\t{:.1}\t{}\t{}",
+                    length, count, expect, max_err, count
+                )?;
             }
         }
         writeln!(w)?;
@@ -419,40 +583,73 @@ pub fn write_run_footer<W: Write>(
     config: &TrimConfig,
     stats: &TrimStats,
 ) -> std::io::Result<()> {
-    writeln!(w, "RUN STATISTICS FOR INPUT FILE: {}", config.input_filename)?;
+    writeln!(
+        w,
+        "RUN STATISTICS FOR INPUT FILE: {}",
+        config.input_filename
+    )?;
     writeln!(w, "=============================================")?;
     writeln!(w, "{} sequences processed in total", stats.total_reads)?;
 
     if stats.too_short > 0 {
-        writeln!(w, "Sequences removed because they became shorter than the length cutoff of {} bp:\t{} ({:.1}%)",
-            config.length_cutoff, stats.too_short, percentage(stats.too_short, stats.total_reads))?;
+        writeln!(
+            w,
+            "Sequences removed because they became shorter than the length cutoff of {} bp:\t{} ({:.1}%)",
+            config.length_cutoff,
+            stats.too_short,
+            percentage(stats.too_short, stats.total_reads)
+        )?;
     }
     if stats.too_long > 0 {
-        writeln!(w, "Sequences removed because they were longer than the upper length cutoff:\t{} ({:.1}%)",
-            stats.too_long, percentage(stats.too_long, stats.total_reads))?;
+        writeln!(
+            w,
+            "Sequences removed because they were longer than the upper length cutoff:\t{} ({:.1}%)",
+            stats.too_long,
+            percentage(stats.too_long, stats.total_reads)
+        )?;
     }
     if stats.too_many_n > 0 {
-        writeln!(w, "Sequences removed because of too many N bases:\t{} ({:.1}%)",
-            stats.too_many_n, percentage(stats.too_many_n, stats.total_reads))?;
+        writeln!(
+            w,
+            "Sequences removed because of too many N bases:\t{} ({:.1}%)",
+            stats.too_many_n,
+            percentage(stats.too_many_n, stats.total_reads)
+        )?;
     }
 
     if stats.rrbs_trimmed_3prime > 0 {
-        writeln!(w, "RRBS reads trimmed by additional 2 bp when adapter contamination was detected:\t{} ({:.1}%)",
-            stats.rrbs_trimmed_3prime, percentage(stats.rrbs_trimmed_3prime, stats.total_reads))?;
+        writeln!(
+            w,
+            "RRBS reads trimmed by additional 2 bp when adapter contamination was detected:\t{} ({:.1}%)",
+            stats.rrbs_trimmed_3prime,
+            percentage(stats.rrbs_trimmed_3prime, stats.total_reads)
+        )?;
     }
     if stats.rrbs_trimmed_5prime > 0 {
-        writeln!(w, "RRBS reads trimmed by 2 bp at the start when read started with CAA or CGA in total:\t{} ({:.1}%)",
-            stats.rrbs_trimmed_5prime, percentage(stats.rrbs_trimmed_5prime, stats.total_reads))?;
+        writeln!(
+            w,
+            "RRBS reads trimmed by 2 bp at the start when read started with CAA or CGA in total:\t{} ({:.1}%)",
+            stats.rrbs_trimmed_5prime,
+            percentage(stats.rrbs_trimmed_5prime, stats.total_reads)
+        )?;
     }
     if stats.poly_a_trimmed > 0 {
-        writeln!(w, "Reads with poly-A/T trimmed:\t{} ({:.1}%); {} bp removed",
-            stats.poly_a_trimmed, percentage(stats.poly_a_trimmed, stats.total_reads),
-            format_number(stats.poly_a_bases_trimmed))?;
+        writeln!(
+            w,
+            "Reads with poly-A/T trimmed:\t{} ({:.1}%); {} bp removed",
+            stats.poly_a_trimmed,
+            percentage(stats.poly_a_trimmed, stats.total_reads),
+            format_number(stats.poly_a_bases_trimmed)
+        )?;
     }
     if stats.poly_g_trimmed > 0 {
-        writeln!(w, "Reads with poly-G/C trimmed:\t{} ({:.1}%); {} bp removed",
-            stats.poly_g_trimmed, percentage(stats.poly_g_trimmed, stats.total_reads),
-            format_number(stats.poly_g_bases_trimmed))?;
+        writeln!(
+            w,
+            "Reads with poly-G/C trimmed:\t{} ({:.1}%); {} bp removed",
+            stats.poly_g_trimmed,
+            percentage(stats.poly_g_trimmed, stats.total_reads),
+            format_number(stats.poly_g_bases_trimmed)
+        )?;
     }
 
     writeln!(w)?;
@@ -509,7 +706,17 @@ pub fn write_json_report<W: Write>(
         }
     }
     writeln!(w, "],")?;
-    json_str(w, i1, "mode", if config.paired { "paired-end" } else { "single-end" }, true)?;
+    json_str(
+        w,
+        i1,
+        "mode",
+        if config.paired {
+            "paired-end"
+        } else {
+            "single-end"
+        },
+        true,
+    )?;
     writeln!(w, "{}\"read_number\": {},", i1, read_number)?;
     json_str(w, i1, "command_line", &config.command_line, true)?;
 
@@ -519,14 +726,28 @@ pub fn write_json_report<W: Write>(
     // Adapters as array of objects
     write!(w, "{}\"adapters\": [", i2)?;
     for (i, (name, seq)) in config.adapters.iter().enumerate() {
-        write!(w, "{{\"name\": \"{}\", \"sequence\": \"{}\"}}", json_escape_string(name), json_escape_string(seq))?;
-        if i + 1 < config.adapters.len() { write!(w, ", ")?; }
+        write!(
+            w,
+            "{{\"name\": \"{}\", \"sequence\": \"{}\"}}",
+            json_escape_string(name),
+            json_escape_string(seq)
+        )?;
+        if i + 1 < config.adapters.len() {
+            write!(w, ", ")?;
+        }
     }
     writeln!(w, "],")?;
     write!(w, "{}\"adapters_r2\": [", i2)?;
     for (i, (name, seq)) in config.adapters_r2.iter().enumerate() {
-        write!(w, "{{\"name\": \"{}\", \"sequence\": \"{}\"}}", json_escape_string(name), json_escape_string(seq))?;
-        if i + 1 < config.adapters_r2.len() { write!(w, ", ")?; }
+        write!(
+            w,
+            "{{\"name\": \"{}\", \"sequence\": \"{}\"}}",
+            json_escape_string(name),
+            json_escape_string(seq)
+        )?;
+        if i + 1 < config.adapters_r2.len() {
+            write!(w, ", ")?;
+        }
     }
     writeln!(w, "],")?;
     json_int(w, i2, "times", config.times, true)?;
@@ -543,28 +764,64 @@ pub fn write_json_report<W: Write>(
     json_bool(w, i2, "poly_g", config.poly_g, true)?;
     json_opt_int(w, i2, "clip_r1", extra.clip_r1, true)?;
     json_opt_int(w, i2, "clip_r2", extra.clip_r2, true)?;
-    json_opt_int(w, i2, "three_prime_clip_r1", extra.three_prime_clip_r1, true)?;
-    json_opt_int(w, i2, "three_prime_clip_r2", extra.three_prime_clip_r2, true)?;
+    json_opt_int(
+        w,
+        i2,
+        "three_prime_clip_r1",
+        extra.three_prime_clip_r1,
+        true,
+    )?;
+    json_opt_int(
+        w,
+        i2,
+        "three_prime_clip_r2",
+        extra.three_prime_clip_r2,
+        true,
+    )?;
     json_opt_float(w, i2, "max_n", extra.max_n, true)?;
     json_bool(w, i2, "discard_untrimmed", extra.discard_untrimmed, true)?;
-    json_opt_int(w, i2, "consider_already_trimmed", extra.consider_already_trimmed, false)?;
+    json_opt_int(
+        w,
+        i2,
+        "consider_already_trimmed",
+        extra.consider_already_trimmed,
+        false,
+    )?;
     writeln!(w, "{}}},", i1)?;
 
     // ── Read processing ──────────────────────────────────────────
     writeln!(w, "{}\"read_processing\": {{", i1)?;
     json_int(w, i2, "total_reads", stats.total_reads, true)?;
-    json_int(w, i2, "reads_with_adapter", stats.total_reads_with_adapter, true)?;
+    json_int(
+        w,
+        i2,
+        "reads_with_adapter",
+        stats.total_reads_with_adapter,
+        true,
+    )?;
     json_int(w, i2, "reads_written", stats.reads_written, true)?;
     json_int(w, i2, "reads_too_short", stats.too_short, true)?;
     json_int(w, i2, "reads_too_long", stats.too_long, true)?;
     json_int(w, i2, "reads_too_many_n", stats.too_many_n, true)?;
-    json_int(w, i2, "reads_discarded_untrimmed", stats.discarded_untrimmed, false)?;
+    json_int(
+        w,
+        i2,
+        "reads_discarded_untrimmed",
+        stats.discarded_untrimmed,
+        false,
+    )?;
     writeln!(w, "{}}},", i1)?;
 
     // ── Basepair processing ──────────────────────────────────────
     writeln!(w, "{}\"basepair_processing\": {{", i1)?;
     json_int(w, i2, "total_bp_processed", stats.total_bp_processed, true)?;
-    json_int(w, i2, "quality_trimmed_bp", stats.bases_quality_trimmed, true)?;
+    json_int(
+        w,
+        i2,
+        "quality_trimmed_bp",
+        stats.bases_quality_trimmed,
+        true,
+    )?;
     json_int(w, i2, "total_bp_written", stats.total_bp_written, false)?;
     writeln!(w, "{}}},", i1)?;
 
@@ -577,7 +834,11 @@ pub fn write_json_report<W: Write>(
     };
     writeln!(w, "{}\"adapter_trimming\": [", i1)?;
     for (adapter_idx, (name, seq)) in adapters.iter().enumerate() {
-        let times_trimmed = stats.reads_with_adapter.get(adapter_idx).copied().unwrap_or(0);
+        let times_trimmed = stats
+            .reads_with_adapter
+            .get(adapter_idx)
+            .copied()
+            .unwrap_or(0);
         writeln!(w, "{}{{", i2)?;
         json_str(w, i3, "name", name, true)?;
         json_str(w, i3, "sequence", seq, true)?;
@@ -589,7 +850,9 @@ pub fn write_json_report<W: Write>(
         let length_counts = stats.adapter_length_counts.get(adapter_idx);
         let entries: Vec<(usize, usize)> = length_counts
             .map(|counts| {
-                counts.iter().enumerate()
+                counts
+                    .iter()
+                    .enumerate()
                     .filter(|&(i, &count)| i > 0 && count > 0)
                     .map(|(i, &count)| (i, count))
                     .collect()
@@ -602,12 +865,20 @@ pub fn write_json_report<W: Write>(
             writeln!(w, "{}\"length_distribution\": {{", i3)?;
             let i4 = "        ";
             for (entry_idx, &(length, count)) in entries.iter().enumerate() {
-                let comma = if entry_idx < entries.len() - 1 { "," } else { "" };
+                let comma = if entry_idx < entries.len() - 1 {
+                    ","
+                } else {
+                    ""
+                };
                 writeln!(w, "{}\"{}\": {}{}", i4, length, count, comma)?;
             }
             writeln!(w, "{}}}", i3)?;
         }
-        let comma = if adapter_idx < adapters.len() - 1 { "," } else { "" };
+        let comma = if adapter_idx < adapters.len() - 1 {
+            ","
+        } else {
+            ""
+        };
         writeln!(w, "{}}}{}", i2, comma)?;
     }
     writeln!(w, "{}],", i1)?;
@@ -628,7 +899,13 @@ pub fn write_json_report<W: Write>(
     writeln!(w, "{}\"rrbs\": {{", i1)?;
     json_int(w, i2, "trimmed_3prime", stats.rrbs_trimmed_3prime, true)?;
     json_int(w, i2, "trimmed_5prime", stats.rrbs_trimmed_5prime, true)?;
-    json_int(w, i2, "r2_clipped_5prime", stats.rrbs_r2_clipped_5prime, false)?;
+    json_int(
+        w,
+        i2,
+        "r2_clipped_5prime",
+        stats.rrbs_r2_clipped_5prime,
+        false,
+    )?;
     writeln!(w, "{}}},", i1)?;
 
     // ── Pair validation ──────────────────────────────────────────
@@ -640,7 +917,13 @@ pub fn write_json_report<W: Write>(
             json_int(w, i2, "pairs_analyzed", ps.pairs_analyzed, true)?;
             json_int(w, i2, "pairs_removed", ps.pairs_removed, true)?;
             json_int(w, i2, "pairs_removed_n", ps.pairs_removed_n, true)?;
-            json_int(w, i2, "pairs_removed_too_long", ps.pairs_removed_too_long, true)?;
+            json_int(
+                w,
+                i2,
+                "pairs_removed_too_long",
+                ps.pairs_removed_too_long,
+                true,
+            )?;
             json_int(w, i2, "r1_unpaired", ps.r1_unpaired, true)?;
             json_int(w, i2, "r2_unpaired", ps.r2_unpaired, false)?;
             writeln!(w, "{}}}", i1)?;
@@ -676,45 +959,110 @@ fn json_escape_string(s: &str) -> String {
     escaped
 }
 
-fn json_str<W: Write>(w: &mut W, indent: &str, key: &str, value: &str, comma: bool) -> std::io::Result<()> {
-    writeln!(w, "{}\"{}\": \"{}\"{}",
-        indent, key, json_escape_string(value), if comma { "," } else { "" })
+fn json_str<W: Write>(
+    w: &mut W,
+    indent: &str,
+    key: &str,
+    value: &str,
+    comma: bool,
+) -> std::io::Result<()> {
+    writeln!(
+        w,
+        "{}\"{}\": \"{}\"{}",
+        indent,
+        key,
+        json_escape_string(value),
+        if comma { "," } else { "" }
+    )
 }
 
-fn json_int<W: Write>(w: &mut W, indent: &str, key: &str, value: usize, comma: bool) -> std::io::Result<()> {
-    writeln!(w, "{}\"{}\": {}{}",
-        indent, key, value, if comma { "," } else { "" })
+fn json_int<W: Write>(
+    w: &mut W,
+    indent: &str,
+    key: &str,
+    value: usize,
+    comma: bool,
+) -> std::io::Result<()> {
+    writeln!(
+        w,
+        "{}\"{}\": {}{}",
+        indent,
+        key,
+        value,
+        if comma { "," } else { "" }
+    )
 }
 
-fn json_float<W: Write>(w: &mut W, indent: &str, key: &str, value: f64, comma: bool) -> std::io::Result<()> {
+fn json_float<W: Write>(
+    w: &mut W,
+    indent: &str,
+    key: &str,
+    value: f64,
+    comma: bool,
+) -> std::io::Result<()> {
     if !value.is_finite() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!("non-finite float value for JSON key \"{}\": {}", key, value),
         ));
     }
-    writeln!(w, "{}\"{}\": {}{}",
-        indent, key, value, if comma { "," } else { "" })
+    writeln!(
+        w,
+        "{}\"{}\": {}{}",
+        indent,
+        key,
+        value,
+        if comma { "," } else { "" }
+    )
 }
 
-fn json_bool<W: Write>(w: &mut W, indent: &str, key: &str, value: bool, comma: bool) -> std::io::Result<()> {
-    writeln!(w, "{}\"{}\": {}{}",
-        indent, key, if value { "true" } else { "false" }, if comma { "," } else { "" })
+fn json_bool<W: Write>(
+    w: &mut W,
+    indent: &str,
+    key: &str,
+    value: bool,
+    comma: bool,
+) -> std::io::Result<()> {
+    writeln!(
+        w,
+        "{}\"{}\": {}{}",
+        indent,
+        key,
+        if value { "true" } else { "false" },
+        if comma { "," } else { "" }
+    )
 }
 
 fn json_null<W: Write>(w: &mut W, indent: &str, key: &str, comma: bool) -> std::io::Result<()> {
-    writeln!(w, "{}\"{}\": null{}",
-        indent, key, if comma { "," } else { "" })
+    writeln!(
+        w,
+        "{}\"{}\": null{}",
+        indent,
+        key,
+        if comma { "," } else { "" }
+    )
 }
 
-fn json_opt_int<W: Write>(w: &mut W, indent: &str, key: &str, value: Option<usize>, comma: bool) -> std::io::Result<()> {
+fn json_opt_int<W: Write>(
+    w: &mut W,
+    indent: &str,
+    key: &str,
+    value: Option<usize>,
+    comma: bool,
+) -> std::io::Result<()> {
     match value {
         Some(v) => json_int(w, indent, key, v, comma),
         None => json_null(w, indent, key, comma),
     }
 }
 
-fn json_opt_float<W: Write>(w: &mut W, indent: &str, key: &str, value: Option<f64>, comma: bool) -> std::io::Result<()> {
+fn json_opt_float<W: Write>(
+    w: &mut W,
+    indent: &str,
+    key: &str,
+    value: Option<f64>,
+    comma: bool,
+) -> std::io::Result<()> {
     match value {
         Some(v) => json_float(w, indent, key, v, comma),
         None => json_null(w, indent, key, comma),
@@ -722,7 +1070,11 @@ fn json_opt_float<W: Write>(w: &mut W, indent: &str, key: &str, value: Option<f6
 }
 
 /// Write the "No. of allowed errors" section (cosmetic, not parsed by MultiQC).
-fn write_allowed_errors<W: Write>(w: &mut W, adapter_len: usize, error_rate: f64) -> std::io::Result<()> {
+fn write_allowed_errors<W: Write>(
+    w: &mut W,
+    adapter_len: usize,
+    error_rate: f64,
+) -> std::io::Result<()> {
     writeln!(w, "No. of allowed errors:")?;
     let mut parts = Vec::new();
     let mut range_start = 1;
@@ -732,15 +1084,23 @@ fn write_allowed_errors<W: Write>(w: &mut W, adapter_len: usize, error_rate: f64
         let max_err = (len as f64 * error_rate).floor() as usize;
         if max_err != current_max_err {
             // Close previous range
-            if range_start <= len - 1 {
-                parts.push(format!("{}-{} bp: {}", range_start, len - 1, current_max_err));
+            if range_start < len {
+                parts.push(format!(
+                    "{}-{} bp: {}",
+                    range_start,
+                    len - 1,
+                    current_max_err
+                ));
             }
             range_start = len;
             current_max_err = max_err;
         }
     }
     // Close final range
-    parts.push(format!("{}-{} bp: {}", range_start, adapter_len, current_max_err));
+    parts.push(format!(
+        "{}-{} bp: {}",
+        range_start, adapter_len, current_max_err
+    ));
     writeln!(w, "{}", parts.join("; "))?;
 
     Ok(())
@@ -878,8 +1238,8 @@ mod tests {
         let mut buf = Vec::new();
         write_json_report(&mut buf, &config, &stats, None, 1, &extra).unwrap();
 
-        let json: serde_json::Value = serde_json::from_slice(&buf)
-            .expect("JSON output must be valid");
+        let json: serde_json::Value =
+            serde_json::from_slice(&buf).expect("JSON output must be valid");
 
         assert_eq!(json["tool"], "Trim Galore");
         assert_eq!(json["schema_version"], 1);
@@ -890,8 +1250,14 @@ mod tests {
 
         // Parameters
         assert_eq!(json["parameters"]["quality_cutoff"], 20);
-        assert_eq!(json["parameters"]["adapters"][0]["sequence"], "AGATCGGAAGAGC");
-        assert_eq!(json["parameters"]["adapters_r2"].as_array().unwrap().len(), 0);
+        assert_eq!(
+            json["parameters"]["adapters"][0]["sequence"],
+            "AGATCGGAAGAGC"
+        );
+        assert_eq!(
+            json["parameters"]["adapters_r2"].as_array().unwrap().len(),
+            0
+        );
         assert_eq!(json["parameters"]["times"], 1);
         assert_eq!(json["parameters"]["error_rate"], 0.1);
         assert_eq!(json["parameters"]["stringency"], 1);
@@ -1029,7 +1395,9 @@ mod tests {
         write_json_report(&mut buf2, &config, &stats, None, 1, &extra).unwrap();
         let json2: serde_json::Value = serde_json::from_slice(&buf2).unwrap();
 
-        let ld2 = json2["adapter_trimming"][0]["length_distribution"].as_object().unwrap();
+        let ld2 = json2["adapter_trimming"][0]["length_distribution"]
+            .as_object()
+            .unwrap();
         assert_eq!(ld2.len(), 2);
         assert_eq!(ld2["3"], 42);
         assert_eq!(ld2["7"], 7);
@@ -1038,7 +1406,8 @@ mod tests {
     #[test]
     fn test_write_json_report_special_characters() {
         let mut config = test_config();
-        config.command_line = r#"trim_galore --fastqc_args "--nogroup" "my file.fq.gz""#.to_string();
+        config.command_line =
+            r#"trim_galore --fastqc_args "--nogroup" "my file.fq.gz""#.to_string();
         config.input_filename = "my file.fq.gz".to_string();
         config.input_filenames = vec!["my file.fq.gz".to_string()];
 
@@ -1049,8 +1418,8 @@ mod tests {
         write_json_report(&mut buf, &config, &stats, None, 1, &extra).unwrap();
 
         // Must produce valid JSON despite quotes and spaces in values
-        let json: serde_json::Value = serde_json::from_slice(&buf)
-            .expect("JSON with special characters must be valid");
+        let json: serde_json::Value =
+            serde_json::from_slice(&buf).expect("JSON with special characters must be valid");
 
         assert_eq!(json["input_filenames"][0], "my file.fq.gz");
         // Command line with embedded quotes is escaped correctly
@@ -1084,8 +1453,8 @@ mod tests {
         let extra = test_extra_params();
         let mut buf = Vec::new();
         write_json_report(&mut buf, &config, &stats, None, 1, &extra).unwrap();
-        let json: serde_json::Value = serde_json::from_slice(&buf)
-            .expect("Multi-adapter JSON must be valid");
+        let json: serde_json::Value =
+            serde_json::from_slice(&buf).expect("Multi-adapter JSON must be valid");
 
         // Parameters: adapters array with 3 elements
         let params_adapters = json["parameters"]["adapters"].as_array().unwrap();
@@ -1153,9 +1522,9 @@ mod tests {
         worker_b.total_reads_with_adapter = 40;
         worker_b.reads_with_adapter = vec![30, 15, 0];
         worker_b.adapter_length_counts = vec![
-            vec![0, 10, 15, 5],  // adapter 0: longer length distribution than worker A
-            vec![0, 0, 8, 7],    // adapter 1: 8 at len=2, 7 at len=3
-            vec![],              // adapter 2: no matches
+            vec![0, 10, 15, 5], // adapter 0: longer length distribution than worker A
+            vec![0, 0, 8, 7],   // adapter 1: 8 at len=2, 7 at len=3
+            vec![],             // adapter 2: no matches
         ];
 
         main_stats.merge(&worker_a);
@@ -1188,8 +1557,8 @@ mod tests {
         let mut buf = Vec::new();
         write_json_report(&mut buf, &config, &stats, None, 1, &extra).unwrap();
 
-        let json: serde_json::Value = serde_json::from_slice(&buf)
-            .expect("All-zero JSON must be valid");
+        let json: serde_json::Value =
+            serde_json::from_slice(&buf).expect("All-zero JSON must be valid");
 
         assert_eq!(json["read_processing"]["total_reads"], 0);
         assert_eq!(json["read_processing"]["reads_written"], 0);

--- a/src/specialty.rs
+++ b/src/specialty.rs
@@ -3,7 +3,7 @@
 //! These modes (--hardtrim5, --hardtrim3, --clock, --implicon) process
 //! input files with simple fixed operations and exit immediately.
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use std::path::{Path, PathBuf};
 
 use crate::fastq::{FastqReader, FastqWriter};
@@ -21,8 +21,12 @@ pub fn hardtrim5(
     cores: usize,
 ) -> Result<()> {
     let output_path = hardtrim_output_name(input, keep, "5prime", output_dir, gzip);
-    eprintln!("Writing hard-trimmed (first {}bp) version of '{}' to '{}'",
-        keep, input.display(), output_path.display());
+    eprintln!(
+        "Writing hard-trimmed (first {}bp) version of '{}' to '{}'",
+        keep,
+        input.display(),
+        output_path.display()
+    );
 
     let mut reader = FastqReader::open(input)?;
     let mut writer = FastqWriter::create(&output_path, gzip, cores)?;
@@ -59,8 +63,12 @@ pub fn hardtrim3(
     cores: usize,
 ) -> Result<()> {
     let output_path = hardtrim_output_name(input, keep, "3prime", output_dir, gzip);
-    eprintln!("Writing hard-trimmed (last {}bp) version of '{}' to '{}'",
-        keep, input.display(), output_path.display());
+    eprintln!(
+        "Writing hard-trimmed (last {}bp) version of '{}' to '{}'",
+        keep,
+        input.display(),
+        output_path.display()
+    );
 
     let mut reader = FastqReader::open(input)?;
     let mut writer = FastqWriter::create(&output_path, gzip, cores)?;
@@ -110,8 +118,16 @@ pub fn clock(
     let out1 = clock_output_name(input_r1, "R1", output_dir, gzip);
     let out2 = clock_output_name(input_r2, "R2", output_dir, gzip);
 
-    eprintln!("Writing Clock-processed version of '{}' to '{}'", input_r1.display(), out1.display());
-    eprintln!("Writing Clock-processed version of '{}' to '{}'", input_r2.display(), out2.display());
+    eprintln!(
+        "Writing Clock-processed version of '{}' to '{}'",
+        input_r1.display(),
+        out1.display()
+    );
+    eprintln!(
+        "Writing Clock-processed version of '{}' to '{}'",
+        input_r2.display(),
+        out2.display()
+    );
 
     let mut reader_r1 = FastqReader::open(input_r1)?;
     let mut reader_r2 = FastqReader::open(input_r2)?;
@@ -139,7 +155,9 @@ pub fn clock(
                 if r1_seq.len() < 13 || r2_seq.len() < 15 {
                     bail!(
                         "Read too short for Clock processing at read {}: R1={}bp, R2={}bp (need >=13, >=15)",
-                        count, r1_seq.len(), r2_seq.len()
+                        count,
+                        r1_seq.len(),
+                        r2_seq.len()
                     );
                 }
 
@@ -188,7 +206,10 @@ pub fn clock(
         "N/A".to_string()
     };
     eprintln!("\nSequences processed in total: {}", count);
-    eprintln!("thereof had fixed sequence CAGT in both R1 and R2: {} ({}%)\n", filtered_count, perc);
+    eprintln!(
+        "thereof had fixed sequence CAGT in both R1 and R2: {} ({}%)\n",
+        filtered_count, perc
+    );
 
     Ok(())
 }
@@ -209,8 +230,16 @@ pub fn implicon(
     let out1 = implicon_output_name(input_r1, umi_length, "R1", output_dir, gzip);
     let out2 = implicon_output_name(input_r2, umi_length, "R2", output_dir, gzip);
 
-    eprintln!("Writing UMI-trimmed version of '{}' to '{}'", input_r1.display(), out1.display());
-    eprintln!("Writing UMI-trimmed version of '{}' to '{}'", input_r2.display(), out2.display());
+    eprintln!(
+        "Writing UMI-trimmed version of '{}' to '{}'",
+        input_r1.display(),
+        out1.display()
+    );
+    eprintln!(
+        "Writing UMI-trimmed version of '{}' to '{}'",
+        input_r2.display(),
+        out2.display()
+    );
 
     let mut reader_r1 = FastqReader::open(input_r1)?;
     let mut reader_r2 = FastqReader::open(input_r2)?;
@@ -233,7 +262,9 @@ pub fn implicon(
                 if r2.seq.len() < umi_length {
                     bail!(
                         "R2 read {} is shorter ({} bp) than UMI length ({})",
-                        count, r2.seq.len(), umi_length
+                        count,
+                        r2.seq.len(),
+                        umi_length
                     );
                 }
 
@@ -271,7 +302,13 @@ pub fn implicon(
 
 // --- Output naming helpers ---
 
-fn hardtrim_output_name(input: &Path, keep: usize, end: &str, output_dir: Option<&Path>, gzip: bool) -> PathBuf {
+fn hardtrim_output_name(
+    input: &Path,
+    keep: usize,
+    end: &str,
+    output_dir: Option<&Path>,
+    gzip: bool,
+) -> PathBuf {
     let stem = naming::strip_fastq_extensions(input);
     let ext = if gzip { ".fq.gz" } else { ".fq" };
     let filename = format!("{}.{}bp_{}{}", stem, keep, end, ext);
@@ -291,7 +328,13 @@ fn clock_output_name(input: &Path, read: &str, output_dir: Option<&Path>, gzip: 
     }
 }
 
-fn implicon_output_name(input: &Path, umi_len: usize, read: &str, output_dir: Option<&Path>, gzip: bool) -> PathBuf {
+fn implicon_output_name(
+    input: &Path,
+    umi_len: usize,
+    read: &str,
+    output_dir: Option<&Path>,
+    gzip: bool,
+) -> PathBuf {
     let mut stem = naming::strip_fastq_extensions(input);
     // TrimGalore strips _R1 from R1 stem and _R2/_R3/_R4 from R2 stem
     // to avoid double-R in the output filename (e.g., sample_R1_8bp_UMI_R1.fastq)

--- a/src/trimmer.rs
+++ b/src/trimmer.rs
@@ -3,12 +3,12 @@
 //! This module wires together quality trimming, adapter trimming, clipping,
 //! filtering, and report generation into complete processing pipelines.
 
-use anyhow::Result;
 use crate::alignment;
 use crate::fastq::{FastqReader, FastqRecord, FastqWriter};
 use crate::filters::{self, FilterResult, MaxNFilter, PairFilterResult};
 use crate::quality;
-use crate::report::{TrimStats, PairValidationStats};
+use crate::report::{PairValidationStats, TrimStats};
+use anyhow::Result;
 
 /// Configuration for the trimming pipeline.
 pub struct TrimConfig {
@@ -43,7 +43,11 @@ pub struct TrimConfig {
 impl TrimConfig {
     /// Number of adapters used for R2 (falls back to R1 adapter count when no R2-specific adapters are set).
     pub fn r2_adapter_count(&self) -> usize {
-        if self.adapters_r2.is_empty() { self.adapters.len() } else { self.adapters_r2.len() }
+        if self.adapters_r2.is_empty() {
+            self.adapters.len()
+        } else {
+            self.adapters_r2.len()
+        }
     }
 }
 
@@ -66,7 +70,7 @@ pub struct TrimResult {
 /// Processing order (matches TrimGalore behavior):
 /// 1. Quality trim (3' BWA algorithm)
 /// 2. Adapter trim (semi-global alignment)
-/// 2.5. RRBS trim (MspI 2bp artifact removal, if --rrbs)
+///    2.5. RRBS trim (MspI 2bp artifact removal, if --rrbs)
 /// 3. Trim Ns (if --trim-n)
 /// 4. 5'/3' fixed clipping
 ///
@@ -103,13 +107,17 @@ pub fn trim_read(record: &mut FastqRecord, config: &TrimConfig, is_r2: bool) -> 
     let mut adapter_matches: Vec<(usize, usize)> = Vec::new();
 
     for _round in 0..config.times {
-        if record.is_empty() { break; }
+        if record.is_empty() {
+            break;
+        }
 
         let mut best: Option<(usize, alignment::AdapterMatch)> = None;
         let seq_bytes = record.seq.as_bytes();
 
         for (idx, (_name, adapter_seq)) in adapters.iter().enumerate() {
-            if adapter_seq.is_empty() { continue; }
+            if adapter_seq.is_empty() {
+                continue;
+            }
             if let Some(m) = alignment::find_3prime_adapter(
                 seq_bytes,
                 adapter_seq,
@@ -146,8 +154,7 @@ pub fn trim_read(record: &mut FastqRecord, config: &TrimConfig, is_r2: bool) -> 
             // Non-directional: check all reads (R1 and R2)
             if record.seq.len() > 2 {
                 let seq_bytes = record.seq.as_bytes();
-                if seq_bytes.len() >= 3
-                    && (seq_bytes[..3] == *b"CAA" || seq_bytes[..3] == *b"CGA")
+                if seq_bytes.len() >= 3 && (seq_bytes[..3] == *b"CAA" || seq_bytes[..3] == *b"CGA")
                 {
                     // Non-directional artifact: trim 2bp from 5' end
                     record.clip_5prime(2);
@@ -160,11 +167,9 @@ pub fn trim_read(record: &mut FastqRecord, config: &TrimConfig, is_r2: bool) -> 
             }
         } else {
             // Directional RRBS: only R1/SE get 3' trimmed; R2 handled by auto-set clip_r2=2
-            if !(config.is_paired && is_r2) {
-                if record.seq.len() >= 2 && had_adapter {
-                    record.truncate(record.seq.len() - 2);
-                    rrbs_trimmed_3prime = true;
-                }
+            if !(config.is_paired && is_r2) && record.seq.len() >= 2 && had_adapter {
+                record.truncate(record.seq.len() - 2);
+                rrbs_trimmed_3prime = true;
             }
         }
     }
@@ -217,8 +222,16 @@ pub fn trim_read(record: &mut FastqRecord, config: &TrimConfig, is_r2: bool) -> 
     }
 
     // 4. Fixed clipping
-    let clip_5 = if is_r2 { config.clip_r2 } else { config.clip_r1 };
-    let clip_3 = if is_r2 { config.three_prime_clip_r2 } else { config.three_prime_clip_r1 };
+    let clip_5 = if is_r2 {
+        config.clip_r2
+    } else {
+        config.clip_r1
+    };
+    let clip_3 = if is_r2 {
+        config.three_prime_clip_r2
+    } else {
+        config.three_prime_clip_r1
+    };
 
     let mut clip_5prime_applied = false;
     if let Some(n) = clip_5 {
@@ -284,8 +297,12 @@ pub fn run_single_end(
         let result = trim_read(&mut record, config, false);
         stats.bases_quality_trimmed += result.quality_trimmed_bp;
         update_adapter_stats(&mut stats, &result);
-        if result.rrbs_trimmed_3prime { stats.rrbs_trimmed_3prime += 1; }
-        if result.rrbs_trimmed_5prime { stats.rrbs_trimmed_5prime += 1; }
+        if result.rrbs_trimmed_3prime {
+            stats.rrbs_trimmed_3prime += 1;
+        }
+        if result.rrbs_trimmed_5prime {
+            stats.rrbs_trimmed_5prime += 1;
+        }
         if result.poly_a_trimmed > 0 {
             stats.poly_a_trimmed += 1;
             stats.poly_a_bases_trimmed += result.poly_a_trimmed;
@@ -329,6 +346,7 @@ pub fn run_single_end(
 ///
 /// Reads R1 and R2 in lockstep, trims both, applies pair-aware filtering.
 /// This is the key architectural improvement over TrimGalore's 3-pass approach.
+#[allow(clippy::too_many_arguments)]
 pub fn run_paired_end(
     reader_r1: &mut FastqReader,
     reader_r2: &mut FastqReader,
@@ -364,10 +382,18 @@ pub fn run_paired_end(
                 stats_r2.bases_quality_trimmed += result_r2.quality_trimmed_bp;
                 update_adapter_stats(&mut stats_r1, &result_r1);
                 update_adapter_stats(&mut stats_r2, &result_r2);
-                if result_r1.rrbs_trimmed_3prime { stats_r1.rrbs_trimmed_3prime += 1; }
-                if result_r1.rrbs_trimmed_5prime { stats_r1.rrbs_trimmed_5prime += 1; }
-                if result_r2.rrbs_trimmed_3prime { stats_r2.rrbs_trimmed_3prime += 1; }
-                if result_r2.rrbs_trimmed_5prime { stats_r2.rrbs_trimmed_5prime += 1; }
+                if result_r1.rrbs_trimmed_3prime {
+                    stats_r1.rrbs_trimmed_3prime += 1;
+                }
+                if result_r1.rrbs_trimmed_5prime {
+                    stats_r1.rrbs_trimmed_5prime += 1;
+                }
+                if result_r2.rrbs_trimmed_3prime {
+                    stats_r2.rrbs_trimmed_3prime += 1;
+                }
+                if result_r2.rrbs_trimmed_5prime {
+                    stats_r2.rrbs_trimmed_5prime += 1;
+                }
                 if config.rrbs && result_r2.clip_5prime_applied {
                     stats_r2.rrbs_r2_clipped_5prime += 1;
                 }
@@ -478,10 +504,7 @@ mod tests {
 
     /// Build a minimal TrimConfig for adapter-trimming tests.
     /// Quality cutoff 0 disables quality trimming so we test only adapter logic.
-    fn test_config_with_adapters(
-        adapters: Vec<(&str, &str)>,
-        times: usize,
-    ) -> TrimConfig {
+    fn test_config_with_adapters(adapters: Vec<(&str, &str)>, times: usize) -> TrimConfig {
         TrimConfig {
             adapters: adapters
                 .iter()
@@ -529,10 +552,7 @@ mod tests {
         let read_seq = "ACGTACGTACGTACGTACGTCTGTCTCTTATAGGGGGGGGAGATCGGAAGAGC";
         //              |----20bp random----|--Nextera 12bp--|--8bp pad--|--Illumina 13bp--|
         let config = test_config_with_adapters(
-            vec![
-                ("illumina", "AGATCGGAAGAGC"),
-                ("nextera", "CTGTCTCTTATA"),
-            ],
+            vec![("illumina", "AGATCGGAAGAGC"), ("nextera", "CTGTCTCTTATA")],
             1,
         );
 
@@ -573,10 +593,7 @@ mod tests {
         // Read with no adapter sequences at all.
         let read_seq = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
         let config = test_config_with_adapters(
-            vec![
-                ("illumina", "AGATCGGAAGAGC"),
-                ("nextera", "CTGTCTCTTATA"),
-            ],
+            vec![("illumina", "AGATCGGAAGAGC"), ("nextera", "CTGTCTCTTATA")],
             1,
         );
 
@@ -593,10 +610,7 @@ mod tests {
     fn test_trim_read_single_adapter_unchanged() {
         // Regression test: single adapter behavior identical to before multi-adapter.
         let read_seq = "ACGTACGTACGTACGTACGTAAGAGATCGGAAGAGC";
-        let config = test_config_with_adapters(
-            vec![("illumina", "AGATCGGAAGAGC")],
-            1,
-        );
+        let config = test_config_with_adapters(vec![("illumina", "AGATCGGAAGAGC")], 1);
 
         let mut record = make_record(read_seq);
         let result = trim_read(&mut record, &config, false);
@@ -623,10 +637,7 @@ mod tests {
         let adapter = "AGATCGGAAGAGC";
         let read_seq = format!("ACGTACGTACGTACGT{}{}", adapter, adapter);
         // = "ACGTACGTACGTACGTAGATCGGAAGAGCAGATCGGAAGAGC" (16 + 13 + 13 = 42bp)
-        let config = test_config_with_adapters(
-            vec![("illumina", adapter)],
-            2,
-        );
+        let config = test_config_with_adapters(vec![("illumina", adapter)], 2);
 
         let mut record = make_record(&read_seq);
         let result = trim_read(&mut record, &config, false);
@@ -636,7 +647,7 @@ mod tests {
         // Round 2: 16bp with no adapter → stops
         // So only 1 match (the first round trims BOTH copies at once since
         // the alignment finds the leftmost match).
-        assert!(result.adapter_matches.len() >= 1);
+        assert!(!result.adapter_matches.is_empty());
         assert_eq!(record.seq, "ACGTACGTACGTACGT");
     }
 
@@ -646,10 +657,7 @@ mod tests {
         // Use min_overlap=3 (realistic default) and a read whose remaining portion
         // after trimming is pure TTTT — no chance of accidental adapter matches.
         let read_seq = "TTTTTTTTTTTTTTTTTTTTAAGAGATCGGAAGAGC";
-        let mut config = test_config_with_adapters(
-            vec![("illumina", "AGATCGGAAGAGC")],
-            3,
-        );
+        let mut config = test_config_with_adapters(vec![("illumina", "AGATCGGAAGAGC")], 3);
         config.min_overlap = 3;
 
         let mut record = make_record(read_seq);


### PR DESCRIPTION
## Summary

Lifts four hardening items from [ruSTAR PR #2](https://github.com/nf-core/rustar/pull/2) into the Oxidized Edition of TrimGalore:

1. **Build provenance** — `build.rs` embeds the git short-hash, ISO-8601 UTC build timestamp, and target triple (os/arch) into the binary at compile time. Surfaced via:
   - `trim_galore --version` (long form, two lines)
   - Startup banner (stderr, printed once before any trim work)
   - Respects `SOURCE_DATE_EPOCH` per Debian reproducible-builds spec. Malformed input hard-fails the build rather than silently falling back to wall-clock (matches Debian strictness). `.trim()` absorbs shell-expansion whitespace like `SOURCE_DATE_EPOCH="\$(git log -1 --format=%ct) "`.
   - `-V` (short form) stays terse — no provenance line.

2. **Lint gate** — new `lint` CI job runs `cargo fmt --all -- --check` + `cargo clippy --all-targets --release -- -D warnings`. Wired into `validation.needs: [rust-tests, lint]` so downstream gates block on lint failure. Clippy cleanup (needless_range_loop, collapsible_if, len_zero, write_with_newline, doc_lazy_continuation) + cargo fmt drift normalization across `src/` to clear `-D warnings` on first contact.

3. **Reproducibility** — dedicated CI job builds twice under `SOURCE_DATE_EPOCH=1700000000`, asserts byte-identical `sha256`. Plus a malformed-epoch hard-fail test (exit 101, message contains `SOURCE_DATE_EPOCH`). Own cache key (`cargo-repro-`), `target/` excluded from cache (the job does `cargo clean` twice anyway).

4. **Supply-chain** — `rustsec/audit-check@v2` runs on push/PR and weekly `schedule: "0 6 * * 1"` so new CVEs surface during quiet weeks. Non-audit jobs guarded with `if: github.event_name != 'schedule'`. Plus `.github/dependabot.yml` tracking `cargo` + `github-actions` weekly Mondays, capped at 5 open PRs, assigned to @FelixKrueger.

### Intentional non-gating on release.yml

`release.yml` is **not** gated on lint/clippy — it runs against a pre-cut tag rather than PR content, so adding a fail-stop there provides minimal marginal safety over the PR gate. Header comment in `release.yml` documents this decision and calls out the hotfix-tag caveat (a tag cut directly against the release branch, bypassing PR review, would bypass the lint gate entirely). Social convention + pre-flight checks at release time mitigate in practice.

## Review trail

Reviewed under dual-independent reviewers + plan-manager coverage audit per the project's CLAUDE.md workflow. Reports retained under `plans/build-provenance/`:
- `PLAN.md` — design document (folded 5 consensus edits from dual plan-review before implementation)
- `COVERAGE_TABLE.md` — 18/18 items ✅ (verdict: COMPLETE)
- `CODE_REVIEW_CORE_A.md` / `CODE_REVIEW_CORE_B.md` — dual independent review of `build.rs` + clap + banner
- `CODE_REVIEW_CI.md` — CI + Dependabot + release.yml
- `CODE_REVIEW_CLIPPY.md` — 9-item clippy / fmt-drift review (all preserve behavior)

All Medium and Low findings from the review trail were applied before commit (SOURCE_DATE_EPOCH `.trim()`, narrower reproducibility `restore-keys`, weekly audit schedule).

## Test plan

Local verification (already green):

- [x] \`cargo build --release\` — no warnings, no errors
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --all-targets --release -- -D warnings\` — zero warnings
- [x] \`cargo test --release\` — 99 passed / 0 failed
- [x] \`trim_galore --version\` → two-line output matching the expected provenance regex
- [x] \`trim_galore -V\` → one-line terse output (no provenance)
- [x] Reproducibility: two clean builds with \`SOURCE_DATE_EPOCH=1700000000\` → identical sha256 \`f9f7527b…34c4d\`
- [x] \`SOURCE_DATE_EPOCH="1700000000 "\` (trailing whitespace) → builds successfully (the Medium fix)
- [x] \`SOURCE_DATE_EPOCH=garbage\` → exit 101 with panic message mentioning \`SOURCE_DATE_EPOCH\`
- [x] \`.git\` present + git binary absent → falls through to \`unknown\` without panic

CI coverage (pending the first green run on this branch):

- [x] \`rust-tests\` — positive + negative \`--version\` assertions
- [x] \`reproducibility\` — sha256 equality + malformed-epoch hard-fail
- [x] \`lint\` — fmt-check + clippy -D warnings
- [x] \`audit\` — no advisories block merge (advisories are signals, not gates)
- [x] \`validation\` — Perl parity on single-end, paired-end, multi-pair, clock, demux, hardtrim (blocked on \`rust-tests\` + \`lint\`)

## Post-merge follow-ups (optional, not in scope)

- Pre-create a \`dependencies\` label (\`gh label create dependencies --color 0366d6\`) before the first Dependabot PR lands, if we want consistent categorization.
- Struct-refactor ticket: bundle paired-IO args to retire the three \`#[allow(clippy::too_many_arguments)]\` on \`trimmer.rs\` / \`parallel.rs\` — pragmatic sidestep for this pass, design fix for a separate PR.