### PR TITLE
refactor(filters): bundle unpaired-rescue thresholds into UnpairedLengths struct

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -56,6 +56,15 @@ pub enum PairFilterResult {
     TooLong,
 }
 
+/// Per-side minimum length thresholds for unpaired rescue under
+/// `--retain_unpaired`. When a pair fails the length check, a read survives
+/// on its own if its length meets the corresponding threshold.
+#[derive(Debug, Clone, Copy)]
+pub struct UnpairedLengths {
+    pub r1: usize,
+    pub r2: usize,
+}
+
 /// Check if a read pair passes filters.
 ///
 /// Key asymmetry: N-content failure always discards the entire pair (no
@@ -67,8 +76,7 @@ pub fn filter_paired_end(
     length_cutoff: usize,
     max_length: Option<usize>,
     max_n: Option<MaxNFilter>,
-    unpaired_length_r1: usize,
-    unpaired_length_r2: usize,
+    unpaired: UnpairedLengths,
 ) -> PairFilterResult {
     // N-content check — ALWAYS discards entire pair, no rescue
     if let Some(ref max_n_filter) = max_n {
@@ -83,8 +91,8 @@ pub fn filter_paired_end(
 
     if r1_short || r2_short {
         return PairFilterResult::TooShort {
-            r1_ok: !r1_short && r1.len() >= unpaired_length_r1,
-            r2_ok: !r2_short && r2.len() >= unpaired_length_r2,
+            r1_ok: !r1_short && r1.len() >= unpaired.r1,
+            r2_ok: !r2_short && r2.len() >= unpaired.r2,
         };
     }
 
@@ -182,7 +190,14 @@ mod tests {
     fn test_paired_n_filter_no_rescue() {
         let r1 = make_record("ACGTACGT");
         let r2 = make_record("NNNNNNNN"); // All N
-        let result = filter_paired_end(&r1, &r2, 5, None, Some(MaxNFilter::Count(2)), 35, 35);
+        let result = filter_paired_end(
+            &r1,
+            &r2,
+            5,
+            None,
+            Some(MaxNFilter::Count(2)),
+            UnpairedLengths { r1: 35, r2: 35 },
+        );
         assert_eq!(result, PairFilterResult::TooManyN);
     }
 
@@ -190,10 +205,10 @@ mod tests {
     fn test_paired_length_rescue() {
         let r1 = make_record("ACGTACGTACGT"); // 12bp, long enough
         let r2 = make_record("AC"); // 2bp, too short
-        let result = filter_paired_end(&r1, &r2, 5, None, None, 10, 10);
+        let result = filter_paired_end(&r1, &r2, 5, None, None, UnpairedLengths { r1: 10, r2: 10 });
         match result {
             PairFilterResult::TooShort { r1_ok, r2_ok } => {
-                assert!(r1_ok); // R1 is rescuable (>= unpaired_length_r1)
+                assert!(r1_ok); // R1 is rescuable (>= unpaired.r1)
                 assert!(!r2_ok); // R2 is too short even for unpaired
             }
             _ => panic!("Expected TooShort"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use trim_galore::adapter;
 use trim_galore::cli::Cli;
 use trim_galore::demux;
 use trim_galore::fastq::{FastqReader, FastqWriter};
-use trim_galore::filters::MaxNFilter;
+use trim_galore::filters::{MaxNFilter, UnpairedLengths};
 use trim_galore::io as naming;
 use trim_galore::parallel;
 use trim_galore::report;
@@ -625,8 +625,10 @@ fn run_paired(
             config,
             cli.cores,
             gzip,
-            cli.length_1,
-            cli.length_2,
+            UnpairedLengths {
+                r1: cli.length_1,
+                r2: cli.length_2,
+            },
         )?
     } else {
         // Sequential path (--cores 1)
@@ -651,8 +653,10 @@ fn run_paired(
             unpaired_w1.as_mut(),
             unpaired_w2.as_mut(),
             config,
-            cli.length_1,
-            cli.length_2,
+            UnpairedLengths {
+                r1: cli.length_1,
+                r2: cli.length_2,
+            },
         )?;
 
         writer_r1.flush()?;

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use std::sync::mpsc;
 
 use crate::fastq::{FastqReader, FastqRecord};
-use crate::filters::{self, FilterResult, PairFilterResult};
+use crate::filters::{self, FilterResult, PairFilterResult, UnpairedLengths};
 use crate::report::{PairValidationStats, TrimStats};
 use crate::trimmer::{self, TrimConfig, update_adapter_stats};
 
@@ -66,8 +66,7 @@ pub fn run_paired_end_parallel(
     config: &TrimConfig,
     cores: usize,
     gzip: bool,
-    unpaired_length_r1: usize,
-    unpaired_length_r2: usize,
+    unpaired: UnpairedLengths,
 ) -> Result<(TrimStats, TrimStats, PairValidationStats)> {
     let retain_unpaired = unpaired_r1_path.is_some();
 
@@ -99,8 +98,7 @@ pub fn run_paired_end_parallel(
                         config,
                         gzip,
                         retain_unpaired,
-                        unpaired_length_r1,
-                        unpaired_length_r2,
+                        unpaired,
                     ) {
                         Ok(result) => {
                             if rtx.send(result).is_err() {
@@ -225,7 +223,6 @@ pub fn run_paired_end_parallel(
 }
 
 /// Process a batch of paired reads: trim, filter, compress into gzip blocks.
-#[allow(clippy::too_many_arguments)]
 fn process_paired_batch(
     batch_seq: u64,
     reads_r1: &mut [FastqRecord],
@@ -233,8 +230,7 @@ fn process_paired_batch(
     config: &TrimConfig,
     gzip: bool,
     retain_unpaired: bool,
-    unpaired_length_r1: usize,
-    unpaired_length_r2: usize,
+    unpaired: UnpairedLengths,
 ) -> Result<PairedBatchResult> {
     let mut stats_r1 = TrimStats::with_adapter_count(config.adapters.len());
     let mut stats_r2 = TrimStats::with_adapter_count(config.r2_adapter_count());
@@ -274,8 +270,7 @@ fn process_paired_batch(
                 &mut gz_r2,
                 gz_up_r1.as_mut(),
                 gz_up_r2.as_mut(),
-                unpaired_length_r1,
-                unpaired_length_r2,
+                unpaired,
             )?;
 
             gz_r1.finish()?;
@@ -307,8 +302,7 @@ fn process_paired_batch(
             } else {
                 None
             },
-            unpaired_length_r1,
-            unpaired_length_r2,
+            unpaired,
         )?;
     }
 
@@ -340,8 +334,7 @@ fn process_pairs<W: Write>(
     writer_r2: &mut W,
     mut writer_up_r1: Option<&mut W>,
     mut writer_up_r2: Option<&mut W>,
-    unpaired_length_r1: usize,
-    unpaired_length_r2: usize,
+    unpaired: UnpairedLengths,
 ) -> Result<()> {
     for (r1, r2) in reads_r1.iter_mut().zip(reads_r2.iter_mut()) {
         stats_r1.total_reads += 1;
@@ -406,8 +399,7 @@ fn process_pairs<W: Write>(
             config.length_cutoff,
             config.max_length,
             config.max_n.clone(),
-            unpaired_length_r1,
-            unpaired_length_r2,
+            unpaired,
         ) {
             PairFilterResult::Pass => {
                 stats_r1.total_bp_written += r1.seq.len();

--- a/src/trimmer.rs
+++ b/src/trimmer.rs
@@ -355,8 +355,7 @@ pub fn run_paired_end(
     mut unpaired_r1: Option<&mut FastqWriter>,
     mut unpaired_r2: Option<&mut FastqWriter>,
     config: &TrimConfig,
-    unpaired_length_r1: usize,
-    unpaired_length_r2: usize,
+    unpaired: crate::filters::UnpairedLengths,
 ) -> Result<(TrimStats, TrimStats, PairValidationStats)> {
     let mut stats_r1 = TrimStats::with_adapter_count(config.adapters.len());
     let mut stats_r2 = TrimStats::with_adapter_count(config.r2_adapter_count());
@@ -433,8 +432,7 @@ pub fn run_paired_end(
                     config.length_cutoff,
                     config.max_length,
                     config.max_n.clone(),
-                    unpaired_length_r1,
-                    unpaired_length_r2,
+                    unpaired,
                 ) {
                     PairFilterResult::Pass => {
                         stats_r1.total_bp_written += r1.seq.len();


### PR DESCRIPTION
## Summary
- Pure parameter-shape refactor — no behaviour change, no new flags, no new tests needed.
- Bundles the per-side minimum-length thresholds for `--retain_unpaired` into one struct `UnpairedLengths { r1, r2 }`. These two values are set together at CLI parse and threaded unchanged through `filter_paired_end`, `run_paired_end`, and the parallel pipeline, so they belong together.
- Retires one `#[allow(clippy::too_many_arguments)]` on `process_paired_batch` (8 → 7 args — exactly at clippy's default threshold). The other two hot-path entrypoints (`run_paired_end_parallel`, `process_pairs`) stay at 10 args and keep the attribute — a broader config-bundle refactor for those is tracked separately.

## Why now
Came out of a brief survey of the three `#[allow(clippy::too_many_arguments)]` sites. This is the narrow, obviously-correct slice — two fields that always travel together and have the same semantic role (per-side unpaired-rescue minimums). The other two sites would need a larger design conversation about config grouping, so they stay as-is for this beta.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo test --release` — 99 passed, 0 failed (the 2 paired-filter tests use the new struct literal)
- [x] `cargo clippy --all-targets --release -- -D warnings` silent (confirms the removed `#[allow]` on `process_paired_batch` is fine at 7 args)
- [x] `cargo fmt --all -- --check` silent
- [ ] CI green on PR