### PR TITLE
polish(multi-pair): name both colliding paths, catch duplicate-pair typo, add Cli::validate tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,9 +259,13 @@ jobs:
       - name: Validate --basename rejected with multi-pair
         run: |
           set +e
+          # Use two DISTINCT pairs — R1/R2 repeated twice now trips the
+          # cross-pair duplicate check (added in PR #219) before the basename
+          # branch is reached. The assertion here is about basename rejection,
+          # not duplicate detection, so exercise with BS-seq + SRR24766921.
           ./target/release/trim_galore --paired --basename foo \
             test_files/BS-seq_10K_R1.fastq.gz test_files/BS-seq_10K_R2.fastq.gz \
-            test_files/BS-seq_10K_R1.fastq.gz test_files/BS-seq_10K_R2.fastq.gz 2>&1 | tee /tmp/bn.log
+            test_files/SRR24766921_RRBS_R1.fastq.gz test_files/SRR24766921_RRBS_R2.fastq.gz 2>&1 | tee /tmp/bn.log
           rc=${PIPESTATUS[0]}
           set -e
           test $rc -ne 0
@@ -317,7 +321,10 @@ jobs:
           set -e
           test $rc -ne 0
           grep -q "Output path collision" /tmp/case.log
-          grep -q "case-insensitive match" /tmp/case.log
+          # PR #219 reworded the qualifier from "case-insensitive match"
+          # to "case-insensitive, for APFS/NTFS safety" when it switched the
+          # error to name both colliding paths. Tighten grep to the new form.
+          grep -q "case-insensitive, for APFS/NTFS safety" /tmp/case.log
           test -z "$(ls /tmp/op_case/out/*.fq.gz 2>/dev/null)"
 
       - name: Validate multi-pair with --cores 1 (sequential path)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@
   is case-insensitive (ASCII) so filenames differing only in letter-case are
   caught on APFS/NTFS (macOS/Windows default) as well as ext4 (Linux). Fixes
   issue #216.
+  - On opt-in case-sensitive APFS/ZFS volumes, filenames differing only in
+    letter-case are legitimately distinct; the pre-flight will still reject
+    them. Use distinct base names or `--basename` per sample to work around
+    this.
+  - On partial failure at pair K, pairs 1..K&#8722;1 retain their complete
+    outputs on disk and pair K may have a partial output file; pairs
+    K+1..N are not attempted. Inspect and re-run only the failing pair —
+    matches v0.6.x Perl behaviour (no rollback across pairs).
 
 
 ### Version 2.1.0 (Beta, Release on 18 Apr 2026)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -302,6 +302,26 @@ impl Cli {
                     );
                 }
             }
+            // Catch accidental copy-paste of the same pair twice. Without this,
+            // a duplicate pair trips the case-insensitive output-collision
+            // pre-flight in main() with an APFS/NTFS message that misdirects
+            // the user — here we emit a precise "duplicate of pair N" error.
+            let pairs: Vec<(&std::path::PathBuf, &std::path::PathBuf)> =
+                self.input.chunks(2).map(|c| (&c[0], &c[1])).collect();
+            for (i, (r1, r2)) in pairs.iter().enumerate() {
+                for (j, (pr1, pr2)) in pairs.iter().enumerate().take(i) {
+                    if r1 == pr1 && r2 == pr2 {
+                        anyhow::bail!(
+                            "Pair {} ({}, {}) is a duplicate of pair {}. \
+                             Did you mean to pass different files?",
+                            i + 1,
+                            r1.display(),
+                            r2.display(),
+                            j + 1
+                        );
+                    }
+                }
+            }
         }
 
         if !self.paired && self.input.len() > 1 && self.basename.is_some() {
@@ -433,5 +453,102 @@ impl Cli {
     /// Otherwise uses the standard `--quality` value.
     pub fn effective_quality_cutoff(&self) -> u8 {
         self.nextseq.unwrap_or(self.quality)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    // All fixtures live in test_files/ and are guaranteed to exist under the
+    // repo root during `cargo test` (cwd = crate root).
+    const R1: &str = "test_files/BS-seq_10K_R1.fastq.gz";
+    const R2: &str = "test_files/BS-seq_10K_R2.fastq.gz";
+    const ALT_R1: &str = "test_files/SRR24766921_RRBS_R1.fastq.gz";
+    const ALT_R2: &str = "test_files/SRR24766921_RRBS_R2.fastq.gz";
+
+    #[test]
+    fn test_validate_paired_odd_count_rejected() {
+        for inputs in [
+            vec![R1],
+            vec![R1, R2, ALT_R1],
+            vec![R1, R2, ALT_R1, ALT_R2, R1],
+        ] {
+            let mut argv = vec!["trim_galore", "--paired"];
+            argv.extend(inputs.iter().copied());
+            let cli = Cli::parse_from(argv);
+            let err = cli.validate().unwrap_err().to_string();
+            assert!(
+                err.contains("even number of input files"),
+                "expected even-number error, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_paired_r1_r2_equal_rejected_within_pair() {
+        let cli = Cli::parse_from(["trim_galore", "--paired", R1, R1]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("appear to be the same file"),
+            "expected within-pair duplicate error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_paired_duplicate_pair_rejected_across_pairs() {
+        let cli = Cli::parse_from(["trim_galore", "--paired", R1, R2, R1, R2]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("duplicate of pair"),
+            "expected cross-pair duplicate error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_paired_basename_rejected_multi_pair() {
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--paired",
+            "--basename",
+            "foo",
+            R1,
+            R2,
+            ALT_R1,
+            ALT_R2,
+        ]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("basename cannot be used with multiple"),
+            "expected multi-pair basename rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_paired_single_end_basename_still_allowed() {
+        // Regression guard: SE `--basename` with a single input must still pass.
+        let cli = Cli::parse_from(["trim_galore", "--basename", "foo", R1]);
+        cli.validate()
+            .expect("SE --basename with one input should validate");
+    }
+
+    #[test]
+    fn test_validate_paired_two_files_accepted() {
+        // Regression guard: the 2-file golden path must keep working.
+        let cli = Cli::parse_from(["trim_galore", "--paired", R1, R2]);
+        cli.validate().expect("two-file paired-end should validate");
+    }
+
+    #[test]
+    fn test_validate_clock_still_requires_exactly_2() {
+        // Regression guard: --clock must not have been widened by the
+        // multi-pair --paired relaxation.
+        let cli = Cli::parse_from(["trim_galore", "--clock", R1, R2, ALT_R1, ALT_R2]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("clock requires exactly 2"),
+            "expected --clock strict-2 rejection, got: {err}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,8 @@ fn main() -> Result<()> {
         // Pragmatic trade-off: on opt-in case-sensitive APFS volumes this may
         // false-positive, but the penalty is a loud early error rather than
         // silent data loss.
-        let mut out_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut out_paths: std::collections::HashMap<String, std::path::PathBuf> =
+            std::collections::HashMap::new();
         let norm = |p: &std::path::Path| -> String { p.to_string_lossy().to_ascii_lowercase() };
         for chunk in cli.input.chunks(2) {
             let (o1, o2) = naming::paired_end_output_names(
@@ -109,12 +110,13 @@ fn main() -> Result<()> {
                 candidates.push(u2);
             }
             for p in candidates {
-                if !out_paths.insert(norm(&p)) {
+                if let Some(existing) = out_paths.insert(norm(&p), p.clone()) {
                     anyhow::bail!(
-                        "Output path collision: {} would be written twice \
-                         (case-insensitive match, for APFS/NTFS safety). \
+                        "Output path collision (case-insensitive, for APFS/NTFS safety): \
+                         {} and {} would be written to the same file. \
                          Check that input pairs produce distinct output paths \
                          (e.g., different source directories or `--output-dir`).",
+                        existing.display(),
                         p.display()
                     );
                 }


### PR DESCRIPTION
## Summary

Five improvements surfaced by a dual independent review of the multi-pair regression fix (commits `1b57ebd` / `8a6cfc5` / `aa92493` on `optimus_prime`). UX polish + test coverage on top of already-shipped behaviour — no new features, no new flags.

- **`src/main.rs`** — collision pre-flight now keeps `HashMap<String, PathBuf>` keyed on ASCII-lowercase and names *both* the previously-claimed and newly-claimed paths in the error. The previous `HashSet<String>` only knew one.
- **`src/cli.rs`** — dedicated `Pair N ({r1}, {r2}) is a duplicate of pair M` error for accidental copy-paste of the same pair twice. Previously tripped the APFS/NTFS collision check with a misdirecting message; now caught early in `Cli::validate()` with a precise message, leaving the collision check to catch its actual purpose (different inputs → same outputs via case folding).
- **`src/cli.rs`** — `#[cfg(test)] mod tests` with 7 tests covering odd-count / within-pair-equal / cross-pair-duplicate / multi-pair-basename rejections plus three regression guards (SE `--basename`, 2-file paired golden, `--clock` strict-2).
- **`CHANGELOG.md`** — two addenda inside the existing collision-fix bullet: opt-in case-sensitive APFS/ZFS caveat, and partial-failure no-rollback note (matches v0.6.x Perl behaviour).

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — 106 tests pass (99 existing + 7 new)
- [x] `cargo clippy --all-targets --release -- -D warnings` — silent
- [x] `cargo fmt --all -- --check` — silent
- [x] Manual UX: `A_R1 A_R2 A_R1 A_R2` → `Pair 2 (...) is a duplicate of pair 1`
- [x] Manual UX: case-differing pairs in separate dirs → `Output path collision (case-insensitive, for APFS/NTFS safety): /.../sample_R1_val_1.fq.gz and /.../SAMPLE_R1_val_1.fq.gz ...` (both paths named, output dir stays empty)
- [ ] CI green on all 5 gates (lint, reproducibility, tests, audit, Perl validation)