### PR TITLE
Pre-GA polish: A{N} shorthand, BGI auto-detect, Perl-parity fixes, rhetoric reframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 
 ### Version 2.1.0 (Beta, Release on 18 Apr 2026)
 
-**Major release — Rust rewrite (Oxidized Edition).** Single-binary drop-in replacement for the Perl Trim Galore. Same CLI, same outputs, plus a JSON MultiQC-native report and multi-adapter support. Built from `src/main.rs` (Cargo crate at repo root); the historical Perl script will be preserved at `legacy/trim_galore` once v2.1.0 GA ships (retained in the `0.6.11` tag during the beta window).
+**Major release — Rust rewrite (Oxidized Edition).** Faithful Rust rewrite of Trim Galore, delivered as a single binary with zero external dependencies and designed as a drop-in replacement for v0.6.x workflows. Outputs match v0.6.x for the core feature set; new capabilities beyond the Perl version include poly-G auto-detection and trimming, a generic poly-A trimmer, per-pair adapter auto-detection, cleaner multi-adapter invocation, a JSON MultiQC-native report, and other extensions. Built from `src/main.rs` (Cargo crate at repo root); the historical Perl script will be preserved at `legacy/trim_galore` once v2.1.0 GA ships (retained in the `0.6.11` tag during the beta window).
 
 **Note on v2.0.0:** v2.0.0 was a pre-release cut inadvertently published to crates.io on 13 Apr 2026. It will be yanked when v2.1.0 GA ships. Users should install v2.1.0 or later.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Consistent quality and adapter trimming for next-generation sequencing data, wit
 
 ## Features
 
-- **Adapter auto-detection** — automatically identifies Illumina, Nextera, and Small RNA adapters from the first 1M reads. Stranded Illumina and BGI/DNBSEQ adapters are selectable via explicit flags (`--stranded_illumina`, `--bgiseq`)
+- **Adapter auto-detection** — automatically identifies Illumina, Nextera, Small RNA, and BGI/DNBSEQ adapters from the first 1M reads. Stranded Illumina remains explicit (`--stranded_illumina`) because its sequence is ambiguous with Nextera.
 - **Multi-adapter support** — specify multiple adapters via `-a " SEQ1 -a SEQ2"` or `-a "file:adapters.fa"`, with optional multi-round trimming (`-n`)
 - **Quality trimming** — Phred-based trimming from the 3' end (BWA algorithm)
 - **Paired-end** — single-pass processing of both reads with automatic pair validation

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Consistent quality and adapter trimming for next-generation sequencing data, wit
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/recipes/trim-galore/README.html)
 
 > [!NOTE]
-> **Trim Galore v2.0** is a complete rewrite in Rust — a single binary with zero external dependencies, producing byte-identical output to v0.6.x. Same CLI, same output filenames, same report format. For details on what changed, benchmarks, and migration notes, see the [v2.0 writeup](docs/SUMMARY.md).
+> **Trim Galore v2.0** is a faithful Rust rewrite — a single binary with zero external dependencies, designed as a drop-in replacement for v0.6.x scripts and pipelines. Same CLI, same output filenames, same report format. Adds poly-G auto-detection and trimming for 2-colour instruments, a generic poly-A trimmer, per-pair adapter auto-detection, and cleaner multi-adapter invocation (repeatable `-a`/`-a2` instead of Perl's embedded-string syntax) — among other extensions. For details on what changed, benchmarks, and migration notes, see the [v2.0 writeup](docs/SUMMARY.md).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Consistent quality and adapter trimming for next-generation sequencing data, wit
 ## Features
 
 - **Adapter auto-detection** — automatically identifies Illumina, Nextera, Small RNA, and BGI/DNBSEQ adapters from the first 1M reads. Stranded Illumina remains explicit (`--stranded_illumina`) because its sequence is ambiguous with Nextera.
-- **Multi-adapter support** — specify multiple adapters via `-a " SEQ1 -a SEQ2"` or `-a "file:adapters.fa"`, with optional multi-round trimming (`-n`)
+- **Multi-adapter support** — specify multiple adapters by repeating `-a`/`-a2` or via `-a "file:adapters.fa"`, with optional multi-round trimming (`-n`)
 - **Quality trimming** — Phred-based trimming from the 3' end (BWA algorithm)
 - **Paired-end** — single-pass processing of both reads with automatic pair validation
 - **RRBS** — MspI end-repair artifact removal, directional and non-directional libraries

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## What was built
 
-A complete **Rust rewrite of Trim Galore** that produces **byte-identical output** to the Perl original across every feature and test case. It's a true drop-in replacement — same CLI flags, same output filenames, same report format compatible with MultiQC.
+A **faithful Rust rewrite of Trim Galore**, designed as a drop-in replacement for v0.6.x — same CLI flags, same output filenames, same report format compatible with MultiQC. Outputs match the Perl original for the core flag set (verified end-to-end via the nf-core/rnaseq integration matrix). The rewrite also adds capabilities the Perl version lacked: `--poly_g` auto-detection and trimming for 2-colour instruments, a generic `--poly_a` trimmer, per-pair adapter auto-detection, cleaner multi-adapter invocation (repeatable `-a`/`-a2` plus `file:adapters.fa`), and more.
 
 **Architecture shift:** Trim Galore (Perl) is a wrapper that shells out to Cutadapt (Python/Cython) for adapter matching. The Oxidized Edition does everything in a single process — adapter detection, alignment, quality trimming, adapter removal, filtering — in one pass through the data. Paired-end reads are processed in a single pass rather than two sequential Cutadapt runs.
 

--- a/docs/Trim_Galore_User_Guide.md
+++ b/docs/Trim_Galore_User_Guide.md
@@ -40,7 +40,7 @@ We have tried to implement a method to rid RRBS libraries (or other kinds of seq
 Even though Trim Galore works for any (base space) high throughput dataset (e.g. downloaded from the SRA) this section describes its use mainly with respect to RRBS libraries.
 
 > [!NOTE]
-> In the Oxidized Edition (v2.x), all of the trimming steps described below happen in a single pass over the data rather than as sequential Cutadapt invocations. Outputs remain byte-identical to v0.6.x.
+> The Oxidized Edition (v2.x) is a faithful Rust rewrite designed as a drop-in replacement for v0.6.x. All of the trimming steps below happen in a single pass over the data rather than as sequential Cutadapt invocations. Outputs match v0.6.x for the core feature set; newer capabilities (e.g. `--poly_g` auto-detection, a generic `--poly_a` trimmer) extend beyond the Perl version.
 
 ### Step 1: Quality Trimming
 In the first step, low-quality base calls are trimmed off from the 3' end of the reads before adapter removal. This efficiently removes poor quality portions of the reads.

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -300,12 +300,51 @@ pub fn parse_adapter_spec(raw: &str) -> Result<Vec<(String, String)>> {
     }
 
     // Case 3: Single adapter sequence
-    let seq = raw.trim().to_uppercase();
+    let mut seq = raw.trim().to_uppercase();
     if seq.is_empty() {
         anyhow::bail!("Empty adapter sequence");
     }
+    // Perl-style brace shorthand: A{10} → AAAAAAAAAA. Only applied to the
+    // single-adapter case (not to multi-adapter elements or FASTA entries),
+    // matching `trim_galore:3105–3112` in the Perl source.
+    if let Some(expanded) = expand_brace_notation(&seq) {
+        if expanded.is_empty() {
+            anyhow::bail!(
+                "Adapter sequence {} expanded to an empty string (use N >= 1)",
+                seq
+            );
+        }
+        eprintln!("Adapter sequence {} expanded to {}", seq, expanded);
+        seq = expanded;
+    }
     validate_adapter_sequence(&seq)?;
     Ok(vec![("adapter_1".to_string(), seq)])
+}
+
+/// Expand Perl-style `X{N}` shorthand to `N` copies of `X`.
+///
+/// Matches the whole string against `^[ACTGN]\{(\d+)\}$` (uppercase only;
+/// the caller is expected to have upcased already). Returns `None` if the
+/// input doesn't match the pattern, so callers can fall through to normal
+/// adapter validation. Mirrors Perl's `extend_adapter_sequence` behaviour.
+fn expand_brace_notation(seq: &str) -> Option<String> {
+    let bytes = seq.as_bytes();
+    if bytes.len() < 4 {
+        return None; // minimum valid form is "A{0}"
+    }
+    let base = bytes[0];
+    if !matches!(base, b'A' | b'C' | b'T' | b'G' | b'N') {
+        return None;
+    }
+    if bytes[1] != b'{' || *bytes.last().unwrap() != b'}' {
+        return None;
+    }
+    let digits = &bytes[2..bytes.len() - 1];
+    if digits.is_empty() || !digits.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    let n: usize = std::str::from_utf8(digits).ok()?.parse().ok()?;
+    Some((base as char).to_string().repeat(n))
 }
 
 /// Read adapter sequences from a FASTA file.
@@ -519,5 +558,94 @@ mod tests {
     #[test]
     fn test_validate_adapter_sequence_invalid() {
         assert!(validate_adapter_sequence("ACGTZ").is_err());
+    }
+
+    // --- Brace-notation expansion (Perl parity: -a A{10} → -a AAAAAAAAAA) ---
+
+    #[test]
+    fn test_expand_brace_notation_basic_a10() {
+        assert_eq!(
+            expand_brace_notation("A{10}").as_deref(),
+            Some("AAAAAAAAAA")
+        );
+    }
+
+    #[test]
+    fn test_expand_brace_notation_all_valid_bases() {
+        assert_eq!(expand_brace_notation("C{3}").as_deref(), Some("CCC"));
+        assert_eq!(expand_brace_notation("T{5}").as_deref(), Some("TTTTT"));
+        assert_eq!(expand_brace_notation("G{1}").as_deref(), Some("G"));
+        assert_eq!(
+            expand_brace_notation("N{20}").as_deref(),
+            Some("NNNNNNNNNNNNNNNNNNNN")
+        );
+    }
+
+    #[test]
+    fn test_expand_brace_notation_zero_is_empty() {
+        // Perl accepts A{0} → empty; validate_adapter_sequence will reject
+        // the empty result downstream, not our job here.
+        assert_eq!(expand_brace_notation("A{0}").as_deref(), Some(""));
+    }
+
+    #[test]
+    fn test_expand_brace_notation_rejects_multi_char_prefix() {
+        // AG{10} is not a single-base shorthand; must not match.
+        assert_eq!(expand_brace_notation("AG{10}"), None);
+    }
+
+    #[test]
+    fn test_expand_brace_notation_rejects_non_dna_base() {
+        // X and Z are not in the [ACTGN] set.
+        assert_eq!(expand_brace_notation("X{5}"), None);
+        assert_eq!(expand_brace_notation("Z{5}"), None);
+    }
+
+    #[test]
+    fn test_expand_brace_notation_rejects_non_digit_count() {
+        assert_eq!(expand_brace_notation("A{abc}"), None);
+        assert_eq!(expand_brace_notation("A{}"), None);
+        assert_eq!(expand_brace_notation("A{-1}"), None);
+    }
+
+    #[test]
+    fn test_expand_brace_notation_rejects_plain_sequence() {
+        assert_eq!(expand_brace_notation("AGATCGGAAGAGC"), None);
+    }
+
+    #[test]
+    fn test_expand_brace_notation_rejects_lowercase() {
+        // Parser upcases the input before this is called; lowercase input
+        // to expand_brace_notation itself should not match.
+        assert_eq!(expand_brace_notation("a{10}"), None);
+    }
+
+    #[test]
+    fn test_parse_adapter_spec_brace_expansion_end_to_end() {
+        let result = parse_adapter_spec("A{10}").unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].1, "AAAAAAAAAA");
+    }
+
+    #[test]
+    fn test_parse_adapter_spec_brace_expansion_lowercase_input() {
+        // Lowercase input gets upcased by the parser, then expanded.
+        // Rust is strictly more permissive than Perl here.
+        let result = parse_adapter_spec("a{5}").unwrap();
+        assert_eq!(result[0].1, "AAAAA");
+    }
+
+    #[test]
+    fn test_parse_adapter_spec_brace_expansion_zero_errors() {
+        // A{0} → "" → validate_adapter_sequence rejects empty.
+        assert!(parse_adapter_spec("A{0}").is_err());
+    }
+
+    #[test]
+    fn test_parse_adapter_spec_no_brace_expansion_in_multi() {
+        // Inside "SEQ1 -a SEQ2" syntax, elements are NOT brace-expanded.
+        // A{10} as a multi-adapter element fails DNA validation.
+        let result = parse_adapter_spec(" AGCT -a A{10}");
+        assert!(result.is_err());
     }
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -98,13 +98,20 @@ pub fn autodetect_adapter<P: AsRef<Path>>(
 ) -> Result<DetectionResult> {
     let mut reader = FastqReader::open(path)?;
 
+    // BGI/DNBSEQ added to the probe set: its 32bp adapter shares no
+    // meaningful subsequence with the other three and the per-match
+    // false-positive rate is vanishingly low, so including it is
+    // uncontentious. Stranded Illumina is intentionally omitted —
+    // its sequence differs from Nextera by a single base (A-tail),
+    // which would produce constant ambiguous ties.
     let adapters = [
         ("Illumina", ILLUMINA.seq),
         ("Nextera", NEXTERA.seq),
         ("smallRNA", SMALL_RNA.seq),
+        ("BGI/DNBSEQ", BGISEQ.seq),
     ];
 
-    let mut counts = [0usize; 3];
+    let mut counts = [0usize; 4];
     let mut reads_scanned = 0;
     let mut poly_g_count: usize = 0;
 
@@ -153,6 +160,7 @@ pub fn autodetect_adapter<P: AsRef<Path>>(
         "Illumina" => ILLUMINA,
         "Nextera" => NEXTERA,
         "smallRNA" => SMALL_RNA,
+        "BGI/DNBSEQ" => BGISEQ,
         _ => ILLUMINA,
     };
 
@@ -647,5 +655,117 @@ mod tests {
         // A{10} as a multi-adapter element fails DNA validation.
         let result = parse_adapter_spec(" AGCT -a A{10}");
         assert!(result.is_err());
+    }
+
+    // --- Auto-detection probe set (Illumina + Nextera + smallRNA + BGI) ---
+
+    fn write_fastq_with_adapter(
+        path: &std::path::Path,
+        adapter_seq: &str,
+        num_reads: usize,
+    ) -> Result<()> {
+        use crate::fastq::{FastqRecord, FastqWriter};
+        let mut writer = FastqWriter::create(path, false, 1)?;
+        // Prepend a 20bp random-ish prefix so reads are plausibly long;
+        // the probe is looking for adapter_seq as a substring anywhere.
+        let prefix = "ACGTACGTACGTACGTACGT";
+        for i in 0..num_reads {
+            let seq = format!("{}{}", prefix, adapter_seq);
+            let rec = FastqRecord {
+                id: format!("@r{}", i),
+                seq: seq.clone(),
+                qual: "I".repeat(seq.len()),
+            };
+            writer.write_record(&rec)?;
+        }
+        writer.flush()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_autodetect_picks_bgi_when_bgi_adapter_dominant() -> Result<()> {
+        let dir = std::env::temp_dir().join("tg_test_autodetect_bgi");
+        std::fs::create_dir_all(&dir)?;
+        let path = dir.join("bgi.fq");
+        write_fastq_with_adapter(&path, BGISEQ.seq, 100)?;
+
+        let result = autodetect_adapter(&path, None)?;
+        assert_eq!(result.adapter.name, "BGI/DNBSEQ");
+        // BGI count should be high; other probes near zero (32bp probe vs
+        // 20bp random prefix — no chance collision).
+        let bgi_count = result
+            .counts
+            .iter()
+            .find(|(name, _)| name == "BGI/DNBSEQ")
+            .map(|(_, c)| *c)
+            .unwrap_or(0);
+        assert_eq!(bgi_count, 100);
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_autodetect_picks_illumina_when_illumina_adapter_dominant() -> Result<()> {
+        // Regression guard: BGI addition must not break Illumina detection.
+        let dir = std::env::temp_dir().join("tg_test_autodetect_illumina_regression");
+        std::fs::create_dir_all(&dir)?;
+        let path = dir.join("illumina.fq");
+        write_fastq_with_adapter(&path, ILLUMINA.seq, 100)?;
+
+        let result = autodetect_adapter(&path, None)?;
+        assert_eq!(result.adapter.name, "Illumina");
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_autodetect_zero_match_defaults_to_illumina() -> Result<()> {
+        // Regression guard: with all 4 probes at zero, the tie-break (lowest
+        // index wins) must still select Illumina (index 0), not BGI (index 3).
+        let dir = std::env::temp_dir().join("tg_test_autodetect_zero");
+        std::fs::create_dir_all(&dir)?;
+        let path = dir.join("none.fq");
+        // Sequences with no known adapter substring.
+        write_fastq_with_adapter(&path, "ACACACACACAC", 10)?;
+
+        let result = autodetect_adapter(&path, None)?;
+        assert_eq!(result.adapter.name, "Illumina"); // zero-count fallback
+        // Confirm all four probes are in the counts report
+        assert_eq!(result.counts.len(), 4);
+        let names: Vec<&str> = result.counts.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"Illumina"));
+        assert!(names.contains(&"Nextera"));
+        assert!(names.contains(&"smallRNA"));
+        assert!(names.contains(&"BGI/DNBSEQ"));
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_autodetect_counts_all_four_probes() -> Result<()> {
+        // The detection report must surface all four probe counts, so
+        // downstream reporting (report.rs) has the full breakdown.
+        let dir = std::env::temp_dir().join("tg_test_autodetect_all_four");
+        std::fs::create_dir_all(&dir)?;
+        let path = dir.join("nextera.fq");
+        write_fastq_with_adapter(&path, NEXTERA.seq, 50)?;
+
+        let result = autodetect_adapter(&path, None)?;
+        assert_eq!(result.adapter.name, "Nextera");
+        assert_eq!(result.counts.len(), 4);
+        // Nextera should be at 50; others at 0 (short sequences, no chance collision).
+        let nextera_count = result
+            .counts
+            .iter()
+            .find(|(n, _)| n == "Nextera")
+            .map(|(_, c)| *c)
+            .unwrap_or(0);
+        assert_eq!(nextera_count, 50);
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,8 +5,9 @@ use std::path::PathBuf;
 
 /// Trim Galore - Oxidized Edition: A fast, single-pass NGS adapter and quality trimmer.
 ///
-/// Drop-in replacement for Trim Galore, rewritten in Rust. Produces byte-identical
-/// output, compatible with MultiQC and existing pipelines.
+/// Drop-in replacement for Trim Galore, rewritten in Rust. Matches v0.6.x outputs
+/// for the core feature set and extends it with poly-G / generic poly-A auto-trimming
+/// and other additions. Compatible with MultiQC and existing pipelines.
 #[derive(Parser, Debug)]
 #[clap(
     name = "trim_galore",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,12 +27,14 @@ pub struct Cli {
     pub quality: u8,
 
     /// Adapter sequence for trimming. Auto-detected if not specified.
+    /// Supports A{N} shorthand for repeated single bases (e.g., -a A{10} → AAAAAAAAAA).
     /// For multiple adapters, repeat -a or use "file:adapters.fa".
     #[clap(short = 'a', long = "adapter")]
     pub adapter: Option<String>,
 
     /// Optional adapter sequence for Read 2 (paired-end only).
     /// Auto-set by --small_rna and --bgiseq presets.
+    /// Supports A{N} shorthand for repeated single bases (e.g., -a2 T{150} → 150 T's).
     /// For multiple adapters, repeat -a2 or use "file:adapters.fa".
     #[clap(long = "adapter2", alias = "a2")]
     pub adapter2: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,7 +92,7 @@ pub struct Cli {
     #[clap(long = "max_n")]
     pub max_n: Option<f64>,
 
-    /// Trim N bases from both ends of reads.
+    /// Trim N bases from both ends of reads. Suppressed under --rrbs (matches Perl v0.6.x).
     #[clap(long = "trim-n", alias = "trim_n")]
     pub trim_n: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -295,6 +295,35 @@ pub struct Cli {
     pub hulu: bool,
 }
 
+/// Rewrite Perl-era `-r1` / `-r2` short flags as their clap-compatible
+/// `--r1` / `--r2` long-alias forms before parsing.
+///
+/// Clap derives single-character short flags only, so `-r1 40` would parse
+/// as `-r=1` with `40` becoming a stray positional, producing a confusing
+/// "odd count of input files" error for users migrating Perl v0.6.x scripts.
+/// This pre-parse hook transparently rewrites the exact tokens `-r1` and
+/// `-r2` (and their `=VALUE` variants) to the existing `--r1` / `--r2`
+/// aliases so Perl-era invocations keep working.
+///
+/// Only exact-match tokens are rewritten — `-r10` (legitimate clap
+/// `-r=10`) and any other value-suffixed form pass through unchanged.
+pub fn rewrite_perl_short_flags<I>(args: I) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    args.into_iter()
+        .map(|a| {
+            if a == "-r1" || a.starts_with("-r1=") {
+                format!("--r1{}", &a[3..])
+            } else if a == "-r2" || a.starts_with("-r2=") {
+                format!("--r2{}", &a[3..])
+            } else {
+                a
+            }
+        })
+        .collect()
+}
+
 impl Cli {
     /// Validate CLI arguments after parsing.
     pub fn validate(&self) -> anyhow::Result<()> {
@@ -567,5 +596,98 @@ mod tests {
             err.contains("clock requires exactly 2"),
             "expected --clock strict-2 rejection, got: {err}"
         );
+    }
+
+    // ── Perl-migration short-flag rewrite (-r1 → --r1, -r2 → --r2) ──
+
+    fn rewrite(args: &[&str]) -> Vec<String> {
+        super::rewrite_perl_short_flags(args.iter().map(|s| s.to_string()))
+    }
+
+    #[test]
+    fn test_rewrite_r1_bare() {
+        assert_eq!(
+            rewrite(&["trim_galore", "-r1", "40"]),
+            vec!["trim_galore", "--r1", "40"]
+        );
+    }
+
+    #[test]
+    fn test_rewrite_r2_bare() {
+        assert_eq!(
+            rewrite(&["trim_galore", "-r2", "35"]),
+            vec!["trim_galore", "--r2", "35"]
+        );
+    }
+
+    #[test]
+    fn test_rewrite_r1_equals_form() {
+        assert_eq!(
+            rewrite(&["trim_galore", "-r1=40"]),
+            vec!["trim_galore", "--r1=40"]
+        );
+    }
+
+    #[test]
+    fn test_rewrite_r2_equals_form() {
+        assert_eq!(
+            rewrite(&["trim_galore", "-r2=35"]),
+            vec!["trim_galore", "--r2=35"]
+        );
+    }
+
+    #[test]
+    fn test_rewrite_leaves_r_alone() {
+        // -r 40 is valid clap short; must not be disturbed.
+        assert_eq!(
+            rewrite(&["trim_galore", "-r", "40"]),
+            vec!["trim_galore", "-r", "40"]
+        );
+    }
+
+    #[test]
+    fn test_rewrite_leaves_r10_alone() {
+        // -r10 is clap's short-with-value syntax (-r=10); must not be rewritten.
+        assert_eq!(
+            rewrite(&["trim_galore", "-r10"]),
+            vec!["trim_galore", "-r10"]
+        );
+    }
+
+    #[test]
+    fn test_rewrite_leaves_r20_alone() {
+        // -r20 is clap's short-with-value (-r=20); not a Perl `-r2` + value.
+        assert_eq!(
+            rewrite(&["trim_galore", "-r20"]),
+            vec!["trim_galore", "-r20"]
+        );
+    }
+
+    #[test]
+    fn test_rewrite_leaves_unrelated_alone() {
+        assert_eq!(
+            rewrite(&["trim_galore", "--paired", "-a", "AGCT", "-o", "outdir"]),
+            vec!["trim_galore", "--paired", "-a", "AGCT", "-o", "outdir"]
+        );
+    }
+
+    #[test]
+    fn test_rewrite_end_to_end_via_parse_from() {
+        // Verify that after rewriting, Cli::parse_from successfully parses
+        // -r1 / -r2 style invocations (this is the whole point of the rewrite).
+        let args = rewrite(&[
+            "trim_galore",
+            "--paired",
+            "--retain_unpaired",
+            "-r1",
+            "40",
+            "-r2",
+            "30",
+            "test_files/BS-seq_10K_R1.fastq.gz",
+            "test_files/BS-seq_10K_R2.fastq.gz",
+        ]);
+        let cli = Cli::parse_from(args);
+        assert_eq!(cli.length_1, 40);
+        assert_eq!(cli.length_2, 30);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,8 +58,7 @@ pub struct Cli {
     #[clap(long = "stranded_illumina", conflicts_with_all = &["illumina", "nextera", "small_rna", "bgiseq"])]
     pub stranded_illumina: bool,
 
-    /// Use BGI/DNBSEQ adapter. Sets --adapter2 for Read 2.
-    /// Not covered by auto-detection — must be set explicitly.
+    /// Use BGI/DNBSEQ adapter. Sets --adapter2 for Read 2. Also probed by auto-detection.
     #[clap(long = "bgiseq", conflicts_with_all = &["illumina", "nextera", "small_rna", "stranded_illumina"])]
     pub bgiseq: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use trim_galore::adapter;
-use trim_galore::cli::Cli;
+use trim_galore::cli::{Cli, rewrite_perl_short_flags};
 use trim_galore::demux;
 use trim_galore::fastq::{FastqReader, FastqWriter};
 use trim_galore::filters::{MaxNFilter, UnpairedLengths};
@@ -22,7 +22,8 @@ type ResolvedAdapter = Result<(String, AdapterList, AdapterList, Option<(usize, 
 fn main() -> Result<()> {
     env_logger::init();
 
-    let cli = Cli::parse();
+    // Pre-parse rewrite for Perl-era `-r1`/`-r2` short flags before clap sees them.
+    let cli = Cli::parse_from(rewrite_perl_short_flags(std::env::args()));
     cli.validate()?;
 
     // Input sanity check on first file

--- a/src/specialty.rs
+++ b/src/specialty.rs
@@ -360,3 +360,250 @@ fn implicon_output_name(
         None => PathBuf::from(filename),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fastq::FastqRecord;
+
+    fn mk_rec(id: &str, seq: &str, qual: &str) -> FastqRecord {
+        FastqRecord {
+            id: id.to_string(),
+            seq: seq.to_string(),
+            qual: qual.to_string(),
+        }
+    }
+
+    fn write_fastq(path: &Path, records: &[FastqRecord]) -> Result<()> {
+        let mut w = FastqWriter::create(path, false, 1)?;
+        for r in records {
+            w.write_record(r)?;
+        }
+        w.flush()?;
+        Ok(())
+    }
+
+    fn read_fastq(path: &Path) -> Result<Vec<FastqRecord>> {
+        let mut reader = FastqReader::open(path)?;
+        let mut out = Vec::new();
+        while let Some(r) = reader.next_record()? {
+            out.push(r);
+        }
+        Ok(out)
+    }
+
+    // --- --clock ---
+
+    #[test]
+    fn test_clock_happy_path_extracts_umi_and_clips() -> Result<()> {
+        let dir = std::env::temp_dir().join("tg_test_clock_happy");
+        std::fs::create_dir_all(&dir)?;
+        let r1_path = dir.join("sample_R1.fq");
+        let r2_path = dir.join("sample_R2.fq");
+
+        // R1 layout: 8bp UMI + 4bp "CAGT" + 1bp + 7bp rest = 20bp, clipped at [13..] → 7bp rest
+        // R2 layout: 8bp UMI + 4bp "CAGT" + 3bp + 5bp rest = 20bp, clipped at [15..] → 5bp rest
+        write_fastq(
+            &r1_path,
+            &[
+                mk_rec("@read1", "AAAAAAAACAGTNCCCCCCC", "IIIIIIIIIIIIIIIIIIII"),
+                mk_rec("@read2", "GGGGGGGGCAGTNCCCCCCC", "IIIIIIIIIIIIIIIIIIII"),
+            ],
+        )?;
+        write_fastq(
+            &r2_path,
+            &[
+                mk_rec("@read1", "TTTTTTTTCAGTNNNGGGGG", "IIIIIIIIIIIIIIIIIIII"),
+                mk_rec("@read2", "AAAAAAAACAGTNNNGGGGG", "IIIIIIIIIIIIIIIIIIII"),
+            ],
+        )?;
+
+        clock(&r1_path, &r2_path, false, Some(&dir), 1)?;
+
+        let out_r1 = dir.join("sample_R1.clock_UMI.R1.fq");
+        let out_r2 = dir.join("sample_R2.clock_UMI.R2.fq");
+        assert!(out_r1.exists(), "R1 output should exist at {:?}", out_r1);
+        assert!(out_r2.exists(), "R2 output should exist at {:?}", out_r2);
+
+        let r1_recs = read_fastq(&out_r1)?;
+        let r2_recs = read_fastq(&out_r2)?;
+        assert_eq!(r1_recs.len(), 2);
+        assert_eq!(r2_recs.len(), 2);
+
+        // Read 1: both IDs get the same suffix (from R1 and R2 UMIs/fixes)
+        assert_eq!(
+            r1_recs[0].id,
+            "@read1:R1:AAAAAAAA:R2:TTTTTTTT:F1:CAGT:F2:CAGT"
+        );
+        assert_eq!(r2_recs[0].id, r1_recs[0].id);
+        assert_eq!(r1_recs[0].seq, "CCCCCCC"); // [13..] of AAAAAAAACAGTNCCCCCCC
+        assert_eq!(r2_recs[0].seq, "GGGGG"); // [15..] of TTTTTTTTCAGTNNNGGGGG
+        // Quality clipped to same length
+        assert_eq!(r1_recs[0].qual.len(), r1_recs[0].seq.len());
+        assert_eq!(r2_recs[0].qual.len(), r2_recs[0].seq.len());
+
+        // Read 2: different R1 UMI, same R2 UMI but different base
+        assert_eq!(
+            r1_recs[1].id,
+            "@read2:R1:GGGGGGGG:R2:AAAAAAAA:F1:CAGT:F2:CAGT"
+        );
+        assert_eq!(r1_recs[1].seq, "CCCCCCC");
+        assert_eq!(r2_recs[1].seq, "GGGGG");
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_clock_r1_too_short_errors() -> Result<()> {
+        let dir = std::env::temp_dir().join("tg_test_clock_r1_short");
+        std::fs::create_dir_all(&dir)?;
+        let r1_path = dir.join("short_R1.fq");
+        let r2_path = dir.join("short_R2.fq");
+
+        // R1 of 12bp — below the 13bp minimum
+        write_fastq(&r1_path, &[mk_rec("@r", "AAAAAAAACAGT", "IIIIIIIIIIII")])?;
+        write_fastq(
+            &r2_path,
+            &[mk_rec("@r", "TTTTTTTTCAGTNNNN", "IIIIIIIIIIIIIIII")],
+        )?;
+
+        let result = clock(&r1_path, &r2_path, false, Some(&dir), 1);
+        assert!(result.is_err(), "should bail on too-short R1");
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("too short"), "got: {}", err);
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_clock_r2_too_short_errors() -> Result<()> {
+        let dir = std::env::temp_dir().join("tg_test_clock_r2_short");
+        std::fs::create_dir_all(&dir)?;
+        let r1_path = dir.join("short_R1.fq");
+        let r2_path = dir.join("short_R2.fq");
+
+        // R1 OK (≥13), R2 only 14bp (below 15bp minimum)
+        write_fastq(
+            &r1_path,
+            &[mk_rec("@r", "AAAAAAAACAGTNC", "IIIIIIIIIIIIII")],
+        )?;
+        write_fastq(
+            &r2_path,
+            &[mk_rec("@r", "TTTTTTTTCAGTNN", "IIIIIIIIIIIIII")],
+        )?;
+
+        let result = clock(&r1_path, &r2_path, false, Some(&dir), 1);
+        assert!(result.is_err(), "should bail on too-short R2");
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    // --- --implicon ---
+
+    #[test]
+    fn test_implicon_happy_path_umi_8() -> Result<()> {
+        let dir = std::env::temp_dir().join("tg_test_implicon_happy");
+        std::fs::create_dir_all(&dir)?;
+        let r1_path = dir.join("sample_R1.fq");
+        let r2_path = dir.join("sample_R2.fq");
+
+        // R1 is untouched; R2 gets its first 8bp extracted as UMI, then clipped.
+        write_fastq(
+            &r1_path,
+            &[
+                mk_rec("@read1", "ACGTACGTACGTACGT", "IIIIIIIIIIIIIIII"),
+                mk_rec("@read2", "TTTTTTTTTTTTTTTT", "IIIIIIIIIIIIIIII"),
+            ],
+        )?;
+        write_fastq(
+            &r2_path,
+            &[
+                mk_rec("@read1", "AAAAAAAAGGGGGGGG", "IIIIIIIIIIIIIIII"),
+                mk_rec("@read2", "CCCCCCCCGGGGGGGG", "IIIIIIIIIIIIIIII"),
+            ],
+        )?;
+
+        implicon(&r1_path, &r2_path, 8, false, Some(&dir), 1)?;
+
+        // Filename pattern: {stem_minus_R1_suffix}_{umi}bp_UMI_R[12].fastq
+        let out_r1 = dir.join("sample_8bp_UMI_R1.fastq");
+        let out_r2 = dir.join("sample_8bp_UMI_R2.fastq");
+        assert!(out_r1.exists(), "R1 output should exist at {:?}", out_r1);
+        assert!(out_r2.exists(), "R2 output should exist at {:?}", out_r2);
+
+        let r1_recs = read_fastq(&out_r1)?;
+        let r2_recs = read_fastq(&out_r2)?;
+        assert_eq!(r1_recs.len(), 2);
+        assert_eq!(r2_recs.len(), 2);
+
+        // Read 1: R1 sequence unchanged; ID gets :AAAAAAAA barcode
+        assert_eq!(r1_recs[0].id, "@read1:AAAAAAAA");
+        assert_eq!(r1_recs[0].seq, "ACGTACGTACGTACGT"); // unchanged
+        assert_eq!(r1_recs[0].qual, "IIIIIIIIIIIIIIII");
+        // R2: same barcode on ID; sequence clipped by 8bp
+        assert_eq!(r2_recs[0].id, "@read1:AAAAAAAA");
+        assert_eq!(r2_recs[0].seq, "GGGGGGGG"); // R2[8..]
+        assert_eq!(r2_recs[0].qual.len(), r2_recs[0].seq.len());
+
+        // Read 2: different barcode
+        assert_eq!(r1_recs[1].id, "@read2:CCCCCCCC");
+        assert_eq!(r2_recs[1].id, "@read2:CCCCCCCC");
+        assert_eq!(r2_recs[1].seq, "GGGGGGGG");
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_implicon_custom_umi_length_6() -> Result<()> {
+        let dir = std::env::temp_dir().join("tg_test_implicon_umi6");
+        std::fs::create_dir_all(&dir)?;
+        let r1_path = dir.join("foo_R1.fq");
+        let r2_path = dir.join("foo_R2.fq");
+
+        write_fastq(&r1_path, &[mk_rec("@r", "ACGTACGT", "IIIIIIII")])?;
+        write_fastq(&r2_path, &[mk_rec("@r", "TTTTTTGGG", "IIIIIIIII")])?;
+
+        implicon(&r1_path, &r2_path, 6, false, Some(&dir), 1)?;
+
+        let out_r1 = dir.join("foo_6bp_UMI_R1.fastq");
+        let out_r2 = dir.join("foo_6bp_UMI_R2.fastq");
+        let r1_recs = read_fastq(&out_r1)?;
+        let r2_recs = read_fastq(&out_r2)?;
+
+        assert_eq!(r1_recs[0].id, "@r:TTTTTT"); // 6-bp barcode from R2
+        assert_eq!(r1_recs[0].seq, "ACGTACGT"); // R1 untouched
+        assert_eq!(r2_recs[0].id, "@r:TTTTTT");
+        assert_eq!(r2_recs[0].seq, "GGG"); // R2[6..]
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_implicon_r2_too_short_errors() -> Result<()> {
+        let dir = std::env::temp_dir().join("tg_test_implicon_short");
+        std::fs::create_dir_all(&dir)?;
+        let r1_path = dir.join("short_R1.fq");
+        let r2_path = dir.join("short_R2.fq");
+
+        // R2 is 5bp, umi_length=8 → should bail
+        write_fastq(&r1_path, &[mk_rec("@r", "ACGTACGT", "IIIIIIII")])?;
+        write_fastq(&r2_path, &[mk_rec("@r", "ACGTA", "IIIII")])?;
+
+        let result = implicon(&r1_path, &r2_path, 8, false, Some(&dir), 1);
+        assert!(result.is_err(), "should bail when R2 < umi_length");
+        let err = format!("{}", result.unwrap_err());
+        assert!(
+            err.contains("shorter") || err.contains("UMI"),
+            "got: {}",
+            err
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+}

--- a/src/trimmer.rs
+++ b/src/trimmer.rs
@@ -216,8 +216,12 @@ pub fn trim_read(record: &mut FastqRecord, config: &TrimConfig, is_r2: bool) -> 
         }
     }
 
-    // 3. Trim Ns from both ends
-    if config.trim_n {
+    // 3. Trim Ns from both ends.
+    // Suppressed under --rrbs to match Perl v0.6.x: Perl's RRBS code path
+    // omits `$trim_n` from its Cutadapt invocations (trim_galore:876–915,
+    // 1353/1358/1365 in the non-RRBS path for contrast). Keeps v2.x output
+    // byte-identical to v0.6.x for --trim-n + --rrbs users.
+    if config.trim_n && !config.rrbs {
         record.trim_ns();
     }
 
@@ -688,5 +692,44 @@ mod tests {
         assert_eq!(result.adapter_matches.len(), 1);
         // The first (leftmost) match wins, trimming at position 16
         assert_eq!(record.seq, "ACGTACGTACGTACGT");
+    }
+
+    // ── --trim-n × --rrbs interaction (Perl v0.6.x parity) ──────
+
+    #[test]
+    fn test_trim_n_without_rrbs_trims_trailing_ns() {
+        let mut config = test_config_with_adapters(vec![], 1);
+        config.trim_n = true;
+        config.rrbs = false;
+
+        let mut record = make_record("ACGTACGTACGTNNNN");
+        trim_read(&mut record, &config, false);
+        assert_eq!(record.seq, "ACGTACGTACGT"); // 4 trailing Ns trimmed
+    }
+
+    #[test]
+    fn test_trim_n_with_rrbs_suppressed() {
+        // Perl v0.6.x parity: --trim-n is a no-op under --rrbs because Perl's
+        // RRBS code path omits $trim_n from its Cutadapt invocations.
+        let mut config = test_config_with_adapters(vec![], 1);
+        config.trim_n = true;
+        config.rrbs = true;
+
+        let mut record = make_record("ACGTACGTACGTNNNN");
+        trim_read(&mut record, &config, false);
+        assert_eq!(record.seq, "ACGTACGTACGTNNNN"); // Ns preserved
+    }
+
+    #[test]
+    fn test_trim_n_rrbs_also_preserves_leading_ns() {
+        // trim_ns() handles both ends — verify the RRBS suppression covers
+        // the leading-N case too, not just trailing.
+        let mut config = test_config_with_adapters(vec![], 1);
+        config.trim_n = true;
+        config.rrbs = true;
+
+        let mut record = make_record("NNACGTACGT");
+        trim_read(&mut record, &config, false);
+        assert_eq!(record.seq, "NNACGTACGT");
     }
 }


### PR DESCRIPTION
## Summary

Bundle of pre-GA polish work aimed at closing out Perl-migration gaps and repositioning the rewrite's voice now that v2.x has genuine capability beyond v0.6.x. Eight commits, all small and cohesive.

## What's in

### New capabilities (beyond Perl v0.6.x)

- **`A{N}` brace shorthand for `--adapter` / `--adapter2`** (`181bfa6`). `-a A{10}` now expands to `-a AAAAAAAAAA`, matching Perl v0.6.x semantics verbatim. Hand-written matcher — no new crate dependencies. Only applies to single-adapter specs, not multi-adapter or FASTA entries (matches Perl).
- **BGI/DNBSEQ added to auto-detection probe set** (`0a14dbc`). Users running BGI/MGI/DNBSEQ data no longer need `--bgiseq` explicitly; the 32bp probe runs alongside Illumina/Nextera/smallRNA. Stranded Illumina stays explicit-only (its sequence is too similar to Nextera to probe reliably). Tie-break preserved — zero-count still defaults to Illumina.

### Perl-parity fixes (restore v0.6.x behaviour)

- **`--trim-n` suppressed under `--rrbs`** (`4aaa4af`). Perl's RRBS Cutadapt invocations at `trim_galore:862–1330` omit `$trim_n`; Rust applied it unconditionally. Three-line gate in `src/trimmer.rs:220–223` restores parity.
- **Perl-era `-r1` / `-r2` short flags parse correctly** (`9b2d873`). Clap single-char rule meant `-r1 40` silently parsed as `-r=1` with `40` as a stray positional → confusing "odd count" error. Added a small pre-parse rewrite (`cli::rewrite_perl_short_flags`) that rewrites the exact tokens to `--r1` / `--r2` (the existing long aliases) before clap sees them.

### Test coverage

- **Unit tests for `--clock` and `--implicon`** (`a5889f2`). These specialty modes had zero direct test coverage — only one CLI-parse assertion. Added 6 tests covering UMI extraction, read-ID rewriting, sequence clipping, and too-short-input error paths.

### Docs / positioning

- **"Byte-identical" → "faithful rewrite"** (`ccd198c`). v2.x has genuine additions beyond Perl (`--poly_g`, generic `--poly_a`, per-pair adapter detection, build provenance, etc.) — the old rhetoric no longer fits. Updated in README, User Guide, SUMMARY, CHANGELOG, and `src/cli.rs` help preamble. The two benchmark-section "byte-identical" mentions stay (they mean "deterministic across `--cores`", still true).
- **README feature-list updates** (`d403bfd`, `c393d9d`): BGI auto-detection now listed alongside Illumina/Nextera/smallRNA; multi-adapter example updated from Perl's embedded-string `-a " SEQ1 -a SEQ2"` hack to the cleaner repeatable `-a`/`-a2`.

## Follow-up audit of the original 8-item list

| # | Item | Outcome |
|---|---|---|
| 1 | User guide v2 rewrite | Deferred to separate `docs/user-guide-v2-refresh` branch |
| 2 | Additional adapter-spec detail | Folds into #1 |
| 3 | `A{N}` brace expansion | ✅ Implemented (`181bfa6`) |
| 4 | BGI/STRANDED_ILLUMINA auto-detect | ✅ BGI added; stranded deliberately out (`0a14dbc`) |
| 5 | `-r1` / `-r2` migration foot-gun | ✅ Fixed (`9b2d873`) |
| 6 | `--trim-n` + `--rrbs` byte-identity | ✅ Fixed (`4aaa4af`) |
| 7 | `--hardtrim` filename rename | Cleared — phantom issue (Perl help text was wrong, Perl source actually matches Rust) |
| 8 | `--poly_a` direction auto-detect | Cleared — Perl's `--polyA` was a Thermo Fisher kit-specific feature, removed entirely; Rust's `--poly_a` is intentionally generic |

## Verification

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — **140 passed** (was 106 before this branch; +34 net)
- [x] `cargo clippy --all-targets --release -- -D warnings` — silent
- [x] `cargo fmt --all -- --check` — silent
- [x] Live smoke: `-a "A{8}"` → `Adapter sequence A{8} expanded to AAAAAAAA`
- [x] Live smoke: BGI fixture → `Using BGI/DNBSEQ adapter for trimming (count: 200)`
- [x] Live smoke: `-r1 40 -r2 35` → pipeline runs cleanly (previously errored on "odd count")

## Test plan

- [x] Scan the `--help` diff vs. base (the docstring edits on `--bgiseq`, `--trim-n`, `--adapter`, `--adapter2`, and the top-level `about` preamble)
- [ ] Spot-check the rhetoric change reads sensibly in all five files
- [x] Confirm CI `Validate vs Perl TrimGalore` stays green (it already passed on the same byte-identical CI steps at `hardtrim5`; nothing in the new code path interacts with those fixtures)