### PR TITLE
fix(specialty): multi-pair --clock and --implicon (same shape as beta.2 --paired fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,16 +271,63 @@ jobs:
           test $rc -ne 0
           grep -q "basename cannot be used with multiple" /tmp/bn.log
 
-      - name: Validate --clock still requires exactly 2 inputs (no multi-pair widening)
+      - name: Validate multi-pair --clock (regression guard for the v2.x widening)
+        run: |
+          rm -rf /tmp/clock_multi; mkdir -p /tmp/clock_multi
+          for sample in A B; do
+            cp test_files/clock_10K_R1.fastq.gz /tmp/clock_multi/${sample}_R1.fastq.gz
+            cp test_files/clock_10K_R2.fastq.gz /tmp/clock_multi/${sample}_R2.fastq.gz
+          done
+          ./target/release/trim_galore --clock -o /tmp/clock_multi \
+            /tmp/clock_multi/A_R1.fastq.gz /tmp/clock_multi/A_R2.fastq.gz \
+            /tmp/clock_multi/B_R1.fastq.gz /tmp/clock_multi/B_R2.fastq.gz 2>&1 | tee /tmp/clock_multi.log
+          # Per-pair header should be emitted in multi-pair mode
+          grep -q 'Clock pair 1 of 2' /tmp/clock_multi.log
+          grep -q 'Clock pair 2 of 2' /tmp/clock_multi.log
+          # Per-pair output files should exist
+          for sample in A B; do
+            test -f /tmp/clock_multi/${sample}_R1.clock_UMI.R1.fq.gz
+            test -f /tmp/clock_multi/${sample}_R2.clock_UMI.R2.fq.gz
+          done
+
+      - name: Validate multi-pair --implicon
+        run: |
+          rm -rf /tmp/implicon_multi; mkdir -p /tmp/implicon_multi
+          for sample in A B; do
+            cp test_files/BS-seq_10K_R1.fastq.gz /tmp/implicon_multi/${sample}_R1.fastq.gz
+            cp test_files/BS-seq_10K_R2.fastq.gz /tmp/implicon_multi/${sample}_R2.fastq.gz
+          done
+          ./target/release/trim_galore --implicon -o /tmp/implicon_multi \
+            /tmp/implicon_multi/A_R1.fastq.gz /tmp/implicon_multi/A_R2.fastq.gz \
+            /tmp/implicon_multi/B_R1.fastq.gz /tmp/implicon_multi/B_R2.fastq.gz 2>&1 | tee /tmp/implicon_multi.log
+          grep -q 'IMPLICON pair 1 of 2' /tmp/implicon_multi.log
+          grep -q 'IMPLICON pair 2 of 2' /tmp/implicon_multi.log
+          for sample in A B; do
+            test -f /tmp/implicon_multi/${sample}_8bp_UMI_R1.fastq.gz
+            test -f /tmp/implicon_multi/${sample}_8bp_UMI_R2.fastq.gz
+          done
+
+      - name: Validate --clock duplicate-pair rejection (regression guard)
         run: |
           set +e
           ./target/release/trim_galore --clock \
             test_files/clock_10K_R1.fastq.gz test_files/clock_10K_R2.fastq.gz \
-            test_files/clock_10K_R1.fastq.gz test_files/clock_10K_R2.fastq.gz 2>&1 | tee /tmp/clock.log
+            test_files/clock_10K_R1.fastq.gz test_files/clock_10K_R2.fastq.gz 2>&1 | tee /tmp/clock_dup.log
           rc=${PIPESTATUS[0]}
           set -e
           test $rc -ne 0
-          grep -q "clock requires exactly 2" /tmp/clock.log
+          grep -q 'duplicate of pair' /tmp/clock_dup.log
+
+      - name: Validate --clock odd-count rejection (regression guard)
+        run: |
+          set +e
+          ./target/release/trim_galore --clock \
+            test_files/clock_10K_R1.fastq.gz test_files/clock_10K_R2.fastq.gz \
+            test_files/clock_10K_R1.fastq.gz 2>&1 | tee /tmp/clock_odd.log
+          rc=${PIPESTATUS[0]}
+          set -e
+          test $rc -ne 0
+          grep -q 'even number' /tmp/clock_odd.log
 
       - name: Validate paired-end output-path collision pre-flight
         run: |

--- a/docs/Trim_Galore_User_Guide.md
+++ b/docs/Trim_Galore_User_Guide.md
@@ -126,6 +126,9 @@ Applying these steps to both self-generated and downloaded data can ensure that 
 
 ### Step 4: Specialised Trimming
 
+> [!NOTE]
+> All specialty modes accept multi-pair input. `--hardtrim5` / `--hardtrim3` are single-end-shaped and just process every input file independently. `--clock` and `--implicon` are paired-end-shaped and accept any even number of inputs as consecutive R1/R2 pairs (e.g. `--clock A_R1.fq.gz A_R2.fq.gz B_R1.fq.gz B_R2.fq.gz`). Same pairwise-order requirement as `--paired` applies — a glob like `*fastq.gz` produces alphabetically-sorted output, which for `_R1`/`_R2` naming gives the right pairwise order, but mixed naming may not.
+
 #### Hard-trimming to leave bases at the 5'-end
 The option `--hardtrim5 INT` allows you to hard-clip sequences from their 3' end. This option processes one or more files (plain FastQ or gzip compressed files) and produces hard-trimmed FastQ files ending in `.{INT}bp_5prime.fq(.gz)`. This is useful when you want to shorten reads to a certain read length. Here is an example:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -328,49 +328,61 @@ where
 }
 
 impl Cli {
+    /// Shared validation for any paired-end mode (`--paired`, `--clock`,
+    /// `--implicon`) that takes input files in pairwise (R1, R2, R1, R2, …)
+    /// order. Checks:
+    ///   1. Even count of input files.
+    ///   2. Within each pair, R1 ≠ R2 byte-equal (matches Perl's
+    ///      `$ARGV[$i] eq $ARGV[$i+1]` check at `trim_galore:3208`; does not
+    ///      follow symlinks or canonicalise).
+    ///   3. Across pairs, no duplicate pair (catches accidental copy-paste
+    ///      and emits a precise error rather than the case-insensitive
+    ///      output-collision pre-flight's APFS/NTFS message).
+    ///
+    /// `mode_label` is used in the user-facing error string, e.g.
+    /// `"Paired-end"`, `"--clock"`, `"--implicon"`.
+    fn validate_paired_input(&self, mode_label: &str) -> anyhow::Result<()> {
+        if self.input.len() % 2 != 0 {
+            anyhow::bail!(
+                "{} mode requires an even number of input files (R1/R2 pairs), got {}",
+                mode_label,
+                self.input.len()
+            );
+        }
+        for chunk in self.input.chunks(2) {
+            if chunk[0] == chunk[1] {
+                anyhow::bail!(
+                    "Read 1 and Read 2 appear to be the same file: {}. \
+                     Did you mean to pass distinct R1 and R2 files?",
+                    chunk[0].display()
+                );
+            }
+        }
+        let pairs: Vec<(&std::path::PathBuf, &std::path::PathBuf)> =
+            self.input.chunks(2).map(|c| (&c[0], &c[1])).collect();
+        for (i, (r1, r2)) in pairs.iter().enumerate() {
+            for (j, (pr1, pr2)) in pairs.iter().enumerate().take(i) {
+                if r1 == pr1 && r2 == pr2 {
+                    anyhow::bail!(
+                        "Pair {} ({}, {}) is a duplicate of pair {}. \
+                         Did you mean to pass different files?",
+                        i + 1,
+                        r1.display(),
+                        r2.display(),
+                        j + 1
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Validate CLI arguments after parsing.
     pub fn validate(&self) -> anyhow::Result<()> {
         if self.paired {
             // `#[clap(required = true)]` on `input` guarantees at least one file
             // reaches validate(), so no is_empty() check is needed.
-            if self.input.len() % 2 != 0 {
-                anyhow::bail!(
-                    "Paired-end mode requires an even number of input files (R1/R2 pairs), got {}",
-                    self.input.len()
-                );
-            }
-            // Catch common user error: same file passed twice. Matches Perl's
-            // byte-equality check at trim_galore:3208 (`$ARGV[$i] eq $ARGV[$i+1]`).
-            // Does not follow symlinks or canonicalise.
-            for chunk in self.input.chunks(2) {
-                if chunk[0] == chunk[1] {
-                    anyhow::bail!(
-                        "Read 1 and Read 2 appear to be the same file: {}. \
-                         Did you mean to pass distinct R1 and R2 files?",
-                        chunk[0].display()
-                    );
-                }
-            }
-            // Catch accidental copy-paste of the same pair twice. Without this,
-            // a duplicate pair trips the case-insensitive output-collision
-            // pre-flight in main() with an APFS/NTFS message that misdirects
-            // the user — here we emit a precise "duplicate of pair N" error.
-            let pairs: Vec<(&std::path::PathBuf, &std::path::PathBuf)> =
-                self.input.chunks(2).map(|c| (&c[0], &c[1])).collect();
-            for (i, (r1, r2)) in pairs.iter().enumerate() {
-                for (j, (pr1, pr2)) in pairs.iter().enumerate().take(i) {
-                    if r1 == pr1 && r2 == pr2 {
-                        anyhow::bail!(
-                            "Pair {} ({}, {}) is a duplicate of pair {}. \
-                             Did you mean to pass different files?",
-                            i + 1,
-                            r1.display(),
-                            r2.display(),
-                            j + 1
-                        );
-                    }
-                }
-            }
+            self.validate_paired_input("Paired-end")?;
         }
 
         if !self.paired && self.input.len() > 1 && self.basename.is_some() {
@@ -438,11 +450,11 @@ impl Cli {
                 anyhow::bail!("--hardtrim3 must be between 1 and 999, got {}", n);
             }
         }
-        if self.clock && self.input.len() != 2 {
-            anyhow::bail!("--clock requires exactly 2 paired-end input files");
+        if self.clock {
+            self.validate_paired_input("--clock")?;
         }
-        if self.implicon.is_some() && self.input.len() != 2 {
-            anyhow::bail!("--implicon requires exactly 2 paired-end input files");
+        if self.implicon.is_some() {
+            self.validate_paired_input("--implicon")?;
         }
         if let Some(ref demux_file) = self.demux {
             if self.paired {
@@ -589,15 +601,72 @@ mod tests {
         cli.validate().expect("two-file paired-end should validate");
     }
 
+    // ── Multi-pair widening for --clock and --implicon ──
+    // (Replaces the earlier "strict-2" regression guard. Specialty
+    // run-and-exit modes now share the same pairwise validation as
+    // --paired itself.)
+
     #[test]
-    fn test_validate_clock_still_requires_exactly_2() {
-        // Regression guard: --clock must not have been widened by the
-        // multi-pair --paired relaxation.
+    fn test_validate_clock_two_pairs_accepted() {
         let cli = Cli::parse_from(["trim_galore", "--clock", R1, R2, ALT_R1, ALT_R2]);
+        cli.validate()
+            .expect("two distinct pairs should validate under --clock");
+    }
+
+    #[test]
+    fn test_validate_clock_odd_count_rejected() {
+        let cli = Cli::parse_from(["trim_galore", "--clock", R1, R2, ALT_R1]);
         let err = cli.validate().unwrap_err().to_string();
         assert!(
-            err.contains("clock requires exactly 2"),
-            "expected --clock strict-2 rejection, got: {err}"
+            err.contains("--clock") && err.contains("even number"),
+            "expected --clock even-count rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_clock_r1_equal_r2_within_pair_rejected() {
+        let cli = Cli::parse_from(["trim_galore", "--clock", R1, R1]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("appear to be the same file"),
+            "expected R1==R2 rejection under --clock, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_clock_duplicate_pair_rejected() {
+        let cli = Cli::parse_from(["trim_galore", "--clock", R1, R2, R1, R2]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("duplicate of pair"),
+            "expected duplicate-pair rejection under --clock, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_implicon_two_pairs_accepted() {
+        let cli = Cli::parse_from(["trim_galore", "--implicon", R1, R2, ALT_R1, ALT_R2]);
+        cli.validate()
+            .expect("two distinct pairs should validate under --implicon");
+    }
+
+    #[test]
+    fn test_validate_implicon_odd_count_rejected() {
+        let cli = Cli::parse_from(["trim_galore", "--implicon", R1, R2, ALT_R1]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("--implicon") && err.contains("even number"),
+            "expected --implicon even-count rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_implicon_duplicate_pair_rejected() {
+        let cli = Cli::parse_from(["trim_galore", "--implicon", R1, R2, R1, R2]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("duplicate of pair"),
+            "expected duplicate-pair rejection under --implicon, got: {err}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,17 +53,30 @@ fn main() -> Result<()> {
         return Ok(());
     }
     if cli.clock {
-        specialty::clock(&cli.input[0], &cli.input[1], gzip, output_dir, cli.cores)?;
+        run_specialty_paired(
+            &cli,
+            "Clock",
+            |r1, r2| {
+                (
+                    specialty::clock_output_name(r1, "R1", output_dir, gzip),
+                    specialty::clock_output_name(r2, "R2", output_dir, gzip),
+                )
+            },
+            |r1, r2| specialty::clock(r1, r2, gzip, output_dir, cli.cores),
+        )?;
         return Ok(());
     }
     if let Some(umi_len) = cli.implicon {
-        specialty::implicon(
-            &cli.input[0],
-            &cli.input[1],
-            umi_len,
-            gzip,
-            output_dir,
-            cli.cores,
+        run_specialty_paired(
+            &cli,
+            "IMPLICON",
+            |r1, r2| {
+                (
+                    specialty::implicon_output_name(r1, umi_len, "R1", output_dir, gzip),
+                    specialty::implicon_output_name(r2, umi_len, "R2", output_dir, gzip),
+                )
+            },
+            |r1, r2| specialty::implicon(r1, r2, umi_len, gzip, output_dir, cli.cores),
         )?;
         return Ok(());
     }
@@ -884,4 +897,65 @@ fn pct(part: usize, total: usize) -> f64 {
     } else {
         part as f64 / total as f64 * 100.0
     }
+}
+
+/// Multi-pair driver for the run-and-exit specialty modes (`--clock`,
+/// `--implicon`). Iterates over `cli.input.chunks(2)`, prints a per-pair
+/// header for multi-pair invocations, and runs the supplied per-pair
+/// function. Mirrors `--paired`'s output-collision pre-flight (case-
+/// insensitive on full path) so two pairs that would write to the same
+/// output file fail loudly before any I/O.
+fn run_specialty_paired<NameFn, RunFn>(
+    cli: &Cli,
+    mode_label: &str,
+    mut output_names: NameFn,
+    mut run_pair: RunFn,
+) -> Result<()>
+where
+    NameFn: FnMut(&Path, &Path) -> (std::path::PathBuf, std::path::PathBuf),
+    RunFn: FnMut(&Path, &Path) -> Result<()>,
+{
+    // Pre-flight: detect output-path collisions across pairs (same shape
+    // as the --paired pre-flight at lines 82–125).
+    let mut out_paths: std::collections::HashMap<String, std::path::PathBuf> =
+        std::collections::HashMap::new();
+    let norm = |p: &std::path::Path| -> String { p.to_string_lossy().to_ascii_lowercase() };
+    for chunk in cli.input.chunks(2) {
+        let (o1, o2) = output_names(&chunk[0], &chunk[1]);
+        for p in [o1, o2] {
+            if let Some(existing) = out_paths.insert(norm(&p), p.clone()) {
+                anyhow::bail!(
+                    "Output path collision (case-insensitive, for APFS/NTFS safety): \
+                     {} and {} would be written to the same file. \
+                     Check that input pairs produce distinct output paths \
+                     (e.g., different source directories or `--output_dir`).",
+                    existing.display(),
+                    p.display()
+                );
+            }
+        }
+    }
+
+    let total_pairs = cli.input.len() / 2;
+    for (pair_idx, chunk) in cli.input.chunks(2).enumerate() {
+        if total_pairs > 1 {
+            eprintln!(
+                "\n=== {} pair {} of {} ===",
+                mode_label,
+                pair_idx + 1,
+                total_pairs
+            );
+        }
+        run_pair(&chunk[0], &chunk[1]).with_context(|| {
+            format!(
+                "processing {} pair {} of {} (R1={}, R2={})",
+                mode_label,
+                pair_idx + 1,
+                total_pairs,
+                chunk[0].display(),
+                chunk[1].display()
+            )
+        })?;
+    }
+    Ok(())
 }

--- a/src/specialty.rs
+++ b/src/specialty.rs
@@ -318,7 +318,12 @@ fn hardtrim_output_name(
     }
 }
 
-fn clock_output_name(input: &Path, read: &str, output_dir: Option<&Path>, gzip: bool) -> PathBuf {
+pub fn clock_output_name(
+    input: &Path,
+    read: &str,
+    output_dir: Option<&Path>,
+    gzip: bool,
+) -> PathBuf {
     let stem = naming::strip_fastq_extensions(input);
     let ext = if gzip { ".fq.gz" } else { ".fq" };
     let filename = format!("{}.clock_UMI.{}{}", stem, read, ext);
@@ -328,7 +333,7 @@ fn clock_output_name(input: &Path, read: &str, output_dir: Option<&Path>, gzip: 
     }
 }
 
-fn implicon_output_name(
+pub fn implicon_output_name(
     input: &Path,
     umi_len: usize,
     read: &str,


### PR DESCRIPTION
## Summary

Same regression as the `--paired` beta.1 → beta.2 fix, on a different code path. `--clock` and `--implicon` validation rejected anything other than exactly 2 input files, and `main.rs` dispatch hardcoded `cli.input[0]` / `cli.input[1]` indexing. Users running shell-glob invocations like `trim_galore --implicon --paired *fastq.gz` (the exact pattern reported by Felix) hit:

```
Error: --implicon requires exactly 2 paired-end input files
```

This PR widens both specialty modes to accept multi-pair input, with the same safety net as `--paired`: even-count + within-pair byte-equal R1≠R2 + cross-pair duplicate-pair detection + output-collision pre-flight.

## Changes

### Refactor: shared `validate_paired_input` helper

Extracted `Cli::validate_paired_input(mode_label)` in `src/cli.rs` from the inlined `if self.paired { … }` block. Now reused for `--paired`, `--clock`, and `--implicon` — single source of truth for pairwise-input validation. Error messages name the calling mode explicitly (e.g., `"--clock mode requires an even number of input files (R1/R2 pairs), got 3"`).

### Refactor: shared `run_specialty_paired` dispatch helper

`src/main.rs` gains `run_specialty_paired(cli, mode_label, output_names_fn, run_pair_fn)`. Loops `cli.input.chunks(2)`, prints a per-pair header (`=== Clock pair N of M ===` / `=== IMPLICON pair N of M ===`) for multi-pair invocations, and runs an output-collision pre-flight (case-insensitive for APFS/NTFS safety) before any I/O. Per-pair errors are wrapped via `.with_context` so a failing pair K identifies itself in the error message.

### Visibility tweak

`clock_output_name` / `implicon_output_name` in `src/specialty.rs` widened from private to `pub` so the dispatch helper can use them in the collision pre-flight. They were already computing the canonical output names; now they're reused rather than duplicated inline.

### Tests

Replaced the now-obsolete `test_validate_clock_still_requires_exactly_2` (regression guard for the strict-2 assumption) with **7 new tests**:

- `test_validate_clock_two_pairs_accepted`
- `test_validate_clock_odd_count_rejected`
- `test_validate_clock_r1_equal_r2_within_pair_rejected`
- `test_validate_clock_duplicate_pair_rejected`
- `test_validate_implicon_two_pairs_accepted`
- `test_validate_implicon_odd_count_rejected`
- `test_validate_implicon_duplicate_pair_rejected`

### Documentation

Added a `> [!NOTE]` block at the top of Step 4 (Specialised Trimming) in `docs/Trim_Galore_User_Guide.md` covering multi-pair behaviour across all three specialty modes (`--hardtrim5`, `--hardtrim3`, `--clock`, `--implicon`) with the same pairwise-order caveat that applies to `--paired`.

## Codebase audit (post-commit)

Confirmed no other lurking `cli.input[0]` / `cli.input[1]` single-pair assumptions:

```
$ grep -nE 'cli\.input\[[01]\]|self\.input\[[01]\]' src/*.rs
src/main.rs:37:    FastqReader::sanity_check(&cli.input[0])?;
```

The remaining match at `main.rs:37` is a benign sanity-check (early-fail on a missing/malformed first file) that doesn't make a multi-pair assumption — the dispatch code afterwards handles however many files were passed. **Net single-pair-assumption sites in the codebase: zero.**

## Verification

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — **153 passed** (147 + 6 new)
- [x] `cargo clippy --all-targets --release -- -D warnings` — silent
- [x] `cargo fmt --all -- --check` — silent
- [x] Live smoke: `--clock` with 4 inputs (2 pairs) → 4 outputs with correct `.clock_UMI.{R1,R2}.fq.gz` filenames
- [x] Live smoke: `--implicon` with 4 inputs (2 pairs) → 4 outputs with correct `_8bp_UMI_{R1,R2}.fastq.gz` filenames
- [x] Negative test: cross-source-dir pair pairs that produce identical output filenames are caught by the collision pre-flight before any I/O

## Test plan

- [ ] `gh pr checks N` — confirm 5/5 gates green
- [ ] Spot-check the per-pair `=== Clock pair N of M ===` / `=== IMPLICON pair N of M ===` headers on a multi-pair invocation
- [ ] Confirm the existing single-pair smoke (CI step) for `--clock` / `--implicon` (if any) still passes