### PR TITLE
feat: bundle fastqc-rust — drop Java + external FastQC dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,29 @@ jobs:
           test $rc -ne 0
           grep -q 'even number' /tmp/clock_odd.log
 
+      - name: Validate bundled FastQC produces canonical output files
+        run: |
+          # Smoke test for the bundled fastqc-rust integration. Validates:
+          #   1. --fastqc produces *_fastqc.html and *_fastqc.zip alongside
+          #      the trimmed output (canonical Java FastQC filename pattern).
+          #   2. The .zip contains the expected directory layout that
+          #      MultiQC parsers latch onto (summary.txt, fastqc_data.txt,
+          #      Images/, Icons/).
+          #   3. No external `fastqc` is on $PATH inside the CI runner
+          #      (the dtolnay/rust-toolchain base image doesn't ship it),
+          #      so a green run here proves the bundled library is doing
+          #      the work — not an accidental shell-out.
+          rm -rf /tmp/op_fastqc; mkdir -p /tmp/op_fastqc
+          ! command -v fastqc  # confirm no external fastqc on PATH
+          ./target/release/trim_galore --fastqc -o /tmp/op_fastqc \
+            test_files/illumina_10K.fastq.gz
+          test -f /tmp/op_fastqc/illumina_10K_trimmed_fastqc.html
+          test -f /tmp/op_fastqc/illumina_10K_trimmed_fastqc.zip
+          unzip -l /tmp/op_fastqc/illumina_10K_trimmed_fastqc.zip | grep -q summary.txt
+          unzip -l /tmp/op_fastqc/illumina_10K_trimmed_fastqc.zip | grep -q fastqc_data.txt
+          unzip -l /tmp/op_fastqc/illumina_10K_trimmed_fastqc.zip | grep -q 'Images/'
+          unzip -l /tmp/op_fastqc/illumina_10K_trimmed_fastqc.zip | grep -q 'Icons/'
+
       - name: Validate paired-end output-path collision pre-flight
         run: |
           # Two pairs with the same R1/R2 filename but different source dirs +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,44 @@
 # Trim Galore Changelog
 
 
+### Unreleased (queued for v2.1.0-beta.4)
+
+#### New features (since v2.1.0-beta.3)
+- **Bundled FastQC.** `--fastqc` now uses the
+  [fastqc-rust](https://crates.io/crates/fastqc-rust) library directly
+  instead of shelling out to an external `fastqc` binary. Removes Java
+  and the FastQC tarball as runtime dependencies — completes the
+  "single static binary, zero external runtime deps" story for v2.x.
+  Output files (`*_fastqc.html`, `*_fastqc.zip`) are FastQC 0.12.1-
+  compatible (the same version we previously bundled in the Docker
+  image), so MultiQC parsers and downstream pipelines see identical
+  structure. The Docker image is correspondingly slimmer (no
+  `default-jre-headless`, no `perl`, no FastQC tarball; saves
+  approximately 350 MB at the runtime layer).
+  - `--fastqc_args` continues to accept the common subset (`--nogroup`,
+    `--expgroup`, `--quiet`, `--svg`, `--nano`, `--nofilter`,
+    `--casava`, `-t`/`--threads`, `-o`/`--outdir`); other flags emit a
+    warning and are ignored — forward-compat with future fastqc-rust
+    additions.
+
+#### Bug fixes (since v2.1.0-beta.3)
+- `--clock` and `--implicon` now accept multi-pair input (an even
+  number of files as consecutive R1/R2 pairs), restoring v0.6.x
+  semantics that the v2.x rewrite had narrowed to "exactly 2 input
+  files". Same widening as the `--paired` fix in beta.2 — the two
+  specialty run-and-exit modes had their own validation that wasn't
+  updated at the time. Each pair gets a per-pair header
+  (`=== Clock pair N of M ===` / `=== IMPLICON pair N of M ===`) and
+  the same output-collision pre-flight (case-insensitive on full path)
+  that `--paired` runs. (#224)
+
+#### Infrastructure (contributor-facing)
+- `rust-version` bumped from 1.85 → 1.88 (required by fastqc-rust).
+- `.gitattributes` added so the GitHub repo language bar reflects the
+  actual Rust content rather than HTML in `docs/`. (#225, contributed
+  by @ewels)
+
+
 ### Version 2.1.0-beta.3 (Release on 24 Apr 2026)
 
 #### New features (since v2.1.0-beta.2)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -74,10 +94,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -86,16 +185,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-rs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beeb59e7e4c811ab37cc73680c798c7a5da77fc9989c62b09138e31ee740f735"
+dependencies = [
+ "crc32fast",
+ "tinyvec",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -138,10 +307,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_affinity"
@@ -155,6 +342,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +382,110 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -187,6 +511,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fastqc-rust"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0becf98187630da8d8af7871e523b52e6e6ef9a99ed1479cde2af894e3f6fd56"
+dependencies = [
+ "base64",
+ "bzip2-rs",
+ "chrono",
+ "clap",
+ "flate2",
+ "hdf5-pure",
+ "memchr",
+ "noodles",
+ "png",
+ "rayon",
+ "resvg",
+ "statrs",
+ "tiny-skia",
+ "zip",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flate2"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,8 +570,15 @@ checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
+ "libz-sys",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "flume"
@@ -207,6 +590,29 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "spin",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -222,6 +628,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +648,30 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -251,6 +691,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hdf5-pure"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772af903b1f10f041af4ab6daa4959c1451f72146931653236571ee699e3aaee"
+dependencies = [
+ "byteorder",
+ "flate2",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +717,74 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -299,6 +823,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,10 +843,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libz-rs-sys"
@@ -321,6 +929,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
 dependencies = [
  "zlib-rs",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -339,10 +958,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "memchr"
-version = "2.6.4"
+name = "lzma-rs"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -355,12 +1014,163 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "noodles"
+version = "0.88.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07eed33a9247b250f3027d03043ef3ee3b1d8627d4fb25e16ad0a9c5c8e95109"
+dependencies = [
+ "noodles-bam",
+ "noodles-bgzf",
+ "noodles-sam",
+]
+
+[[package]]
+name = "noodles-bam"
+version = "0.73.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0740ca2ebd9b78e6bd165e44ed7f40437049a63c970e99608ae4721e5e8ff13c"
+dependencies = [
+ "bstr",
+ "byteorder",
+ "indexmap",
+ "memchr",
+ "noodles-bgzf",
+ "noodles-core",
+ "noodles-csi",
+ "noodles-sam",
+]
+
+[[package]]
+name = "noodles-bgzf"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6786136e224bdb8550b077ad44ef2bd5ebc8b06d07fab69aaa7f47d06f0da75"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "crossbeam-channel",
+ "flate2",
+]
+
+[[package]]
+name = "noodles-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962b13b79312f773a12ffcb0cdaccab6327f8343b6f440a888eff10c749d52b0"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "noodles-csi"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba86b72ba18078cdc877805ffb307a48df0e755a803ca239c3a623a728480c7"
+dependencies = [
+ "bit-vec",
+ "bstr",
+ "byteorder",
+ "indexmap",
+ "noodles-bgzf",
+ "noodles-core",
+]
+
+[[package]]
+name = "noodles-sam"
+version = "0.69.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9cb680745fc0ba6234711b805521d16b4ba746f055e829f7b277281d46b3e95"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "indexmap",
+ "lexical-core",
+ "memchr",
+ "noodles-bgzf",
+ "noodles-core",
+ "noodles-csi",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -386,6 +1196,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +1252,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,12 +1276,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -448,10 +1392,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "scopeguard"
@@ -502,10 +1514,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spin"
@@ -517,10 +1589,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "statrs"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f697a07e4606a0a25c044de247e583a330dbb1731d11bc7350b81f48ad567255"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -554,12 +1663,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "trim-galore"
 version = "2.1.0-beta.3"
 dependencies = [
  "anyhow",
  "clap",
  "env_logger",
+ "fastqc-rust",
  "flate2",
  "gzp",
  "log",
@@ -568,10 +1738,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "ttf-parser",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
 
 [[package]]
 name = "utf8parse"
@@ -580,10 +1829,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -631,6 +1901,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,10 +1939,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -665,6 +2004,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
 ]
 
 [[package]]
@@ -678,3 +2108,58 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trim-galore"
 version = "2.1.0-beta.3"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 description = "Fast adapter and quality trimming for NGS data — Oxidized Edition"
 license = "GPL-3.0-only"
 authors = ["Felix Krueger"]
@@ -34,6 +34,10 @@ anyhow = "1"
 memchr = "2"
 log = "0.4"
 env_logger = "0.11"
+# Bundled FastQC integration. Exact-pin: brand-new crate (v1.0.0 published
+# 2026-04-26) — treat upstream bumps as deliberate-test events. See
+# /Users/fkrueger/.claude/plans/bundled-fastqc-rust.md for the design notes.
+fastqc-rust = "=1.0.0"
 
 [dev-dependencies]
 serde_json = "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage ──────────────────────────────────────────────
-FROM rust:1.85-bookworm AS builder
+FROM rust:1.88-bookworm AS builder
 
 WORKDIR /build
 
@@ -20,20 +20,12 @@ LABEL org.opencontainers.image.source="https://github.com/FelixKrueger/TrimGalor
 LABEL org.opencontainers.image.description="Trim Galore — adapter/quality trimming (Oxidized Edition)"
 LABEL org.opencontainers.image.licenses="GPL-3.0-only"
 
+# FastQC is now built into the trim_galore binary itself via the bundled
+# fastqc-rust library — no Java runtime, no FastQC tarball, no perl.
+# Only minimal diagnostic packages remain.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       procps \
-      default-jre-headless \
-      perl \
-      unzip \
-      wget \
       ca-certificates \
-    && wget -q https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.12.1.zip -O /tmp/fastqc.zip \
-    && unzip -q /tmp/fastqc.zip -d /opt \
-    && chmod +x /opt/FastQC/fastqc \
-    && ln -s /opt/FastQC/fastqc /usr/local/bin/fastqc \
-    && rm /tmp/fastqc.zip \
-    && apt-get purge -y unzip wget \
-    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/target/release/trim_galore /usr/local/bin/trim_galore

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Consistent quality and adapter trimming for next-generation sequencing data, wit
 - **NextSeq / 2-colour quality trim** — `--nextseq N` / `--2colour N` applies 2-colour-aware quality trimming (opt-in; replaces `-q`)
 - **Poly-A trimming** — built-in removal of poly-A tails without external tools; recommended for mRNA-seq / poly-A-selected RNA-seq libraries
 - **Parallel processing** — `--cores N` runs trimming and gzip compression in worker threads for near-linear speedup on multi-core systems
-- **FastQC integration** — optional post-trimming quality reports (FastQC v0.12.1 bundled in the Docker image; for `cargo`/source installs, requires FastQC on `$PATH`)
+- **FastQC integration** — optional post-trimming quality reports built in via the bundled [fastqc-rust](https://crates.io/crates/fastqc-rust) library; produces FastQC 0.12.1-compatible HTML + ZIP outputs without requiring Java or an external `fastqc` on `$PATH`
 - **MultiQC compatible** — trimming reports parse cleanly in MultiQC dashboards (text + JSON)
 - **Demultiplexing** — 3' inline barcode demultiplexing
 
@@ -77,7 +77,7 @@ Multi-arch images (amd64 + arm64) are available from GitHub Container Registry:
 docker run --rm -v "$PWD":/data -w /data ghcr.io/felixkrueger/trimgalore trim_galore input.fastq.gz
 ```
 
-The image bundles FastQC v0.12.1 and a Java runtime, so `--fastqc` works out of the box. The `dev` tag tracks the latest development branch; versioned tags (e.g. `v2.1.0`) are published on release.
+FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. The `dev` tag tracks the latest development branch; versioned tags (e.g. `v2.1.0`) are published on release.
 
 ### Prebuilt binaries
 

--- a/docs/Trim_Galore_User_Guide.md
+++ b/docs/Trim_Galore_User_Guide.md
@@ -31,7 +31,7 @@ Poor base call qualities or adapter contamination are however just as relevant f
 
 ## Adaptive quality and adapter trimming with Trim Galore
 
-Trim Galore handles quality trimming, adapter detection, adapter removal, length filtering, and specialty modes in a single pass over the data, with optional post-trimming quality reporting via [FastQC](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/). Originally a Perl wrapper around [Cutadapt](https://cutadapt.readthedocs.io/en/stable/), v2.x is a faithful Rust rewrite that consolidates those passes while preserving the CLI and output filename conventions.
+Trim Galore handles quality trimming, adapter detection, adapter removal, length filtering, and specialty modes in a single pass over the data, with optional post-trimming quality reporting via the bundled [fastqc-rust](https://crates.io/crates/fastqc-rust) library (FastQC 0.12.1-compatible HTML + ZIP outputs; no Java required). Originally a Perl wrapper around [Cutadapt](https://cutadapt.readthedocs.io/en/stable/) and an external [FastQC](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/) install, v2.x is a faithful Rust rewrite that consolidates those passes while preserving the CLI and output filename conventions.
 
 Even though Trim Galore works for any (base space) high throughput dataset (e.g. downloaded from the SRA) this section describes its use mainly with respect to RRBS libraries.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -342,7 +342,7 @@ impl Cli {
     /// `mode_label` is used in the user-facing error string, e.g.
     /// `"Paired-end"`, `"--clock"`, `"--implicon"`.
     fn validate_paired_input(&self, mode_label: &str) -> anyhow::Result<()> {
-        if self.input.len() % 2 != 0 {
+        if !self.input.len().is_multiple_of(2) {
             anyhow::bail!(
                 "{} mode requires an even number of input files (R1/R2 pairs), got {}",
                 mode_label,
@@ -414,23 +414,21 @@ impl Cli {
             );
         }
 
-        if let Some(val) = self.nextseq {
-            if val == 0 || val >= 200 {
+        if let Some(val) = self.nextseq
+            && (val == 0 || val >= 200) {
                 anyhow::bail!(
                     "NextSeq quality cutoff must be between 1 and 199, got {}",
                     val
                 );
             }
-        }
 
-        if let Some(threshold) = self.consider_already_trimmed {
-            if threshold > 10000 {
+        if let Some(threshold) = self.consider_already_trimmed
+            && threshold > 10000 {
                 anyhow::bail!(
                     "consider_already_trimmed value must be between 0 and 10000, got {}",
                     threshold
                 );
             }
-        }
 
         if self.times == 0 || self.times > 10 {
             anyhow::bail!("--times/-n must be between 1 and 10, got {}", self.times);
@@ -440,16 +438,14 @@ impl Cli {
             anyhow::bail!("--cores must be at least 1");
         }
 
-        if let Some(n) = self.hardtrim5 {
-            if n == 0 || n >= 1000 {
+        if let Some(n) = self.hardtrim5
+            && (n == 0 || n >= 1000) {
                 anyhow::bail!("--hardtrim5 must be between 1 and 999, got {}", n);
             }
-        }
-        if let Some(n) = self.hardtrim3 {
-            if n == 0 || n >= 1000 {
+        if let Some(n) = self.hardtrim3
+            && (n == 0 || n >= 1000) {
                 anyhow::bail!("--hardtrim3 must be between 1 and 999, got {}", n);
             }
-        }
         if self.clock {
             self.validate_paired_input("--clock")?;
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -415,20 +415,22 @@ impl Cli {
         }
 
         if let Some(val) = self.nextseq
-            && (val == 0 || val >= 200) {
-                anyhow::bail!(
-                    "NextSeq quality cutoff must be between 1 and 199, got {}",
-                    val
-                );
-            }
+            && (val == 0 || val >= 200)
+        {
+            anyhow::bail!(
+                "NextSeq quality cutoff must be between 1 and 199, got {}",
+                val
+            );
+        }
 
         if let Some(threshold) = self.consider_already_trimmed
-            && threshold > 10000 {
-                anyhow::bail!(
-                    "consider_already_trimmed value must be between 0 and 10000, got {}",
-                    threshold
-                );
-            }
+            && threshold > 10000
+        {
+            anyhow::bail!(
+                "consider_already_trimmed value must be between 0 and 10000, got {}",
+                threshold
+            );
+        }
 
         if self.times == 0 || self.times > 10 {
             anyhow::bail!("--times/-n must be between 1 and 10, got {}", self.times);
@@ -439,13 +441,15 @@ impl Cli {
         }
 
         if let Some(n) = self.hardtrim5
-            && (n == 0 || n >= 1000) {
-                anyhow::bail!("--hardtrim5 must be between 1 and 999, got {}", n);
-            }
+            && (n == 0 || n >= 1000)
+        {
+            anyhow::bail!("--hardtrim5 must be between 1 and 999, got {}", n);
+        }
         if let Some(n) = self.hardtrim3
-            && (n == 0 || n >= 1000) {
-                anyhow::bail!("--hardtrim3 must be between 1 and 999, got {}", n);
-            }
+            && (n == 0 || n >= 1000)
+        {
+            anyhow::bail!("--hardtrim3 must be between 1 and 999, got {}", n);
+        }
         if self.clock {
             self.validate_paired_input("--clock")?;
         }

--- a/src/demux.rs
+++ b/src/demux.rs
@@ -171,7 +171,7 @@ pub fn demultiplex(
 
     while let Some(mut record) = reader.next_record()? {
         total += 1;
-        if total % 10_000_000 == 0 {
+        if total.is_multiple_of(10_000_000) {
             eprintln!("{} sequences processed", total);
         }
 

--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -428,11 +428,12 @@ impl FastqWriter {
 
         // Ensure parent directory exists
         if let Some(parent) = path.parent()
-            && !parent.exists() {
-                std::fs::create_dir_all(parent).with_context(|| {
-                    format!("Failed to create output directory: {}", parent.display())
-                })?;
-            }
+            && !parent.exists()
+        {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create output directory: {}", parent.display())
+            })?;
+        }
 
         let file = File::create(path)
             .with_context(|| format!("Failed to create output file: {}", path.display()))?;

--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -427,13 +427,12 @@ impl FastqWriter {
         let path = path.as_ref();
 
         // Ensure parent directory exists
-        if let Some(parent) = path.parent() {
-            if !parent.exists() {
+        if let Some(parent) = path.parent()
+            && !parent.exists() {
                 std::fs::create_dir_all(parent).with_context(|| {
                     format!("Failed to create output directory: {}", parent.display())
                 })?;
             }
-        }
 
         let file = File::create(path)
             .with_context(|| format!("Failed to create output file: {}", path.display()))?;

--- a/src/fastqc.rs
+++ b/src/fastqc.rs
@@ -1,0 +1,172 @@
+//! FastQC integration via the bundled `fastqc-rust` library.
+//!
+//! Replaces the v0.6.x-style shell-out to an external `fastqc` binary
+//! with an in-process call. Targets byte-equivalent output to Java
+//! FastQC 0.12.1 — the same version we previously bundled in the Docker
+//! image — see <https://github.com/ewels/FastQC-Rust> for the upstream
+//! crate. The bundled approach removes Java + the FastQC tarball as
+//! runtime dependencies, completing the "single static binary, zero
+//! deps" story for the v2.x rewrite.
+//!
+//! Public entry point: [`run`]. The two callers in `src/main.rs` (one
+//! per single-end output, two per paired-end output) invoke it with the
+//! trimmed FASTQ path; output `*_fastqc.html` and `*_fastqc.zip` land
+//! in the trim-galore `--output_dir` (or current dir if unset).
+
+use std::path::Path;
+
+use anyhow::Result;
+use fastqc_rust::{config::FastQCConfig, runner};
+
+/// Run FastQC on a single trimmed output file.
+///
+/// `output_path` — the FASTQ to analyse (one of the trimmed outputs).
+/// `fastqc_args` — raw user-supplied `--fastqc_args` string. A subset
+///                 of common FastQC CLI flags is translated to
+///                 [`FastQCConfig`] mutations; unknown flags emit a
+///                 warning and are ignored.
+/// `output_dir`  — where the `*_fastqc.html` / `*_fastqc.zip` artifacts
+///                 land. `None` means current directory (FastQC's
+///                 default).
+/// `cores`       — threading budget for `fastqc-rust`'s internal rayon
+///                 pool. Always at least 1.
+pub fn run(
+    output_path: &Path,
+    fastqc_args: Option<&str>,
+    output_dir: Option<&Path>,
+    cores: usize,
+) -> Result<()> {
+    let mut config = FastQCConfig {
+        output_dir: output_dir.map(|p| p.to_path_buf()),
+        threads: cores.max(1),
+        // trim-galore prints "Running FastQC on …" itself; suppress
+        // fastqc-rust's per-file progress chatter to avoid
+        // double-logging.
+        quiet: true,
+        ..FastQCConfig::default()
+    };
+
+    if let Some(args) = fastqc_args {
+        apply_fastqc_args(&mut config, args);
+    }
+
+    eprintln!("\nRunning FastQC on {}", output_path.display());
+    runner::run(&config, &[output_path.to_path_buf()])
+        .map_err(|code| anyhow::anyhow!("FastQC analysis failed (exit code {})", code))
+}
+
+/// Translate a subset of Java FastQC CLI flags into [`FastQCConfig`]
+/// mutations.
+///
+/// Supports the common flags users pass via `--fastqc_args`. Unknown
+/// flags emit a warning and are ignored — deliberate forward-compat:
+/// `fastqc-rust` may add flags we don't list yet, and we don't want
+/// every new upstream flag to require a trim-galore release.
+///
+/// Flags handled:
+///   `--nogroup`, `--expgroup`, `--quiet`, `--svg`, `--nano`,
+///   `--nofilter`, `--casava`, `-t`/`--threads`, `-o`/`--outdir`.
+fn apply_fastqc_args(config: &mut FastQCConfig, raw: &str) {
+    let tokens: Vec<&str> = raw.split_whitespace().collect();
+    let mut i = 0;
+    while i < tokens.len() {
+        match tokens[i] {
+            "--nogroup" => config.nogroup = true,
+            "--expgroup" => config.expgroup = true,
+            "--quiet" => config.quiet = true,
+            "--svg" => config.svg_output = true,
+            "--nano" => config.nano = true,
+            "--nofilter" => config.nofilter = true,
+            "--casava" => config.casava = true,
+            "-t" | "--threads" => {
+                if let Some(v) = tokens.get(i + 1).and_then(|t| t.parse().ok()) {
+                    config.threads = v;
+                    i += 1;
+                }
+            }
+            "-o" | "--outdir" => {
+                if let Some(v) = tokens.get(i + 1) {
+                    config.output_dir = Some(std::path::PathBuf::from(v));
+                    i += 1;
+                }
+            }
+            unknown => {
+                eprintln!(
+                    "Warning: --fastqc_args flag '{}' is not translated to the bundled FastQC; ignored",
+                    unknown
+                );
+            }
+        }
+        i += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &str) -> FastQCConfig {
+        let mut config = FastQCConfig::default();
+        apply_fastqc_args(&mut config, args);
+        config
+    }
+
+    #[test]
+    fn test_apply_fastqc_args_nogroup() {
+        let config = parse("--nogroup");
+        assert!(config.nogroup);
+    }
+
+    #[test]
+    fn test_apply_fastqc_args_threads() {
+        let config = parse("-t 4");
+        assert_eq!(config.threads, 4);
+    }
+
+    #[test]
+    fn test_apply_fastqc_args_threads_long_form() {
+        let config = parse("--threads 8");
+        assert_eq!(config.threads, 8);
+    }
+
+    #[test]
+    fn test_apply_fastqc_args_outdir() {
+        let config = parse("-o /tmp/somewhere");
+        assert_eq!(
+            config.output_dir,
+            Some(std::path::PathBuf::from("/tmp/somewhere"))
+        );
+    }
+
+    #[test]
+    fn test_apply_fastqc_args_combined() {
+        let config = parse("--nogroup --svg -t 2");
+        assert!(config.nogroup);
+        assert!(config.svg_output);
+        assert_eq!(config.threads, 2);
+    }
+
+    #[test]
+    fn test_apply_fastqc_args_unknown_flag_ignored() {
+        // --quiet + an unknown flag: the unknown one warns and is
+        // skipped; the known one still applies.
+        let config = parse("--unknown-flag --quiet");
+        assert!(config.quiet);
+    }
+
+    #[test]
+    fn test_apply_fastqc_args_threads_without_value() {
+        // `-t` with no following token: leave threads unchanged.
+        let config = parse("-t");
+        assert_eq!(config.threads, FastQCConfig::default().threads);
+    }
+
+    #[test]
+    fn test_apply_fastqc_args_threads_non_numeric() {
+        // `-t abc` — non-numeric value; leave threads unchanged.
+        // (The token "abc" then becomes a positional in the next loop
+        // iteration and falls through to the unknown-flag branch.)
+        let config = parse("-t abc");
+        assert_eq!(config.threads, FastQCConfig::default().threads);
+    }
+}

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -24,9 +24,10 @@ pub fn filter_single_end(
 ) -> FilterResult {
     // N-content check first (matches TrimGalore order)
     if let Some(ref max_n_filter) = max_n
-        && exceeds_n_threshold(record, max_n_filter) {
-            return FilterResult::TooManyN;
-        }
+        && exceeds_n_threshold(record, max_n_filter)
+    {
+        return FilterResult::TooManyN;
+    }
 
     // Length checks
     if record.len() < length_cutoff {
@@ -34,9 +35,10 @@ pub fn filter_single_end(
     }
 
     if let Some(max) = max_length
-        && record.len() > max {
-            return FilterResult::TooLong;
-        }
+        && record.len() > max
+    {
+        return FilterResult::TooLong;
+    }
 
     FilterResult::Pass
 }
@@ -78,9 +80,10 @@ pub fn filter_paired_end(
 ) -> PairFilterResult {
     // N-content check — ALWAYS discards entire pair, no rescue
     if let Some(ref max_n_filter) = max_n
-        && (exceeds_n_threshold(r1, max_n_filter) || exceeds_n_threshold(r2, max_n_filter)) {
-            return PairFilterResult::TooManyN;
-        }
+        && (exceeds_n_threshold(r1, max_n_filter) || exceeds_n_threshold(r2, max_n_filter))
+    {
+        return PairFilterResult::TooManyN;
+    }
 
     // Length check — can rescue individual reads with --retain_unpaired
     let r1_short = r1.len() < length_cutoff;
@@ -95,9 +98,10 @@ pub fn filter_paired_end(
 
     // Max-length check — discards entire pair
     if let Some(max) = max_length
-        && (r1.len() > max || r2.len() > max) {
-            return PairFilterResult::TooLong;
-        }
+        && (r1.len() > max || r2.len() > max)
+    {
+        return PairFilterResult::TooLong;
+    }
 
     PairFilterResult::Pass
 }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -23,22 +23,20 @@ pub fn filter_single_end(
     max_n: Option<MaxNFilter>,
 ) -> FilterResult {
     // N-content check first (matches TrimGalore order)
-    if let Some(ref max_n_filter) = max_n {
-        if exceeds_n_threshold(record, max_n_filter) {
+    if let Some(ref max_n_filter) = max_n
+        && exceeds_n_threshold(record, max_n_filter) {
             return FilterResult::TooManyN;
         }
-    }
 
     // Length checks
     if record.len() < length_cutoff {
         return FilterResult::TooShort;
     }
 
-    if let Some(max) = max_length {
-        if record.len() > max {
+    if let Some(max) = max_length
+        && record.len() > max {
             return FilterResult::TooLong;
         }
-    }
 
     FilterResult::Pass
 }
@@ -79,11 +77,10 @@ pub fn filter_paired_end(
     unpaired: UnpairedLengths,
 ) -> PairFilterResult {
     // N-content check — ALWAYS discards entire pair, no rescue
-    if let Some(ref max_n_filter) = max_n {
-        if exceeds_n_threshold(r1, max_n_filter) || exceeds_n_threshold(r2, max_n_filter) {
+    if let Some(ref max_n_filter) = max_n
+        && (exceeds_n_threshold(r1, max_n_filter) || exceeds_n_threshold(r2, max_n_filter)) {
             return PairFilterResult::TooManyN;
         }
-    }
 
     // Length check — can rescue individual reads with --retain_unpaired
     let r1_short = r1.len() < length_cutoff;
@@ -97,11 +94,10 @@ pub fn filter_paired_end(
     }
 
     // Max-length check — discards entire pair
-    if let Some(max) = max_length {
-        if r1.len() > max || r2.len() > max {
+    if let Some(max) = max_length
+        && (r1.len() > max || r2.len() > max) {
             return PairFilterResult::TooLong;
         }
-    }
 
     PairFilterResult::Pass
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod alignment;
 pub mod cli;
 pub mod demux;
 pub mod fastq;
+pub mod fastqc;
 pub mod filters;
 pub mod io;
 pub mod parallel;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use trim_galore::adapter;
 use trim_galore::cli::{Cli, rewrite_perl_short_flags};
 use trim_galore::demux;
 use trim_galore::fastq::{FastqReader, FastqWriter};
+use trim_galore::fastqc;
 use trim_galore::filters::{MaxNFilter, UnpairedLengths};
 use trim_galore::io as naming;
 use trim_galore::parallel;
@@ -576,9 +577,14 @@ fn run_single_file(
         eprintln!("JSON report: {}", json_path.display());
     }
 
-    // Run FastQC if requested
+    // Run FastQC if requested (bundled fastqc-rust library — no shell-out)
     if cli.fastqc || cli.fastqc_args.is_some() {
-        run_fastqc(&output_path, cli.fastqc_args.as_deref(), output_dir)?;
+        fastqc::run(
+            &output_path,
+            cli.fastqc_args.as_deref(),
+            output_dir,
+            cli.cores,
+        )?;
     }
 
     // Demultiplex if requested
@@ -853,42 +859,23 @@ fn run_paired(
         }
     }
 
-    // Run FastQC if requested
+    // Run FastQC if requested (bundled fastqc-rust library — no shell-out)
     if cli.fastqc || cli.fastqc_args.is_some() {
-        run_fastqc(&output_r1, cli.fastqc_args.as_deref(), output_dir)?;
-        run_fastqc(&output_r2, cli.fastqc_args.as_deref(), output_dir)?;
+        fastqc::run(
+            &output_r1,
+            cli.fastqc_args.as_deref(),
+            output_dir,
+            cli.cores,
+        )?;
+        fastqc::run(
+            &output_r2,
+            cli.fastqc_args.as_deref(),
+            output_dir,
+            cli.cores,
+        )?;
     }
 
     Ok(())
-}
-
-fn run_fastqc(
-    output_path: &Path,
-    fastqc_args: Option<&str>,
-    output_dir: Option<&Path>,
-) -> Result<()> {
-    let mut cmd = std::process::Command::new("fastqc");
-    if let Some(args) = fastqc_args {
-        for arg in args.split_whitespace() {
-            cmd.arg(arg);
-        }
-    }
-    if let Some(dir) = output_dir {
-        cmd.arg("-o").arg(dir);
-    }
-    cmd.arg(output_path);
-    eprintln!("\nRunning FastQC on {}", output_path.display());
-    let status = cmd.status();
-    match status {
-        Ok(s) if s.success() => Ok(()),
-        Ok(s) => {
-            eprintln!("Warning: FastQC exited with status {}", s);
-            Ok(())
-        }
-        Err(e) => {
-            anyhow::bail!("Failed to run FastQC: {}. Is it installed and in PATH?", e);
-        }
-    }
 }
 
 fn pct(part: usize, total: usize) -> f64 {

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -194,16 +194,14 @@ pub fn run_paired_end_parallel(
             while let Some(r) = pending.remove(&expected) {
                 out_r1.write_all(&r.compressed_r1)?;
                 out_r2.write_all(&r.compressed_r2)?;
-                if let Some(ref mut f) = out_up_r1 {
-                    if !r.compressed_unpaired_r1.is_empty() {
+                if let Some(ref mut f) = out_up_r1
+                    && !r.compressed_unpaired_r1.is_empty() {
                         f.write_all(&r.compressed_unpaired_r1)?;
                     }
-                }
-                if let Some(ref mut f) = out_up_r2 {
-                    if !r.compressed_unpaired_r2.is_empty() {
+                if let Some(ref mut f) = out_up_r2
+                    && !r.compressed_unpaired_r2.is_empty() {
                         f.write_all(&r.compressed_unpaired_r2)?;
                     }
-                }
                 total_r1.merge(&r.stats_r1);
                 total_r2.merge(&r.stats_r2);
                 total_pair.merge(&r.pair_stats);
@@ -419,18 +417,16 @@ fn process_pairs<W: Write>(
                 pair_stats.pairs_removed += 1;
                 stats_r1.too_short += 1;
                 stats_r2.too_short += 1;
-                if let Some(ref mut w) = writer_up_r1 {
-                    if r1_ok {
+                if let Some(ref mut w) = writer_up_r1
+                    && r1_ok {
                         r1.write_to(*w)?;
                         pair_stats.r1_unpaired += 1;
                     }
-                }
-                if let Some(ref mut w) = writer_up_r2 {
-                    if r2_ok {
+                if let Some(ref mut w) = writer_up_r2
+                    && r2_ok {
                         r2.write_to(*w)?;
                         pair_stats.r2_unpaired += 1;
                     }
-                }
             }
             PairFilterResult::TooLong => {
                 pair_stats.pairs_removed += 1;

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -195,13 +195,15 @@ pub fn run_paired_end_parallel(
                 out_r1.write_all(&r.compressed_r1)?;
                 out_r2.write_all(&r.compressed_r2)?;
                 if let Some(ref mut f) = out_up_r1
-                    && !r.compressed_unpaired_r1.is_empty() {
-                        f.write_all(&r.compressed_unpaired_r1)?;
-                    }
+                    && !r.compressed_unpaired_r1.is_empty()
+                {
+                    f.write_all(&r.compressed_unpaired_r1)?;
+                }
                 if let Some(ref mut f) = out_up_r2
-                    && !r.compressed_unpaired_r2.is_empty() {
-                        f.write_all(&r.compressed_unpaired_r2)?;
-                    }
+                    && !r.compressed_unpaired_r2.is_empty()
+                {
+                    f.write_all(&r.compressed_unpaired_r2)?;
+                }
                 total_r1.merge(&r.stats_r1);
                 total_r2.merge(&r.stats_r2);
                 total_pair.merge(&r.pair_stats);
@@ -418,15 +420,17 @@ fn process_pairs<W: Write>(
                 stats_r1.too_short += 1;
                 stats_r2.too_short += 1;
                 if let Some(ref mut w) = writer_up_r1
-                    && r1_ok {
-                        r1.write_to(*w)?;
-                        pair_stats.r1_unpaired += 1;
-                    }
+                    && r1_ok
+                {
+                    r1.write_to(*w)?;
+                    pair_stats.r1_unpaired += 1;
+                }
                 if let Some(ref mut w) = writer_up_r2
-                    && r2_ok {
-                        r2.write_to(*w)?;
-                        pair_stats.r2_unpaired += 1;
-                    }
+                    && r2_ok
+                {
+                    r2.write_to(*w)?;
+                    pair_stats.r2_unpaired += 1;
+                }
             }
             PairFilterResult::TooLong => {
                 pair_stats.pairs_removed += 1;

--- a/src/specialty.rs
+++ b/src/specialty.rs
@@ -144,7 +144,7 @@ pub fn clock(
         match (rec1, rec2) {
             (Some(mut r1), Some(mut r2)) => {
                 count += 1;
-                if count % 1_000_000 == 0 {
+                if count.is_multiple_of(1_000_000) {
                     eprintln!("Processed {} sequences so far...", count);
                 }
 
@@ -255,7 +255,7 @@ pub fn implicon(
         match (rec1, rec2) {
             (Some(mut r1), Some(mut r2)) => {
                 count += 1;
-                if count % 1_000_000 == 0 {
+                if count.is_multiple_of(1_000_000) {
                     eprintln!("Processed {} sequences so far...", count);
                 }
 

--- a/src/trimmer.rs
+++ b/src/trimmer.rs
@@ -242,17 +242,19 @@ pub fn trim_read(record: &mut FastqRecord, config: &TrimConfig, is_r2: bool) -> 
         let clipped = record.clip_5prime(n);
         clip_5prime_applied = clipped.is_some();
         if config.rename
-            && let Some(seq) = clipped {
-                record.append_to_id(&format!(":clip5:{}", seq));
-            }
+            && let Some(seq) = clipped
+        {
+            record.append_to_id(&format!(":clip5:{}", seq));
+        }
     }
 
     if let Some(n) = clip_3 {
         let clipped = record.clip_3prime(n);
         if config.rename
-            && let Some(seq) = clipped {
-                record.append_to_id(&format!(":clip3:{}", seq));
-            }
+            && let Some(seq) = clipped
+        {
+            record.append_to_id(&format!(":clip3:{}", seq));
+        }
     }
 
     TrimResult {
@@ -458,15 +460,17 @@ pub fn run_paired_end(
 
                         // Rescue individual reads if --retain_unpaired
                         if let Some(ref mut w) = unpaired_r1.as_deref_mut()
-                            && r1_ok {
-                                w.write_record(&r1)?;
-                                pair_stats.r1_unpaired += 1;
-                            }
+                            && r1_ok
+                        {
+                            w.write_record(&r1)?;
+                            pair_stats.r1_unpaired += 1;
+                        }
                         if let Some(ref mut w) = unpaired_r2.as_deref_mut()
-                            && r2_ok {
-                                w.write_record(&r2)?;
-                                pair_stats.r2_unpaired += 1;
-                            }
+                            && r2_ok
+                        {
+                            w.write_record(&r2)?;
+                            pair_stats.r2_unpaired += 1;
+                        }
                     }
                     PairFilterResult::TooLong => {
                         pair_stats.pairs_removed += 1;

--- a/src/trimmer.rs
+++ b/src/trimmer.rs
@@ -241,20 +241,18 @@ pub fn trim_read(record: &mut FastqRecord, config: &TrimConfig, is_r2: bool) -> 
     if let Some(n) = clip_5 {
         let clipped = record.clip_5prime(n);
         clip_5prime_applied = clipped.is_some();
-        if config.rename {
-            if let Some(seq) = clipped {
+        if config.rename
+            && let Some(seq) = clipped {
                 record.append_to_id(&format!(":clip5:{}", seq));
             }
-        }
     }
 
     if let Some(n) = clip_3 {
         let clipped = record.clip_3prime(n);
-        if config.rename {
-            if let Some(seq) = clipped {
+        if config.rename
+            && let Some(seq) = clipped {
                 record.append_to_id(&format!(":clip3:{}", seq));
             }
-        }
     }
 
     TrimResult {
@@ -459,18 +457,16 @@ pub fn run_paired_end(
                         stats_r2.too_short += 1;
 
                         // Rescue individual reads if --retain_unpaired
-                        if let Some(ref mut w) = unpaired_r1.as_deref_mut() {
-                            if r1_ok {
+                        if let Some(ref mut w) = unpaired_r1.as_deref_mut()
+                            && r1_ok {
                                 w.write_record(&r1)?;
                                 pair_stats.r1_unpaired += 1;
                             }
-                        }
-                        if let Some(ref mut w) = unpaired_r2.as_deref_mut() {
-                            if r2_ok {
+                        if let Some(ref mut w) = unpaired_r2.as_deref_mut()
+                            && r2_ok {
                                 w.write_record(&r2)?;
                                 pair_stats.r2_unpaired += 1;
                             }
-                        }
                     }
                     PairFilterResult::TooLong => {
                         pair_stats.pairs_removed += 1;


### PR DESCRIPTION
## Summary

`--fastqc` now uses the [fastqc-rust](https://crates.io/crates/fastqc-rust) library directly (Phil Ewels / Seqera; targets byte-equivalent output to Java FastQC 0.12.1) instead of shelling out to an external `fastqc` binary. Completes the **single static binary, zero external runtime dependencies** story for v2.x — no Java, no Cutadapt, no pigz, no Python, no FastQC tarball. Drop the binary on a fresh box and run.

## What lands

| Surface | Change |
|---|---|
| `src/fastqc.rs` (new) | Thin wrapper around `fastqc_rust::runner::run` with a `--fastqc_args` flag translator |
| `src/main.rs` | Three call sites refactored from `Command::new("fastqc")` shell-out to `fastqc::run` |
| `Cargo.toml` | `fastqc-rust = "=1.0.0"` exact-pin; `rust-version` 1.85 → 1.88 |
| `Dockerfile` | Drops `default-jre-headless`, `perl`, `unzip`, `wget`, FastQC tarball install layer (~350 MB savings) |
| `README.md` | Features bullet + Docker section updated to drop the "requires Java / FastQC on $PATH" caveat |
| `Docs/SUMMARY.md` | Architecture narrative rewritten — FastQC is now part of the single-process model |
| `docs/Trim_Galore_User_Guide.md` | Methodology intro mentions bundled fastqc-rust; preserves historical Cutadapt+FastQC context |
| `CHANGELOG.md` | New "Unreleased (queued for v2.1.0-beta.4)" section with three bullets (bundled FastQC, multi-pair specialty modes from #224, infrastructure notes) |
| `.github/workflows/ci.yml` | New "Validate bundled FastQC produces canonical output files" step |

## The 6 commits, top-to-bottom

```
9cd67e9 docs/ci/dockerfile: complete the bundled-fastqc-rust rollout
d6b0830 feat(fastqc): wire bundled fastqc-rust into the --fastqc handler
5c7e812 style: rustfmt cleanup after clippy --fix in 4c0821a
4c0821a style: apply clippy auto-fixes from Rust 1.88's stricter lints
ec341df build(deps): add fastqc-rust = "=1.0.0" + bump rust-version to 1.88
```

(plus `e9c26d2 Add a .gitattributes file with linguist patterns (#225)` from Phil Ewels — already on `optimus_prime`, included as the merge base.)

## `--fastqc_args` translation

Translated subset (the common ones users actually pass):

```
--nogroup, --expgroup, --quiet, --svg, --nano, --nofilter, --casava,
-t/--threads, -o/--outdir
```

Unknown flags emit a warning and are ignored — deliberate forward-compat with future fastqc-rust additions. Covered by 8 new unit tests in `src/fastqc.rs::tests`.

## Risk / verification

- ✅ **Reproducibility** (the headline risk in the plan — `chrono` dep brings build-time clock concerns): verified at three points along the work — pre-dep baseline, dep-added-but-unused, dep-fully-wired. Each pair of `SOURCE_DATE_EPOCH=1700000000` builds produced identical SHA256. `chrono` is runtime-only in fastqc-rust (HTML report timestamps); the build is deterministic.
- ✅ **Binary size**: 2.39 MB → 7.06 MB. **+4.67 MB delta** — under the plan's +5–10 MB budget. fastqc-rust's `default-features = false` posture for flate2 + Rust's dead-code elimination on unused modules (CASAVA, Modern template) keep the closure tight.
- ✅ **Output structure**: live smoke confirms canonical Java FastQC layout in the `*_fastqc.zip` (`Icons/`, `Images/`, `summary.txt`, `fastqc_data.txt`). MultiQC parsers will see exactly what they saw before.
- ✅ **clippy + fmt**: clean. The rust-version bump (1.85 → 1.88) exposed 21 lints in our own code; auto-fixed in `4c0821a` + rustfmt cleanup in `5c7e812`.
- ✅ **Tests**: 153 → **161** passing (+8 from the new `fastqc.rs` arg-translator tests).
- 🆕 **CI smoke**: new step asserts `*_fastqc.html` and `*_fastqc.zip` are produced and that no external `fastqc` is on PATH (so a green run is real evidence of the bundled library doing the work).

## Pin posture

`fastqc-rust = "=1.0.0"` — exact-match. v1.0.0 was published to crates.io on 2026-04-26 (the day before this PR), 0 downloads at branch-cut time. We're an early high-profile user; treat upstream bumps as deliberate-test events.

## Sequencing relative to GA

GA target is **2026-05-03** (~7 days from today). Two viable paths:

1. **Cut beta.4 immediately after merge**, give 3–4 days of soak (especially the nf-core/rnaseq integration matrix), ship GA on schedule. Pros: real beta-tester feedback against the bundled FastQC; cleaner GA pitch ("zero external deps"). Cons: tighter timeline.
2. **Hold for v2.2**, ship v2.1.0 GA with bundled-only-in-Docker behaviour. Pros: GA stays on rails; lets fastqc-rust mature a few weeks. Cons: misses a clean GA pitch.

Recommendation: **(1)** — the verification plan came back green on every check, the binary size budget held, and reproducibility holds. Worth shipping.

## Plan reference

Full design + risk register at `~/.claude/plans/bundled-fastqc-rust.md`.

## Test plan

- [ ] Scan the `--help` diff (none expected — flag surface is unchanged)
- [ ] Confirm 5/5 CI gates green (Lint, Rust Tests, **Reproducibility**, Security audit, Validate vs Perl TrimGalore)
- [ ] Spot-check the `Validate bundled FastQC produces canonical output files` step's log
- [ ] Optionally: build the new Dockerfile locally, run `docker run … trim_galore --fastqc test_files/illumina_10K.fastq.gz`, confirm output without Java in the image