### PR TITLE
docs(cli): mention bundled fastqc-rust in --fastqc / --fastqc_args help

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -4,7 +4,7 @@
 
 A **faithful Rust rewrite of Trim Galore**, designed as a drop-in replacement for v0.6.x — same CLI flags, same output filenames, same report format compatible with MultiQC. Outputs match the Perl original for the core flag set (verified end-to-end via the nf-core/rnaseq integration matrix). The rewrite also adds capabilities the Perl version lacked: `--poly_g` auto-detection and trimming for 2-colour instruments, a generic `--poly_a` trimmer, per-pair adapter auto-detection, cleaner multi-adapter invocation (repeatable `-a`/`-a2` plus `file:adapters.fa`), and more.
 
-**Architecture shift:** Trim Galore (Perl) is a wrapper that shells out to Cutadapt (Python/Cython) for adapter matching. The Oxidized Edition does everything in a single process — adapter detection, alignment, quality trimming, adapter removal, filtering — in one pass through the data. Paired-end reads are processed in a single pass rather than two sequential Cutadapt runs.
+**Architecture shift:** Trim Galore (Perl) is a wrapper that shells out to Cutadapt (Python/Cython) for adapter matching, and additionally requires Java + the FastQC tarball for `--fastqc` to work. The Oxidized Edition does everything in a single process — adapter detection, alignment, quality trimming, adapter removal, filtering, *and* FastQC reporting (via the bundled [fastqc-rust](https://crates.io/crates/fastqc-rust) library) — in one pass through the data. Paired-end reads are processed in a single pass rather than two sequential Cutadapt runs. No Java, no Python, no Cutadapt, no external FastQC: the runtime is one static binary.
 
 ## Feature parity
 
@@ -22,7 +22,7 @@ A **faithful Rust rewrite of Trim Galore**, designed as a drop-in replacement fo
 | `--clock` (Epigenetic Clock UMI) | Done |
 | `--implicon` (UMI from R2) | Done |
 | `--demux` (3' barcode demultiplexing) | Done |
-| `--fastqc` / `--fastqc_args` | Done |
+| `--fastqc` / `--fastqc_args` | Done (bundled via fastqc-rust — no external Java/FastQC needed) |
 | `--rename`, `--trim-n`, `--max_n`, `--max_length` | Done |
 | `--retain_unpaired`, `--clip_R1/R2`, `--three_prime_clip_R1/R2` | Done |
 | `--cores N` (worker-pool parallelism) | Done |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -182,11 +182,16 @@ pub struct Cli {
     #[clap(long = "non_directional", requires = "rrbs")]
     pub non_directional: bool,
 
-    /// Run FastQC on the trimmed output files.
+    /// Run FastQC on the trimmed output files (built in via the bundled
+    /// fastqc-rust library; no external Java or FastQC binary needed).
+    /// Produces FastQC 0.12.1-compatible *_fastqc.html / *_fastqc.zip artifacts.
     #[clap(long = "fastqc")]
     pub fastqc: bool,
 
     /// Additional arguments to pass to FastQC. Implies --fastqc.
+    /// Common flags are translated to the bundled engine: --nogroup, --expgroup,
+    /// --quiet, --svg, --nano, --nofilter, --casava, -t/--threads, -o/--outdir.
+    /// Unrecognised flags emit a warning and are ignored.
     #[clap(long = "fastqc_args", allow_hyphen_values = true)]
     pub fastqc_args: Option<String>,
 


### PR DESCRIPTION
## Summary

The `--help` text for `--fastqc` and `--fastqc_args` still described the old shell-out behaviour ("Run FastQC on the trimmed output files"). PR #226 landed the bundled fastqc-rust integration but the surface-level docstrings on the two flags weren't refreshed.

This PR brings the rendered `--help` into alignment with what the binary actually does:

- **`--fastqc`** — explicitly states the integration is built in via the bundled fastqc-rust library, no Java / external FastQC binary needed, and that the artifacts are FastQC 0.12.1-compatible HTML/ZIP.
- **`--fastqc_args`** — enumerates the translated flag subset (`--nogroup`, `--expgroup`, `--quiet`, `--svg`, `--nano`, `--nofilter`, `--casava`, `-t/--threads`, `-o/--outdir`) so users see the supported set without reading source. Matches the dispatch table in `src/fastqc.rs:74-87`.

Also picked up two `docs/SUMMARY.md` polish lines that were drafted alongside #226 but missed that merge:
- Architecture-shift paragraph now flags Java + FastQC tarball as part of what the Perl wrapper required, and the static-binary outcome ("No Java, no Python, no Cutadapt, no external FastQC: the runtime is one static binary").
- Parity-table row for `--fastqc / --fastqc_args` annotated "(bundled via fastqc-rust — no external Java/FastQC needed)".

Pure docstring/markdown change. Zero runtime delta.

## Rendered `--help` (after)

```
      --fastqc
          Run FastQC on the trimmed output files (built in via the bundled
          fastqc-rust library; no external Java or FastQC binary needed).
          Produces FastQC 0.12.1-compatible *_fastqc.html / *_fastqc.zip
          artifacts

      --fastqc_args <FASTQC_ARGS>
          Additional arguments to pass to FastQC. Implies --fastqc. Common
          flags are translated to the bundled engine: --nogroup, --expgroup,
          --quiet, --svg, --nano, --nofilter, --casava, -t/--threads,
          -o/--outdir. Unrecognised flags emit a warning and are ignored
```

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release --lib fastqc` — 8/8 pass (translator unit tests)
- [x] Visual spot-check of `./target/release/trim_galore --help` for the two flags
- [x] Translator-flag list in docstring matches `src/fastqc.rs:74-87` exactly
- [ ] CI green (clippy + fmt + full test matrix)