### PR TITLE
fix(report): MultiQC-parity gaps surfaced in nf-core pre-GA review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,53 @@
 # Trim Galore Changelog
 
 
+### Unreleased (queued for v2.1.0-beta.6)
+
+#### Bug fixes (since v2.1.0-beta.5) — surfaced by the nf-core pre-GA validation review
+
+- **RRBS samples: `Total written (filtered)` cutadapt-section line now matches
+  Perl v0.6.x byte-for-byte.** Beta.4's `eedbc66` MultiQC-parity fix introduced
+  `total_bp_after_trim` (incremented after the full per-read trimming pipeline)
+  but didn't account for the `--rrbs` 2 bp 3' truncation. The reported value
+  drifted from v0.6.x by `RRBS-trimmed-reads × 2 bp`. `TrimResult` now carries
+  a `bp_after_cutadapt` field captured immediately after quality + adapter
+  trimming and before RRBS / poly-A/G / N-trim / clipping, and that's what
+  drives `total_bp_after_trim` in both single-end and paired-end pipelines.
+  Trimmed FASTQ output is unchanged — this fix only affects the reported
+  count. (#232)
+- **`RUN STATISTICS` filter-removed lines are now always emitted, even when
+  the count is 0.** The `if stats.too_short > 0` / `too_long` / `too_many_n`
+  guards (and the PE counterpart `pairs_removed_n` line) caused MultiQC's
+  canonical fallback parser to break on samples that pass 100% of reads
+  through length / max-N filters — the parser greps for the exact line and
+  treats absence as a parse failure. v0.6.x always emits the line. Now we do
+  too, with zero-protected percentage display. (#233)
+
+#### Documentation (since v2.1.0-beta.5)
+
+- **Migration notes: trimming-report behaviour changes vs Perl v0.6.x.** The
+  pre-GA review surfaced four intentional report-text changes that were not
+  filed because they match the v2.x reference report attached to MultiQC #3529.
+  Documented for users / parsers expecting the v0.6.x shape:
+  - **RRBS quality-trim line shape** changed from `Sequences were truncated to
+    a varying degree because of deteriorating qualities …: N (P%)` (counts
+    *reads*, v0.6.x RRBS only) to the cutadapt-style `Quality-trimmed: N bp
+    (P%)` (counts *bp*, v2.x both modes). Non-RRBS mode is unchanged in both
+    implementations. v2.x is more consistent across modes, but a regex tuned
+    to one shape won't match the other. (#234)
+  - **Adapter family-name annotation** dropped — v2.x emits the bare
+    sequence (e.g. `'AGATCGGAAGAGC'`) where v0.6.x emitted family names
+    (Illumina TruSeq, Nextera, smallRNA). The family is still tracked
+    internally but not rendered in the report.
+  - **"Bases preceding removed adapters" histogram** omitted from the
+    `=== Adapter N ===` block.
+  - **Per-adapter "Minimum overlap" line** not repeated under each adapter
+    block (the same datum is in the parameter summary at the top).
+  - **Length-distribution `max.err` column** uses the modern Cutadapt formula
+    `floor(L × error_rate)`. v0.6.x's display capped this at 1 in many
+    positions. The `count` column is unchanged byte-for-byte.
+
+
 ### Version 2.1.0-beta.5 (Release on 27 Apr 2026)
 
 #### Bug fixes (since v2.1.0-beta.4)

--- a/src/report.rs
+++ b/src/report.rs
@@ -404,18 +404,19 @@ pub fn write_pair_validation_stats<W: Write>(
         format_number(stats.pairs_removed)
     )?;
 
-    if stats.pairs_removed_n > 0 {
-        writeln!(
-            w,
-            "Number of pairs removed for N content ({:.2}%):",
-            percentage(stats.pairs_removed_n, stats.pairs_analyzed)
-        )?;
-        writeln!(
-            w,
-            "                             {:>10}",
-            format_number(stats.pairs_removed_n)
-        )?;
-    }
+    // PE counterpart to the RUN-STATISTICS unconditional emission (#233).
+    // Always emit so MultiQC parsers see a consistent line shape regardless of
+    // whether N-content filtering rejected any pairs.
+    writeln!(
+        w,
+        "Number of pairs removed for N content ({:.2}%):",
+        percentage(stats.pairs_removed_n, stats.pairs_analyzed)
+    )?;
+    writeln!(
+        w,
+        "                             {:>10}",
+        format_number(stats.pairs_removed_n)
+    )?;
 
     if stats.r1_unpaired > 0 || stats.r2_unpaired > 0 {
         writeln!(w)?;
@@ -594,31 +595,30 @@ pub fn write_run_footer<W: Write>(
     writeln!(w, "=============================================")?;
     writeln!(w, "{} sequences processed in total", stats.total_reads)?;
 
-    if stats.too_short > 0 {
-        writeln!(
-            w,
-            "Sequences removed because they became shorter than the length cutoff of {} bp:\t{} ({:.1}%)",
-            config.length_cutoff,
-            stats.too_short,
-            percentage(stats.too_short, stats.total_reads)
-        )?;
-    }
-    if stats.too_long > 0 {
-        writeln!(
-            w,
-            "Sequences removed because they were longer than the upper length cutoff:\t{} ({:.1}%)",
-            stats.too_long,
-            percentage(stats.too_long, stats.total_reads)
-        )?;
-    }
-    if stats.too_many_n > 0 {
-        writeln!(
-            w,
-            "Sequences removed because of too many N bases:\t{} ({:.1}%)",
-            stats.too_many_n,
-            percentage(stats.too_many_n, stats.total_reads)
-        )?;
-    }
+    // RUN-STATISTICS filter-removed lines are emitted unconditionally to match
+    // Perl v0.6.x — guarding on `> 0` broke MultiQC's canonical fallback parser
+    // ("Sequences removed because they became shorter…") on samples that happen
+    // to pass 100% of reads through length / max-N filters. See #233 and the
+    // long discussion at MultiQC #200.
+    writeln!(
+        w,
+        "Sequences removed because they became shorter than the length cutoff of {} bp:\t{} ({:.1}%)",
+        config.length_cutoff,
+        stats.too_short,
+        percentage(stats.too_short, stats.total_reads)
+    )?;
+    writeln!(
+        w,
+        "Sequences removed because they were longer than the upper length cutoff:\t{} ({:.1}%)",
+        stats.too_long,
+        percentage(stats.too_long, stats.total_reads)
+    )?;
+    writeln!(
+        w,
+        "Sequences removed because of too many N bases:\t{} ({:.1}%)",
+        stats.too_many_n,
+        percentage(stats.too_many_n, stats.total_reads)
+    )?;
 
     if stats.rrbs_trimmed_3prime > 0 {
         writeln!(
@@ -1567,5 +1567,67 @@ mod tests {
         assert_eq!(json["read_processing"]["reads_written"], 0);
         assert_eq!(json["basepair_processing"]["total_bp_processed"], 0);
         assert_eq!(json["adapter_trimming"][0]["times_trimmed"], 0);
+    }
+
+    // ── #233 regression: RUN-STATISTICS lines emitted even when count is 0 ─
+
+    #[test]
+    fn test_run_footer_emits_zero_count_filter_lines() {
+        // Perl v0.6.x always emits the "Sequences removed because they became
+        // shorter…" line — and the canonical MultiQC parser greps for it as a
+        // fallback when the embedded Cutadapt summary reports 100% passing.
+        // Guarding the line on `> 0` (the v2.0–beta.5 behaviour) broke that
+        // parser. See FelixKrueger/TrimGalore#233.
+        let config = test_config();
+        let mut stats = TrimStats::with_adapter_count(1);
+        stats.total_reads = 100;
+        stats.reads_written = 100;
+        stats.too_short = 0;
+        stats.too_long = 0;
+        stats.too_many_n = 0;
+
+        let mut buf = Vec::new();
+        write_run_footer(&mut buf, &config, &stats).unwrap();
+        let text = String::from_utf8(buf).unwrap();
+
+        assert!(
+            text.contains("Sequences removed because they became shorter than the length cutoff"),
+            "too_short line must be emitted even at count 0"
+        );
+        assert!(
+            text.contains(
+                "Sequences removed because they were longer than the upper length cutoff"
+            ),
+            "too_long line must be emitted even at count 0"
+        );
+        assert!(
+            text.contains("Sequences removed because of too many N bases"),
+            "too_many_n line must be emitted even at count 0"
+        );
+        // And the values appear as "0 (0.0%)".
+        assert!(
+            text.contains("0 (0.0%)"),
+            "zero counts must render with percentage"
+        );
+    }
+
+    #[test]
+    fn test_pair_validation_emits_zero_n_count_line() {
+        // Same shape on the PE side: pairs_removed_n is now always emitted.
+        let pair_stats = PairValidationStats {
+            pairs_analyzed: 1000,
+            pairs_removed: 0,
+            pairs_removed_n: 0,
+            ..PairValidationStats::default()
+        };
+
+        let mut buf = Vec::new();
+        write_pair_validation_stats(&mut buf, &pair_stats).unwrap();
+        let text = String::from_utf8(buf).unwrap();
+
+        assert!(
+            text.contains("Number of pairs removed for N content"),
+            "pairs_removed_n line must be emitted even at count 0"
+        );
     }
 }

--- a/src/trimmer.rs
+++ b/src/trimmer.rs
@@ -58,6 +58,13 @@ pub struct TrimResult {
     /// Per-round matches: (adapter_index, match_len). Empty if no adapter found.
     pub adapter_matches: Vec<(usize, usize)>,
     pub quality_trimmed_bp: usize, // bases removed by quality trimming
+    /// Sequence length after quality + adapter trimming, BEFORE the RRBS 2 bp
+    /// adjustment, poly-A/G trimming, N-trimming, and fixed clipping. Used to
+    /// drive `total_bp_after_trim` so the cutadapt-section "Total written
+    /// (filtered)" line matches Perl v0.6.x on RRBS samples (Perl reports
+    /// what its cutadapt subprocess wrote, before the wrapper's 2 bp RRBS
+    /// truncation). See FelixKrueger/TrimGalore#232.
+    pub bp_after_cutadapt: usize,
     pub rrbs_trimmed_3prime: bool,
     pub rrbs_trimmed_5prime: bool,
     pub poly_a_trimmed: usize, // number of bases trimmed (0 = no poly-A found)
@@ -144,6 +151,12 @@ pub fn trim_read(record: &mut FastqRecord, config: &TrimConfig, is_r2: bool) -> 
     }
 
     let had_adapter = !adapter_matches.is_empty();
+
+    // Capture sequence length AFTER quality + adapter trim, BEFORE any further
+    // adjustments (RRBS, poly-A/G, N-trim, clipping). Drives the cutadapt-
+    // section "Total written (filtered)" stat so it matches Perl v0.6.x on
+    // RRBS samples. See `TrimResult::bp_after_cutadapt` and #232.
+    let bp_after_cutadapt = record.seq.len();
 
     // 2.5. RRBS trimming (MspI 2bp end-repair artifact removal)
     let mut rrbs_trimmed_3prime = false;
@@ -261,6 +274,7 @@ pub fn trim_read(record: &mut FastqRecord, config: &TrimConfig, is_r2: bool) -> 
         had_adapter,
         adapter_matches,
         quality_trimmed_bp,
+        bp_after_cutadapt,
         rrbs_trimmed_3prime,
         rrbs_trimmed_5prime,
         poly_a_trimmed,
@@ -322,8 +336,10 @@ pub fn run_single_end(
             continue;
         }
 
-        // Track bp after trimming but before length filtering (Cutadapt-compatible stat)
-        stats.total_bp_after_trim += record.seq.len();
+        // Track bp after trimming but before length filtering (Cutadapt-compatible stat).
+        // Use the post-quality / post-adapter length captured in trim_read so the
+        // RRBS 2 bp truncation isn't double-subtracted vs Perl v0.6.x. See #232.
+        stats.total_bp_after_trim += result.bp_after_cutadapt;
 
         // Apply filters
         match filters::filter_single_end(
@@ -425,9 +441,11 @@ pub fn run_paired_end(
                     continue;
                 }
 
-                // Track bp after trimming but before pair/length filtering (Cutadapt-compatible stat)
-                stats_r1.total_bp_after_trim += r1.seq.len();
-                stats_r2.total_bp_after_trim += r2.seq.len();
+                // Track bp after trimming but before pair/length filtering (Cutadapt-compatible
+                // stat). Use post-quality / post-adapter lengths from trim_read so the RRBS
+                // 2 bp truncation isn't double-subtracted vs Perl v0.6.x. See #232.
+                stats_r1.total_bp_after_trim += result_r1.bp_after_cutadapt;
+                stats_r2.total_bp_after_trim += result_r2.bp_after_cutadapt;
 
                 // Pair-aware filtering
                 match filters::filter_paired_end(
@@ -731,5 +749,45 @@ mod tests {
         let mut record = make_record("NNACGTACGT");
         trim_read(&mut record, &config, false);
         assert_eq!(record.seq, "NNACGTACGT");
+    }
+
+    // ── #232 regression: bp_after_cutadapt captures pre-RRBS length ─────
+
+    #[test]
+    fn test_bp_after_cutadapt_skips_rrbs_truncation() {
+        // RRBS truncates 2 bp from the 3' end on adapter-contaminated reads.
+        // bp_after_cutadapt must capture the length BEFORE that truncation so
+        // the cutadapt-section "Total written (filtered)" stat matches Perl
+        // v0.6.x. See FelixKrueger/TrimGalore#232.
+        let mut config = test_config_with_adapters(vec![("illumina", "AGATCGGAAGAGC")], 1);
+        config.rrbs = true;
+
+        // 30 bp random + 13 bp adapter = 43 bp input.
+        // After adapter trim: 30 bp. After RRBS 2-bp truncation: 28 bp.
+        let read_seq = "ACGTACGTACGTACGTACGTACGTACGTACAGATCGGAAGAGC";
+        assert_eq!(read_seq.len(), 43);
+        let mut record = make_record(read_seq);
+        let result = trim_read(&mut record, &config, false);
+
+        assert!(result.had_adapter, "adapter must be detected");
+        assert!(result.rrbs_trimmed_3prime, "RRBS 3' trim must fire");
+        assert_eq!(record.seq.len(), 28, "post-RRBS length");
+        // The fix: bp_after_cutadapt is captured BEFORE RRBS truncation.
+        assert_eq!(
+            result.bp_after_cutadapt, 30,
+            "bp_after_cutadapt must reflect post-adapter, pre-RRBS length"
+        );
+    }
+
+    #[test]
+    fn test_bp_after_cutadapt_equals_seq_len_when_no_rrbs() {
+        // Without RRBS, bp_after_cutadapt and the final record length should
+        // match for reads that don't undergo poly-A/G/N-trim/clipping.
+        let config = test_config_with_adapters(vec![("illumina", "AGATCGGAAGAGC")], 1);
+        let mut record = make_record("ACGTACGTACGTACGTACGTAGATCGGAAGAGC");
+        let result = trim_read(&mut record, &config, false);
+
+        assert!(result.had_adapter);
+        assert_eq!(result.bp_after_cutadapt, record.seq.len());
     }
 }


### PR DESCRIPTION
## Summary

The nf-core/rnaseq team filed a [pre-GA validation report](#) on v2.1.0-beta.5 yesterday — three issues filed (#232, #233, #234) plus four acknowledged-as-design report-text changes. **Trimmed FASTQ records remain byte-identical to Perl v0.6.10** across the smoke matrix; every filed issue is in the trimming-report *text*, not the data layer.

This PR fixes #232 + #233 in code and covers #234 plus the four acknowledged changes via a CHANGELOG migration note.

## What changed

### #232 — RRBS samples: cutadapt-section "Total written (filtered)" drifts from v0.6.x

Beta.4's `eedbc66` ("Fix cutadapt-section report to match v0.6.x MultiQC-parsed values") introduced `total_bp_after_trim` for MultiQC parity, but incremented it *after* the full per-read pipeline — including the `--rrbs` 2 bp 3' truncation. The reported value drifted from v0.6.x by `RRBS-trimmed-reads × 2 bp`.

Fix: capture `bp_after_cutadapt: usize` on `TrimResult` immediately after quality + adapter trim and **before** RRBS / poly-A/G / N-trim / clipping. Use that for `total_bp_after_trim` in both single-end (`src/trimmer.rs:run_single_end`) and paired-end (`src/trimmer.rs:run_paired_end`) pipelines.

### #233 — RUN STATISTICS filter-removed lines omitted at zero count

`src/report.rs` had four `if stats.X > 0` guards (`too_short`, `too_long`, `too_many_n`, plus PE counterpart `pairs_removed_n`). v0.6.x always emits these even when zero. MultiQC's canonical fallback parser greps for the literal line as the "100% passing" path — guarding broke that parser on samples that pass everything.

Fix: drop the guards. The existing `percentage()` helper already returns `0.0` on zero denominator, so zero-count rendering is safe.

### #234 — RRBS quality-trim line shape (CHANGELOG only)

v0.6.x emits `Sequences were truncated to a varying degree because of deteriorating qualities …: N (P%)` on RRBS (counts *reads*); v2.x emits the cutadapt-style `Quality-trimmed: N bp (P%)` (counts *bp*). Reviewer flagged this as "arguably wontfix" because v2.x is more consistent across modes. Documented in the v2.1.0 migration notes alongside the four acknowledged design changes (dropped adapter family-name annotation, omitted "Bases preceding removed adapters" histogram, dropped per-adapter "Minimum overlap" line, modern Cutadapt `floor(L × error_rate)` `max.err` formula).

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test --release` — **165 passed** (was 161; +2 for #232 RRBS pre-truncation capture, +2 for #233 zero-count emission on SE and PE paths)
- [x] `cargo fmt --all -- --check` — clean after auto-format
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [x] Manual review against the nf-core report's cited line numbers (`src/trimmer.rs:148-175,326`, `src/report.rs:597,606,614,407`) — all match
- [ ] CI green

## Validation against the report's claims

| Reviewer claim | Verified against current `optimus_prime` HEAD |
|---|---|
| `total_bp_after_trim` at `trimmer.rs:326` after RRBS truncation | ✅ confirmed |
| `if stats.too_short > 0` guard at `report.rs:597` | ✅ confirmed |
| Same pattern at `too_long` (line 606) and `too_many_n` (line 614) | ✅ confirmed |
| PE pair-removal counterpart guard | ✅ found at `report.rs:407` (`pairs_removed_n`) |

## Closes

- Closes #232
- Closes #233
- Documents #234 (left open until reviewer agrees the CHANGELOG note is sufficient)