### PR TITLE
docs(site): disable smartypants — was mangling --flag inside <code>

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -6,6 +6,11 @@ export default defineConfig({
   site: 'https://felixkrueger.github.io',
   base: '/TrimGalore',
   trailingSlash: 'ignore',
+  // Disable smartypants. It rewrites `--` to em-dashes (—) even inside
+  // JSX <code> elements in MDX, which silently mangles CLI flag names
+  // like --fastqc → —fastqc on the homepage. Em-dashes we actually want
+  // are typed literally throughout, so nothing is lost.
+  markdown: { smartypants: false },
   integrations: [
     starlight({
       title: 'Trim Galore',


### PR DESCRIPTION
## Summary

Reported by Felix: the homepage rendered \`Pass —fastqc and it just works\` instead of \`Pass --fastqc\`. Confirmed live via curl:

\`\`\`
<code>—fastqc</code>     # rendered
<code>—nextseq</code>    # rendered
speed-up at —cores N     # rendered (in proof-bar label)
\`\`\`

Source has \`--fastqc\` / \`--nextseq\` / \`--cores\` correctly in all three places.

## Root cause

\`@astrojs/mdx\` runs \`remark-smartypants\` by default. It rewrites \`--\` → em-dash (—) in MDX content, **including inside JSX \`<code>\` elements**. Markdown backtick code spans (\`\`--rrbs\`\`) are correctly skipped, which is why the user-guide \`.md\` pages weren't affected.

## Fix

Set \`markdown: { smartypants: false }\` in \`astro.config.mjs\`. We type the em-dashes we actually want literally throughout (tagline, proof-bar labels, prose), so nothing is lost.

## Test plan

- [x] Local rebuild — \`Docs/dist/index.html\` now contains \`<code>--fastqc</code>\` and \`--cores N\` (verified with grep)
- [x] CI build (will run on this PR)
- [ ] Post-merge: verify live homepage shows \`--fastqc\` again