### PR TITLE
fix(cli): auto-create -o/--output_dir if missing (was hanging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 
 ### Unreleased (queued for v2.1.0-beta.6)
 
+#### Bug fixes (since v2.1.0-beta.5)
+
+- **`-o/--output_dir DIR` no longer hangs when `DIR` doesn't exist.** The
+  parallel paired-end path opened output files via raw `File::create`,
+  which fails immediately on a missing parent — but by then reader and
+  worker threads were already spawned, the `?` exit dropped the receiver
+  channel, and the process deadlocked at near-zero CPU (workers stuck
+  producing into a queue with no consumers). Reported via beta.5 user
+  feedback (24h wall / 4s CPU on a SLURM cluster). Fix: hoist
+  `create_dir_all` into `main()` immediately after CLI parse, covering
+  every downstream code path (parallel, single-threaded, paired,
+  single-end, every specialty mode) in one place. Restores Perl v0.6.x
+  behaviour ("If an output directory which was specified with -o
+  output_directory did not exist, it will be created for you", v0.6.0
+  changelog).
+
 #### Bug fixes (since v2.1.0-beta.5) — surfaced by the nf-core pre-GA validation review
 
 - **RRBS samples: `Total written (filtered)` cutadapt-section line now matches

--- a/src/io.rs
+++ b/src/io.rs
@@ -6,7 +6,35 @@
 //! - Unpaired: *_unpaired_1.fq(.gz) / *_unpaired_2.fq(.gz)
 //! - Reports: *_trimming_report.txt
 
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
+
+/// Ensure the user-supplied `--output_dir` exists, creating it (and any
+/// missing ancestors) if not. No-op when no `--output_dir` was passed or
+/// the directory already exists.
+///
+/// Why this lives at the top of `main()` rather than at the per-file
+/// writer: the parallel paired-end path opens its outputs via raw
+/// `File::create` (see `parallel.rs`), which fails immediately on a
+/// missing parent. By that point reader and worker threads have already
+/// been spawned, so the early-return drops the receiver channel and the
+/// process deadlocks with reader+workers stuck producing into a queue
+/// nobody is draining. Hoisting the directory-create here covers every
+/// downstream code path (parallel, single-threaded, paired, single-end,
+/// every specialty mode) in one shot.
+///
+/// Matches Perl v0.6.x behaviour: "If an output directory which was
+/// specified with -o output_directory did not exist, it will be created
+/// for you" (v0.6.0 changelog).
+pub fn ensure_output_dir(dir: Option<&Path>) -> Result<()> {
+    let Some(dir) = dir else { return Ok(()) };
+    if dir.exists() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("Failed to create output directory: {}", dir.display()))?;
+    Ok(())
+}
 
 /// Generate the trimmed output filename for single-end mode.
 ///
@@ -225,5 +253,46 @@ mod tests {
             out,
             PathBuf::from("/output/sample.fq.gz_trimming_report.json")
         );
+    }
+
+    #[test]
+    fn test_ensure_output_dir_creates_missing() {
+        // Pick a path that does not exist; ensure_output_dir should create
+        // it (along with any missing intermediate components). Regression
+        // test for the parallel-path deadlock on missing --output_dir
+        // (reported via beta.5 user feedback).
+        let base = std::env::temp_dir().join("tg_ensure_dir_creates_missing");
+        let _ = std::fs::remove_dir_all(&base);
+        let nested = base.join("a").join("b").join("c");
+        assert!(!nested.exists());
+
+        ensure_output_dir(Some(&nested)).unwrap();
+        assert!(nested.exists());
+        assert!(nested.is_dir());
+
+        std::fs::remove_dir_all(&base).unwrap();
+    }
+
+    #[test]
+    fn test_ensure_output_dir_idempotent_on_existing() {
+        // Calling on an already-existing directory must succeed silently
+        // without altering the directory's mtime in a surprising way.
+        let dir = std::env::temp_dir().join("tg_ensure_dir_idempotent");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        ensure_output_dir(Some(&dir)).unwrap();
+        assert!(dir.exists());
+        // Second call also succeeds.
+        ensure_output_dir(Some(&dir)).unwrap();
+        assert!(dir.exists());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn test_ensure_output_dir_none_is_noop() {
+        // No --output_dir was passed; helper must be a clean no-op.
+        ensure_output_dir(None).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,10 @@ fn main() -> Result<()> {
     let gzip = !cli.dont_gzip;
     let output_dir = cli.output_dir.as_deref();
 
+    // Auto-create --output_dir if it doesn't exist. See io::ensure_output_dir
+    // for why this has to happen here and not lazily per-file.
+    naming::ensure_output_dir(output_dir)?;
+
     // Specialty modes — bypass normal trimming pipeline entirely
     if let Some(n) = cli.hardtrim5 {
         for input in &cli.input {


### PR DESCRIPTION
## Summary

Reported via beta.5 user feedback: a SLURM-cluster paired-end run with \`-j 10 -o ../outdir\` against plain-text \`.fastq\` input hung at **4 seconds CPU after 24 hours wall** when \`../outdir\` didn't exist beforehand. User confirmed re-running with the directory pre-created succeeded in ~7 minutes.

## Root cause

\`src/fastq.rs:430-436\` (single-threaded \`FastqWriter::create\`) creates the parent dir lazily — but \`src/parallel.rs:179-182\` (parallel paired-end path) opens outputs via raw \`File::create(...)?\`, which fails immediately on a missing parent. By that point reader and worker threads have already been spawned upstream. The \`?\` exit drops the receiver channel; workers stay stuck producing into a queue with no consumers; deadlock at near-zero CPU.

## Fix

New \`io::ensure_output_dir\` helper called from \`main()\` immediately after CLI parse, before any threads are spawned. Single choke-point covers every downstream code path:

- parallel paired-end (the originally-broken one)
- single-threaded paired-end
- single-end (any cores)
- \`--hardtrim5\` / \`--hardtrim3\`
- \`--clock\` / \`--implicon\`
- \`--demux\`

Restores Perl v0.6.x behaviour: *"If an output directory which was specified with -o output_directory did not exist, it will be created for you"* (v0.6.0 changelog).

## Tests

3 new \`io::tests\` covering the three cases:
- \`creates_missing\` — \`Some(nested non-existent path)\`, asserts created
- \`idempotent_on_existing\` — \`Some(existing path)\`, called twice
- \`none_is_noop\` — \`None\` passes through cleanly

Total test count: **165 → 168**. \`cargo fmt\` clean, \`cargo clippy --all-targets --release -- -D warnings\` clean.

## Test plan

- [x] \`cargo test --release ensure_output_dir\` — all 3 pass
- [x] \`cargo test --release\` — 168 passed, 0 failed
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --all-targets --release -- -D warnings\` — clean
- [ ] CI on this PR
- [ ] Manual smoke (post-merge): \`trim_galore --paired -j 4 -o /tmp/nonexistent_$(date +%s) test_files/BS-seq_10K_R1.fastq.gz test_files/BS-seq_10K_R2.fastq.gz\` should now succeed instead of hanging

## CHANGELOG

Queued for v2.1.0-beta.6 (top of the existing \`Bug fixes (since v2.1.0-beta.5)\` list — feels appropriate to surface this loudly given it's a deadlock not a cosmetic bug).