### PR TITLE
docs(logos): restore `npm run logos` script line dropped from #239

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "logos": "node scripts/generate-png-logos.mjs"
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.4",


### PR DESCRIPTION
## Summary

PR #239 added \`Docs/scripts/generate-png-logos.mjs\` and its npm shortcut to \`package.json\`. The package.json edit got lost in the squash — the script file landed but the alias didn't. \`npm run logos\` doesn't work without it.

One-line restore.

## Test plan

- [x] \`cd Docs && npm run logos\` — exits 0, regenerates the 6 PNGs