### PR TITLE
fix: Perl-parity bundle (#242, #245, #246, #247) + #243 UX polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,19 @@ jobs:
 
       - name: Install Perl Trim Galore (v0.6.11) + Cutadapt
         run: |
-          conda create -n perl_tg -y -c conda-forge -c bioconda cutadapt=5.2 "xopen<2"
-          curl -fsSL https://raw.githubusercontent.com/FelixKrueger/TrimGalore/0.6.11/trim_galore -o /usr/local/bin/trim_galore_perl
+          # Cutadapt 5.2 build-number pinned to *_0 (#247 item 6): the
+          # validation matrix uses Cutadapt's output as the Perl-side
+          # oracle, so an unannounced bioconda revision bump (5.2-1, etc.)
+          # could silently shift the md5 baseline. Pin to the first build
+          # of 5.2 — bumps become visible failures, not invisible drift.
+          conda create -n perl_tg -y -c conda-forge -c bioconda 'cutadapt=5.2=*_0' "xopen<2"
+          # Fetch the legacy Perl source from the local repo's `master`
+          # branch (#247 item 5). master tracks the v0.6.x release line;
+          # this gives byte-identical content to the previous
+          # raw.githubusercontent curl with zero external network
+          # dependency, eliminating a flaky source.
+          git fetch --depth=1 origin master
+          git show origin/master:trim_galore > /usr/local/bin/trim_galore_perl
           chmod +x /usr/local/bin/trim_galore_perl
 
       - name: Verify Perl Trim Galore
@@ -500,3 +511,28 @@ jobs:
 
       - name: All validations passed
         run: echo "All Oxidized Edition outputs are byte-identical to Perl TrimGalore 0.6.11"
+
+      # #247 item 1: when any md5 oracle step above fails, the /tmp
+      # outputs that triggered the mismatch are otherwise lost — the
+      # runner cleans them up before the failed step's logs scroll past.
+      # Uploading them on failure turns "guess what the binary actually
+      # produced" into a one-click download. Useful in particular for
+      # reviewing perf PRs that intentionally change output bytes
+      # (e.g. a default gzip-level change) — diffing the new artefacts
+      # against the Perl baseline is the fastest path to the new oracle.
+      - name: Upload validation outputs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: validation-outputs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            /tmp/tg/
+            /tmp/op/
+            /tmp/op_multi/
+            /tmp/op_multi2/
+            /tmp/op_multi_seq/
+            /tmp/op_retain/
+            /tmp/op_case/
+            /tmp/*.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,32 @@ proptest harness — tracked as separate followups.
   max_scan=1M, asserts full-file scan). Public `autodetect_adapter`
   API unchanged.
 
+#### Infrastructure (contributor-facing, since v2.1.0-beta.5) — CI hardening (#247)
+
+Three CI improvements landed from @an-altosian's audit (#247). Touches
+only `.github/workflows/ci.yml`; no runtime change.
+
+- **Validation outputs uploaded on failure.** When any md5 oracle
+  step fails, the `/tmp/tg`, `/tmp/op*`, and `/tmp/*.log` paths that
+  triggered the mismatch were previously lost when the runner cleaned
+  up. New `if: failure()` step uploads them as a 7-day artifact under
+  `validation-outputs-<run_id>-<attempt>`. Especially useful for
+  reviewing perf PRs that intentionally change output bytes (e.g. a
+  default gzip-level change) — the new artefacts can be diffed
+  against the Perl baseline directly.
+- **Perl Trim Galore source fetched from local `master` instead of
+  `raw.githubusercontent`.** The Perl v0.6.x release line lives at
+  `master:trim_galore` in this repo; replacing the curl with
+  `git fetch --depth=1 origin master && git show
+  origin/master:trim_galore` gives byte-identical content with zero
+  external network dependency, eliminating a class of CI flake.
+- **Cutadapt bioconda revision pinned (`cutadapt=5.2=*_0`).** The
+  validation matrix uses Cutadapt's output as the Perl-side oracle,
+  so an unannounced bioconda revision bump (5.2-1, etc.) could
+  silently shift the md5 baseline. Pin to the first build of 5.2 so
+  any rev bump becomes a visible CI failure rather than invisible
+  drift.
+
 #### Bug fixes (since v2.1.0-beta.5) — surfaced by the nf-core pre-GA validation review
 
 - **RRBS samples: `Total written (filtered)` cutadapt-section line now matches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@
   Added lowercase aliases on all four flags. Reported and diagnosed by
   @an-altosian during a Phase-1B Perl-parity hunt. (#242)
 
+- **`--max_n` fraction-mode now logs the Perl-style notice on entry**
+  ("`--max_n will be interpreted as a fraction of the read length
+  (0.5)`"). Investigating @an-altosian's #243 confirmed the dispatch
+  and filter chain behave correctly: values in `(0.0, 1.0)` already
+  build `MaxNFilter::Fraction` and `n_count/length > threshold`
+  filtering matches Perl v0.6.8+ behaviour byte-for-byte. The
+  reproducer-fixture's max-N fraction (3/153 ≈ 0.02) just doesn't
+  exceed the 0.5 threshold, so neither implementation filters
+  anything — *not* a bug. Adding the same warning Perl prints
+  (`master:trim_galore:3328`) makes the selected mode visible at
+  runtime so users don't have to derive it from output statistics.
+  (#243)
+
 #### Bug fixes (since v2.1.0-beta.5)
 
 - **`-o/--output_dir DIR` no longer hangs when `DIR` doesn't exist.** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,42 @@
   Added lowercase aliases on all four flags. Reported and diagnosed by
   @an-altosian during a Phase-1B Perl-parity hunt. (#242)
 
+- **Output gzip compression now mirrors input compression by default.**
+  Plain `.fastq` input → plain `.fq` output; `.fastq.gz` → `.fq.gz`.
+  Restores Perl v0.6.x behaviour. Rust v2.1.0-beta.5 always emitted
+  gzipped output regardless of input, breaking pipelines that globbed
+  `*.fq` (no `.gz`) for outputs from plain-text inputs. `--dont_gzip`
+  still works as the explicit "always plain" override. The first input
+  determines the mode for the whole run; mixing plain and gzipped
+  inputs in one invocation isn't a supported configuration. Reported
+  by @an-altosian via #245 (item A).
+
+- **`--retain_unpaired` now routes both mates independently to their
+  unpaired files when both mates fail the discard `--length` cutoff,
+  if each is individually long enough for the per-side `--length_{1,2}`
+  threshold.** Rust v2.1.0-beta.5 had an extra `!r{1,2}_short` clause in
+  `filters::filter_paired_end` that gated unpaired rescue on the read
+  itself passing the discard cutoff, which silently dropped reads when
+  both mates failed `--length` together but were individually long
+  enough. Matches Perl `master:trim_galore:2325-2343`. Slight caveat:
+  Perl's behaviour diverges from its own user-guide wording ("rescue
+  the surviving mate"); we match the implementation, not the docs, to
+  preserve byte-identity for the documented byte-identity flag paths.
+  Regression test added. Reported by @an-altosian via #245 (item C).
+
+#### Behavioural notes (v2.x intentional widenings, since v2.1.0-beta.5)
+
+- **`--clock` and `--implicon` now imply `--paired`** — passing either
+  flag without `--paired` is no longer rejected. Both modes are
+  inherently paired-end specialty modes; requiring users to pass
+  `--paired` redundantly was noise. Pipelines using the explicit Perl
+  form (`--clock --paired` / `--implicon --paired`) continue to work
+  unchanged. Consistent with the multi-pair widening pattern documented
+  for these specialty modes in beta.4. Surfaced by @an-altosian via
+  #245 (item D).
+
+#### Bug fixes (since v2.1.0-beta.5) — Perl-parity regressions (contributor-reported, continued)
+
 - **`--max_n` fraction-mode now logs the Perl-style notice on entry**
   ("`--max_n will be interpreted as a fraction of the read length
   (0.5)`"). Investigating @an-altosian's #243 confirmed the dispatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,61 @@
   output_directory did not exist, it will be created for you", v0.6.0
   changelog).
 
+#### Tests (since v2.1.0-beta.5) — coverage gaps closed (#246)
+
+Five new unit tests landed across `report.rs`, `demux.rs`, `fastq.rs`,
+and `adapter.rs`. Closes 5 of the 6 `§5.x` items from the test-coverage
+audit. Total test count: 171 → 177. Items still open from #246:
+parallel/serial stat-tracking parity (§5.2), comprehensive
+`parallel.rs` coverage, optional upstreaming of @an-altosian's
+proptest harness — tracked as separate followups.
+
+- **§5.4 PE param-summary `removed-end:` regression guard**
+  (`report.rs::tests`). Beta.3 fixed a stray `-end` suffix in the
+  paired-end parameter-summary line (`...sequence pair gets
+  removed-end: 20 bp` → `...removed: 20 bp`); MultiQC parsers grep
+  for the literal `removed:` form. Test renders the PE header and
+  asserts both `!contains("removed-end")` and the canonical phrase —
+  any reintroduction of the typo class fails the assertion.
+
+- **§5.5 Demux CRLF samplesheet handling** (`demux.rs::tests`).
+  Windows-authored barcode sheets use `\r\n` line endings; without
+  the `trim_end_matches('\r')` strip in `read_barcode_file`, the
+  trailing `\r` would pollute the parsed barcode and fail the
+  ACGTN-only validator with a confusing "barcode must contain only
+  A, C, T, G, N" error. Test writes a CRLF samplesheet and asserts
+  no stray `\r` survives on any parsed entry.
+
+- **§5.6 Demux short-read NoCode routing** (`demux.rs::tests`).
+  When a trimmed read is shorter than the barcode length,
+  `demultiplex` (`src/demux.rs:178-187`) routes it to the NoCode
+  bucket instead of slicing past the read end. End-to-end test:
+  fixture with one 5 bp read, one non-matching 16 bp read, and one
+  matching 16 bp read; asserts both NoCode-bound reads land in
+  `*_NoCode.fq` (with cleared seq+qual for the too-short one) and
+  the matching read lands in the per-sample bucket. Together with
+  §5.5 closes the `demux.rs` zero-tests module gap.
+
+- **§5.1 Multi-member gzip reader round-trip** (`fastq.rs::tests`).
+  The parallel writer (`--cores N`) emits each worker's chunk as
+  its own gzip member; the concatenated stream is a valid RFC 1952
+  multi-member gzip file. Test crafts a 2-member buffer with
+  `GzEncoder::finish` twice, concatenates, and asserts
+  `FastqReader` (using `MultiGzDecoder`) yields records from BOTH
+  members in order. Originally fixed in `9dcf519` (pre-beta.1) but
+  never had a unit-level regression test.
+
+- **§5.3 Adapter auto-detect `MAX_SCAN_READS` boundary**
+  (`adapter.rs::tests`). The 1M-read scan cap was unverified at the
+  unit level; generating a >1M-read fixture per test run is too
+  slow. Refactored: extracted `autodetect_adapter_with_max_scan`
+  (crate-private) so tests can exercise the same `increment-then-
+  break` control flow at scale 7. Two paired tests: cap-bounded
+  (input has 100 records, max_scan=7, asserts `reads_scanned == 7`
+  and matches < 100) and cap-unbounded (input has 50 records,
+  max_scan=1M, asserts full-file scan). Public `autodetect_adapter`
+  API unchanged.
+
 #### Bug fixes (since v2.1.0-beta.5) — surfaced by the nf-core pre-GA validation review
 
 - **RRBS samples: `Total written (filtered)` cutadapt-section line now matches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 
 ### Unreleased (queued for v2.1.0-beta.6)
 
+#### Bug fixes (since v2.1.0-beta.5) — Perl-parity regressions (contributor-reported)
+
+- **Lowercase clip-flag spellings (`--clip_r1`, `--clip_r2`,
+  `--three_prime_clip_r1`, `--three_prime_clip_r2`) are now accepted.**
+  Perl `trim_galore` accepted both lowercase and uppercase spellings;
+  the Rust port matched the uppercase canonical only and rejected the
+  lowercase forms with a clap parse error (exit 2). Every Perl-era
+  pipeline using the documented lowercase spelling broke under v2.x.
+  Added lowercase aliases on all four flags. Reported and diagnosed by
+  @an-altosian during a Phase-1B Perl-parity hunt. (#242)
+
 #### Bug fixes (since v2.1.0-beta.5)
 
 - **`-o/--output_dir DIR` no longer hangs when `DIR` doesn't exist.** The

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ trim_galore --help
 | Paired-end | `*_val_1.fq.gz` / `*_val_2.fq.gz` | per-read text + JSON reports |
 | Unpaired (with `--retain_unpaired`) | `*_unpaired_1.fq.gz` / `*_unpaired_2.fq.gz` | |
 
+Output compression mirrors the input: gzipped input (`*.fastq.gz`) produces gzipped output (`*.fq.gz`); plain input (`*.fastq`) produces plain output (`*.fq`). Pass `--dont_gzip` to force plain output regardless.
+
 The JSON report contains the same statistics as the text report in a structured format (schema v1), designed for native parsing by MultiQC.
 
 ## Documentation

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -96,6 +96,20 @@ pub fn autodetect_adapter<P: AsRef<Path>>(
     path: P,
     consider_already_trimmed: Option<usize>,
 ) -> Result<DetectionResult> {
+    autodetect_adapter_with_max_scan(path, consider_already_trimmed, MAX_SCAN_READS)
+}
+
+/// Inner implementation of [`autodetect_adapter`] with the per-call scan
+/// cap exposed as a parameter. Crate-private so unit tests can exercise
+/// the boundary behaviour with a small `max_scan` instead of needing a
+/// fixture larger than 1M reads; production callers always go through
+/// the [`autodetect_adapter`] wrapper which pins the cap at
+/// `MAX_SCAN_READS`.
+pub(crate) fn autodetect_adapter_with_max_scan<P: AsRef<Path>>(
+    path: P,
+    consider_already_trimmed: Option<usize>,
+    max_scan: usize,
+) -> Result<DetectionResult> {
     let mut reader = FastqReader::open(path)?;
 
     // BGI/DNBSEQ added to the probe set: its 32bp adapter shares no
@@ -117,7 +131,7 @@ pub fn autodetect_adapter<P: AsRef<Path>>(
 
     while let Some(record) = reader.next_record()? {
         reads_scanned += 1;
-        if reads_scanned >= MAX_SCAN_READS {
+        if reads_scanned >= max_scan {
             break;
         }
 
@@ -820,6 +834,74 @@ mod tests {
             .map(|(_, c)| *c)
             .unwrap_or(0);
         assert_eq!(nextera_count, 50);
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    /// §5.3 regression: the auto-detection scan caps at `MAX_SCAN_READS`
+    /// (1,000,000 in production). Verified here via the crate-private
+    /// `autodetect_adapter_with_max_scan` helper with a small `max_scan`
+    /// — generating a >1M-read fixture every test run is prohibitively
+    /// slow, so the boundary contract is exercised at scale 7 instead
+    /// of scale 1e6 (same control-flow shape: increment-then-break).
+    /// Asserts both that scanning stops at the cap and that
+    /// `reads_scanned` reflects the cap value, not the file's record
+    /// count.
+    #[test]
+    fn test_autodetect_respects_max_scan_boundary() -> Result<()> {
+        let dir = std::env::temp_dir().join("tg_test_autodetect_max_scan");
+        std::fs::create_dir_all(&dir)?;
+        let path = dir.join("plenty.fq");
+        // 100 records, all with the Illumina adapter embedded → if scanning
+        // ran to EOF, the Illumina count would be 100. With max_scan=7 the
+        // count must be strictly less.
+        write_fastq_with_adapter(&path, ILLUMINA.seq, 100)?;
+
+        let result = autodetect_adapter_with_max_scan(&path, None, 7)?;
+        assert_eq!(
+            result.reads_scanned, 7,
+            "reads_scanned must equal max_scan when input has more records than the cap"
+        );
+        let illumina_count = result
+            .counts
+            .iter()
+            .find(|(n, _)| n == "Illumina")
+            .map(|(_, c)| *c)
+            .unwrap_or(0);
+        // The cap is checked AFTER `reads_scanned += 1` so the 7th increment
+        // breaks before the loop body that would have counted the 7th match.
+        // Concretely: 6 records contribute to the count, 7 reads_scanned.
+        assert!(
+            illumina_count < 100,
+            "Illumina count must be capped (got {illumina_count}, expected < 100)"
+        );
+        assert!(
+            illumina_count <= 7,
+            "Illumina count must be at most max_scan (got {illumina_count})"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    /// Sanity test: with `max_scan` larger than the input record count,
+    /// scanning runs to EOF and `reads_scanned` equals the file size.
+    /// Pairs with `test_autodetect_respects_max_scan_boundary` so a
+    /// regression that breaks the cap (e.g. always-stop-at-7) wouldn't
+    /// pass both tests at once.
+    #[test]
+    fn test_autodetect_below_max_scan_processes_full_file() -> Result<()> {
+        let dir = std::env::temp_dir().join("tg_test_autodetect_full_scan");
+        std::fs::create_dir_all(&dir)?;
+        let path = dir.join("small.fq");
+        write_fastq_with_adapter(&path, ILLUMINA.seq, 50)?;
+
+        let result = autodetect_adapter_with_max_scan(&path, None, 1_000_000)?;
+        assert_eq!(
+            result.reads_scanned, 50,
+            "below-cap inputs must scan to EOF"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
         Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,7 +136,9 @@ pub struct Cli {
     #[clap(long = "basename")]
     pub basename: Option<String>,
 
-    /// Do not gzip-compress output files.
+    /// Do not gzip-compress output files. Forces plain output regardless of
+    /// input compression. By default, output compression mirrors the input
+    /// (plain → plain, .gz → .gz; matches Perl v0.6.x behaviour).
     #[clap(long = "dont_gzip")]
     pub dont_gzip: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,20 +97,20 @@ pub struct Cli {
     pub trim_n: bool,
 
     /// Remove N bases from the 5' end of Read 1. Useful for removing 5' quality-bias regions.
-    #[clap(long = "clip_R1")]
+    #[clap(long = "clip_R1", alias = "clip_r1")]
     pub clip_r1: Option<usize>,
 
     /// Remove N bases from the 5' end of Read 2 (paired-end only).
     /// For paired-end bisulfite-seq, the end-repair step can introduce methylation bias; see Bismark User Guide.
-    #[clap(long = "clip_R2")]
+    #[clap(long = "clip_R2", alias = "clip_r2")]
     pub clip_r2: Option<usize>,
 
     /// Remove N bases from the 3' end of Read 1, after adapter/quality trimming.
-    #[clap(long = "three_prime_clip_R1")]
+    #[clap(long = "three_prime_clip_R1", alias = "three_prime_clip_r1")]
     pub three_prime_clip_r1: Option<usize>,
 
     /// Remove N bases from the 3' end of Read 2 (paired-end only), after adapter/quality trimming.
-    #[clap(long = "three_prime_clip_R2")]
+    #[clap(long = "three_prime_clip_R2", alias = "three_prime_clip_r2")]
     pub three_prime_clip_r2: Option<usize>,
 
     /// NextSeq/NovaSeq 2-colour quality trimming. Trailing high-quality G bases
@@ -812,5 +812,53 @@ mod tests {
         let cli = Cli::parse_from(args);
         assert_eq!(cli.adapter, vec!["AGCT"]);
         assert_eq!(cli.adapter2, vec!["GCAT", "AAAA"]);
+    }
+
+    /// Perl `trim_galore` accepts the lowercase clip-flag spellings
+    /// (`--clip_r1` / `--clip_r2` / `--three_prime_clip_r1` /
+    /// `--three_prime_clip_r2`) alongside the uppercase forms. The Rust port
+    /// historically only matched the uppercase canonical, breaking every
+    /// Perl-era pipeline using the lowercase spelling. Regression for #242.
+    #[test]
+    fn test_clip_flags_accept_lowercase_aliases() {
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--paired",
+            "--clip_r1",
+            "5",
+            "--clip_r2",
+            "6",
+            "--three_prime_clip_r1",
+            "7",
+            "--three_prime_clip_r2",
+            "8",
+            R1,
+            R2,
+        ]);
+        assert_eq!(cli.clip_r1, Some(5));
+        assert_eq!(cli.clip_r2, Some(6));
+        assert_eq!(cli.three_prime_clip_r1, Some(7));
+        assert_eq!(cli.three_prime_clip_r2, Some(8));
+
+        // The canonical uppercase forms must of course still work. Mix a few
+        // to confirm both aliases resolve to the same field.
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--paired",
+            "--clip_R1",
+            "1",
+            "--clip_r2",
+            "2",
+            "--three_prime_clip_R1",
+            "3",
+            "--three_prime_clip_r2",
+            "4",
+            R1,
+            R2,
+        ]);
+        assert_eq!(cli.clip_r1, Some(1));
+        assert_eq!(cli.clip_r2, Some(2));
+        assert_eq!(cli.three_prime_clip_r1, Some(3));
+        assert_eq!(cli.three_prime_clip_r2, Some(4));
     }
 }

--- a/src/demux.rs
+++ b/src/demux.rs
@@ -261,3 +261,135 @@ fn output_filename(base_name: &str, sample_name: &str, gzip: bool) -> String {
         format!("{}_{}.fq", base_name, sample_name)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    /// Set up a unique tempdir for a test, removing any leftover from a
+    /// prior aborted run. Mirrors the project's existing test convention
+    /// (`std::env::temp_dir().join("tg_test_*")`).
+    fn fresh_tmpdir(slug: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(slug);
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// §5.5 regression: Windows-authored barcode samplesheets use CRLF
+    /// (`\r\n`) line endings. Perl strips the trailing `\r` before
+    /// parsing; Rust's `read_barcode_file` does the same via
+    /// `trim_end_matches('\r').trim_end()`. This test locks down that
+    /// behaviour — without the trim, the barcode field would include a
+    /// trailing `\r`, fail the ACGTN-only validator, and bail with a
+    /// confusing "barcode must contain only A, C, T, G, N" error.
+    #[test]
+    fn test_read_barcode_file_handles_crlf_line_endings() {
+        let dir = fresh_tmpdir("tg_demux_crlf_samplesheet");
+        let path = dir.join("barcodes.tsv");
+        // Three barcodes with explicit CRLF, plus a trailing empty line
+        // to exercise the empty-line branch.
+        let mut f = File::create(&path).unwrap();
+        f.write_all(b"sample1\tACGTACGT\r\nsample2\tGTCAGTCA\r\nsample3\tTGCATGCA\r\n\r\n")
+            .unwrap();
+        f.flush().unwrap();
+
+        let entries = read_barcode_file(&path).expect("CRLF samplesheet must parse");
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].sample_name, "sample1");
+        assert_eq!(entries[0].barcode, "ACGTACGT");
+        assert_eq!(entries[1].sample_name, "sample2");
+        assert_eq!(entries[1].barcode, "GTCAGTCA");
+        assert_eq!(entries[2].sample_name, "sample3");
+        assert_eq!(entries[2].barcode, "TGCATGCA");
+        // Critical: no stray '\r' must survive on the parsed barcode.
+        for e in &entries {
+            assert!(
+                !e.barcode.contains('\r'),
+                "barcode '{}' contains stray \\r — CRLF strip failed",
+                e.barcode.escape_default()
+            );
+        }
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// §5.6 regression: when a read is shorter than the barcode length,
+    /// `demultiplex` (src/demux.rs:178-187) routes it to the NoCode
+    /// bucket rather than slicing past the read end (which would either
+    /// panic on a non-UTF8 boundary or compare against an empty string).
+    /// End-to-end via `demultiplex` because the routing decision is
+    /// inline with file I/O — easier to verify by inspecting NoCode
+    /// output than to refactor for in-isolation testability.
+    #[test]
+    fn test_demultiplex_short_reads_route_to_nocode() {
+        let dir = fresh_tmpdir("tg_demux_short_nocode");
+        let trimmed = dir.join("input_trimmed.fq");
+
+        // Three reads: one too-short (5 bp < 8 bp barcode), one normal
+        // length but non-matching barcode, one normal length matching
+        // sample1's barcode at the 3' end.
+        let mut f = File::create(&trimmed).unwrap();
+        // Record 1: 5 bp — must route to NoCode (too short).
+        // Record 2: 16 bp ending in ZZZZZZZZ — invalid bases, but the
+        //           extracted 8 bp tail is "GGGGTTTT" → no match → NoCode.
+        // Record 3: 16 bp ending in ACGTACGT — matches sample1's barcode.
+        f.write_all(
+            b"@short\nACGTA\n+\nIIIII\n\
+              @nomatch\nNNNNNNNNGGGGTTTT\n+\nIIIIIIIIIIIIIIII\n\
+              @hit\nNNNNNNNNACGTACGT\n+\nIIIIIIIIIIIIIIII\n",
+        )
+        .unwrap();
+        f.flush().unwrap();
+
+        let barcodes = vec![BarcodeEntry {
+            sample_name: "sample1".to_string(),
+            barcode: "ACGTACGT".to_string(),
+        }];
+
+        demultiplex(&trimmed, &barcodes, false, Some(&dir), 1).unwrap();
+
+        // Output base is the trimmed-file basename minus .gz/.fq suffixes:
+        // "input_trimmed.fq" → "input_trimmed" + "_<sample>.fq".
+        let nocode = dir.join("input_trimmed_NoCode.fq");
+        let sample1 = dir.join("input_trimmed_sample1.fq");
+
+        let nocode_text = fs::read_to_string(&nocode).unwrap();
+        let sample1_text = fs::read_to_string(&sample1).unwrap();
+
+        // Both the too-short read and the non-matching one land in NoCode.
+        assert!(
+            nocode_text.contains("@short_BC:"),
+            "short read must route to NoCode. NoCode contents:\n{nocode_text}"
+        );
+        assert!(
+            nocode_text.contains("@nomatch_BC:"),
+            "non-matching read must route to NoCode. NoCode contents:\n{nocode_text}"
+        );
+        // The short read's seq + qual are cleared (no slice past EOR).
+        let short_block = nocode_text
+            .lines()
+            .skip_while(|l| !l.starts_with("@short_BC:"))
+            .take(4)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            short_block.len(),
+            4,
+            "short record must still emit a 4-line FASTQ block"
+        );
+        assert_eq!(short_block[1], "", "short read seq must be cleared");
+        assert_eq!(short_block[3], "", "short read qual must be cleared");
+
+        // The matching read lands in the sample bucket.
+        assert!(
+            sample1_text.contains("@hit_BC:ACGTACGT"),
+            "matching read must route to sample1 bucket. sample1 contents:\n{sample1_text}"
+        );
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -620,4 +620,59 @@ mod tests {
 
         Ok(())
     }
+
+    /// §5.1 regression: the parallel writer (`--cores N`) emits each
+    /// worker's chunk as its own independently-compressed gzip member,
+    /// then concatenates them (RFC 1952 — multi-member gzip is a valid
+    /// `.gz` file that decompresses to the concatenation of each
+    /// member's payload). The reader has to use `MultiGzDecoder`, NOT
+    /// the single-member `GzDecoder`, or it silently truncates output
+    /// to whatever fits in the first gzip member when that file is fed
+    /// back through Trim Galore as a follow-on input. Originally fixed
+    /// in commit 9dcf519 (pre-beta.1) but never had a unit-level
+    /// regression test. Locks down the contract: a manually-crafted
+    /// 2-member gzip file round-trips through `FastqReader` with all
+    /// records from both members.
+    #[test]
+    fn test_multi_member_gzip_round_trip() -> Result<()> {
+        let dir = std::env::temp_dir().join("tg_multi_member_gzip");
+        std::fs::create_dir_all(&dir)?;
+        let path = dir.join("two_member.fq.gz");
+
+        // Member 1: 2 records.
+        let mut member1: Vec<u8> = Vec::new();
+        {
+            let mut enc = GzEncoder::new(&mut member1, Compression::default());
+            enc.write_all(b"@m1_r1\nACGT\n+\nIIII\n")?;
+            enc.write_all(b"@m1_r2\nGGCC\n+\n!!!!\n")?;
+            enc.finish()?;
+        }
+        // Member 2: 2 more records, separately-compressed.
+        let mut member2: Vec<u8> = Vec::new();
+        {
+            let mut enc = GzEncoder::new(&mut member2, Compression::default());
+            enc.write_all(b"@m2_r1\nTTAA\n+\nJJJJ\n")?;
+            enc.write_all(b"@m2_r2\nNNNN\n+\n????\n")?;
+            enc.finish()?;
+        }
+        // Concatenate the two gzip members and verify our crafted file
+        // is genuinely multi-member (would-be a parsing-error point for
+        // single-member decoders).
+        std::fs::write(&path, [member1, member2].concat())?;
+
+        let mut reader = FastqReader::open(&path)?;
+        let mut ids: Vec<String> = Vec::new();
+        while let Some(rec) = reader.next_record()? {
+            ids.push(rec.id);
+        }
+
+        assert_eq!(
+            ids,
+            vec!["@m1_r1", "@m1_r2", "@m2_r1", "@m2_r2"],
+            "MultiGzDecoder must yield records from both gzip members"
+        );
+
+        std::fs::remove_file(&path)?;
+        Ok(())
+    }
 }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -240,14 +240,8 @@ mod tests {
         let seq = "A".repeat(50);
         let r1 = make_record(&seq);
         let r2 = make_record(&seq);
-        let result = filter_paired_end(
-            &r1,
-            &r2,
-            80,
-            None,
-            None,
-            UnpairedLengths { r1: 35, r2: 35 },
-        );
+        let result =
+            filter_paired_end(&r1, &r2, 80, None, None, UnpairedLengths { r1: 35, r2: 35 });
         match result {
             PairFilterResult::TooShort { r1_ok, r2_ok } => {
                 assert!(r1_ok, "R1 (50 bp >= 35) should rescue to unpaired");

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -85,14 +85,25 @@ pub fn filter_paired_end(
         return PairFilterResult::TooManyN;
     }
 
-    // Length check — can rescue individual reads with --retain_unpaired
+    // Length check — can rescue individual reads with --retain_unpaired.
+    //
+    // Perl-parity note (matches `master:trim_galore:2325-2343`):
+    // when at least one mate fails the discard cutoff, each read is
+    // independently routed to its unpaired file based solely on its own
+    // length vs the per-side cutoff (`--length_1` / `--length_2`). There
+    // is no requirement that the OTHER mate must have failed; both sides
+    // can land in unpaired in the same record. Rust v2.1.0-beta.5 had an
+    // extra `!r{1,2}_short` clause here that gated unpaired-rescue on
+    // the read passing the discard cutoff, which silently dropped reads
+    // when both mates failed `--length` but were individually long
+    // enough for `--length_{1,2}`. See #245 (parity-hunt).
     let r1_short = r1.len() < length_cutoff;
     let r2_short = r2.len() < length_cutoff;
 
     if r1_short || r2_short {
         return PairFilterResult::TooShort {
-            r1_ok: !r1_short && r1.len() >= unpaired.r1,
-            r2_ok: !r2_short && r2.len() >= unpaired.r2,
+            r1_ok: r1.len() >= unpaired.r1,
+            r2_ok: r2.len() >= unpaired.r2,
         };
     }
 
@@ -212,6 +223,37 @@ mod tests {
                 assert!(!r2_ok); // R2 is too short even for unpaired
             }
             _ => panic!("Expected TooShort"),
+        }
+    }
+
+    /// Perl parity (master:trim_galore:2325-2343): when BOTH mates fail
+    /// the discard `--length` cutoff but each is individually long enough
+    /// for the per-side `--length_{1,2}` threshold, both reads route to
+    /// their unpaired files. Regression for #245 — Rust previously had a
+    /// `!r{1,2}_short` clause that gated unpaired rescue on the read
+    /// itself passing the discard cutoff, which silently dropped reads
+    /// when both mates failed `--length` together.
+    #[test]
+    fn test_paired_both_mates_fail_discard_both_routable_to_unpaired() {
+        // 50 bp reads, --length 80 (both fail), --length_1 = --length_2 = 35
+        // (default per-side); each individually >= 35 so both should rescue.
+        let seq = "A".repeat(50);
+        let r1 = make_record(&seq);
+        let r2 = make_record(&seq);
+        let result = filter_paired_end(
+            &r1,
+            &r2,
+            80,
+            None,
+            None,
+            UnpairedLengths { r1: 35, r2: 35 },
+        );
+        match result {
+            PairFilterResult::TooShort { r1_ok, r2_ok } => {
+                assert!(r1_ok, "R1 (50 bp >= 35) should rescue to unpaired");
+                assert!(r2_ok, "R2 (50 bp >= 35) should rescue to unpaired");
+            }
+            other => panic!("Expected TooShort, got {:?}", other),
         }
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -9,6 +9,17 @@
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
+/// True iff `path` ends with a `.gz` extension. The same heuristic that
+/// `FastqReader` uses to decide whether to wrap the input in a gzip
+/// decoder, so output naming + reader behaviour stay consistent.
+///
+/// Used to mirror input compression in the output filename / writer:
+/// `plain.fastq` → `plain_trimmed.fq` (plain), `plain.fastq.gz` →
+/// `plain_trimmed.fq.gz`. Matches Perl v0.6.x behaviour.
+pub fn is_gzipped(path: &Path) -> bool {
+    path.extension().is_some_and(|ext| ext == "gz")
+}
+
 /// Ensure the user-supplied `--output_dir` exists, creating it (and any
 /// missing ancestors) if not. No-op when no `--output_dir` was passed or
 /// the directory already exists.
@@ -294,5 +305,20 @@ mod tests {
     fn test_ensure_output_dir_none_is_noop() {
         // No --output_dir was passed; helper must be a clean no-op.
         ensure_output_dir(None).unwrap();
+    }
+
+    #[test]
+    fn test_is_gzipped() {
+        // Common extensions that indicate gzip.
+        assert!(is_gzipped(Path::new("sample.fastq.gz")));
+        assert!(is_gzipped(Path::new("sample.fq.gz")));
+        assert!(is_gzipped(Path::new("/some/dir/x.gz")));
+        // Plain FASTQ — no gzip.
+        assert!(!is_gzipped(Path::new("sample.fastq")));
+        assert!(!is_gzipped(Path::new("sample.fq")));
+        assert!(!is_gzipped(Path::new("/some/dir/x")));
+        // Heuristic is extension-based (matches FastqReader's gzip detection),
+        // so a misnamed file doesn't trigger.
+        assert!(!is_gzipped(Path::new("sample.gz.fastq")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,11 +250,18 @@ fn setup_trimming(cli: &Cli, input_file: &Path) -> SetupResult {
     });
     eprintln!();
 
-    // Build max_n filter
+    // Build max_n filter. Values in (0.0, 1.0) are interpreted as a fraction
+    // of the read length, matching Perl v0.6.8+ behaviour. The fraction case
+    // is easy to enter accidentally (e.g. typing `--max_n 0.5` when meaning
+    // "half a read"), so emit the same warning Perl does so users can see
+    // which mode their invocation actually selected. See issue #243.
     let max_n = cli.max_n.map(|v| {
         if v >= 1.0 {
             MaxNFilter::Count(v as usize)
         } else {
+            eprintln!(
+                "--max_n will be interpreted as a fraction of the read length ({v})"
+            );
             MaxNFilter::Fraction(v)
         }
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,14 @@ fn main() -> Result<()> {
 
     FastqReader::sanity_check(&cli.input[0])?;
 
-    let gzip = !cli.dont_gzip;
+    // Output gzip mode. Mirror Perl: by default the output's compression
+    // matches the input's (plain `.fastq` → plain `.fq`, gzipped `.fastq.gz`
+    // → gzipped `.fq.gz`). `--dont_gzip` overrides to always-plain. The
+    // first input determines the mode for the whole run; mixing plain and
+    // gzipped inputs in one invocation isn't a supported configuration.
+    // See #245 for the parity rationale (Rust v2.1.0-beta.5 always gzipped
+    // regardless of input, breaking pipelines that globbed `*.fq` no-gz).
+    let gzip = !cli.dont_gzip && naming::is_gzipped(&cli.input[0]);
     let output_dir = cli.output_dir.as_deref();
 
     // Auto-create --output_dir if it doesn't exist. See io::ensure_output_dir

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,9 +266,7 @@ fn setup_trimming(cli: &Cli, input_file: &Path) -> SetupResult {
         if v >= 1.0 {
             MaxNFilter::Count(v as usize)
         } else {
-            eprintln!(
-                "--max_n will be interpreted as a fraction of the read length ({v})"
-            );
+            eprintln!("--max_n will be interpreted as a fraction of the read length ({v})");
             MaxNFilter::Fraction(v)
         }
     });

--- a/src/report.rs
+++ b/src/report.rs
@@ -1611,6 +1611,36 @@ mod tests {
         );
     }
 
+    /// Beta.3 had a paired-end-only regression where the parameter-summary
+    /// line emitted `...sequence pair gets removed-end: 20 bp` (a stray
+    /// `-end` from the PE branch suffix leaking into the rendered template)
+    /// instead of `...sequence pair gets removed: 20 bp`. MultiQC parsers
+    /// grep for the literal "removed:" form, so the typo broke aggregation.
+    /// Lock down a class-of-typo regression: any reintroduction would fail
+    /// the assertion.
+    #[test]
+    fn test_paired_param_summary_no_removed_end_typo() {
+        let mut config = test_config();
+        config.paired = true;
+        config.length_cutoff = 20;
+        config.input_filename = "sample_R1.fq.gz".to_string();
+
+        let mut buf = Vec::new();
+        write_report_header(&mut buf, &config).unwrap();
+        let text = String::from_utf8(buf).unwrap();
+
+        assert!(
+            !text.contains("removed-end"),
+            "PE param summary must not contain the legacy 'removed-end:' typo. \
+             Rendered:\n{text}"
+        );
+        assert!(
+            text.contains("sequence pair gets removed: 20 bp"),
+            "PE param summary must contain canonical 'removed: 20 bp' form. \
+             Rendered:\n{text}"
+        );
+    }
+
     #[test]
     fn test_pair_validation_emits_zero_n_count_line() {
         // Same shape on the PE side: pairs_removed_n is now always emitted.


### PR DESCRIPTION
## Summary

Bundles six commits closing or partially-closing five issues raised during @an-altosian's Phase-1B Perl-parity hunt. All commits are independently scoped and individually revert-clean if any one needs to be backed out post-merge.

## Commits in this PR

| Commit | What | Issue |
|---|---|---|
| \`110c199\` | \`fix(cli)\` — accept lowercase clip-flag spellings (\`--clip_r1\` etc.) | **#242** |
| \`832e2ea\` | \`feat(cli)\` — warn when \`--max_n\` enters fraction mode (Perl parity) | **#243** |
| \`e5bf8fc\` | \`fix(cli/filters)\` — Perl-parity for output gzip + \`--retain_unpaired\` | **#245** items A, C, D |
| \`68bb475\` | \`docs(readme)\` — note that output compression mirrors input | (follow-up to #245-A) |
| \`4605e8e\` | \`test(coverage)\` — close 5 of 6 §5.x items from the test-coverage audit | **#246** items §5.1, §5.3, §5.4, §5.5, §5.6 |
| \`d7b3f6c\` | \`ci\` — hardening: failure artifacts + local Perl source + Cutadapt rev pin | **#247** items 1, 5, 6 |

## Highlights

**Real Perl-parity bugs fixed**:
- Lowercase clip-flag spellings now accepted (every Perl-era pipeline using \`--clip_r1\` was broken under v2.x).
- Output gzip mirrors input compression by default (plain in → plain out, .gz in → .gz out). \`--dont_gzip\` still forces plain.
- \`--retain_unpaired\` now correctly routes both mates to their unpaired files when both fail \`--length\` but each is individually long enough for \`--length_{1,2}\`.

**UX warnings added**:
- \`--max_n 0.5\` now logs the same notice Perl prints, so users can see at runtime which mode they're in.

**Test coverage**:
- \`demux.rs\` zero-tests gap closed (CRLF samplesheet handling + short-read NoCode routing).
- \`fastq.rs\` multi-member gzip round-trip regression test (covers a pre-beta.1 fix that never had a unit test).
- \`adapter.rs\` 1M-read scan-limit boundary verified at scale 7 via a crate-private \`autodetect_adapter_with_max_scan\` helper.
- \`report.rs\` PE param-summary \`removed-end:\` typo class locked down for MultiQC parsers.
- Total tests: 165 → 177.

**CI hardening**:
- \`if: failure()\` artifact upload on the validation job — md5 mismatches now surface the actual outputs as a downloadable artifact.
- Perl Trim Galore source fetched from local \`origin/master\` instead of curling \`raw.githubusercontent\` — no external network dependency.
- Cutadapt bioconda revision pinned to \`5.2=*_0\` so an unannounced rev bump can't silently shift the validation matrix's md5 baseline.

## Items deliberately deferred

Each of these is tracked on the source issue and warrants a focused PR of its own:
- **#245 item B** — \`-a 'A{15}'\` adapter-alignment difference on highly-repetitive patterns (brace expansion is correct; the divergence is in the alignment DP tolerance, separate investigation).
- **#246 §5.2** — parallel/serial \`TrimStats\` parity (needs harness scaffolding to expose stats from a parallel run).
- **#246 module-gap** — comprehensive \`parallel.rs\` unit-level coverage.
- **#246 bonus** — upstreaming @an-altosian's \`tests/parity_proptest.rs\` harness.
- **#247 item 2** — macOS runner in \`rust-tests\` (doubles wall time).
- **#247 item 3** — \`cargo test --release\` step.
- **#247 item 4** — coverage reporting (cargo-llvm-cov / tarpaulin).
- **#247 item 7** — \`justfile\` for local CI parity.
- **#247 item 8** — \`cargo nextest\` adoption.
- **#248** — three confirmed perf wins (gzip-level, single buffered write, Myers' alignment); deferred entirely to await @an-altosian's incoming PRs (#2 → #4 → #1 in his stated order).

## Test plan

- [x] \`cargo test --release\` — 177 passed, 0 failed
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --all-targets --release -- -D warnings\` — clean
- [x] YAML \`ci.yml\` parses (\`python3 -c 'import yaml; yaml.safe_load(open(...))'\`)
- [x] End-to-end smoke for the parity fixes:
  - \`--clip_r1 5\` parses correctly
  - Plain \`.fastq\` input → plain \`.fq\` output; \`.fastq.gz\` input → \`.fq.gz\` output; \`--dont_gzip\` overrides
  - \`--paired --retain_unpaired --length 80\` populates both \`_unpaired_*.fq.gz\` files (~9996/10000 records each on \`BS-seq_10K\`)
  - \`--max_n 0.5\` emits the fraction-mode warning to stderr
- [ ] Validation matrix runs green on this PR — particularly important for the CI changes (item 5 \`git show origin/master:trim_galore\` and item 6 Cutadapt \`*_0\` pin)

Closes #242