### PR TITLE
fix(fmt): hotfix rustfmt-version diff post-#250 (gzip-level imports)

### DIFF
--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -57,8 +57,7 @@ impl FastqRecord {
         // amortising the per-call overhead — at Buckberry scale (84M
         // reads, 38% adapter rate) this is ~10% wall-clock at cores=8.
         // See #248 (item #2 in @an-altosian's perf audit).
-        let mut buf =
-            Vec::with_capacity(self.id.len() + self.seq.len() + self.qual.len() + 5);
+        let mut buf = Vec::with_capacity(self.id.len() + self.seq.len() + self.qual.len() + 5);
         buf.extend_from_slice(self.id.as_bytes());
         buf.push(b'\n');
         buf.extend_from_slice(self.seq.as_bytes());

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -20,7 +20,7 @@ use std::io::Write;
 use std::path::Path;
 use std::sync::mpsc;
 
-use crate::fastq::{FastqReader, FastqRecord};
+use crate::fastq::{FastqReader, FastqRecord, OUTPUT_GZIP_LEVEL};
 use crate::filters::{self, FilterResult, PairFilterResult, UnpairedLengths};
 use crate::report::{PairValidationStats, TrimStats};
 use crate::trimmer::{self, TrimConfig, update_adapter_stats};
@@ -246,15 +246,21 @@ fn process_paired_batch(
         // Scoped block: GzEncoders borrow the buffers; finish() before block
         // ends releases the borrows so we can return the buffers.
         {
-            let mut gz_r1 = GzEncoder::new(&mut buf_r1, Compression::new(crate::fastq::OUTPUT_GZIP_LEVEL));
-            let mut gz_r2 = GzEncoder::new(&mut buf_r2, Compression::new(crate::fastq::OUTPUT_GZIP_LEVEL));
+            let mut gz_r1 = GzEncoder::new(&mut buf_r1, Compression::new(OUTPUT_GZIP_LEVEL));
+            let mut gz_r2 = GzEncoder::new(&mut buf_r2, Compression::new(OUTPUT_GZIP_LEVEL));
             let mut gz_up_r1 = if retain_unpaired {
-                Some(GzEncoder::new(&mut buf_up_r1, Compression::new(crate::fastq::OUTPUT_GZIP_LEVEL)))
+                Some(GzEncoder::new(
+                    &mut buf_up_r1,
+                    Compression::new(OUTPUT_GZIP_LEVEL),
+                ))
             } else {
                 None
             };
             let mut gz_up_r2 = if retain_unpaired {
-                Some(GzEncoder::new(&mut buf_up_r2, Compression::new(crate::fastq::OUTPUT_GZIP_LEVEL)))
+                Some(GzEncoder::new(
+                    &mut buf_up_r2,
+                    Compression::new(OUTPUT_GZIP_LEVEL),
+                ))
             } else {
                 None
             };
@@ -560,7 +566,7 @@ fn process_single_batch(
 
     if gzip {
         {
-            let mut gz = GzEncoder::new(&mut buf, Compression::new(crate::fastq::OUTPUT_GZIP_LEVEL));
+            let mut gz = GzEncoder::new(&mut buf, Compression::new(OUTPUT_GZIP_LEVEL));
             process_reads(reads, config, &mut stats, &mut gz)?;
             gz.finish()?;
         }


### PR DESCRIPTION
Hotfix: CI's stable rustfmt and my local 1.9.0-stable disagreed on line-wrap choices around the new `OUTPUT_GZIP_LEVEL` call sites and the buffered-write `Vec::with_capacity`. Local was clean pre-merge but CI rejected post-merge ([run 25103753614](https://github.com/FelixKrueger/TrimGalore/actions/runs/25103753614)).

Two targeted fixes:
- `src/parallel.rs`: import `OUTPUT_GZIP_LEVEL` at the top so call sites are unqualified; rustfmt then naturally splits the longer `Some(GzEncoder::new(...))` expressions.
- `src/fastq.rs`: collapse the `Vec::with_capacity` into a single line.

No behaviour change. `cargo fmt`, `cargo clippy --all-targets --release -- -D warnings`, and 177 tests all clean.