### PR TITLE
fix(io): --basename foo --paired produces foo_val_{1,2}.fq.gz (#244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ from @an-altosian.
 
 #### Bug fixes (since v2.1.0-beta.5) — Perl-parity regressions (contributor-reported)
 
+- **`--basename foo --paired` now produces `foo_val_1.fq.gz` /
+  `foo_val_2.fq.gz`, not `foo_R1_val_1.fq.gz` / `foo_R2_val_2.fq.gz`.**
+  The `_R{1,2}` segment was interpolated between the basename and the
+  `_val_{1,2}` suffix in `io::paired_end_output_names` and
+  `io::unpaired_output_names`, breaking the documented Perl v0.6.5+
+  filename contract — every nf-core / Snakemake pipeline globbing
+  the documented `${basename}_val_*` path silently missed outputs
+  under v2.1.0-beta.5. Trimmed read content was unaffected, only the
+  filenames differed. Two regression tests added covering the
+  basename branches of both functions. Reported by @an-altosian
+  during the Phase-1C parity hunt. (#244)
+
 - **Lowercase clip-flag spellings (`--clip_r1`, `--clip_r2`,
   `--three_prime_clip_r1`, `--three_prime_clip_r2`) are now accepted.**
   Perl `trim_galore` accepted both lowercase and uppercase spellings;

--- a/src/io.rs
+++ b/src/io.rs
@@ -89,8 +89,19 @@ pub fn paired_end_output_names(
 ) -> (PathBuf, PathBuf) {
     let ext = if gzip { ".fq.gz" } else { ".fq" };
 
+    // When --basename is supplied, both stems are exactly that basename:
+    // `foo` → `foo_val_1.fq.gz` / `foo_val_2.fq.gz`. The `_val_{1,2}`
+    // suffix carries the pair-side distinction; there's no `_R1`/`_R2`
+    // segment between the basename and the suffix. Matches Perl v0.6.5+
+    // behaviour (CHANGELOG: "In a `--paired --basename BASE` scenario,
+    // the output files will now be called `BASE_val_1.fq.gz
+    // BASE_val_2.fq.gz` as described in the documentation"). Beta.5
+    // had a `_R1`/`_R2` interpolation here that broke the documented
+    // contract — silently miss-pathed outputs for any nf-core /
+    // Snakemake pipeline globbing the documented `${basename}_val_*`.
+    // See #244.
     let (stem1, stem2) = match basename {
-        Some(b) => (format!("{}_R1", b), format!("{}_R2", b)),
+        Some(b) => (b.to_string(), b.to_string()),
         None => (
             strip_fastq_extensions(input_r1),
             strip_fastq_extensions(input_r2),
@@ -117,8 +128,11 @@ pub fn unpaired_output_names(
 ) -> (PathBuf, PathBuf) {
     let ext = if gzip { ".fq.gz" } else { ".fq" };
 
+    // Same `--basename` semantic as paired_end_output_names — the
+    // `_unpaired_{1,2}` suffix carries the pair-side, no `_R{1,2}`
+    // segment is interpolated. Matches Perl v0.6.5+ behaviour. See #244.
     let (stem1, stem2) = match basename {
-        Some(b) => (format!("{}_R1", b), format!("{}_R2", b)),
+        Some(b) => (b.to_string(), b.to_string()),
         None => (
             strip_fastq_extensions(input_r1),
             strip_fastq_extensions(input_r2),
@@ -241,6 +255,46 @@ mod tests {
         let (o1, o2) = paired_end_output_names(r1, r2, None, None, true);
         assert_eq!(o1, PathBuf::from("/data/sample_R1_val_1.fq.gz"));
         assert_eq!(o2, PathBuf::from("/data/sample_R2_val_2.fq.gz"));
+    }
+
+    /// #244 regression: `--basename foo --paired` must produce
+    /// `foo_val_1.fq.gz` / `foo_val_2.fq.gz`, NOT `foo_R1_val_1.fq.gz`
+    /// / `foo_R2_val_2.fq.gz`. Beta.5 silently interpolated `_R1`/`_R2`
+    /// between the basename and the `_val_{1,2}` suffix, which broke
+    /// every nf-core / Snakemake pipeline globbing the documented
+    /// Perl path. Matches Perl v0.6.5+ semantics.
+    #[test]
+    fn test_paired_end_output_names_with_basename() {
+        let r1 = Path::new("/data/sample_R1.fq.gz");
+        let r2 = Path::new("/data/sample_R2.fq.gz");
+        // No --output_dir: falls back to input parent dir.
+        let (o1, o2) = paired_end_output_names(r1, r2, None, Some("foo"), true);
+        assert_eq!(o1, PathBuf::from("/data/foo_val_1.fq.gz"));
+        assert_eq!(o2, PathBuf::from("/data/foo_val_2.fq.gz"));
+
+        // With --output_dir
+        let out = Path::new("/tmp/out");
+        let (o1, o2) = paired_end_output_names(r1, r2, Some(out), Some("foo"), true);
+        assert_eq!(o1, PathBuf::from("/tmp/out/foo_val_1.fq.gz"));
+        assert_eq!(o2, PathBuf::from("/tmp/out/foo_val_2.fq.gz"));
+
+        // gzip=false suffix
+        let (o1, o2) = paired_end_output_names(r1, r2, None, Some("foo"), false);
+        assert_eq!(o1, PathBuf::from("/data/foo_val_1.fq"));
+        assert_eq!(o2, PathBuf::from("/data/foo_val_2.fq"));
+    }
+
+    /// #244 regression for the `--retain_unpaired` companion path —
+    /// same `_R1`/`_R2` interpolation bug, same fix. With basename "foo"
+    /// the unpaired files must be `foo_unpaired_1.fq.gz` /
+    /// `foo_unpaired_2.fq.gz`.
+    #[test]
+    fn test_unpaired_output_names_with_basename() {
+        let r1 = Path::new("/data/sample_R1.fq.gz");
+        let r2 = Path::new("/data/sample_R2.fq.gz");
+        let (o1, o2) = unpaired_output_names(r1, r2, None, Some("foo"), true);
+        assert_eq!(o1, PathBuf::from("/data/foo_unpaired_1.fq.gz"));
+        assert_eq!(o2, PathBuf::from("/data/foo_unpaired_2.fq.gz"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reported by @an-altosian (#244): in paired-end mode, \`--basename foo\` was producing \`foo_R1_val_1.fq.gz\` / \`foo_R2_val_2.fq.gz\` instead of the documented Perl v0.6.5+ form \`foo_val_1.fq.gz\` / \`foo_val_2.fq.gz\`. Trimmed read content was identical to Perl byte-for-byte; only the filenames differed — but that's enough to silently break every nf-core / Snakemake pipeline that constructs expected output paths as \`\${basename}_val_1.fq.gz\`.

## Root cause

\`io::paired_end_output_names\` and \`io::unpaired_output_names\` both built per-side stems as \`format!("{}_R1", b)\` / \`format!("{}_R2", b)\` even when \`--basename\` was supplied, then appended \`_val_{1,2}\` / \`_unpaired_{1,2}\` on top — producing the double-suffix shape \`foo_R1_val_1\`. The \`_val_{1,2}\` (or \`_unpaired_{1,2}\`) suffix already carries the pair-side distinction, so the \`_R{1,2}\` segment was redundant *and* divergent from Perl.

## Fix

When basename is supplied, use it as the stem directly for both sides:

\`\`\`rust
let (stem1, stem2) = match basename {
    Some(b) => (b.to_string(), b.to_string()),  // was: (format!("{}_R1", b), format!("{}_R2", b))
    None => (strip_fastq_extensions(input_r1), strip_fastq_extensions(input_r2)),
};
\`\`\`

Same fix in both functions.

## Historical note

The v0.6.5 CHANGELOG (19 Nov 2019) literally documents Perl having this exact bug and fixing it twice:

> *"In a \`--paired --basename BASE\` scenario, the output files will now be called \`BASE_val_1.fq.gz BASE_val_2.fq.gz\` as described in the documentation (we previously also added \`_R1\` and \`_R2\`). This had to be addressed twice (...) as the first approach was generating the Read 1 twice."*

The Rust port reintroduced the original v0.6.4 buggy form.

## Tests

Two new regression tests in \`io::tests\`:
- \`test_paired_end_output_names_with_basename\` — covers \`--output_dir\` on/off, gzip on/off
- \`test_unpaired_output_names_with_basename\` — covers the \`--retain_unpaired\` companion path

Total tests: 177 → 179.

## Test plan

- [x] \`cargo test --release\` — 179 passed
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --all-targets --release -- -D warnings\` — clean
- [x] End-to-end smoke: \`trim_galore --paired --basename foo -o /tmp/smoke \\\\\\n  test_files/BS-seq_10K_R1.fastq.gz test_files/BS-seq_10K_R2.fastq.gz\` now produces \`foo_val_1.fq.gz\` and \`foo_val_2.fq.gz\` ✓
- [ ] CI validation matrix (md5 oracle path) — unaffected; this fix is filename-only

Closes #244