### PR TITLE
chore: clear deferred CI + test items (#246 §5.2, #247 #2/#3/#4/#7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,17 @@ on:
 
 jobs:
   rust-tests:
-    name: Rust Tests
+    name: Rust Tests (${{ matrix.os }})
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    # OS matrix (#247 item 2): catch Apple Silicon regressions before
+    # release tagging. macos-latest is GitHub's hosted Apple Silicon
+    # runner. fail-fast: false so an OS-specific failure on one entry
+    # doesn't kill the other; we want both reports.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,8 +45,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Run tests
+      - name: Run tests (debug)
         run: cargo test
+
+      # #247 item 3: release-profile tests catch LTO-only and
+      # codegen-units=1 interactions that the default debug build
+      # doesn't see. Cheap to add (target dir is already populated by
+      # the next step's cargo build --release).
+      - name: Run tests (release)
+        run: cargo test --release
 
       - name: Build release
         run: cargo build --release
@@ -133,6 +148,52 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # #247 item 4: line/branch coverage reporting via `cargo-llvm-cov`.
+  # Generates an LCOV file as an artifact (downloadable from the Actions
+  # run UI). No external uploader (Codecov/Coveralls) — keeping coverage
+  # data local for now; integration with a third-party service is a
+  # separate decision.
+  coverage:
+    name: Coverage (cargo-llvm-cov)
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: llvm-tools-preview
+      - name: Cache cargo (coverage job)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          # ~/.cargo/bin is cached so cargo-llvm-cov persists across runs;
+          # avoids the ~5-minute cold-build cost on every PR.
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-coverage-
+      - name: Install cargo-llvm-cov
+        run: |
+          if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+            cargo install --locked cargo-llvm-cov
+          fi
+      - name: Generate coverage (LCOV + summary)
+        run: |
+          # Workspace coverage in LCOV format for the artifact, then a
+          # text summary in the job log so reviewers can eyeball totals
+          # without downloading the artifact.
+          cargo llvm-cov --workspace --lcov --output-path lcov.info
+          cargo llvm-cov report --summary-only
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-lcov-${{ github.run_id }}
+          path: lcov.info
+          retention-days: 14
+          if-no-files-found: error
 
   validation:
     name: Validate vs Perl TrimGalore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,7 +177,49 @@ proptest harness — tracked as separate followups.
   max_scan=1M, asserts full-file scan). Public `autodetect_adapter`
   API unchanged.
 
+#### Tests (since v2.1.0-beta.5) — parallel/serial stats parity (#246 §5.2)
+
+- **`parallel::run_single_end_parallel` and `trimmer::run_single_end`
+  must yield field-identical `TrimStats` on the same input.** First
+  unit test in `src/parallel.rs` (closes the zero-tests module gap
+  noted in #246). Beta.0/1 had per-field stat drift between the two
+  paths (commits 82d1e34, 3996fc5 fixed `total_bp_after_trim` /
+  `rrbs_r2_clipped_5prime`); this test locks the invariant down at
+  the unit level. `TrimStats` gained a `PartialEq` derive so a
+  single `assert_eq!` covers every field — any future field added
+  to the struct is automatically covered without test edits.
+  Closes #246 §5.2.
+
 #### Infrastructure (contributor-facing, since v2.1.0-beta.5) — CI hardening (#247)
+
+The five remaining deferred items from the original CI audit landed
+in this round (items 2, 3, 4, 7 — item 8 cargo-nextest deferred
+pending a focused per-test-isolation audit since some existing tests
+share `std::env::temp_dir().join(...)` paths):
+
+- **#247 item 2 — macOS matrix on `rust-tests`.** Job now runs on
+  both `ubuntu-latest` and `macos-latest` (Apple Silicon hosted
+  runner). Catches Apple-Silicon-specific regressions before
+  release-tag time. `fail-fast: false` so an OS-specific failure on
+  one entry doesn't kill the other.
+- **#247 item 3 — release-profile test step.** New `Run tests
+  (release)` step alongside the existing debug-profile run. Catches
+  LTO + `codegen-units=1` interactions that the default debug build
+  doesn't see. Cheap because the next step (`cargo build --release`)
+  was already populating the same target dir.
+- **#247 item 4 — line/branch coverage reporting via
+  `cargo-llvm-cov`.** New `coverage` job emits an LCOV file as a
+  CI artifact (downloadable from the Actions run UI) plus a text
+  summary in the job log. No third-party uploader integration —
+  Codecov / Coveralls is a separate decision.
+- **#247 item 7 — `justfile` for local CI parity.** New top-level
+  `justfile` with targets `fmt`, `clippy`, `test`, `test-release`,
+  `ci`, `reproduce`, `validate-paired-end`, `logos`, `docs`. Run
+  `just` (or `just ci`) to execute the same portable checks CI
+  runs on every push. Pairs cleanly with the contributor docs
+  flow.
+
+
 
 Three CI improvements landed from @an-altosian's audit (#247). Touches
 only `.github/workflows/ci.yml`; no runtime change.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,98 @@
+# Trim Galore — local CI parity
+#
+# Run `just` (or `just default`) to run the same checks CI runs on every
+# push, in the same order. `just <target>` to run individual checks.
+#
+# Install just via `cargo install just` or your package manager.
+# See https://github.com/casey/just for more.
+#
+# Notes:
+# - All targets are run from the crate root; `just` automatically `cd`s here.
+# - The validate target requires `cutadapt`, `conda`, and a Perl Trim Galore
+#   on PATH; without those, only `just lint test` is portable. Use `just ci`
+#   to run the portable subset locally before pushing.
+
+# Default: run the full portable check suite (lint + tests in both profiles).
+default: ci
+
+# Portable CI parity: everything `rust-tests` and `lint` jobs run on PR.
+ci: fmt clippy test test-release
+    @echo "✓ all portable CI checks passed"
+
+# Format check (matches CI's `cargo fmt --all -- --check`).
+fmt:
+    cargo fmt --all -- --check
+
+# Apply formatting fixes in-place.
+fmt-fix:
+    cargo fmt --all
+
+# Clippy with -D warnings (matches CI's lint job).
+clippy:
+    cargo clippy --all-targets --release -- -D warnings
+
+# Debug-profile test suite.
+test:
+    cargo test
+
+# Release-profile test suite (matches the new `Run tests (release)` step).
+test-release:
+    cargo test --release
+
+# Build the release binary (target/release/trim_galore).
+build:
+    cargo build --release
+
+# Run the bundled binary's --version (provenance + git-hash check).
+version: build
+    ./target/release/trim_galore --version
+
+# Reproducibility check: build twice with the same SOURCE_DATE_EPOCH and
+# diff the binaries. Mirrors the `reproducibility` CI job.
+reproduce:
+    @echo "Building binary twice under SOURCE_DATE_EPOCH=1700000000..."
+    cargo clean
+    SOURCE_DATE_EPOCH=1700000000 cargo build --release
+    cp target/release/trim_galore /tmp/trim_galore.repro1
+    cargo clean
+    SOURCE_DATE_EPOCH=1700000000 cargo build --release
+    cp target/release/trim_galore /tmp/trim_galore.repro2
+    diff /tmp/trim_galore.repro1 /tmp/trim_galore.repro2 && echo "✓ bit-identical"
+
+# Validation matrix vs Perl 0.6.11 — requires Perl trim_galore + cutadapt
+# on PATH. The CI `validation` job orchestrates this with conda; use this
+# target to spot-check a single comparison locally if those tools are
+# already installed.
+validate-paired-end:
+    rm -rf /tmp/tg_validate /tmp/op_validate
+    mkdir -p /tmp/tg_validate /tmp/op_validate
+    trim_galore_perl --paired -o /tmp/tg_validate \
+        test_files/BS-seq_10K_R1.fastq.gz test_files/BS-seq_10K_R2.fastq.gz
+    cargo build --release
+    ./target/release/trim_galore --paired -o /tmp/op_validate \
+        test_files/BS-seq_10K_R1.fastq.gz test_files/BS-seq_10K_R2.fastq.gz
+    @for f in BS-seq_10K_R1_val_1.fq.gz BS-seq_10K_R2_val_2.fq.gz; do \
+        TG_MD5=$(gzip -dc /tmp/tg_validate/$f | md5sum | cut -d' ' -f1); \
+        OP_MD5=$(gzip -dc /tmp/op_validate/$f | md5sum | cut -d' ' -f1); \
+        if [ "$TG_MD5" = "$OP_MD5" ]; then \
+            echo "✓ $f matches"; \
+        else \
+            echo "✗ $f DIFFERS (Perl=$TG_MD5 Rust=$OP_MD5)"; exit 1; \
+        fi; \
+    done
+
+# Regenerate PNG logos from the SVG sources (in Docs/).
+logos:
+    cd Docs && npm run logos
+
+# Build the docs site (in Docs/).
+docs:
+    cd Docs && npm run build
+
+# Serve the docs site locally for preview (in Docs/).
+docs-dev:
+    cd Docs && npm run dev
+
+# Show all available recipes.
+help:
+    @just --list

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -636,3 +636,118 @@ fn process_reads<W: Write>(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fastq::{FastqReader, FastqWriter};
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn fresh_tmpdir(slug: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(slug);
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Minimal TrimConfig for the parity test: single adapter, no
+    /// quality trimming or length filtering so the stats verifying
+    /// equality see only the adapter-trim accounting we care about.
+    fn parity_test_config() -> TrimConfig {
+        TrimConfig {
+            adapters: vec![("Illumina".to_string(), b"AGATCGGAAGAGC".to_vec())],
+            adapters_r2: Vec::new(),
+            times: 1,
+            quality_cutoff: 0,
+            phred_offset: 33,
+            error_rate: 0.1,
+            min_overlap: 1,
+            length_cutoff: 0,
+            max_length: None,
+            max_n: None,
+            trim_n: false,
+            clip_r1: None,
+            clip_r2: None,
+            three_prime_clip_r1: None,
+            three_prime_clip_r2: None,
+            rename: false,
+            nextseq: false,
+            rrbs: false,
+            non_directional: false,
+            is_paired: false,
+            poly_a: false,
+            poly_g: false,
+            discard_untrimmed: false,
+        }
+    }
+
+    /// #246 §5.2 regression: `trimmer::run_single_end` (serial path)
+    /// and `parallel::run_single_end_parallel` (worker pool) must
+    /// produce field-identical `TrimStats` on the same input. Beta.0/1
+    /// had per-field stat drift between paths (commits 82d1e34,
+    /// 3996fc5 fixed `total_bp_after_trim` / `rrbs_r2_clipped_5prime`);
+    /// this test locks the invariant down. Closes the
+    /// `parallel.rs` zero-tests module gap as a side effect.
+    #[test]
+    fn test_parallel_serial_trim_stats_parity() -> Result<()> {
+        let dir = fresh_tmpdir("tg_parallel_serial_parity");
+        let input_path = dir.join("input.fq");
+
+        // 30 reads: alternating adapter-bearing and clean. Sized to
+        // span more than one record but well under the 4096 batch
+        // size — this exercises the merge path with a single non-full
+        // batch, which is where stat drift bugs tend to live.
+        let mut content = String::new();
+        for i in 0..30 {
+            let seq = if i % 2 == 0 {
+                // 30 bp of random-looking bases + 13 bp Illumina adapter.
+                "ACGTACGTACGTACGTACGTACGTACGTACAGATCGGAAGAGC"
+            } else {
+                // 34 bp clean (no adapter substring).
+                "ACGTACGTACGTACGTACGTACGTACGTACGTAC"
+            };
+            let qual = "I".repeat(seq.len());
+            content.push_str(&format!("@read_{i}\n{seq}\n+\n{qual}\n"));
+        }
+        fs::write(&input_path, content)?;
+
+        let config = parity_test_config();
+
+        // Serial path — open reader/writer directly, drive the
+        // single-threaded `run_single_end` entry point.
+        let serial_output = dir.join("serial_out.fq");
+        let stats_serial = {
+            let mut reader = FastqReader::open(&input_path)?;
+            let mut writer = FastqWriter::create(&serial_output, false, 1)?;
+            let stats = crate::trimmer::run_single_end(&mut reader, &mut writer, &config)?;
+            writer.flush()?;
+            stats
+        };
+
+        // Parallel path — same input, 4 workers, plain output.
+        let parallel_output = dir.join("parallel_out.fq");
+        let stats_parallel =
+            run_single_end_parallel(&input_path, &parallel_output, &config, 4, false)?;
+
+        // Field-identical stats across paths. PartialEq derive on
+        // TrimStats means a single equality check covers every field.
+        assert_eq!(
+            stats_serial, stats_parallel,
+            "TrimStats must match between serial (cores=1) and parallel (cores=4) paths.\n\
+             serial:   {stats_serial:#?}\n\
+             parallel: {stats_parallel:#?}"
+        );
+
+        // Sanity-check that the test fixture actually exercised
+        // adapter trimming — otherwise we'd be passing trivially.
+        assert_eq!(stats_serial.total_reads, 30);
+        assert!(
+            stats_serial.total_reads_with_adapter > 0,
+            "test fixture must have at least one adapter-bearing read"
+        );
+
+        fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -5,7 +5,7 @@
 use std::io::Write;
 
 /// Statistics collected during trimming.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct TrimStats {
     /// Total sequences processed
     pub total_reads: usize,


### PR DESCRIPTION
## Summary

Sweeps the previously-deferred items from #246 / #247 into a single bundle. All additive, none touch the trimming hot path.

## Items in this PR

| | What | Source |
|---|---|---|
| 1 | macOS matrix on \`rust-tests\` (\`ubuntu-latest\` + \`macos-latest\`) | **#247 #2** |
| 2 | \`Run tests (release)\` step (LTO catch) | **#247 #3** |
| 3 | \`coverage\` CI job via \`cargo-llvm-cov\` (LCOV artifact, 14-day retention) | **#247 #4** |
| 4 | \`justfile\` for local CI parity (\`fmt\`, \`clippy\`, \`test\`, \`test-release\`, \`ci\`, \`reproduce\`, \`validate-paired-end\`, \`logos\`, \`docs\`, \`docs-dev\`) | **#247 #7** |
| 5 | First unit test in \`src/parallel.rs\`: parallel/serial \`TrimStats\` parity | **#246 §5.2** |

\`TrimStats\` gained a \`PartialEq\` derive so a single \`assert_eq!\` covers every field — future fields are automatically covered without test edits.

## Deliberately NOT here

- **#247 #8** (\`cargo-nextest\`) — process-isolation swap is non-trivial. Several existing tests share \`std::env::temp_dir().join(...)\` paths that could collide under nextest's per-process model. Wants its own focused audit.
- **#246 comprehensive \`parallel.rs\` coverage** — naturally iterative; the §5.2 parity test is a meaningful start.
- **#246 bonus** (upstream Dongze's proptest harness) — needs his code.
- **#248 #4** (Myers' alignment) — needs his ephemeral branch (gone).
- **#245 B** (poly-A alignment divergence) — investigation, not fix.

## Test plan

- [x] \`cargo test --release\` — 180 passed (179 + 1 new)
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --all-targets --release -- -D warnings\` — clean
- [x] YAML \`ci.yml\` parses
- [ ] CI on this PR exercises the new matrix entry (\`Rust Tests (macos-latest)\`), the new \`coverage\` job, and the new release-profile test step
- [ ] Coverage artifact downloadable from the run UI after merge

Addresses #246, #247.