### PR TITLE
docs(install): bump v2.1.0-beta.5 → v2.1.0-beta.6 references (followup to #254)

### DIFF
--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -5,11 +5,11 @@ description: Install Trim Galore via cargo, bioconda, Docker, or prebuilt binari
 
 Trim Galore v2 ships as a single static binary. No Python, no Perl, no Cutadapt, no Java, no `igzip`, no `pigz`, no external FastQC. Pick whichever channel fits the rest of your stack.
 
-:::caution[Beta testing v2.1.0-beta.5]
+:::caution[Beta testing v2.1.0-beta.6]
 The current stable release on crates.io is **v2.0.0**. v2.1.0 is in beta. `cargo install trim-galore` without `--version` installs v2.0.0. To install the beta:
 
 ```bash
-cargo install trim-galore --version 2.1.0-beta.5
+cargo install trim-galore --version 2.1.0-beta.6
 docker pull ghcr.io/felixkrueger/trimgalore:beta
 ```
 
@@ -63,8 +63,8 @@ FastQC is built in via the bundled [`fastqc-rust`](https://crates.io/crates/fast
 
 | Tag | Updates |
 | --- | --- |
-| `:beta` | latest prerelease (currently v2.1.0-beta.5) |
-| `:2.1.0-beta.5` | pinned to a specific prerelease |
+| `:beta` | latest prerelease (currently v2.1.0-beta.6) |
+| `:2.1.0-beta.6` | pinned to a specific prerelease |
 | `:dev` | every push to the `optimus_prime` development branch |
 | `:latest` | latest stable release (publishes from v2.1.0 GA onward) |
 
@@ -85,7 +85,7 @@ trim_galore --version
 Should print:
 
 ```
-trim_galore 2.1.0-beta.5 (Oxidized Edition)
+trim_galore 2.1.0-beta.6 (Oxidized Edition)
 <git-hash> — <os>/<arch> — built <ISO-8601-UTC>
 ```
 


### PR DESCRIPTION
Followup to #254. The Cargo.toml + CHANGELOG + README bumps all landed cleanly, but `Docs/src/content/docs/install.md` got dropped from the squash — same macOS case-insensitive-path quirk that hit #239. This catches the stragglers.

5 references bumped: caution heading, cargo install command, Docker tag table description, pinned-tag example, `--version` output example.

After merge: ready to `gh workflow run release.yml --ref optimus_prime`.