### PR TITLE
docs: GHCR tag prefix fix + README Docker example uses :beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ The `--force` flag overwrites any existing `trim_galore` binary (e.g. a v2.0.0 i
 Multi-arch images (amd64 + arm64) are available from GitHub Container Registry:
 
 ```bash
-docker run --rm -v "$PWD":/data -w /data ghcr.io/felixkrueger/trimgalore trim_galore input.fastq.gz
+docker run --rm -v "$PWD":/data -w /data ghcr.io/felixkrueger/trimgalore:beta trim_galore input.fastq.gz
 ```
 
-FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. The `dev` tag tracks the latest development branch; versioned tags (e.g. `v2.1.0`) are published on release.
+FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:beta` (latest prerelease, currently `v2.1.0-beta.6`), `:v2.1.0-beta.6` (pinned to a specific prerelease), `:dev` (every push to `optimus_prime`), and `:latest` will track stable releases starting at v2.1.0 GA. See the [docs site install page](https://felixkrueger.github.io/TrimGalore/install/) for the full table.
 
 ### Prebuilt binaries
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -64,7 +64,7 @@ FastQC is built in via the bundled [`fastqc-rust`](https://crates.io/crates/fast
 | Tag | Updates |
 | --- | --- |
 | `:beta` | latest prerelease (currently v2.1.0-beta.6) |
-| `:2.1.0-beta.6` | pinned to a specific prerelease |
+| `:v2.1.0-beta.6` | pinned to a specific prerelease |
 | `:dev` | every push to the `optimus_prime` development branch |
 | `:latest` | latest stable release (publishes from v2.1.0 GA onward) |
 


### PR DESCRIPTION
Two related docs bugs surfaced during v2.1.0-beta.6 release verification.

## #1 — Docs install.md tag table documents non-existent example

The Docker tag table example for the pinned-prerelease form documented \`:2.1.0-beta.6\` (no prefix), but the actual tags pushed to GHCR carry the \`v\` prefix. Verified post-release:
- 200 on \`/v2/felixkrueger/trimgalore/manifests/v2.1.0-beta.6\` (digest \`sha256:e060f5392e25bcbc5666bda8ada9760fcce5e4a71f821fdbf0c614096cd8d124\`, same digest as \`:beta\`)
- 404 on the non-prefix form

Reading \`/v2/.../tags/list\` confirms every version tag carries the \`v\` prefix:
\`v2.1.0-beta.1\` through \`v2.1.0-beta.6\`, plus \`:beta\` and \`:dev\`. The non-prefix form has *never* been pushed.

This was a standing docs bug — the Docker tag table has documented non-existent example tags since the table was added.

## #2 — README Docker example implicit :latest fails during beta

\`docker run ... ghcr.io/felixkrueger/trimgalore trim_galore ...\` resolves to \`:latest\`, but per \`release.yml:289\`, \`:latest\` is gated on \`is_prerelease == 'false'\` and isn't pushed during the beta window. The example would fail with manifest-not-found for any user reading the README during beta.

Fix: pin to \`:beta\` (which always points at the latest prerelease during beta), and inline the full tag set so readers don't have to bounce to the docs site to figure out which tag to use.

## Test plan

- [x] curl manifest lookup confirms \`:v2.1.0-beta.6\` exists and \`:2.1.0-beta.6\` 404s on the same digest
- [x] curl confirms \`:beta\` exists with same digest as \`:v2.1.0-beta.6\`
- [ ] Manual: \`docker pull ghcr.io/felixkrueger/trimgalore:beta\` works (will get verified by anyone running the README example post-merge)