### PR TITLE
docs(migration): note -a 'A{N}' poly-A divergence vs --poly_a (closes #245)

### DIFF
--- a/docs/src/content/docs/reference/migration.md
+++ b/docs/src/content/docs/reference/migration.md
@@ -48,6 +48,10 @@ A small pre-parse hook recognises Perl-era flag spellings and rewrites them to t
 - Colorspace input. Rejected with a clear error message, matching v0.6.x behaviour. Colorspace data has not been generated in years.
 - The per-flag `Cutadapt version` and `Python version` lines in the parameter summary. Cutadapt and Python are not subprocesses in v2, so those lines are dropped. The MultiQC parser already handles their absence.
 
+## Note on `-a 'A{N}'` for poly-A trimming
+
+For poly-A trimming, prefer the dedicated `--poly_a` flag — it has proper paired-end semantics (3' end on R1, 5' end on R2) and is the supported v2 path. The `-a 'A{N}'` form (a v0.6.x workaround that pre-dates `--poly_a`) still works and the brace expansion still produces `AAAA…` byte-for-byte, but the alignment DP may produce slightly different matches than Perl v0.6.x on highly-repetitive adapter patterns: every position in a poly-A read has potential matches, so the choice of "where the adapter starts" reduces to a tie-break that Cutadapt and the Rust port resolve differently. Both are valid global-best alignments under their respective tie-break rules — neither is wrong by spec — but the byte-identity guarantee in the table above does not extend to single-base repeating adapters.
+
 ## Migration checklist
 
 To move an existing pipeline from v0.6.x to v2:


### PR DESCRIPTION
Adds a new section to `reference/migration.md` documenting the `-a 'A{N}'` poly-A trimming divergence as intentional / not-pursued.

Brace expansion itself is byte-identical (verified `bec0aacbc27939c7db1b1f24e6e07cd8` for both `-a 'A{15}'` and literal `-a AAAAAAAAAAAAAAA`). The Perl-vs-Rust difference is purely in the alignment DP's tie-break behaviour on highly-repetitive adapter patterns — both produce valid global-best alignments. The dedicated `--poly_a` flag is the right v2 path for poly-A trimming.

This closes #245 by documenting item B as intentional rather than pursuing a Cutadapt-tie-break-mirror in our DP. A/C/D were already shipped in v2.1.0-beta.6.

cc @an-altosian.