### PR TITLE
chore(release): v2.1.0-beta.7 + benchmark driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,44 @@
 # Trim Galore Changelog
 
 
+### Version 2.1.0-beta.7 (Release on 29 Apr 2026)
+
+#### Performance (since v2.1.0-beta.6) — third Buckberry-scale win (#248 #4)
+
+- **Myers' bit-parallel adapter alignment prefilter.** Wraps an O(n)
+  bit-vector approximate-matching pass (Hyyrö 2001 formulation) in
+  front of the existing scalar DP in `find_3prime_adapter`. The
+  prefilter is conservative by design — it short-circuits ONLY when
+  it can rigorously prove that no adapter match exists, considering
+  both the full-match (last DP row) and partial-match (last DP
+  column) cases. False positives fall through to the unchanged
+  scalar DP, keeping the byte-identity invariant intact by
+  construction. Limited to adapters ≤ 64 bp (single u64 bit-vector;
+  the project's adapters are all ≤ 32 bp). End-to-end byte-identity
+  verified locally and by the CI validation matrix; Dongze's
+  Buckberry-scale measurement (84M reads, 38% adapter rate, cores=8)
+  was −13.6% wall on his prototype, so this lands the third and
+  final perf win from the #248 audit. Co-authored with @an-altosian
+  (Dongze He). (#258)
+
+#### Documentation (since v2.1.0-beta.6)
+
+- **Migration guide note on `-a 'A{N}'` poly-A divergence.** Closes
+  #245 item B as intentional / not-pursued: brace expansion is
+  byte-identical between Perl and Rust, but the alignment DP's
+  tie-break behaviour on highly-repetitive adapter patterns differs
+  between Cutadapt and our reimplementation. Both produce valid
+  global-best alignments. The dedicated `--poly_a` flag is the
+  right v2 path for poly-A trimming; the `-a 'A{N}'` form remains
+  supported as a v0.6.x compat shim. (#257)
+- **GHCR tag prefix correction.** Docker images carry the `v` prefix
+  (`:v2.1.0-beta.6`), not bare semver — verified against
+  `/v2/.../tags/list`. Docs install table fixed; the prior
+  `:2.1.0-beta.6` example was 404. README Docker example switched
+  from implicit `:latest` (which doesn't exist during prerelease) to
+  `:beta`, with the full tag set documented inline. (#256)
+
+
 ### Version 2.1.0-beta.6 (Release on 29 Apr 2026)
 
 #### Performance (since v2.1.0-beta.5) — Buckberry-scale audit (#248)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "trim-galore"
-version = "2.1.0-beta.6"
+version = "2.1.0-beta.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trim-galore"
-version = "2.1.0-beta.6"
+version = "2.1.0-beta.7"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast adapter and quality trimming for NGS data — Oxidized Edition"

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Consistent quality and adapter trimming for next-generation sequencing data, wit
 ## Installation
 
 > [!IMPORTANT]
-> **Beta testing v2.1.0-beta.6.** The current stable release on crates.io is v2.0.0; v2.1.0 is in beta testing. Running `cargo install trim-galore` without `--version` installs v2.0.0 (the stable). To install the beta:
+> **Beta testing v2.1.0-beta.7.** The current stable release on crates.io is v2.0.0; v2.1.0 is in beta testing. Running `cargo install trim-galore` without `--version` installs v2.0.0 (the stable). To install the beta:
 >
 > ```bash
-> cargo install trim-galore --version 2.1.0-beta.6
+> cargo install trim-galore --version 2.1.0-beta.7
 > docker pull ghcr.io/felixkrueger/trimgalore:beta
 > ```
 >
@@ -85,7 +85,7 @@ Multi-arch images (amd64 + arm64) are available from GitHub Container Registry:
 docker run --rm -v "$PWD":/data -w /data ghcr.io/felixkrueger/trimgalore:beta trim_galore input.fastq.gz
 ```
 
-FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:beta` (latest prerelease, currently `v2.1.0-beta.6`), `:v2.1.0-beta.6` (pinned to a specific prerelease), `:dev` (every push to `optimus_prime`), and `:latest` will track stable releases starting at v2.1.0 GA. See the [docs site install page](https://felixkrueger.github.io/TrimGalore/install/) for the full table.
+FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:beta` (latest prerelease, currently `v2.1.0-beta.7`), `:v2.1.0-beta.7` (pinned to a specific prerelease), `:dev` (every push to `optimus_prime`), and `:latest` will track stable releases starting at v2.1.0 GA. See the [docs site install page](https://felixkrueger.github.io/TrimGalore/install/) for the full table.
 
 ### Prebuilt binaries
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -5,11 +5,11 @@ description: Install Trim Galore via cargo, bioconda, Docker, or prebuilt binari
 
 Trim Galore v2 ships as a single static binary. No Python, no Perl, no Cutadapt, no Java, no `igzip`, no `pigz`, no external FastQC. Pick whichever channel fits the rest of your stack.
 
-:::caution[Beta testing v2.1.0-beta.6]
+:::caution[Beta testing v2.1.0-beta.7]
 The current stable release on crates.io is **v2.0.0**. v2.1.0 is in beta. `cargo install trim-galore` without `--version` installs v2.0.0. To install the beta:
 
 ```bash
-cargo install trim-galore --version 2.1.0-beta.6
+cargo install trim-galore --version 2.1.0-beta.7
 docker pull ghcr.io/felixkrueger/trimgalore:beta
 ```
 
@@ -63,8 +63,8 @@ FastQC is built in via the bundled [`fastqc-rust`](https://crates.io/crates/fast
 
 | Tag | Updates |
 | --- | --- |
-| `:beta` | latest prerelease (currently v2.1.0-beta.6) |
-| `:v2.1.0-beta.6` | pinned to a specific prerelease |
+| `:beta` | latest prerelease (currently v2.1.0-beta.7) |
+| `:v2.1.0-beta.7` | pinned to a specific prerelease |
 | `:dev` | every push to the `optimus_prime` development branch |
 | `:latest` | latest stable release (publishes from v2.1.0 GA onward) |
 
@@ -85,7 +85,7 @@ trim_galore --version
 Should print:
 
 ```
-trim_galore 2.1.0-beta.6 (Oxidized Edition)
+trim_galore 2.1.0-beta.7 (Oxidized Edition)
 <git-hash> — <os>/<arch> — built <ISO-8601-UTC>
 ```
 

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Trim Galore — Buckberry-scale benchmark driver.
+#
+# Reproducible perf comparison across:
+#   - Perl Trim Galore 0.6.11 + Cutadapt 5.2 (cores 1, 4, 8, 16; igzip + pigz)
+#   - Rust v2.1.0-beta.5 (cores 1, 4, 8, 16, 24)  — pre-Buckberry-audit
+#   - Rust v2.1.0-beta.7 (cores 1, 4, 8, 16, 24)  — post-Myers' prefilter
+#
+# Methodology mirrors @an-altosian's #248 audit:
+#   - hyperfine --warmup 1 --runs 10 per condition
+#   - --export-json per condition for downstream plotting / aggregation
+#   - filesystem cache warmed once up front via cat ... > /dev/null
+#   - md5 sanity-check at the end: beta.5 vs beta.7 decompressed output
+#     must match (Myers' is byte-identity-preserving by construction)
+#
+# Designed to run on the Altos `oxy` EKS instance (`dcli ssh oxy`)
+# where `/home/fkrueger/benchmark_TG_oxy/` is the canonical fixture
+# directory. Override via env vars if running elsewhere — see below.
+#
+# Wall-time estimate at Buckberry scale (84M PE reads, 2.1 GiB
+# gzipped): roughly 13 hours total. Run under tmux/nohup. Skip the
+# Perl cores=1 row (PERL_CORES="4 8 16") to save ~5 hours if you've
+# already got that datapoint from a previous run.
+
+set -euo pipefail
+
+# -- Config (override via env) --
+
+# Fixture: Buckberry SRR24827373, the Dongze-#248-audit dataset
+DATA_DIR="${DATA_DIR:-/home/fkrueger/benchmark_TG_oxy}"
+R1="${R1:-$DATA_DIR/SRR24827373_GSM7445361_32F_NB3_p28_p2n2p_p10_rep1_Homo_sapiens_Bisulfite-Seq_R1.fastq.gz}"
+R2="${R2:-$DATA_DIR/SRR24827373_GSM7445361_32F_NB3_p28_p2n2p_p10_rep1_Homo_sapiens_Bisulfite-Seq_R2.fastq.gz}"
+
+# Binaries -- install via:
+#   cargo install trim-galore --version 2.1.0-beta.5 --root ~/.cargo-tg-beta5 --locked
+#   cargo install trim-galore --version 2.1.0-beta.7 --root ~/.cargo-tg-beta7 --locked
+# (Override paths if you've installed elsewhere or built from source.)
+RUST_BETA5="${RUST_BETA5:-$HOME/.cargo-tg-beta5/bin/trim_galore}"
+RUST_BETA7="${RUST_BETA7:-$HOME/.cargo-tg-beta7/bin/trim_galore}"
+PERL_TG="${PERL_TG:-$HOME/TrimGalore/trim_galore}"
+
+# Cores ladder
+RUST_CORES="${RUST_CORES:-1 4 8 16 24}"
+PERL_CORES="${PERL_CORES:-1 4 8 16}"
+
+# Hyperfine settings -- match Dongze's #248 methodology
+WARMUP="${WARMUP:-1}"
+RUNS="${RUNS:-10}"
+
+# Output dirs
+WORK_ROOT="${WORK_ROOT:-/tmp/tg_bench}"
+RESULTS_DIR="${RESULTS_DIR:-$PWD/perf_data/$(date -u +%Y-%m-%d)}"
+
+# -- Pre-flight --
+
+for tool in hyperfine md5sum gzip; do
+    command -v "$tool" >/dev/null || { echo "ERROR: '$tool' not on PATH"; exit 1; }
+done
+[[ -r "$R1" && -r "$R2" ]] || { echo "ERROR: cannot read R1/R2 ($R1, $R2)"; exit 1; }
+[[ -x "$RUST_BETA5" ]] || { echo "ERROR: Rust beta.5 binary not executable at $RUST_BETA5"; exit 1; }
+[[ -x "$RUST_BETA7" ]] || { echo "ERROR: Rust beta.7 binary not executable at $RUST_BETA7"; exit 1; }
+[[ -x "$PERL_TG" ]] || { echo "ERROR: Perl trim_galore not executable at $PERL_TG"; exit 1; }
+
+mkdir -p "$WORK_ROOT" "$RESULTS_DIR"
+
+echo "=========================================="
+echo "Trim Galore benchmark driver"
+echo "=========================================="
+echo "Date:              $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "Host:              $(hostname)"
+echo "Cores (host):      $(nproc)"
+echo "CPU model:         $(grep 'model name' /proc/cpuinfo | head -1 | sed 's/.*: //')"
+echo "Memory:            $(free -h | awk '/^Mem:/{print $2}')"
+echo "R1:                $R1"
+echo "R2:                $R2"
+echo "Rust beta.5:       $RUST_BETA5 ($($RUST_BETA5 --version | head -1))"
+echo "Rust beta.7:       $RUST_BETA7 ($($RUST_BETA7 --version | head -1))"
+echo "Perl trim_galore:  $PERL_TG ($($PERL_TG --version 2>&1 | grep -i 'version:' | head -1 | tr -s ' '))"
+echo "Cutadapt:          $(cutadapt --version 2>&1 | head -1)"
+echo "hyperfine:         $(hyperfine --version | head -1)"
+echo "Cores ladder:      Rust=[$RUST_CORES]  Perl=[$PERL_CORES]"
+echo "Hyperfine:         --warmup $WARMUP --runs $RUNS"
+echo "Results dir:       $RESULTS_DIR"
+echo "=========================================="
+echo ""
+
+# -- Cache warming --
+echo "[1/5] Warming filesystem cache (one-time, ~30s on EFS)..."
+time { cat "$R1" > /dev/null; cat "$R2" > /dev/null; }
+echo ""
+
+# -- Helpers --
+
+# Run one hyperfine sweep for a single (binary, cores, label) tuple.
+# Each iteration cleans the output dir so we measure end-to-end work,
+# not no-op overwrites.
+run_sweep() {
+    local label="$1"; shift
+    local cores="$1"; shift
+    local cmd_template="$1"; shift  # e.g. "$BIN --paired --cores {cores} -o {outdir} $R1 $R2"
+
+    local outdir="$WORK_ROOT/${label}_c${cores}"
+    local json="$RESULTS_DIR/${label}_c${cores}.json"
+    local md="$RESULTS_DIR/${label}_c${cores}.md"
+
+    echo "----- ${label} cores=${cores} -----"
+    rm -rf "$outdir"
+    mkdir -p "$outdir"
+
+    # Substitute {outdir} and {cores} in the template.
+    local cmd="${cmd_template//\{outdir\}/$outdir}"
+    cmd="${cmd//\{cores\}/$cores}"
+
+    hyperfine \
+        --warmup "$WARMUP" \
+        --runs "$RUNS" \
+        --prepare "rm -rf $outdir && mkdir -p $outdir" \
+        --command-name "${label}-c${cores}" \
+        --export-json "$json" \
+        --export-markdown "$md" \
+        "$cmd"
+
+    echo ""
+}
+
+# -- Sweeps --
+
+echo "[2/5] Rust v2.1.0-beta.5 (pre-Buckberry audit)"
+for c in $RUST_CORES; do
+    run_sweep "rust-beta5" "$c" "$RUST_BETA5 --paired --cores {cores} -o {outdir} $R1 $R2"
+done
+
+echo "[3/5] Rust v2.1.0-beta.7 (post-Myers' prefilter)"
+for c in $RUST_CORES; do
+    run_sweep "rust-beta7" "$c" "$RUST_BETA7 --paired --cores {cores} -o {outdir} $R1 $R2"
+done
+
+echo "[4/5] Perl Trim Galore 0.6.11 + Cutadapt 5.2 (igzip + pigz)"
+for c in $PERL_CORES; do
+    run_sweep "perl-0.6.11" "$c" "$PERL_TG --paired -j {cores} -o {outdir} $R1 $R2"
+done
+
+# -- Cross-version byte-identity sanity --
+
+echo "[5/5] Byte-identity cross-check: beta.5 vs beta.7 (decompressed)"
+
+# Pick cores=8 outputs from each -- should be byte-identical when
+# decompressed (Myers' is a transparent prefilter; gzip-level is
+# the same in both releases).
+B5_DIR="$WORK_ROOT/rust-beta5_c8"
+B7_DIR="$WORK_ROOT/rust-beta7_c8"
+SUMMARY="$RESULTS_DIR/byte_identity_summary.txt"
+{
+    echo "Cross-version byte-identity check (cores=8 outputs)"
+    echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo ""
+    for f in $(ls "$B5_DIR" | grep -E '\.fq\.gz$'); do
+        if [[ -f "$B7_DIR/$f" ]]; then
+            B5_MD5=$(gzip -dc "$B5_DIR/$f" | md5sum | awk '{print $1}')
+            B7_MD5=$(gzip -dc "$B7_DIR/$f" | md5sum | awk '{print $1}')
+            if [[ "$B5_MD5" == "$B7_MD5" ]]; then
+                echo "MATCH    $f  $B5_MD5"
+            else
+                echo "MISMATCH $f  beta.5=$B5_MD5  beta.7=$B7_MD5"
+            fi
+        else
+            echo "MISSING  $f  (only in beta.5)"
+        fi
+    done
+} | tee "$SUMMARY"
+
+echo ""
+echo "=========================================="
+echo "DONE. Results landed in: $RESULTS_DIR"
+echo "  - per-condition: <label>_c<cores>.{json,md}"
+echo "  - byte-identity: byte_identity_summary.txt"
+echo "Run 'tar czf bench-$(date -u +%Y%m%d).tar.gz $RESULTS_DIR' to ship."
+echo "=========================================="


### PR DESCRIPTION
## v2.1.0-beta.7

Single substantive change since beta.6: **Myers' bit-parallel adapter alignment prefilter** ([#258](https://github.com/FelixKrueger/TrimGalore/pull/258), [#248](https://github.com/FelixKrueger/TrimGalore/issues/248) item 4). Wraps an O(n) bit-vector pass in front of the existing scalar DP; conservative by design (only short-circuits when no match can possibly exist), preserving byte-identity by construction. @an-altosian measured this at −13.6% wall at cores=8 on his Buckberry prototype. Co-authored with him.

Three doc-only PRs also since beta.6: poly-A divergence migration note (#257, closing out #245), GHCR tag prefix correction (#256), install.md squash-followup (#255).

## scripts/benchmark.sh

New reproducible perf-benchmark driver for the Buckberry-scale comparison:

| Configuration | Cores | Tooling |
|---|---|---|
| Perl Trim Galore 0.6.11 + Cutadapt 5.2 | 1, 4, 8, 16 | igzip + pigz |
| Rust v2.1.0-beta.5 (pre-Buckberry-audit) | 1, 4, 8, 16, 24 | zlib-rs + gzp |
| Rust v2.1.0-beta.7 (post-Myers' prefilter) | 1, 4, 8, 16, 24 | zlib-rs + gzp |

`hyperfine --warmup 1 --runs 10` per condition, `--export-json` for downstream plotting, filesystem cache warmed once up front, beta.5-vs-beta.7 byte-identity cross-check on cores=8 output as a paranoia gate.

Designed for the Altos `oxy` EKS instance; all paths/cores/runs overridable via env vars. Full-matrix wall-time at Buckberry scale (84M PE reads): ~13 h. Run under tmux/nohup.

## Test plan

- [x] \`cargo build --release\` reports \`trim_galore 2.1.0-beta.7 (Oxidized Edition)\`
- [x] Tests still pass on this branch (188, unchanged from optimus_prime tip)
- [x] No stale beta.6 forward-pin references left (historical mentions in CHANGELOG / code comments preserved)
- [x] \`bash -n scripts/benchmark.sh\` parses clean
- [ ] Post-merge: \`gh workflow run release.yml --ref optimus_prime\` to actually publish
- [ ] Post-release: run \`scripts/benchmark.sh\` on \`oxy\` against Buckberry SRR24827373

Co-authored-by: Dongze He <171858310+an-altosian@users.noreply.github.com>