### PR TITLE
ci/test: cargo-nextest adoption + parallel.rs coverage (closes #246, #247)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,27 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Run tests (debug)
-        run: cargo test
+      # #247 item 8: cargo-nextest for the debug-profile run. Per-test
+      # process isolation catches latent shared-state bugs (e.g. tests
+      # writing to a static `std::env::temp_dir()` slug) that cargo
+      # test's thread-pool model masks. Pinned via taiki-e/install-action,
+      # which fetches the prebuilt binary release (much faster than
+      # `cargo install`). Per-test isolation audit complete: 19
+      # `temp_dir().join(...)` callsites all use unique slugs (no
+      # shared paths), and no `static mut` / `OnceCell` / `env::set_var`
+      # globals exist — the codebase is nextest-clean.
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@daa3c1f1f9a9d46f686d9fc2f65773d0c293688b # v2.62.13
+        with:
+          tool: nextest
+
+      - name: Run tests (debug, nextest)
+        run: cargo nextest run
 
       # #247 item 3: release-profile tests catch LTO-only and
       # codegen-units=1 interactions that the default debug build
-      # doesn't see. Cheap to add (target dir is already populated by
-      # the next step's cargo build --release).
+      # doesn't see. Kept on cargo test (rather than nextest) so we
+      # also exercise the canonical test-runner path on every CI run.
       - name: Run tests (release)
         run: cargo test --release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,20 @@ jobs:
       # #247 item 8: cargo-nextest for the debug-profile run. Per-test
       # process isolation catches latent shared-state bugs (e.g. tests
       # writing to a static `std::env::temp_dir()` slug) that cargo
-      # test's thread-pool model masks. Pinned via taiki-e/install-action,
-      # which fetches the prebuilt binary release (much faster than
-      # `cargo install`). Per-test isolation audit complete: 19
-      # `temp_dir().join(...)` callsites all use unique slugs (no
-      # shared paths), and no `static mut` / `OnceCell` / `env::set_var`
-      # globals exist — the codebase is nextest-clean.
+      # test's thread-pool model masks. Per-test isolation audit
+      # complete: 19 `temp_dir().join(...)` callsites all use unique
+      # slugs (no shared paths), and no `static mut` / `OnceCell` /
+      # `env::set_var` globals exist — the codebase is nextest-clean.
+      #
+      # Installed via `cargo install` (not taiki-e/install-action's
+      # prebuilt binary path) because the action's CDN endpoint
+      # (get.nexte.st) consistently 403'd on the ubuntu-latest runner
+      # pool during PR #260; macos-latest was unaffected. Building
+      # from source is ~2-3 min on a cache-warm runner, no third-party
+      # CDN dependency, and amortizes to ~5s on cache-hit runs once
+      # the version is in `~/.cargo/.crates.toml`.
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@daa3c1f1f9a9d46f686d9fc2f65773d0c293688b # v2.62.13
-        with:
-          tool: nextest
+        run: cargo install cargo-nextest --locked
 
       - name: Run tests (debug, nextest)
         run: cargo nextest run

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -668,7 +668,12 @@ mod tests {
                 1,
             ),
             // BGI partial overlap at 3' end (length 8)
-            (b"NNNNNNNNNNNNAAGTCGGA", b"AAGTCGGAGGCCAAGCGGTCTTAGGAAGACAA", 0.0, 1),
+            (
+                b"NNNNNNNNNNNNAAGTCGGA",
+                b"AAGTCGGAGGCCAAGCGGTCTTAGGAAGACAA",
+                0.0,
+                1,
+            ),
         ];
         for (read, adapter, error_rate, min_overlap) in cases {
             let scalar_result = find_3prime_adapter(read, adapter, *error_rate, *min_overlap);

--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -597,7 +597,7 @@ mod tests {
 
     #[test]
     fn test_round_trip() -> Result<()> {
-        let dir = std::env::temp_dir().join("trim_galore_test");
+        let dir = std::env::temp_dir().join("tg_fastq_round_trip");
         std::fs::create_dir_all(&dir)?;
         let out_path = dir.join("test_round_trip.fq");
 

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -750,4 +750,111 @@ mod tests {
         fs::remove_dir_all(&dir).ok();
         Ok(())
     }
+
+    /// #246 follow-up: the worker pool emits each batch's output as
+    /// its own independently-compressed gzip member, then concatenates
+    /// them. Per RFC 1952 the result is a valid `.gz` file that
+    /// decodes (via `MultiGzDecoder`) to the concatenation of every
+    /// member's payload. `fastq::tests::test_multi_member_gzip_round_trip`
+    /// already locks the **reader** side of this contract; this test
+    /// locks the **producer** side — feeding parallel-trimmed gzip
+    /// output back through `FastqReader::open` (which uses
+    /// `MultiGzDecoder`) recovers every record. Sized to span more
+    /// than one batch (>4096 records) so multiple gzip members are
+    /// guaranteed in the output.
+    #[test]
+    fn test_parallel_gzip_output_decodes_multi_member() -> Result<()> {
+        let dir = fresh_tmpdir("tg_parallel_gzip_multi_member");
+        let input_path = dir.join("input.fq");
+
+        let mut content = String::new();
+        for i in 0..5000 {
+            content.push_str(&format!(
+                "@read_{i}\nACGTACGTACGTACGTACGT\n+\nIIIIIIIIIIIIIIIIIIII\n"
+            ));
+        }
+        fs::write(&input_path, content)?;
+
+        let config = parity_test_config();
+        let output_path = dir.join("out.fq.gz");
+        let stats = run_single_end_parallel(&input_path, &output_path, &config, 4, true)?;
+
+        assert_eq!(stats.total_reads, 5000);
+        assert_eq!(stats.reads_written, 5000);
+
+        let mut reader = FastqReader::open(&output_path)?;
+        let mut count = 0;
+        while reader.next_record()?.is_some() {
+            count += 1;
+        }
+        assert_eq!(
+            count, 5000,
+            "all 5000 records must round-trip through the multi-member gzip output"
+        );
+
+        fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    /// #246 follow-up: single-record input is a boundary case for the
+    /// worker pool — only one of the N workers does any work, the
+    /// others see an empty channel and exit cleanly. Locks down that
+    /// the merge path handles a single non-full batch correctly (no
+    /// off-by-one on stats, no truncated output, no deadlock waiting
+    /// on an extra batch from the reader).
+    #[test]
+    fn test_parallel_single_record_input() -> Result<()> {
+        let dir = fresh_tmpdir("tg_parallel_single_record");
+        let input_path = dir.join("input.fq");
+        fs::write(
+            &input_path,
+            "@only_read\nACGTACGTACGTACGTACGT\n+\nIIIIIIIIIIIIIIIIIIII\n",
+        )?;
+
+        let config = parity_test_config();
+        let output_path = dir.join("out.fq");
+        let stats = run_single_end_parallel(&input_path, &output_path, &config, 4, false)?;
+
+        assert_eq!(stats.total_reads, 1);
+        assert_eq!(stats.reads_written, 1);
+        assert_eq!(stats.total_reads_with_adapter, 0);
+
+        let mut reader = FastqReader::open(&output_path)?;
+        let rec = reader.next_record()?.expect("record must be present");
+        assert_eq!(rec.id, "@only_read");
+        assert_eq!(rec.seq, "ACGTACGTACGTACGTACGT");
+        assert!(reader.next_record()?.is_none());
+
+        fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    /// #246 follow-up: empty input must not deadlock the worker pool.
+    /// The reader thread sees EOF on the first read, signals workers
+    /// to exit, and the main thread returns clean zero-stats. A
+    /// regression here would manifest as the test hanging — hence the
+    /// pointed coverage.
+    #[test]
+    fn test_parallel_empty_input_no_deadlock() -> Result<()> {
+        let dir = fresh_tmpdir("tg_parallel_empty");
+        let input_path = dir.join("input.fq");
+        fs::write(&input_path, "")?;
+
+        let config = parity_test_config();
+        let output_path = dir.join("out.fq");
+        let stats = run_single_end_parallel(&input_path, &output_path, &config, 4, false)?;
+
+        assert_eq!(stats.total_reads, 0);
+        assert_eq!(stats.reads_written, 0);
+        assert_eq!(stats.total_reads_with_adapter, 0);
+
+        let mut reader = FastqReader::open(&output_path)?;
+        assert!(
+            reader.next_record()?.is_none(),
+            "empty input must produce empty output (zero records)"
+        );
+
+        fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

Closes the two umbrella tracking issues from @an-altosian's cross-cutting audit so the GA queue is clean at 5 days out.

- **#247 #8 — `cargo nextest` adoption**: per-test-isolation audit + CI swap. 19 `temp_dir().join(...)` callsites audited (18 already used unique slugs; 1 generic slug `trim_galore_test` in `src/fastq.rs:600` renamed to `tg_fastq_round_trip`). No global mutable state in the codebase (no `static mut` / `OnceCell` / `env::set_var`). 191/191 tests pass under nextest's per-process model in 1.07 s.
- **#246 — `parallel.rs` coverage**: +3 targeted tests covering multi-member gzip output validity (producer side of the §5.1 contract), single-record-input boundary, and empty-input no-deadlock. Tests 188 → 191.
- **Drive-by**: `cargo fmt` on `src/alignment.rs:668`. CI Lint has been red on `optimus_prime` since beta.7 (commit `ef2dce3`) because the Myers'-prefilter test fixture wasn't reformatted before commit. Mechanical one-tuple reformat — Lint goes green again with this PR.

The parity-proptest harness (the §5.x bonus from @an-altosian's fork) remains "open to PR" — out of scope for the GA push at 5 days out, but a clear contribution path for whoever picks it up next. Co-authored-by trailer included for the audit work.

## Test plan

- [x] `cargo test --release` — 191/191 pass
- [x] `cargo nextest run --release` — 191/191 pass (1.07 s)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [ ] CI `Lint (fmt + clippy)` — was red on optimus_prime, expected green here
- [ ] CI `Rust Tests (ubuntu-latest, macos-latest)` — both green under nextest
