### PR TITLE
docs: sweep stale benchmark references after Buckberry refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ trim_galore input.fastq.gz
 trim_galore --paired file_R1.fastq.gz file_R2.fastq.gz
 
 # Parallel processing (recommended for large files)
-# Near-linear speedup up to ~16 cores; diminishing returns beyond ~20
-# (typically I/O-bound at that point, not algorithmic).
+# Near-linear speedup up to ~8 cores on v2.1.0-beta.7; beyond that the
+# gzip-output I/O on the storage layer typically becomes binding.
 trim_galore --cores 8 --paired file_R1.fastq.gz file_R2.fastq.gz
 
 # RRBS mode

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -17,8 +17,8 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <div class="tg-proof not-content">
   <div class="tg-proof-item">
-    <div class="num">−60<em>%</em></div>
-    <div class="label">CPU vs v0.6 — saves time, $, CO₂</div>
+    <div class="num">5.9<em>×</em></div>
+    <div class="label">less CPU vs v0.6 at <code>--cores 8</code> — saves time, $, CO₂</div>
   </div>
   <div class="tg-proof-item">
     <div class="num">N<em>×</em></div>

--- a/docs/src/content/docs/performance/threading.md
+++ b/docs/src/content/docs/performance/threading.md
@@ -52,9 +52,9 @@ At `--cores 1`, the worker-pool is bypassed entirely: a single thread does every
 | 8 | up to ~27 | 12 |
 | 16 | not measured | 20 |
 
-At `-j 8` vs `--cores 8`: up to ~27 vs exactly 12 threads, yet 1.9x faster.
+At `-j 8` vs `--cores 8`: up to ~27 vs exactly 12 threads, yet **4.54× faster** wall and **5.93× less CPU** on the 84M-read Buckberry fixture (v2.1.0-beta.7).
 
-Parallel efficiency on the Xeon: 82% (2 cores) to 82% (4 cores) to 81% (8 cores) to 78% (16 cores) to 64% (24 cores). Scaling remains near-linear up to 16 cores, with diminishing returns beyond that. For most production use, `--cores 8` to `--cores 16` is the sweet spot. Beyond 16, additional cores still help but deliver progressively less benefit per core.
+Parallel efficiency at Buckberry scale: 100% (cores=1) → 72% (cores=8) → 34% (cores=16) → 22% (cores=24). Scaling is near-linear up to `--cores 8`; beyond that, gzip-output I/O on the storage layer typically becomes binding before workers run out of useful per-read work, so adding cores helps progressively less. **`--cores 8` is the sweet spot for nf-core / Snakemake / CWL workflows** — also the saturation point.
 
 ## Memory profile
 
@@ -75,7 +75,7 @@ Each additional worker adds ~10 MB on average. The bulk of which is the per-work
 - **Simpler deployment:** `cargo install` or download a binary. No conda environment needed.
 - **Single-pass paired-end:** Both reads processed together, with guaranteed synchronization, no temp files.
 - **Lower memory:** 5 MB single-threaded, ~10 MB per additional worker. No Python interpreter, no subprocess pipes.
-- **CPU-efficient:** Uses 2.6 to 5x less CPU time than Trim Galore. Meaningful on shared HPC clusters where CPU-hours = money.
+- **CPU-efficient:** Uses 5.9× to 13.5× less CPU time than Trim Galore (nf-core default to single-thread, on the 84M-read Buckberry fixture). Meaningful on shared HPC clusters where CPU-hours = money.
 - **Reproducible:** Pure Rust with deterministic behaviour across platforms.
 - **New features:** Poly-G trimming (auto-detected for 2-colour instruments like NovaSeq/NextSeq) and poly-A trimming, both built in without external tools.
 

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -30,7 +30,7 @@ Outputs:
 
 ## Parallel processing
 
-Speedup is near-linear up to about 16 cores. Beyond about 20 the run is usually I/O-bound, so adding cores helps less.
+Speedup is near-linear up to about 8 cores on v2.1.0-beta.7; beyond that, gzip-output I/O on the storage layer typically becomes binding and adding cores helps less. For nf-core / Snakemake / CWL workflows, `--cores 8` is also the saturation point.
 
 ```bash
 trim_galore --cores 8 --paired sample_R1.fastq.gz sample_R2.fastq.gz


### PR DESCRIPTION
## Summary

After PRs #265 + #266 landed the Buckberry-scale benchmark on the docs site, several other surfaces still quoted the old 56M-fixture numbers. This sweep brings them into line with the new headline numbers (**5.9× to 13.5× less CPU time**; saturation at `--cores 8` on v2.1.0-beta.7).

5 files, +8/−8 lines, all factual updates traceable to the JSON files in `docs/perf_data/buckberry-2026-04-29/`.

## Changes

| File | Old | New |
|---|---|---|
| `docs/src/content/docs/index.mdx` (landing page proof bar) | `−60%` CPU vs v0.6 | **5.9×** less CPU vs v0.6 at `--cores 8` |
| `docs/src/content/docs/performance/threading.md` (Beyond speed bullet) | "2.6 to 5x less CPU" | "5.9× to 13.5× less CPU (nf-core default to single-thread)" |
| `docs/src/content/docs/performance/threading.md` (`-j 8` vs `--cores 8` line) | "1.9x faster" | "4.54× faster wall and 5.93× less CPU" |
| `docs/src/content/docs/performance/threading.md` (parallel-efficiency paragraph) | 82-82-81-78-64% (old fixture) | 100-72-34-22% (Buckberry-derived); sweet spot updated `--cores 8 to 16` → `--cores 8` |
| `README.md` (parallel-processing usage comment) | "near-linear up to ~16 cores; diminishing beyond ~20" | "near-linear up to ~8 cores on v2.1.0-beta.7" |
| `docs/src/content/docs/quickstart.md` (Parallel processing paragraph) | Same fix as README |

No new claims introduced; all numbers traceable to JSON files in `docs/perf_data/buckberry-2026-04-29/` (committed in #266).

## Test plan

- [x] Final grep for stale numbers (2.3-5×, −60%, "16 cores"): clean — no stragglers
- [x] All replaced numbers cross-checked against the canonical hyperfine JSONs
- [x] No code changes; CI should be green on the same checks as the prior two PRs
