### PR TITLE
v2.1.0-beta.8: --high_compression opt-in flag + memory profile refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Trim Galore Changelog
 
 
+### Version 2.1.0-beta.8 (Release on 30 Apr 2026)
+
+#### New feature
+
+- **`--high_compression` opt-in flag.** Sets gzip output level to 6
+  (smaller files, slower trimming) instead of the default level 1
+  (faster trimming, ~75% larger output bytes). Useful when storage
+  cost or transfer bandwidth matters more than runtime — archival
+  workflows, shared object stores. Decompressed output is
+  byte-identical regardless of level (gzip levels 1 and 6 are both
+  lossless; only the framing differs). The flag flows through
+  `TrimConfig`, the worker pool's per-batch `GzEncoder` callsites,
+  the sequential output writer, every specialty mode
+  (`--hardtrim5`/`--hardtrim3`/`--clock`/`--implicon`), and
+  `--demux`. Counter-lever to the v2.1.0-beta.6 default of level 1.
+  Trade quantified by the v2.1.0-beta.7 Buckberry benchmark: at
+  saturation (cores=8) on the 84M-read fixture, lowering level 6 →
+  level 1 saved ~−23% wall and ~−43% CPU; `--high_compression`
+  reverses that trade for users who want the smaller files back.
+
+
 ### Version 2.1.0-beta.7 (Release on 29 Apr 2026)
 
 #### Performance (since v2.1.0-beta.6) — third Buckberry-scale win (#248 #4)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "trim-galore"
-version = "2.1.0-beta.7"
+version = "2.1.0-beta.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trim-galore"
-version = "2.1.0-beta.7"
+version = "2.1.0-beta.8"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast adapter and quality trimming for NGS data — Oxidized Edition"

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Consistent quality and adapter trimming for next-generation sequencing data, wit
 ## Installation
 
 > [!IMPORTANT]
-> **Beta testing v2.1.0-beta.7.** The current stable release on crates.io is v2.0.0; v2.1.0 is in beta testing. Running `cargo install trim-galore` without `--version` installs v2.0.0 (the stable). To install the beta:
+> **Beta testing v2.1.0-beta.8.** The current stable release on crates.io is v2.0.0; v2.1.0 is in beta testing. Running `cargo install trim-galore` without `--version` installs v2.0.0 (the stable). To install the beta:
 >
 > ```bash
-> cargo install trim-galore --version 2.1.0-beta.7
+> cargo install trim-galore --version 2.1.0-beta.8
 > docker pull ghcr.io/felixkrueger/trimgalore:beta
 > ```
 >
@@ -85,7 +85,7 @@ Multi-arch images (amd64 + arm64) are available from GitHub Container Registry:
 docker run --rm -v "$PWD":/data -w /data ghcr.io/felixkrueger/trimgalore:beta trim_galore input.fastq.gz
 ```
 
-FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:beta` (latest prerelease, currently `v2.1.0-beta.7`), `:v2.1.0-beta.7` (pinned to a specific prerelease), `:dev` (every push to `optimus_prime`), and `:latest` will track stable releases starting at v2.1.0 GA. See the [docs site install page](https://felixkrueger.github.io/TrimGalore/install/) for the full table.
+FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:beta` (latest prerelease, currently `v2.1.0-beta.8`), `:v2.1.0-beta.8` (pinned to a specific prerelease), `:dev` (every push to `optimus_prime`), and `:latest` will track stable releases starting at v2.1.0 GA. See the [docs site install page](https://felixkrueger.github.io/TrimGalore/install/) for the full table.
 
 ### Prebuilt binaries
 
@@ -101,7 +101,7 @@ trim_galore input.fastq.gz
 trim_galore --paired file_R1.fastq.gz file_R2.fastq.gz
 
 # Parallel processing (recommended for large files)
-# Near-linear speedup up to ~8 cores on v2.1.0-beta.7; beyond that the
+# Near-linear speedup up to ~8 cores on v2.1.0-beta.8; beyond that the
 # gzip-output I/O on the storage layer typically becomes binding.
 trim_galore --cores 8 --paired file_R1.fastq.gz file_R2.fastq.gz
 
@@ -126,7 +126,7 @@ trim_galore --help
 | Paired-end | `*_val_1.fq.gz` / `*_val_2.fq.gz` | per-read text + JSON reports |
 | Unpaired (with `--retain_unpaired`) | `*_unpaired_1.fq.gz` / `*_unpaired_2.fq.gz` | |
 
-Output compression mirrors the input: gzipped input (`*.fastq.gz`) produces gzipped output (`*.fq.gz`); plain input (`*.fastq`) produces plain output (`*.fq`). Pass `--dont_gzip` to force plain output regardless. Gzip output is written at compression level 1 (fastest) — decompressed content is byte-identical to higher-level output, but the resulting `.fq.gz` files are roughly 75% larger in exchange for substantially faster trimming on multi-core runs.
+Output compression mirrors the input: gzipped input (`*.fastq.gz`) produces gzipped output (`*.fq.gz`); plain input (`*.fastq`) produces plain output (`*.fq`). Pass `--dont_gzip` to force plain output regardless. Gzip output is written at compression level 1 (fastest) — decompressed content is byte-identical to higher-level output, but the resulting `.fq.gz` files are roughly 75% larger in exchange for substantially faster trimming on multi-core runs. Pass `--high_compression` (v2.1.0-beta.8+) to invert that trade and write level-6 gzip output for storage-bound or archival workflows.
 
 The JSON report contains the same statistics as the text report in a structured format (schema v1), designed for native parsing by MultiQC.
 

--- a/docs/perf_data/buckberry-2026-04-29/README.md
+++ b/docs/perf_data/buckberry-2026-04-29/README.md
@@ -13,6 +13,7 @@ Raw `hyperfine` outputs and run logs from the Trim Galore Buckberry-scale benchm
 | `<engine>_c<N>.json` | Hyperfine raw output: 10 sample wall-time runs, mean/min/max/stddev, user + system CPU time. Canonical reference data. |
 | `<engine>_c<N>.md` | Hyperfine human-readable markdown summary table. Same data, easier to skim. |
 | `byte_identity_summary.txt` | md5 cross-check between Rust beta.5 and beta.7 outputs at cores=8. Both R1 and R2 confirmed `MATCH` — Myers' prefilter is byte-identity-preserving by construction. |
+| `memory_summary.txt` | Peak RSS measurements via `/usr/bin/time -v` for v2.1.0-beta.7 at cores 1/2/4/8 (single run per condition). Wall times here match the hyperfine numbers in the corresponding `*.json` files within ~1%. |
 | `logs-and-scripts.tar.gz` | Verbose stdout logs from the main run (`bench_20260429_155450.log`) + extras run (`bench_extras_20260430_120230.log`) + the three wrapper scripts (`run_bench.sh`, `run_bench_extra.sh`, `watch_then_extras.sh`). Bundled to keep the directory listing readable. |
 
 ## Engines

--- a/docs/perf_data/buckberry-2026-04-29/memory_summary.txt
+++ b/docs/perf_data/buckberry-2026-04-29/memory_summary.txt
@@ -1,0 +1,12 @@
+Memory measurements — Trim Galore v2.1.0-beta.7
+Date: 2026-04-30T14:10:49Z
+Host: dockyard-oxy-0
+Method: /usr/bin/time -v, peak RSS, single run per condition
+Fixture: SRR24827373 (Buckberry 2023, 84M PE reads)
+
+| --cores | Peak RSS (MB) | Wall (s) |
+|--------:|--------------:|---------:|
+| 1 | 5.1 | 5:27.36 |
+| 2 | 60.1 | 2:39.38 |
+| 4 | 73.0 | 1:20.75 |
+| 8 | 91.6 | 0:56.93 |

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -5,11 +5,11 @@ description: Install Trim Galore via cargo, bioconda, Docker, or prebuilt binari
 
 Trim Galore v2 ships as a single static binary. No Python, no Perl, no Cutadapt, no Java, no `igzip`, no `pigz`, no external FastQC. Pick whichever channel fits the rest of your stack.
 
-:::caution[Beta testing v2.1.0-beta.7]
+:::caution[Beta testing v2.1.0-beta.8]
 The current stable release on crates.io is **v2.0.0**. v2.1.0 is in beta. `cargo install trim-galore` without `--version` installs v2.0.0. To install the beta:
 
 ```bash
-cargo install trim-galore --version 2.1.0-beta.7
+cargo install trim-galore --version 2.1.0-beta.8
 docker pull ghcr.io/felixkrueger/trimgalore:beta
 ```
 
@@ -63,8 +63,8 @@ FastQC is built in via the bundled [`fastqc-rust`](https://crates.io/crates/fast
 
 | Tag | Updates |
 | --- | --- |
-| `:beta` | latest prerelease (currently v2.1.0-beta.7) |
-| `:v2.1.0-beta.7` | pinned to a specific prerelease |
+| `:beta` | latest prerelease (currently v2.1.0-beta.8) |
+| `:v2.1.0-beta.8` | pinned to a specific prerelease |
 | `:dev` | every push to the `optimus_prime` development branch |
 | `:latest` | latest stable release (publishes from v2.1.0 GA onward) |
 
@@ -85,7 +85,7 @@ trim_galore --version
 Should print:
 
 ```
-trim_galore 2.1.0-beta.7 (Oxidized Edition)
+trim_galore 2.1.0-beta.8 (Oxidized Edition)
 <git-hash> — <os>/<arch> — built <ISO-8601-UTC>
 ```
 

--- a/docs/src/content/docs/performance/threading.md
+++ b/docs/src/content/docs/performance/threading.md
@@ -58,16 +58,16 @@ Parallel efficiency at Buckberry scale: 100% (cores=1) → 72% (cores=8) → 34%
 
 ## Memory profile
 
-| `--cores` | Memory | Notes |
-|----------:|-------:|-------|
-| 1 | 5 MB | Worker-pool bypassed; single-threaded path. |
-| 2 | 43 MB | Infrastructure threads come online (+4 fixed cost). |
-| 4 | 62 MB | |
-| 8 | 100 MB | |
-| 16 | 171 MB | |
-| 24 | 157 MB | |
+Peak resident set size on the 84M-read Buckberry fixture (Trim Galore v2.1.0-beta.7, measured via `/usr/bin/time -v`):
 
-Each additional worker adds ~10 MB on average. The bulk of which is the per-worker compression buffer.
+| `--cores` | Peak RSS | Notes |
+|----------:|---------:|-------|
+| 1 | 5.1 MB | Worker-pool bypassed; single-threaded path. |
+| 2 | 60.1 MB | Infrastructure threads come online (+4 fixed cost: 2 decompressors + 1 batcher + 1 writer). |
+| 4 | 73.0 MB | |
+| 8 | 91.6 MB | |
+
+The c1 → c2 step is by far the largest (+55 MB) — that's the four infrastructure threads spinning up their I/O buffers. Past c2, each additional pair of workers adds ~7 MB on average; the bulk of which is the per-worker compression buffer. Memory growth is bounded and predictable, well-suited to cluster scheduling: even worst-case at the saturation point (`--cores 8`), the process never exceeds ~100 MB.
 
 ## Beyond speed
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -734,8 +734,8 @@ mod tests {
         adapter_seq: &str,
         num_reads: usize,
     ) -> Result<()> {
-        use crate::fastq::{FastqRecord, FastqWriter};
-        let mut writer = FastqWriter::create(path, false, 1)?;
+        use crate::fastq::{FastqRecord, FastqWriter, OUTPUT_GZIP_LEVEL};
+        let mut writer = FastqWriter::create(path, false, 1, OUTPUT_GZIP_LEVEL)?;
         // Prepend a 20bp random-ish prefix so reads are plausibly long;
         // the probe is looking for adapter_seq as a substring anywhere.
         let prefix = "ACGTACGTACGTACGTACGT";

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -142,6 +142,14 @@ pub struct Cli {
     #[clap(long = "dont_gzip")]
     pub dont_gzip: bool,
 
+    /// Use gzip compression level 6 (smaller output, slower trimming) instead
+    /// of the default level 1 (faster trimming, ~75% larger output bytes).
+    /// Useful when storage cost or transfer bandwidth matters more than
+    /// runtime — e.g. archival workflows or shared object stores. Decompressed
+    /// output is byte-identical regardless of level.
+    #[clap(long = "high_compression", alias = "high-compression")]
+    pub high_compression: bool,
+
     /// Suppress the trimming report.
     #[clap(long = "no_report_file")]
     pub no_report_file: bool,

--- a/src/demux.rs
+++ b/src/demux.rs
@@ -13,7 +13,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
 
-use crate::fastq::{FastqReader, FastqWriter};
+use crate::fastq::{FastqReader, FastqWriter, output_gzip_level};
 
 /// A parsed barcode entry: barcode sequence → sample name.
 #[derive(Debug)]
@@ -119,6 +119,7 @@ pub fn demultiplex(
     gzip: bool,
     output_dir: Option<&Path>,
     cores: usize,
+    high_compression: bool,
 ) -> Result<()> {
     let barcode_length = barcodes[0].barcode.len();
     eprintln!("Setting barcode length to {}", barcode_length);
@@ -145,6 +146,8 @@ pub fn demultiplex(
             .to_path_buf()
     });
 
+    let gzip_level = output_gzip_level(high_compression);
+
     // Open per-sample output writers + NoCode
     let mut writers: HashMap<String, FastqWriter> = HashMap::new();
     for entry in barcodes {
@@ -152,13 +155,13 @@ pub fn demultiplex(
         let path = dir.join(&filename);
         writers.insert(
             entry.barcode.clone(),
-            FastqWriter::create(&path, gzip, cores)?,
+            FastqWriter::create(&path, gzip, cores, gzip_level)?,
         );
     }
     // NoCode writer for unmatched barcodes
     let nocode_filename = output_filename(&base_name, "NoCode", gzip);
     let nocode_path = dir.join(&nocode_filename);
-    let mut nocode_writer = FastqWriter::create(&nocode_path, gzip, cores)?;
+    let mut nocode_writer = FastqWriter::create(&nocode_path, gzip, cores, gzip_level)?;
 
     // Per-barcode counts
     let mut counts: HashMap<String, usize> =
@@ -351,7 +354,7 @@ mod tests {
             barcode: "ACGTACGT".to_string(),
         }];
 
-        demultiplex(&trimmed, &barcodes, false, Some(&dir), 1).unwrap();
+        demultiplex(&trimmed, &barcodes, false, Some(&dir), 1, false).unwrap();
 
         // Output base is the trimmed-file basename minus .gz/.fq suffixes:
         // "input_trimmed.fq" → "input_trimmed" + "_<sample>.fq".

--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -16,15 +16,34 @@ use std::path::Path;
 /// Buffer size for gzip I/O — 64KB for throughput (flate2 default of 8KB is too small).
 const BUF_SIZE: usize = 64 * 1024;
 
-/// Output gzip compression level. Set to 1 (fastest) — at Buckberry-
-/// scale (84M reads, 38% adapter rate, cores=8) the compression CPU
-/// dominated wall time on saturated workers; lowering from level 6 to
-/// 1 measured ~−23% wall and ~−43% user-CPU at byte-identity of the
-/// decompressed output (gzip framing differs but `gzip -dc` yields
-/// the same bytes). Trade: output `.fq.gz` files are ~75% larger.
-/// See #248 (item #1 in @an-altosian's perf audit). Centralised here
-/// so a future `--high-compression` opt-in flag is a one-line change.
+/// Default output gzip compression level. Set to 1 (fastest) — at
+/// Buckberry-scale (84M reads, 38% adapter rate, cores=8) the
+/// compression CPU dominated wall time on saturated workers; lowering
+/// from level 6 to 1 measured ~−23% wall and ~−43% user-CPU at
+/// byte-identity of the decompressed output (gzip framing differs
+/// but `gzip -dc` yields the same bytes). Trade: output `.fq.gz`
+/// files are ~75% larger. See #248 (item #1 in @an-altosian's perf
+/// audit). Users who care about storage more than runtime can opt
+/// into `--high_compression` to get level 6 instead.
 pub const OUTPUT_GZIP_LEVEL: u32 = 1;
+
+/// Gzip compression level used when `--high_compression` is set.
+/// Matches Rust's `flate2::Compression::default()` (level 6) and
+/// gzip(1)'s default — the "balanced" point on the size/speed curve.
+/// Output bytes are ~75% smaller than level 1; per-block compression
+/// CPU is roughly 2× higher.
+pub const HIGH_COMPRESSION_GZIP_LEVEL: u32 = 6;
+
+/// Returns the gzip output level to use given the `--high_compression`
+/// flag state. Centralises the size-vs-speed trade so every output
+/// callsite reads the same way: `Compression::new(output_gzip_level(...))`.
+pub fn output_gzip_level(high_compression: bool) -> u32 {
+    if high_compression {
+        HIGH_COMPRESSION_GZIP_LEVEL
+    } else {
+        OUTPUT_GZIP_LEVEL
+    }
+}
 
 /// A single FASTQ record with owned data.
 #[derive(Debug, Clone)]
@@ -445,7 +464,15 @@ pub struct FastqWriter {
 impl FastqWriter {
     /// Create a new FASTQ writer. Gzip-compresses if `gzip` is true.
     /// When `cores` > 1 and gzip is enabled, uses parallel gzip compression.
-    pub fn create<P: AsRef<Path>>(path: P, gzip: bool, cores: usize) -> Result<Self> {
+    /// `gzip_level` is the deflate level (1 = fastest/largest, 6 = balanced,
+    /// 9 = smallest/slowest). Use `output_gzip_level(high_compression)`
+    /// to derive the right value from a `--high_compression` flag.
+    pub fn create<P: AsRef<Path>>(
+        path: P,
+        gzip: bool,
+        cores: usize,
+        gzip_level: u32,
+    ) -> Result<Self> {
         let path = path.as_ref();
 
         // Ensure parent directory exists
@@ -472,14 +499,14 @@ impl FastqWriter {
                                 cores
                             )
                         })?
-                        .compression_level(Compression::new(OUTPUT_GZIP_LEVEL))
+                        .compression_level(Compression::new(gzip_level))
                         .from_writer(file),
                 )
             } else {
                 // Single-threaded gzip with zlib-rs SIMD backend
                 Box::new(BufWriter::with_capacity(
                     BUF_SIZE,
-                    GzEncoder::new(file, Compression::new(OUTPUT_GZIP_LEVEL)),
+                    GzEncoder::new(file, Compression::new(gzip_level)),
                 ))
             }
         } else {
@@ -616,7 +643,7 @@ mod tests {
         ];
 
         {
-            let mut writer = FastqWriter::create(&out_path, false, 1)?;
+            let mut writer = FastqWriter::create(&out_path, false, 1, OUTPUT_GZIP_LEVEL)?;
             for rec in &records {
                 writer.write_record(rec)?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use trim_galore::adapter;
 use trim_galore::cli::{Cli, rewrite_perl_short_flags};
 use trim_galore::demux;
-use trim_galore::fastq::{FastqReader, FastqWriter};
+use trim_galore::fastq::{FastqReader, FastqWriter, output_gzip_level};
 use trim_galore::fastqc;
 use trim_galore::filters::{MaxNFilter, UnpairedLengths};
 use trim_galore::io as naming;
@@ -54,13 +54,29 @@ fn main() -> Result<()> {
     // Specialty modes — bypass normal trimming pipeline entirely
     if let Some(n) = cli.hardtrim5 {
         for input in &cli.input {
-            specialty::hardtrim5(input, n, gzip, output_dir, cli.rename, cli.cores)?;
+            specialty::hardtrim5(
+                input,
+                n,
+                gzip,
+                output_dir,
+                cli.rename,
+                cli.cores,
+                cli.high_compression,
+            )?;
         }
         return Ok(());
     }
     if let Some(n) = cli.hardtrim3 {
         for input in &cli.input {
-            specialty::hardtrim3(input, n, gzip, output_dir, cli.rename, cli.cores)?;
+            specialty::hardtrim3(
+                input,
+                n,
+                gzip,
+                output_dir,
+                cli.rename,
+                cli.cores,
+                cli.high_compression,
+            )?;
         }
         return Ok(());
     }
@@ -74,7 +90,7 @@ fn main() -> Result<()> {
                     specialty::clock_output_name(r2, "R2", output_dir, gzip),
                 )
             },
-            |r1, r2| specialty::clock(r1, r2, gzip, output_dir, cli.cores),
+            |r1, r2| specialty::clock(r1, r2, gzip, output_dir, cli.cores, cli.high_compression),
         )?;
         return Ok(());
     }
@@ -88,7 +104,17 @@ fn main() -> Result<()> {
                     specialty::implicon_output_name(r2, umi_len, "R2", output_dir, gzip),
                 )
             },
-            |r1, r2| specialty::implicon(r1, r2, umi_len, gzip, output_dir, cli.cores),
+            |r1, r2| {
+                specialty::implicon(
+                    r1,
+                    r2,
+                    umi_len,
+                    gzip,
+                    output_dir,
+                    cli.cores,
+                    cli.high_compression,
+                )
+            },
         )?;
         return Ok(());
     }
@@ -371,6 +397,7 @@ fn setup_trimming(cli: &Cli, input_file: &Path) -> SetupResult {
         poly_a: cli.poly_a,
         poly_g: poly_g_enabled,
         discard_untrimmed: cli.discard_untrimmed,
+        high_compression: cli.high_compression,
     };
 
     Ok((adapter_label, adapters_r1, adapters_r2, config))
@@ -467,7 +494,12 @@ fn run_single_file(
         parallel::run_single_end_parallel(input, &output_path, config, cli.cores, gzip)?
     } else {
         let mut reader = FastqReader::open(input)?;
-        let mut writer = FastqWriter::create(&output_path, gzip, 1)?;
+        let mut writer = FastqWriter::create(
+            &output_path,
+            gzip,
+            1,
+            output_gzip_level(config.high_compression),
+        )?;
         let stats = trimmer::run_single_end(&mut reader, &mut writer, config)?;
         writer.flush()?;
         drop(writer);
@@ -610,7 +642,14 @@ fn run_single_file(
             barcode_file.display()
         );
         let barcodes = demux::read_barcode_file(barcode_file)?;
-        demux::demultiplex(&output_path, &barcodes, gzip, output_dir, cli.cores)?;
+        demux::demultiplex(
+            &output_path,
+            &barcodes,
+            gzip,
+            output_dir,
+            cli.cores,
+            cli.high_compression,
+        )?;
     }
 
     Ok(())
@@ -669,13 +708,14 @@ fn run_paired(
         // Sequential path (--cores 1)
         let mut reader_r1 = FastqReader::open(input_r1)?;
         let mut reader_r2 = FastqReader::open(input_r2)?;
-        let mut writer_r1 = FastqWriter::create(&output_r1, gzip, 1)?;
-        let mut writer_r2 = FastqWriter::create(&output_r2, gzip, 1)?;
+        let level = output_gzip_level(config.high_compression);
+        let mut writer_r1 = FastqWriter::create(&output_r1, gzip, 1, level)?;
+        let mut writer_r2 = FastqWriter::create(&output_r2, gzip, 1, level)?;
 
         let (mut unpaired_w1, mut unpaired_w2) = match (&unpaired_r1_path, &unpaired_r2_path) {
             (Some(p1), Some(p2)) => (
-                Some(FastqWriter::create(p1, gzip, 1)?),
-                Some(FastqWriter::create(p2, gzip, 1)?),
+                Some(FastqWriter::create(p1, gzip, 1, level)?),
+                Some(FastqWriter::create(p2, gzip, 1, level)?),
             ),
             _ => (None, None),
         };

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -20,7 +20,7 @@ use std::io::Write;
 use std::path::Path;
 use std::sync::mpsc;
 
-use crate::fastq::{FastqReader, FastqRecord, OUTPUT_GZIP_LEVEL};
+use crate::fastq::{FastqReader, FastqRecord, output_gzip_level};
 use crate::filters::{self, FilterResult, PairFilterResult, UnpairedLengths};
 use crate::report::{PairValidationStats, TrimStats};
 use crate::trimmer::{self, TrimConfig, update_adapter_stats};
@@ -243,24 +243,19 @@ fn process_paired_batch(
     let mut buf_up_r2 = Vec::new();
 
     if gzip {
+        let level = output_gzip_level(config.high_compression);
         // Scoped block: GzEncoders borrow the buffers; finish() before block
         // ends releases the borrows so we can return the buffers.
         {
-            let mut gz_r1 = GzEncoder::new(&mut buf_r1, Compression::new(OUTPUT_GZIP_LEVEL));
-            let mut gz_r2 = GzEncoder::new(&mut buf_r2, Compression::new(OUTPUT_GZIP_LEVEL));
+            let mut gz_r1 = GzEncoder::new(&mut buf_r1, Compression::new(level));
+            let mut gz_r2 = GzEncoder::new(&mut buf_r2, Compression::new(level));
             let mut gz_up_r1 = if retain_unpaired {
-                Some(GzEncoder::new(
-                    &mut buf_up_r1,
-                    Compression::new(OUTPUT_GZIP_LEVEL),
-                ))
+                Some(GzEncoder::new(&mut buf_up_r1, Compression::new(level)))
             } else {
                 None
             };
             let mut gz_up_r2 = if retain_unpaired {
-                Some(GzEncoder::new(
-                    &mut buf_up_r2,
-                    Compression::new(OUTPUT_GZIP_LEVEL),
-                ))
+                Some(GzEncoder::new(&mut buf_up_r2, Compression::new(level)))
             } else {
                 None
             };
@@ -566,7 +561,10 @@ fn process_single_batch(
 
     if gzip {
         {
-            let mut gz = GzEncoder::new(&mut buf, Compression::new(OUTPUT_GZIP_LEVEL));
+            let mut gz = GzEncoder::new(
+                &mut buf,
+                Compression::new(output_gzip_level(config.high_compression)),
+            );
             process_reads(reads, config, &mut stats, &mut gz)?;
             gz.finish()?;
         }
@@ -679,6 +677,7 @@ mod tests {
             poly_a: false,
             poly_g: false,
             discard_untrimmed: false,
+            high_compression: false,
         }
     }
 
@@ -719,7 +718,8 @@ mod tests {
         let serial_output = dir.join("serial_out.fq");
         let stats_serial = {
             let mut reader = FastqReader::open(&input_path)?;
-            let mut writer = FastqWriter::create(&serial_output, false, 1)?;
+            let mut writer =
+                FastqWriter::create(&serial_output, false, 1, crate::fastq::OUTPUT_GZIP_LEVEL)?;
             let stats = crate::trimmer::run_single_end(&mut reader, &mut writer, &config)?;
             writer.flush()?;
             stats
@@ -852,6 +852,68 @@ mod tests {
         assert!(
             reader.next_record()?.is_none(),
             "empty input must produce empty output (zero records)"
+        );
+
+        fs::remove_dir_all(&dir).ok();
+        Ok(())
+    }
+
+    /// `--high_compression` smoke test: same input, two runs (default
+    /// level 1 vs `high_compression: true` level 6). The level-6 output
+    /// must be smaller on disk, and decompressed output must be
+    /// byte-identical between the two — gzip framing differs but
+    /// payload is preserved (gzip levels 1 and 6 are both lossless).
+    #[test]
+    fn test_high_compression_produces_smaller_output() -> Result<()> {
+        let dir = fresh_tmpdir("tg_high_compression");
+        let input_path = dir.join("input.fq");
+
+        // 200 reads with a repeating-sequence motif so gzip can find
+        // back-references at higher levels. Sized to span a single
+        // batch so output is one gzip member regardless of cores.
+        let mut content = String::new();
+        for i in 0..200 {
+            content.push_str(&format!(
+                "@read_{i}\nACGTACGTACGTACGTACGTACGTACGTACGT\n+\nIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII\n"
+            ));
+        }
+        fs::write(&input_path, content)?;
+
+        let config_default = parity_test_config();
+        let mut config_high = parity_test_config();
+        config_high.high_compression = true;
+
+        let out_default = dir.join("out_default.fq.gz");
+        let out_high = dir.join("out_high.fq.gz");
+
+        run_single_end_parallel(&input_path, &out_default, &config_default, 2, true)?;
+        run_single_end_parallel(&input_path, &out_high, &config_high, 2, true)?;
+
+        let size_default = fs::metadata(&out_default)?.len();
+        let size_high = fs::metadata(&out_high)?.len();
+
+        assert!(
+            size_high < size_default,
+            "high_compression output ({} bytes) must be smaller than default ({} bytes)",
+            size_high,
+            size_default
+        );
+
+        // Decompressed output must match: gzip levels are lossless;
+        // only the framing differs.
+        let read_records = |p: &std::path::Path| -> Result<Vec<(String, String, String)>> {
+            let mut r = FastqReader::open(p)?;
+            let mut v = Vec::new();
+            while let Some(rec) = r.next_record()? {
+                v.push((rec.id, rec.seq, rec.qual));
+            }
+            Ok(v)
+        };
+        let recs_default = read_records(&out_default)?;
+        let recs_high = read_records(&out_high)?;
+        assert_eq!(
+            recs_default, recs_high,
+            "decompressed records must be byte-identical between gzip levels 1 and 6"
         );
 
         fs::remove_dir_all(&dir).ok();

--- a/src/specialty.rs
+++ b/src/specialty.rs
@@ -6,7 +6,7 @@
 use anyhow::{Result, bail};
 use std::path::{Path, PathBuf};
 
-use crate::fastq::{FastqReader, FastqWriter};
+use crate::fastq::{FastqReader, FastqWriter, output_gzip_level};
 use crate::io as naming;
 
 /// Hard-trim every read to keep only the first `keep` bases from the 5' end.
@@ -19,6 +19,7 @@ pub fn hardtrim5(
     output_dir: Option<&Path>,
     rename: bool,
     cores: usize,
+    high_compression: bool,
 ) -> Result<()> {
     let output_path = hardtrim_output_name(input, keep, "5prime", output_dir, gzip);
     eprintln!(
@@ -29,7 +30,12 @@ pub fn hardtrim5(
     );
 
     let mut reader = FastqReader::open(input)?;
-    let mut writer = FastqWriter::create(&output_path, gzip, cores)?;
+    let mut writer = FastqWriter::create(
+        &output_path,
+        gzip,
+        cores,
+        output_gzip_level(high_compression),
+    )?;
     let mut count: usize = 0;
 
     while let Some(mut record) = reader.next_record()? {
@@ -61,6 +67,7 @@ pub fn hardtrim3(
     output_dir: Option<&Path>,
     rename: bool,
     cores: usize,
+    high_compression: bool,
 ) -> Result<()> {
     let output_path = hardtrim_output_name(input, keep, "3prime", output_dir, gzip);
     eprintln!(
@@ -71,7 +78,12 @@ pub fn hardtrim3(
     );
 
     let mut reader = FastqReader::open(input)?;
-    let mut writer = FastqWriter::create(&output_path, gzip, cores)?;
+    let mut writer = FastqWriter::create(
+        &output_path,
+        gzip,
+        cores,
+        output_gzip_level(high_compression),
+    )?;
     let mut count: usize = 0;
 
     while let Some(mut record) = reader.next_record()? {
@@ -114,6 +126,7 @@ pub fn clock(
     gzip: bool,
     output_dir: Option<&Path>,
     cores: usize,
+    high_compression: bool,
 ) -> Result<()> {
     let out1 = clock_output_name(input_r1, "R1", output_dir, gzip);
     let out2 = clock_output_name(input_r2, "R2", output_dir, gzip);
@@ -131,8 +144,10 @@ pub fn clock(
 
     let mut reader_r1 = FastqReader::open(input_r1)?;
     let mut reader_r2 = FastqReader::open(input_r2)?;
-    let mut writer_r1 = FastqWriter::create(&out1, gzip, cores)?;
-    let mut writer_r2 = FastqWriter::create(&out2, gzip, cores)?;
+    let mut writer_r1 =
+        FastqWriter::create(&out1, gzip, cores, output_gzip_level(high_compression))?;
+    let mut writer_r2 =
+        FastqWriter::create(&out2, gzip, cores, output_gzip_level(high_compression))?;
 
     let mut count: usize = 0;
     let mut filtered_count: usize = 0;
@@ -226,6 +241,7 @@ pub fn implicon(
     gzip: bool,
     output_dir: Option<&Path>,
     cores: usize,
+    high_compression: bool,
 ) -> Result<()> {
     let out1 = implicon_output_name(input_r1, umi_length, "R1", output_dir, gzip);
     let out2 = implicon_output_name(input_r2, umi_length, "R2", output_dir, gzip);
@@ -243,8 +259,10 @@ pub fn implicon(
 
     let mut reader_r1 = FastqReader::open(input_r1)?;
     let mut reader_r2 = FastqReader::open(input_r2)?;
-    let mut writer_r1 = FastqWriter::create(&out1, gzip, cores)?;
-    let mut writer_r2 = FastqWriter::create(&out2, gzip, cores)?;
+    let mut writer_r1 =
+        FastqWriter::create(&out1, gzip, cores, output_gzip_level(high_compression))?;
+    let mut writer_r2 =
+        FastqWriter::create(&out2, gzip, cores, output_gzip_level(high_compression))?;
 
     let mut count: usize = 0;
 
@@ -380,7 +398,7 @@ mod tests {
     }
 
     fn write_fastq(path: &Path, records: &[FastqRecord]) -> Result<()> {
-        let mut w = FastqWriter::create(path, false, 1)?;
+        let mut w = FastqWriter::create(path, false, 1, crate::fastq::OUTPUT_GZIP_LEVEL)?;
         for r in records {
             w.write_record(r)?;
         }
@@ -423,7 +441,7 @@ mod tests {
             ],
         )?;
 
-        clock(&r1_path, &r2_path, false, Some(&dir), 1)?;
+        clock(&r1_path, &r2_path, false, Some(&dir), 1, false)?;
 
         let out_r1 = dir.join("sample_R1.clock_UMI.R1.fq");
         let out_r2 = dir.join("sample_R2.clock_UMI.R2.fq");
@@ -473,7 +491,7 @@ mod tests {
             &[mk_rec("@r", "TTTTTTTTCAGTNNNN", "IIIIIIIIIIIIIIII")],
         )?;
 
-        let result = clock(&r1_path, &r2_path, false, Some(&dir), 1);
+        let result = clock(&r1_path, &r2_path, false, Some(&dir), 1, false);
         assert!(result.is_err(), "should bail on too-short R1");
         let err = format!("{}", result.unwrap_err());
         assert!(err.contains("too short"), "got: {}", err);
@@ -499,7 +517,7 @@ mod tests {
             &[mk_rec("@r", "TTTTTTTTCAGTNN", "IIIIIIIIIIIIII")],
         )?;
 
-        let result = clock(&r1_path, &r2_path, false, Some(&dir), 1);
+        let result = clock(&r1_path, &r2_path, false, Some(&dir), 1, false);
         assert!(result.is_err(), "should bail on too-short R2");
 
         std::fs::remove_dir_all(&dir).ok();
@@ -531,7 +549,7 @@ mod tests {
             ],
         )?;
 
-        implicon(&r1_path, &r2_path, 8, false, Some(&dir), 1)?;
+        implicon(&r1_path, &r2_path, 8, false, Some(&dir), 1, false)?;
 
         // Filename pattern: {stem_minus_R1_suffix}_{umi}bp_UMI_R[12].fastq
         let out_r1 = dir.join("sample_8bp_UMI_R1.fastq");
@@ -572,7 +590,7 @@ mod tests {
         write_fastq(&r1_path, &[mk_rec("@r", "ACGTACGT", "IIIIIIII")])?;
         write_fastq(&r2_path, &[mk_rec("@r", "TTTTTTGGG", "IIIIIIIII")])?;
 
-        implicon(&r1_path, &r2_path, 6, false, Some(&dir), 1)?;
+        implicon(&r1_path, &r2_path, 6, false, Some(&dir), 1, false)?;
 
         let out_r1 = dir.join("foo_6bp_UMI_R1.fastq");
         let out_r2 = dir.join("foo_6bp_UMI_R2.fastq");
@@ -599,7 +617,7 @@ mod tests {
         write_fastq(&r1_path, &[mk_rec("@r", "ACGTACGT", "IIIIIIII")])?;
         write_fastq(&r2_path, &[mk_rec("@r", "ACGTA", "IIIII")])?;
 
-        let result = implicon(&r1_path, &r2_path, 8, false, Some(&dir), 1);
+        let result = implicon(&r1_path, &r2_path, 8, false, Some(&dir), 1, false);
         assert!(result.is_err(), "should bail when R2 < umi_length");
         let err = format!("{}", result.unwrap_err());
         assert!(

--- a/src/trimmer.rs
+++ b/src/trimmer.rs
@@ -38,6 +38,9 @@ pub struct TrimConfig {
     pub poly_a: bool,
     pub poly_g: bool,
     pub discard_untrimmed: bool,
+    /// `--high_compression` opt-in: when true, output gzip uses level 6
+    /// instead of the default level 1. See `fastq::output_gzip_level()`.
+    pub high_compression: bool,
 }
 
 impl TrimConfig {
@@ -552,6 +555,7 @@ mod tests {
             poly_a: false,
             poly_g: false,
             discard_untrimmed: false,
+            high_compression: false,
         }
     }
 


### PR DESCRIPTION
## Summary

Cuts **v2.1.0-beta.8** with one new feature + a memory profile refresh on the docs site.

### New feature: `--high_compression`

Sets gzip output level to 6 (smaller files, slower trimming) instead of the default level 1 (faster trimming, ~75% larger output bytes). Useful when storage cost or transfer bandwidth matters more than runtime — archival workflows, shared object stores. Decompressed output is byte-identical regardless of level.

The flag is the **counter-lever** to the v2.1.0-beta.6 default of level 1 (which was Dongze's #248 audit win — saved ~−23% wall and ~−43% CPU at saturation, traded ~75% larger output bytes). For users who want the smaller files back, this flag inverts that trade.

### Memory profile docs refresh

Replaces the old (different-fixture) memory table on the threading page with peak-RSS measurements from the Buckberry benchmark machine:

| `--cores` | Peak RSS |
|---:|---:|
| 1 | 5.1 MB |
| 2 | 60.1 MB |
| 4 | 73.0 MB |
| 8 | 91.6 MB |

`docs/perf_data/buckberry-2026-04-29/memory_summary.txt` archives the raw measurements alongside the existing `byte_identity_summary.txt`.

## Implementation surface

The `--high_compression` flag flows through:

- `src/cli.rs` — flag definition (with kebab alias)
- `src/trimmer.rs` (TrimConfig) — `high_compression: bool` field
- `src/fastq.rs` — adds `output_gzip_level(bool) -> u32` helper + a `gzip_level: u32` parameter on `FastqWriter::create`
- `src/parallel.rs` — 5 `GzEncoder` callsites in the worker pool
- `src/specialty.rs` — `hardtrim5`/`hardtrim3`/`clock`/`implicon` all take `high_compression: bool`, plumb to `FastqWriter::create`
- `src/demux.rs` — `demultiplex()` takes `high_compression: bool`
- `src/main.rs` — wires `cli.high_compression` to `TrimConfig` and to every specialty/demux call

Tested via a new unit test (`parallel::tests::test_high_compression_produces_smaller_output`) that verifies (a) high_compression output bytes < default output bytes, (b) decompressed records are byte-identical between gzip levels 1 and 6.

## Test plan

- [x] `cargo test --release` — 192/192 pass (was 191; +1 new test)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [ ] CI passes (Lint / Rust Tests ubuntu+macos / Coverage / Security audit / Reproducibility / Validate vs Perl)
- [ ] After merge: cut `v2.1.0-beta.8` release via `gh workflow run release.yml --ref optimus_prime`

## Release plan

- **Now (PR merge):** beta.8 source + binaries + crates.io publish + GHCR multi-arch
- **Today/tomorrow:** nf-core/rnaseq#1789 repin to beta.8 digest
- **Monday 2026-05-04:** v2.1.0 GA cut

## Out of scope (deferred to follow-up commits on this branch or a separate PR)

- Apple Silicon laptop benchmark re-run (running in background; will replace M1 Pro section in benchmarks.md when complete)
