### PR TITLE
docs: point Astro/Starlight site to www.trimgalore.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Consistent quality and adapter trimming for next-generation sequencing data, wit
 [![Crates.io](https://img.shields.io/crates/v/trim-galore)](https://crates.io/crates/trim-galore)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/recipes/trim-galore/README.html)
 
-<h3 align="center"><a href="https://felixkrueger.github.io/TrimGalore/">https://felixkrueger.github.io/TrimGalore/</a></h3>
+<h3 align="center"><a href="https://www.trimgalore.com/">https://www.trimgalore.com/</a></h3>
 
 > [!NOTE]
-> **Trim Galore v2.0** is a faithful Rust rewrite — a single binary with zero external dependencies, designed as a drop-in replacement for v0.6.x scripts and pipelines. Same CLI, same output filenames, same report format. Adds poly-G auto-detection and trimming for 2-colour instruments, a generic poly-A trimmer, per-pair adapter auto-detection, and cleaner multi-adapter invocation (repeatable `-a`/`-a2` instead of Perl's embedded-string syntax) — among other extensions. For details on what changed, benchmarks, and migration notes, see the [v2.0 migration notes](https://felixkrueger.github.io/TrimGalore/reference/migration/).
+> **Trim Galore v2.0** is a faithful Rust rewrite — a single binary with zero external dependencies, designed as a drop-in replacement for v0.6.x scripts and pipelines. Same CLI, same output filenames, same report format. Adds poly-G auto-detection and trimming for 2-colour instruments, a generic poly-A trimmer, per-pair adapter auto-detection, and cleaner multi-adapter invocation (repeatable `-a`/`-a2` instead of Perl's embedded-string syntax) — among other extensions. For details on what changed, benchmarks, and migration notes, see the [v2.0 migration notes](https://www.trimgalore.com/reference/migration/).
 
 ## Features
 
@@ -85,7 +85,7 @@ Multi-arch images (amd64 + arm64) are available from GitHub Container Registry:
 docker run --rm -v "$PWD":/data -w /data ghcr.io/felixkrueger/trimgalore:beta trim_galore input.fastq.gz
 ```
 
-FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:beta` (latest prerelease, currently `v2.1.0-beta.8`), `:v2.1.0-beta.8` (pinned to a specific prerelease), `:dev` (every push to `optimus_prime`), and `:latest` will track stable releases starting at v2.1.0 GA. See the [docs site install page](https://felixkrueger.github.io/TrimGalore/install/) for the full table.
+FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:beta` (latest prerelease, currently `v2.1.0-beta.8`), `:v2.1.0-beta.8` (pinned to a specific prerelease), `:dev` (every push to `optimus_prime`), and `:latest` will track stable releases starting at v2.1.0 GA. See the [docs site install page](https://www.trimgalore.com/install/) for the full table.
 
 ### Prebuilt binaries
 
@@ -132,12 +132,12 @@ The JSON report contains the same statistics as the text report in a structured 
 
 ## Documentation
 
-Full documentation is published at [https://felixkrueger.github.io/TrimGalore/](https://felixkrueger.github.io/TrimGalore/)
+Full documentation is published at [https://www.trimgalore.com/](https://www.trimgalore.com/)
 
-- [User Guide](https://felixkrueger.github.io/TrimGalore/guide/overview/) — full reference for all options and modes
-- [RRBS Guide](https://felixkrueger.github.io/TrimGalore/rrbs/guide/) — bisulfite sequencing and RRBS-specific guidance
-- [v2.0 migration notes](https://felixkrueger.github.io/TrimGalore/reference/migration/) — what changed in the Rust rewrite
-- [Benchmarks](https://felixkrueger.github.io/TrimGalore/performance/benchmarks/)
+- [User Guide](https://www.trimgalore.com/guide/overview/) — full reference for all options and modes
+- [RRBS Guide](https://www.trimgalore.com/rrbs/guide/) — bisulfite sequencing and RRBS-specific guidance
+- [v2.0 migration notes](https://www.trimgalore.com/reference/migration/) — what changed in the Rust rewrite
+- [Benchmarks](https://www.trimgalore.com/performance/benchmarks/)
 
 ## Credits
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,14 @@
 # Trim Galore documentation
 
 This directory holds the Astro Starlight site that publishes to
-<https://felixkrueger.github.io/TrimGalore/>.
+<https://www.trimgalore.com/>.
 
 ## Local development
 
 ```bash
 cd docs
 npm install
-npm run dev      # dev server on http://localhost:4321/TrimGalore/
+npm run dev      # dev server on http://localhost:4321/
 npm run build    # static build into docs/dist/
 npm run preview  # serve docs/dist/ locally
 ```

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,8 +3,8 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
 export default defineConfig({
-  site: 'https://felixkrueger.github.io',
-  base: '/TrimGalore',
+  site: 'https://www.trimgalore.com',
+  base: '/',
   trailingSlash: 'ignore',
   // Disable smartypants. It rewrites `--` to em-dashes (—) even inside
   // JSX <code> elements in MDX, which silently mangles CLI flag names

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+www.trimgalore.com


### PR DESCRIPTION
## Summary

Custom domain registered at `www.trimgalore.com`. This PR points the docs site at the new domain.

**Repo-side changes (in this PR):**
- `docs/astro.config.mjs` — `site` and `base`
- `docs/public/CNAME` (new file) — `www.trimgalore.com`
- `README.md` — 8 URL refs swapped to the new domain
- `docs/README.md` — stale dev-server URL + publish target reference fixed

**Manual steps required after this merges (out of scope here):**
1. **DNS at the domain registrar:**
   - `www` CNAME → `felixkrueger.github.io`
   - Apex (`trimgalore.com`) A records → `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153` (so apex redirects to www)
2. **GitHub Settings → Pages:**
   - Set Custom Domain to `www.trimgalore.com` (auto-detected from CNAME file once deployed)
   - Wait for DNS validation
   - Enable Enforce HTTPS once Let's Encrypt cert provisions (~5-15 min)

**HTTPS support:** automatic via Let's Encrypt for both apex and www, free, certs auto-renew.

## Local verification

Build green: 28 pages in 7.22s. `dist/CNAME` present, `<link rel="canonical">` and `<meta property="og:url">` rewritten to `https://www.trimgalore.com/`, zero `felixkrueger.github.io` leakage in `dist/`.

## Test plan

- [x] `npm run build` clean
- [x] No stale `felixkrueger.github.io` references anywhere in repo
- [x] CNAME file content correct
- [ ] Post-merge: docs.yml deploys with new domain config
- [ ] Post-merge: DNS configured at registrar (apex + www)
- [ ] Post-merge: Settings → Pages picks up custom domain
- [ ] Post-merge: HTTPS cert provisions, Enforce HTTPS enabled
- [ ] Post-merge: `https://www.trimgalore.com/` renders, `felixkrueger.github.io/TrimGalore/install/` auto-redirects