### PR TITLE
chore(release): v2.1.0 GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,85 @@
 # Trim Galore Changelog
 
 
+### Version 2.1.0 (Release on 4 May 2026)
+
+**First stable release of the Oxidized Edition** — a complete Rust rewrite
+of the original Perl Trim Galore. Drop-in compatible with v0.6.x scripts
+and pipelines (same CLI, same output filenames, same report format).
+Single static binary, zero external runtime dependencies — no Python,
+Perl, Cutadapt, Java, igzip, or pigz required.
+
+#### Highlights
+
+- **Built-in FastQC** via the bundled
+  [`fastqc-rust`](https://crates.io/crates/fastqc-rust) library. Pass
+  `--fastqc` and it just works (no external `fastqc` binary, no Java
+  runtime).
+- **Adapter auto-detection** for Illumina, Nextera, Small RNA, and
+  BGI/DNBSEQ on the first 1M reads. Per-pair detection in paired-end
+  mode (intentional improvement over Perl v0.6.x's once-per-run
+  detection).
+- **Multi-adapter support** via repeatable `-a`/`-a2` or
+  `-a "file:adapters.fa"` to load adapter sets from FASTA. Optional
+  multi-round trimming (`-n N`).
+- **Poly-G trimming** for 2-colour instruments (NovaSeq, NextSeq,
+  NovaSeq X), auto-detected from the data; opt-out with `--no_poly_g`.
+- **Generic poly-A trimming** for mRNA-seq libraries (`--poly_a`).
+- **Worker-pool parallelism** via `--cores N` — near-linear speedup up
+  to ~8 cores on Buckberry-scale data; saturation point depends on
+  per-thread compute vs gzip-output I/O bandwidth on your storage.
+- **Reproducible builds** via `SOURCE_DATE_EPOCH`; release binaries are
+  bit-identical when built twice with the same input. CI verifies this.
+- **Byte-identity to Perl v0.6.11** asserted by the CI validation
+  matrix across SE, PE, RRBS, hardtrim5, Clock, and demux flag paths.
+
+#### Performance vs Trim Galore 0.6.11 + Cutadapt 5.2
+
+Headline numbers from the
+[Buckberry-scale benchmarks](https://www.trimgalore.com/performance/benchmarks/)
+on 84M paired-end reads (Intel Xeon 6975P-C, Granite Rapids):
+
+- **5.93× less CPU time at `--cores 8`** (the nf-core `process_high`
+  default) — ~$7 vs ~$41 per 1000-sample cohort at AWS $0.05/vCPU-hour
+- **13.49× less CPU time at single-thread**
+- **4.54× faster wall time at `--cores 8`**: 57s vs 257s on the 84M
+  paired-end fixture
+
+#### Opt-in flags
+
+- `--high_compression` — gzip output level 6 instead of the default
+  level 1 (~75% smaller files, ~2× slower trimming). For archival
+  workflows where trimmed reads are deliberately retained downstream;
+  the dominant nf-core / Snakemake / CWL use case keeps trimmed FASTQs
+  ephemeral and benefits from the faster default level 1.
+
+#### Migration from v0.6.x
+
+The CLI surface is unchanged from v0.6.x for the dominant workflows.
+Most users will see no behavioural changes — the biggest visible change
+is performance. A few minor differences (mostly improvements: brace
+expansion `-a A{N}`, `-r1`/`-r2` short flags now parse cleanly,
+multi-pair specialty modes) are documented in the
+[v2 migration notes](https://www.trimgalore.com/reference/migration/).
+
+#### Cumulative changes from the v2.1.0 beta arc
+
+This GA release ships the cumulative changes from v2.1.0-beta.1 through
+v2.1.0-beta.8. The Buckberry-scale performance audit (#248, co-authored
+with [@an-altosian](https://github.com/an-altosian) — Dongze He, Altos
+Labs) drove the headline performance wins:
+
+- **beta.6**: gzip output level 6 → 1 (~−23% wall, ~−43% CPU at
+  saturation; output bytes ~75% larger; decompressed bytes
+  byte-identical)
+- **beta.6**: single buffered write per FASTQ record (~−10% wall)
+- **beta.7**: Myers' bit-parallel adapter alignment prefilter
+  (~−13% wall, byte-identity-preserving by construction)
+- **beta.8**: `--high_compression` opt-in flag for storage-bound users
+
+See the per-beta release notes below for full per-step detail.
+
+
 ### Version 2.1.0-beta.8 (Release on 30 Apr 2026)
 
 #### New feature

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "trim-galore"
-version = "2.1.0-beta.8"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trim-galore"
-version = "2.1.0-beta.8"
+version = "2.1.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast adapter and quality trimming for NGS data — Oxidized Edition"

--- a/README.md
+++ b/README.md
@@ -34,19 +34,9 @@ Consistent quality and adapter trimming for next-generation sequencing data, wit
 
 ## Installation
 
-> [!IMPORTANT]
-> **Beta testing v2.1.0-beta.8.** The current stable release on crates.io is v2.0.0; v2.1.0 is in beta testing. Running `cargo install trim-galore` without `--version` installs v2.0.0 (the stable). To install the beta:
->
-> ```bash
-> cargo install trim-galore --version 2.1.0-beta.8
-> docker pull ghcr.io/felixkrueger/trimgalore:beta
-> ```
->
-> Feedback on the beta is welcome — open an issue with the `beta-feedback` label. This section will be removed at v2.1.0 GA.
-
 ### From crates.io
 
-Requires the [Rust toolchain](https://rustup.rs/) (1.85+):
+Requires the [Rust toolchain](https://rustup.rs/) (1.88+):
 
 ```bash
 cargo install trim-galore
@@ -82,10 +72,10 @@ The `--force` flag overwrites any existing `trim_galore` binary (e.g. a v2.0.0 i
 Multi-arch images (amd64 + arm64) are available from GitHub Container Registry:
 
 ```bash
-docker run --rm -v "$PWD":/data -w /data ghcr.io/felixkrueger/trimgalore:beta trim_galore input.fastq.gz
+docker run --rm -v "$PWD":/data -w /data ghcr.io/felixkrueger/trimgalore:latest trim_galore input.fastq.gz
 ```
 
-FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:beta` (latest prerelease, currently `v2.1.0-beta.8`), `:v2.1.0-beta.8` (pinned to a specific prerelease), `:dev` (every push to `optimus_prime`), and `:latest` will track stable releases starting at v2.1.0 GA. See the [docs site install page](https://www.trimgalore.com/install/) for the full table.
+FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:latest` (latest stable, currently `v2.1.0`), `:v2.1.0` (pinned to a specific release), `:beta` (latest prerelease — only set during an active beta cycle), and `:dev` (every push to `optimus_prime`). See the [docs site install page](https://www.trimgalore.com/install/) for the full table.
 
 ### Prebuilt binaries
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -5,17 +5,6 @@ description: Install Trim Galore via cargo, bioconda, Docker, or prebuilt binari
 
 Trim Galore v2 ships as a single static binary. No Python, no Perl, no Cutadapt, no Java, no `igzip`, no `pigz`, no external FastQC. Pick whichever channel fits the rest of your stack.
 
-:::caution[Beta testing v2.1.0-beta.8]
-The current stable release on crates.io is **v2.0.0**. v2.1.0 is in beta. `cargo install trim-galore` without `--version` installs v2.0.0. To install the beta:
-
-```bash
-cargo install trim-galore --version 2.1.0-beta.8
-docker pull ghcr.io/felixkrueger/trimgalore:beta
-```
-
-To send feedback on the beta, open an issue with the `beta-feedback` label. This notice goes away at v2.1.0 GA.
-:::
-
 ## From crates.io
 
 Requires the [Rust toolchain](https://rustup.rs/) (1.88+):
@@ -55,7 +44,7 @@ Multi-arch images (`amd64` and `arm64`) are published to the GitHub Container Re
 
 ```bash
 docker run --rm -v "$PWD":/data -w /data \
-    ghcr.io/felixkrueger/trimgalore:beta \
+    ghcr.io/felixkrueger/trimgalore:latest \
     trim_galore input.fastq.gz
 ```
 
@@ -63,10 +52,10 @@ FastQC is built in via the bundled [`fastqc-rust`](https://crates.io/crates/fast
 
 | Tag | Updates |
 | --- | --- |
-| `:beta` | latest prerelease (currently v2.1.0-beta.8) |
-| `:v2.1.0-beta.8` | pinned to a specific prerelease |
+| `:latest` | latest stable release (currently v2.1.0) |
+| `:v2.1.0` | pinned to a specific release |
+| `:beta` | latest prerelease — only set during an active beta cycle |
 | `:dev` | every push to the `optimus_prime` development branch |
-| `:latest` | latest stable release (publishes from v2.1.0 GA onward) |
 
 ## Prebuilt binaries
 
@@ -85,7 +74,7 @@ trim_galore --version
 Should print:
 
 ```
-trim_galore 2.1.0-beta.8 (Oxidized Edition)
+trim_galore 2.1.0 (Oxidized Edition)
 <git-hash> — <os>/<arch> — built <ISO-8601-UTC>
 ```
 


### PR DESCRIPTION
## Summary

**First stable release of the Oxidized Edition.** Cuts v2.1.0 GA from beta.8.

## Changes

- `Cargo.toml`: `2.1.0-beta.8` → `2.1.0`
- `CHANGELOG.md`: GA narrative consolidating the v2.1.0-beta.1 → -beta.8 arc — Buckberry-audit performance wins (gzip level 6→1, single buffered write, Myers' bit-parallel prefilter), `--high_compression` opt-in, bundled FastQC, multi-arch container, etc. Per-beta sections retained below for full step-by-step history.
- `README.md`: drop the "Beta testing v2.1.0-beta.8" banner — `cargo install trim-galore` now installs 2.1.0 by default. Docker example: `:beta` → `:latest`. Tag-table sentence rewritten for post-GA. Rust toolchain floor bumped `1.85+` → `1.88+` (matches `Cargo.toml` `rust-version`).
- `docs/src/content/docs/install.md`: same banner removal, same `:beta` → `:latest` swap, `--version` output snippet updated to `2.1.0`.

## Headline numbers

From the [Buckberry-scale benchmarks](https://www.trimgalore.com/performance/benchmarks/) on 84M paired-end reads:

- **5.93× less CPU time at `--cores 8`** (the nf-core `process_high` default)
- **13.49× less CPU time at single-thread**
- **4.54× faster wall time at `--cores 8`** vs Perl 0.6.11 + Cutadapt 5.2

## Verification

- [x] `cargo build --release` clean (50s)
- [x] `cargo test --release` — 192/192 green
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [x] `./target/release/trim_galore --version` → `trim_galore 2.1.0 (Oxidized Edition)`
- [ ] CI green on this PR
- [ ] After merge: `gh workflow run release.yml --ref optimus_prime` to actually cut the release (push-only is gated and goes green-but-noop per the saved memory)

## After release.yml fires

- crates.io publishes `trim-galore@2.1.0`
- GHCR multi-arch image at `:v2.1.0` and `:latest`
- GitHub release `v2.1.0` with prebuilt binary tarballs for `linux-x86_64`, `linux-aarch64`, `macos-aarch64`
- Bioconda PR #65012 bumps from `2.1.0b8` → `2.1.0` (one commit on that PR)
- nf-core/rnaseq#1789 repins to the GA digest

Co-authored with [@an-altosian](https://github.com/an-altosian) (Dongze He) for the Buckberry-scale audit + Perl-parity fixes that drove the headline performance wins.