### PR TITLE
chore(branch): rename optimus_prime → dev post-v2.1.0 GA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [master, dev, optimus_prime]
+    branches: [master, dev]
   pull_request:
-    # Trigger on PRs targeting any active integration branch — `optimus_prime`
-    # is the active dev branch for the Oxidized Edition; `master` stays listed
-    # for the Perl release line.
-    branches: [master, optimus_prime]
+    # Trigger on PRs targeting either trunk — `dev` is the active development
+    # branch (renamed from `optimus_prime` post-v2.1.0 GA); `master` is the
+    # stable trunk and the GA-release source.
+    branches: [master, dev]
   # Weekly cron so the `audit` job surfaces new RustSec advisories even during
   # quiet weeks (no pushes / PRs).  Non-audit jobs skip on schedule via the
   # per-job `if: github.event_name != 'schedule'` guard below.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Deploy docs to GitHub Pages
 
 on:
   push:
-    branches: [master, optimus_prime]
+    branches: [master, dev]
     paths:
       - 'docs/**'
       - 'CHANGELOG.md'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ name: Release
 
 on:
   push:
-    branches: [optimus_prime, master]
+    branches: [dev, master]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -74,10 +74,10 @@ jobs:
 
             if [ "${{ github.ref_name }}" = "master" ]; then
               : # always allowed (GA)
-            elif [ "${{ github.ref_name }}" = "optimus_prime" ] && [ "$IS_PRERELEASE" = "true" ]; then
+            elif [ "${{ github.ref_name }}" = "dev" ] && [ "$IS_PRERELEASE" = "true" ]; then
               : # allowed for prereleases only
             else
-              echo "::error::Release must be from master (GA) or optimus_prime (prerelease only); got ${{ github.ref_name }} with version $RAW_VERSION"
+              echo "::error::Release must be from master (GA) or dev (prerelease only); got ${{ github.ref_name }} with version $RAW_VERSION"
               exit 1
             fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Trim Galore — Oxidized Edition — is a Rust rewrite of the original Perl Trim Galore (the v0.6.x script lives upstream and is no longer in this repo). It is a single-binary, single-pass adapter and quality trimmer for NGS FASTQ data. There are no external runtime dependencies: adapter detection, alignment, quality trimming, filtering, gzip compression, **and** FastQC reporting (via the bundled `fastqc-rust` library) all run in-process. No Java, no Python, no Cutadapt, no external `fastqc`.
 
-The active development branch is `optimus_prime`; `master` is retained for the legacy Perl release line. The CI workflow `validation` job md5-compares Oxidized output against Perl Trim Galore 0.6.11 (installed from raw GitHub) for several core flag combinations — preserving byte-identity to v0.6.11 is a hard invariant for those flag paths.
+`master` is the stable trunk (v2.1.0 GA and onwards); `dev` is the active development branch where prereleases are cut from. (Pre-v2.1.0 GA the layout was inverted — `optimus_prime` was the dev trunk and `master` held the legacy Perl release line; PR #214 collapsed that on 2026-05-04 by merging the Rust trunk into `master` and renaming `optimus_prime` to `dev`. The legacy Perl 0.6.11 source remains accessible via the `0.6.11` git tag.) The CI workflow `validation` job md5-compares Oxidized output against Perl Trim Galore 0.6.11 (installed from raw GitHub) for several core flag combinations — preserving byte-identity to v0.6.11 is a hard invariant for those flag paths.
 
 ## Build, lint, test
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Consistent quality and adapter trimming for next-generation sequencing data, with special handling for RRBS libraries.
 
 
-[![CI](https://github.com/FelixKrueger/TrimGalore/actions/workflows/ci.yml/badge.svg?branch=optimus_prime)](https://github.com/FelixKrueger/TrimGalore/actions/workflows/ci.yml)
+[![CI](https://github.com/FelixKrueger/TrimGalore/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/FelixKrueger/TrimGalore/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/trim-galore)](https://crates.io/crates/trim-galore)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/recipes/trim-galore/README.html)
 
@@ -62,7 +62,7 @@ cargo build --release
 To install the latest unreleased changes directly from the development branch:
 
 ```bash
-cargo install --git https://github.com/FelixKrueger/TrimGalore --branch optimus_prime trim-galore --force
+cargo install --git https://github.com/FelixKrueger/TrimGalore --branch dev trim-galore --force
 ```
 
 The `--force` flag overwrites any existing `trim_galore` binary (e.g. a v2.0.0 install from crates.io).
@@ -75,7 +75,7 @@ Multi-arch images (amd64 + arm64) are available from GitHub Container Registry:
 docker run --rm -v "$PWD":/data -w /data ghcr.io/felixkrueger/trimgalore:latest trim_galore input.fastq.gz
 ```
 
-FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:latest` (latest stable, currently `v2.1.0`), `:v2.1.0` (pinned to a specific release), `:beta` (latest prerelease — only set during an active beta cycle), and `:dev` (every push to `optimus_prime`). See the [docs site install page](https://www.trimgalore.com/install/) for the full table.
+FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:latest` (latest stable, currently `v2.1.0`), `:v2.1.0` (pinned to a specific release), `:beta` (latest prerelease — only set during an active beta cycle), and `:dev` (every push to the `dev` branch). See the [docs site install page](https://www.trimgalore.com/install/) for the full table.
 
 ### Prebuilt binaries
 

--- a/docs/perf_data/buckberry-2026-04-29/README.md
+++ b/docs/perf_data/buckberry-2026-04-29/README.md
@@ -32,7 +32,7 @@ Raw `hyperfine` outputs and run logs from the Trim Galore Buckberry-scale benchm
 
 ## Reproducer
 
-`scripts/benchmark.sh` on the `optimus_prime` branch drives the same matrix end-to-end. The fixture path defaults to `~/benchmark_TG_oxy/SRR24827373_*_R{1,2}.fastq.gz`; override via `R1=...` `R2=...` env vars.
+`scripts/benchmark.sh` on the `dev` branch drives the same matrix end-to-end. The fixture path defaults to `~/benchmark_TG_oxy/SRR24827373_*_R{1,2}.fastq.gz`; override via `R1=...` `R2=...` env vars.
 
 ## Headline results
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -33,7 +33,7 @@ cargo build --release
 To install the latest unreleased changes from the development branch:
 
 ```bash
-cargo install --git https://github.com/FelixKrueger/TrimGalore --branch optimus_prime trim-galore --force
+cargo install --git https://github.com/FelixKrueger/TrimGalore --branch dev trim-galore --force
 ```
 
 `--force` overwrites any existing `trim_galore` binary (e.g. a v2.0.0 install from crates.io).
@@ -55,7 +55,7 @@ FastQC is built in via the bundled [`fastqc-rust`](https://crates.io/crates/fast
 | `:latest` | latest stable release (currently v2.1.0) |
 | `:v2.1.0` | pinned to a specific release |
 | `:beta` | latest prerelease — only set during an active beta cycle |
-| `:dev` | every push to the `optimus_prime` development branch |
+| `:dev` | every push to the `dev` development branch |
 
 ## Prebuilt binaries
 

--- a/docs/src/content/docs/performance/benchmarks.md
+++ b/docs/src/content/docs/performance/benchmarks.md
@@ -104,7 +104,7 @@ Three ways to read this:
 
 ## Laptop benchmark: Apple M1 Pro (10 cores, 32 GiB)
 
-Same Buckberry SRR24827373 fixture (84M PE reads, 4.4 GiB gzipped), Trim Galore v2.1.0-beta.7 (Apple Silicon native build via `cargo install`). Methodology: `hyperfine --warmup 1 --runs 3` per condition — intentionally lighter than the server-side `--runs 10` since the goal is a directional cross-platform datapoint, not paper-grade rigor. Cores ladder stops at 6 (of 10 physical) to leave headroom for the OS and other applications. Raw data: [`docs/perf_data/buckberry-2026-04-30-laptop/`](https://github.com/FelixKrueger/TrimGalore/tree/optimus_prime/docs/perf_data/buckberry-2026-04-30-laptop).
+Same Buckberry SRR24827373 fixture (84M PE reads, 4.4 GiB gzipped), Trim Galore v2.1.0-beta.7 (Apple Silicon native build via `cargo install`). Methodology: `hyperfine --warmup 1 --runs 3` per condition — intentionally lighter than the server-side `--runs 10` since the goal is a directional cross-platform datapoint, not paper-grade rigor. Cores ladder stops at 6 (of 10 physical) to leave headroom for the OS and other applications. Raw data: [`docs/perf_data/buckberry-2026-04-30-laptop/`](https://github.com/FelixKrueger/TrimGalore/tree/master/docs/perf_data/buckberry-2026-04-30-laptop).
 
 | `--cores` | Wall time | CPU time | Speedup vs c1 |
 |----------:|----------:|---------:|---------------:|
@@ -139,8 +139,8 @@ Note that the dominant nf-core / Snakemake / CWL use case typically *doesn't* ke
 ## Methodology
 
 - **Timing:** All wall time and CPU time measured via `hyperfine --warmup 1 --runs 10` per condition. CPU time = user + system, summed across all OS threads.
-- **Raw data:** All 20 hyperfine JSON outputs, the markdown summaries, the byte-identity cross-check report, and the run logs are committed to the repo at [`docs/perf_data/buckberry-2026-04-29/`](https://github.com/FelixKrueger/TrimGalore/tree/optimus_prime/docs/perf_data/buckberry-2026-04-29) — anyone can verify the numbers in the tables above against the source data.
-- **Reproducer:** [`scripts/benchmark.sh`](https://github.com/FelixKrueger/TrimGalore/blob/optimus_prime/scripts/benchmark.sh) on the `optimus_prime` branch — drives the full matrix (Rust beta.5/beta.7 at cores 1/4/8/10/12/14/16/24; Perl 0.6.11 + Cutadapt 5.2 at cores 1/4/8/16) with `hyperfine --warmup 1 --runs 10`. Includes a cross-version byte-identity check at the end (beta.5 vs beta.7 cores=8 outputs).
+- **Raw data:** All 20 hyperfine JSON outputs, the markdown summaries, the byte-identity cross-check report, and the run logs are committed to the repo at [`docs/perf_data/buckberry-2026-04-29/`](https://github.com/FelixKrueger/TrimGalore/tree/master/docs/perf_data/buckberry-2026-04-29) — anyone can verify the numbers in the tables above against the source data.
+- **Reproducer:** [`scripts/benchmark.sh`](https://github.com/FelixKrueger/TrimGalore/blob/master/scripts/benchmark.sh) — drives the full matrix (Rust beta.5/beta.7 at cores 1/4/8/10/12/14/16/24; Perl 0.6.11 + Cutadapt 5.2 at cores 1/4/8/16) with `hyperfine --warmup 1 --runs 10`. Includes a cross-version byte-identity check at the end (beta.5 vs beta.7 cores=8 outputs).
 - **Thread counts (TG):** Approximate peak values from architectural reasoning (Cutadapt workers + pigz compression workers + igzip/pigz decompression). Threads are spawned across three independent subprocesses whose lifetimes may not fully overlap.
 - **Thread counts (Oxidized):** Deterministic from the architecture: exactly N+4 threads for `--cores N` (N workers + 2 decompressors + 1 batcher + 1 writer), or exactly 1 thread for `--cores 1`.
 - **igzip:** The bioconda Trim Galore installation includes igzip (Intel ISA-L) for fast single-threaded decompression. Benchmarks run with igzip available to match the nf-core production environment.


### PR DESCRIPTION
## Summary

Post-v2.1.0 GA branch-layout cleanup. PR #214 collapsed the two-trunk model on 2026-05-04 (Rust v2 → master, Perl 0.6.11 → preserved at the `0.6.11` git tag), so the `optimus_prime` name no longer carries meaning. Renamed the branch on GitHub and swept all 17 in-tree references.

- 8 files, 19 / 19 insertion-deletion pairs
- 3 workflow files (CI/docs push+PR triggers, release.yml branch gate + error message)
- README + docs/install.md (CI badge → master, `cargo install --branch dev` snippet, Docker `:dev`-tag explanation reworded)
- benchmarks.md + perf_data README (3 `tree/optimus_prime/...` URLs repointed at `master` since the perf data is archived/immutable)
- CLAUDE.md (opening paragraph reframed for post-GA reality)

Two `optimus_prime` mentions are deliberately retained as historical context (one CI comment, the CLAUDE.md paragraph itself).

GitHub auto-redirects pre-rename URLs and git fetch-by-name for ~6 months. The only user-facing behaviour change is the `cargo install --branch dev` line in the README/install docs.

## Test plan

- [ ] CI (Lint, Rust Tests ubuntu+macos, Coverage, Reproducibility, Security audit, Validate vs Perl) green on the rename branch
- [ ] Pages deploy: docs site rebuilds from `master` after merge with the updated benchmark URLs
- [ ] Smoke: `cargo install --git https://github.com/FelixKrueger/TrimGalore --branch dev trim-galore --force` resolves