### PR TITLE
chore(deps): robust high-compression test + group Dependabot patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@
 # No `labels:` field — Dependabot will auto-create and apply its default
 # `dependencies` label on the first PR per ecosystem.  We can move to explicit
 # labels later if we want fine-grained categorisation.
+#
+# Grouping: patch + minor bumps are batched into a single weekly PR per
+# ecosystem (one for cargo, one for github-actions). Major bumps still open
+# as individual PRs so breaking-change reviews stay focused. This collapsed
+# the post-v2.1.0-GA Dependabot inbox from ~9 emails (3 PRs × ~3 events) to
+# 1-2 emails per cycle.
 version: 2
 updates:
   - package-ecosystem: "cargo"
@@ -21,6 +27,11 @@ updates:
     open-pull-requests-limit: 5
     assignees:
       - "FelixKrueger"
+    groups:
+      cargo-patch-minor:
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -30,3 +41,8 @@ updates:
     open-pull-requests-limit: 5
     assignees:
       - "FelixKrueger"
+    groups:
+      github-actions-patch-minor:
+        update-types:
+          - "patch"
+          - "minor"

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -868,11 +868,18 @@ mod tests {
         let dir = fresh_tmpdir("tg_high_compression");
         let input_path = dir.join("input.fq");
 
-        // 200 reads with a repeating-sequence motif so gzip can find
+        // 5_000 reads with a repeating-sequence motif so gzip can find
         // back-references at higher levels. Sized to span a single
         // batch so output is one gzip member regardless of cores.
+        //
+        // Why 5_000 (was 200): on tiny inputs (~13 KB) the level-6
+        // dictionary/framing overhead can erase the 2-byte compression
+        // win over level-1, and flate2 patch bumps periodically nudge
+        // that crossover (e.g. 1.1.9 flipped 200-reads from 571→573 vs
+        // 573→571). 5_000 reads gives level-6 ~325 KB to amortise the
+        // overhead so the assertion is robust against future tweaks.
         let mut content = String::new();
-        for i in 0..200 {
+        for i in 0..5_000 {
             content.push_str(&format!(
                 "@read_{i}\nACGTACGTACGTACGTACGTACGTACGTACGT\n+\nIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII\n"
             ));


### PR DESCRIPTION
## Summary

Two small housekeeping changes after the v2.1.0 GA Dependabot wave:

1. **\`src/parallel.rs\` — bump high-compression test input from 200 → 5,000 reads.** The 200-read fixture (~13 KiB) was small enough that level-6 gzip framing overhead occasionally erased the 2-3 byte compression win over level-1. flate2 1.1.5 → 1.1.9 (Dependabot #274) tipped it the wrong way: 571 → 573 vs 573 → 571, failing the \`size_high < size_default\` assertion. 5,000 reads (~325 KiB) gives level-6 enough material to amortise the constant overhead so the assertion is robust against future patch-level flate2 tweaks. Test still runs in <50 ms — confirmed locally.

2. **\`.github/dependabot.yml\` — add \`groups\` blocks for cargo + github-actions.** Patch + minor bumps now batch into a single weekly PR per ecosystem. Major bumps continue to open individually so breaking-change reviews stay focused. Collapses the typical post-merge inbox surge (3 PRs × ~3 events ≈ 9 emails) to 1-2 emails per Monday.

After this lands, Dependabot will rebase #274 against master; the test fix should let it go green and merge cleanly.

## Test plan

- [ ] \`Lint (fmt + clippy)\` green
- [ ] \`Rust Tests (ubuntu-latest)\` and \`Rust Tests (macos-latest)\` green
- [ ] \`Coverage\`, \`Reproducibility\`, \`Security audit\`, \`Validate vs Perl\` green
- [ ] After merge: re-run #274 CI; confirm flate2 bump now passes