### PR TITLE
docs/cli: align --cores guidance on N+4 model and 8-core saturation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Consistent quality and adapter trimming for next-generation sequencing data, wit
 - **Poly-G trimming** — sequence-based removal of no-signal G-runs at the 3' end of Read 1 (and poly-C at the 5' end of Read 2) from 2-colour instruments (NovaSeq, NextSeq, NovaSeq X). Auto-detected from the data; opt-out with `--no_poly_g`
 - **NextSeq / 2-colour quality trim** — `--nextseq N` / `--2colour N` applies 2-colour-aware quality trimming (opt-in; replaces `-q`)
 - **Poly-A trimming** — built-in removal of poly-A tails without external tools; recommended for mRNA-seq / poly-A-selected RNA-seq libraries
-- **Parallel processing** — `--cores N` runs trimming and gzip compression in worker threads for near-linear speedup on multi-core systems
+- **Parallel processing** — `--cores N` runs trimming and gzip compression in worker threads under an N+4 thread model (N workers + 2 decompressors + 1 batcher + 1 writer); near-linear speedup up to `--cores 8` for paired-end runs, then gzip-output I/O typically becomes binding
 - **FastQC integration** — optional post-trimming quality reports built in via the bundled [fastqc-rust](https://crates.io/crates/fastqc-rust) library; produces FastQC 0.12.1-compatible HTML + ZIP outputs without requiring Java or an external `fastqc` on `$PATH`
 - **MultiQC compatible** — trimming reports parse cleanly in MultiQC dashboards (text + JSON)
 - **Demultiplexing** — 3' inline barcode demultiplexing

--- a/docs/src/content/docs/performance/threading.md
+++ b/docs/src/content/docs/performance/threading.md
@@ -43,7 +43,7 @@ Oxidized Edition --cores N thread breakdown:
                                                        = N+4 total
 ```
 
-At `--cores 1`, the worker-pool is bypassed entirely: a single thread does everything with zero parallelism overhead (1 thread, 5 MB RAM). The infrastructure cost only applies from `--cores 2` upward, where each additional core adds exactly 1 thread and ~10 MB of memory.
+At `--cores 1`, the worker-pool is bypassed entirely: a single thread does everything with zero parallelism overhead (1 thread, 5 MB RAM). From `--cores 2` upward the **N+4 model** applies — each added core is exactly 1 worker thread plus ~10 MB of memory on top of the 4 fixed-cost threads (2 decompressors + 1 batcher + 1 writer). Wall-clock speedup is **near-linear up to `--cores 8` for paired-end runs**; beyond that, gzip-output I/O on the storage layer typically becomes binding before workers run out of useful per-read work, so each additional core helps progressively less.
 
 | Cores | TG threads (up to ~3N+3) | Oxidized threads (N+4) |
 |------:|-------------------------:|-----------------------:|

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -206,9 +206,12 @@ pub struct Cli {
     pub fastqc_args: Option<String>,
 
     /// Number of worker threads for parallel processing (default: 1).
-    /// Values > 1 run trimming and gzip compression across multiple threads.
-    /// Near-linear speedup through at least 16 cores; diminishing returns beyond ~20
-    /// (typically I/O-bound at that point, not algorithmic).
+    /// At --cores 1 the worker-pool is bypassed (single thread, ~5 MB RAM).
+    /// From --cores 2 upward, an N+4 thread model applies: N workers + 2
+    /// decompressors + 1 batcher + 1 writer. Wall-clock speedup is near-linear
+    /// up to --cores 8 for paired-end runs; beyond that, gzip-output I/O on
+    /// the storage layer typically becomes binding before workers run out of
+    /// useful per-read work, so additional cores help progressively less.
     #[clap(short = 'j', long = "cores", default_value = "1")]
     pub cores: usize,
 


### PR DESCRIPTION
## Summary

Three coordinated edits replacing the older \"near-linear through 16 cores; diminishing beyond ~20\" framing with the v2.1.0-beta.7+ Buckberry-derived story (N+4 thread model + paired-end saturation around \`--cores 8\`).

| File | Change |
|---|---|
| \`src/cli.rs\` (\`--cores\` doc-comment) | Rewrite so \`trim_galore --help\` explicitly names the N+4 thread model (N workers + 2 decompressors + 1 batcher + 1 writer) and near-linear-to-8 PE speedup, with the gzip-output I/O caveat for higher core counts. |
| \`docs/.../performance/threading.md\` | Keep the cores=1 bypass note, but fold N+4 + 8-core saturation into the same paragraph so readers see the full picture before the efficiency table that follows. |
| \`README.md\` (Parallel-processing feature bullet) | Tighten \"near-linear speedup on multi-core systems\" to the same N+4 + 8-core saturation framing. |

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`trim_galore --help\` renders the new text correctly
- [x] \`npm run build\` produces 28 pages clean
- [ ] CI green on the PR (Lint / Rust Tests / Coverage / Reproducibility / Validate vs Perl / Security audit)
- [ ] Pages deploy after merge picks up the threading.md text