### PR TITLE
ci(docs): gate Pages deploy to master only; build still runs on dev

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    # Only the stable trunk publishes to www.trimgalore.com. Pushes to `dev`
+    # still run the `build` job above (validation safety net) but skip this
+    # step — preventing in-progress dev work from silently overwriting the
+    # live docs site. Master pushes deploy as normal. workflow_dispatch
+    # also dispatches a deploy regardless of ref, by design.
+    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

The docs workflow currently fires on push to both \`master\` and \`dev\` and runs both jobs (build → deploy) on each. That means **any push to \`dev\` silently publishes to www.trimgalore.com**, overwriting whatever master last deployed.

For the post-GA "master = stable, dev = work-in-progress" workflow, this is too permissive — a WIP commit to dev (typo, broken layout, in-flight feature docs) lands on the canonical user-facing URL with no gate.

## Change

Gate the \`deploy\` job on \`github.ref == 'refs/heads/master'\` (or manual workflow_dispatch). Build job is untouched and continues to validate on both branches.

\`\`\`diff
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
     environment:
       name: github-pages
\`\`\`

## Behaviour after this lands

| Trigger | Build | Deploy |
|---|---|---|
| push to \`master\` | ✅ | ✅ |
| push to \`dev\` | ✅ | ⏭ skipped |
| \`workflow_dispatch\` (any branch) | ✅ | ✅ |

Net: dev gets validation safety on docs builds without shipping in-progress content to the live site. workflow_dispatch escape hatch preserved for manual re-deploys.

## Test plan

- [ ] After merge, push a docs-touching commit to dev → build runs, deploy is skipped (visible in Actions tab as "Skipped" on the deploy job).
- [ ] Next push to master (or release-time master FF from dev) → both jobs run, site updates as normal.
- [ ] Manual \`gh workflow run docs.yml --ref dev\` still publishes if you ever want to override (though typically you'd want to FF master to dev first instead).