### PR TITLE
ci(docs): revert deploy-gate; dev is the canonical live-content source

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,12 +50,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    # Only the stable trunk publishes to www.trimgalore.com. Pushes to `dev`
-    # still run the `build` job above (validation safety net) but skip this
-    # step — preventing in-progress dev work from silently overwriting the
-    # live docs site. Master pushes deploy as normal. workflow_dispatch
-    # also dispatches a deploy regardless of ref, by design.
-    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+    # `dev` is the canonical live-content source — every push that touches
+    # docs/** ships to www.trimgalore.com immediately. `master` is a release
+    # pin only (updated by FF from dev just before a release cut), and any
+    # push to it still re-deploys defensively in case dev was bypassed.
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

Reverts the deploy gate from #284. The gate was based on a "master = stable, dev = WIP" model that doesn't fit the actual workflow: in practice **dev is where all content lands first**, and master is just the release pin updated by FF from dev right before a release cut.

Under the gate, a docs improvement on dev wouldn't show up on www.trimgalore.com until a release — that's wrong. Docs should track dev's HEAD and reach users immediately.

## Behaviour after this lands

| Trigger | Build | Deploy |
|---|---|---|
| push to \`master\` (release-time, rare) | ✅ | ✅ — defensive redeploy |
| push to \`dev\` (the canonical content channel) | ✅ | ✅ — site updates immediately |
| \`workflow_dispatch\` (any branch) | ✅ | ✅ |

So dev pushes update the live site immediately. Master pushes (rare, only at release time) trigger a redeploy of the same content as a no-op safety net.

## Why a quick revert rather than just editing further

PR #284 was merged ~30 minutes before this; the gate hadn't yet fired in the wild (no docs-touching push to dev since #284 landed). Cleanest history is "added gate → reverted gate" rather than mutating the gate's intent in place — the diff is honest about the decision flip.