### PR TITLE
docs(clumpy): add RRBS to low-complexity list; soften WGBS framing

### DIFF
--- a/docs/src/content/docs/performance/clumpy.md
+++ b/docs/src/content/docs/performance/clumpy.md
@@ -11,8 +11,8 @@ description: Reorder reads in the trimmed FASTQ output to make .fq.gz files sign
 
 ### Clumpify
 
-- ✅ Low complexity data: yes (ATAC-seq, ChIP-seq, Ribo-Seq, RNA-Seq, high sequencing depth WES)
-- ❌ High complexity data: no (whole-genome sequencing) - has no effect
+- ✅ Low complexity data: yes (ATAC-seq, ChIP-seq, Ribo-Seq, RNA-Seq, RRBS, high sequencing depth WES)
+- ❌ High complexity data: no (whole-genome sequencing, WGBS) - may have detrimental impact (flowcell ordering wins)
 - ❌ Long reads: no (Oxford Nanopore) - has no effect
 - ❌ Unusual paired-end formats: no - can have deleterious effect
 


### PR DESCRIPTION
## Summary

Two surgical edits to the \"When to use it → Clumpify\" bullet list at the top of the page:

\`\`\`diff
-- ✅ Low complexity data: yes (ATAC-seq, ChIP-seq, Ribo-Seq, RNA-Seq, high sequencing depth WES)
-- ❌ High complexity data: no (whole-genome sequencing) - has no effect
++ ✅ Low complexity data: yes (ATAC-seq, ChIP-seq, Ribo-Seq, RNA-Seq, RRBS, high sequencing depth WES)
++ ❌ High complexity data: no (whole-genome sequencing, WGBS) - may have detrimental impact (flowcell ordering wins)
\`\`\`

### Why

The detailed per-library table further down (added in #282) already has the RRBS ✅ / WGBS ❌ split. The quick-reference bullet list at the top didn't reflect it — RRBS was missing from the low-complexity examples, and the high-complexity bullet's \"has no effect\" understated the cost.

Our WGBS PE benchmark ([\`docs/perf_data/clumpify-buckberry-2026-05-07/\`](../../../perf_data/clumpify-buckberry-2026-05-07/), merged in #283) measured clumpify making output **+10 to +13 ppt larger** than plain at the same level — flowcell-cluster ordering on the unsorted plain stream beats minimizer ordering when reads are coverage-diverse, and the R2 pair-lockstep amplifies the loss. \"May have detrimental impact (flowcell ordering wins)\" is the honest framing.

## Test plan

- [x] Bullets 3 and 4 (long reads, unusual PE) untouched — they keep their existing wording
- [x] Detailed per-library table further down already has the RRBS/WGBS split — quick-reference bullets now align
- [ ] Pages deploy after merge picks up the change (dev pushes deploy live, per #285)