### PR TITLE
chore(release): v2.2.0 (Clumpify Edition)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Trim Galore Changelog
 
 
-### Unreleased (clumpy branch)
+### Version 2.2.0 (Release on 7 May 2026)
+
+**The Clumpify Edition.** Opt-in read-reordering for tighter `.fq.gz` output via canonical 16-mer minimizer sort, with empirically-validated guidance on which data types benefit and which are hurt. Ships alongside a new `--compression` knob that decouples gzip level from reordering, and a new tool-wide `--memory` budget. Co-developed with Phil Ewels (PR [#282](https://github.com/FelixKrueger/TrimGalore/pull/282)) — see [Clumpy compression](https://www.trimgalore.com/performance/clumpy/) for the full benchmark table and use-case guidance, and [`docs/perf_data/clumpify-{buckberry,rrbs}-2026-05-07/`](https://github.com/FelixKrueger/TrimGalore/tree/master/docs/perf_data) for the WGBS-vs-RRBS contrast that motivated the per-data-type recommendations.
+
+The headline rule of thumb (in `clumpy.md`'s When-to-use section): clumpify helps on **low-complexity** paired-end data where biology produces fragment-level clustering (ATAC, Ribo, RRBS, RNA-seq, WES, MiSeq amplicons — savings ~15–55%), and **hurts** on high-complexity coverage-diverse paired-end data (WGBS PE, scRNA-seq R2 — output grows because R2 follows R1's minimizer order and loses its natural flowcell-cluster locality). The split is driven by the same R2-disruption mechanism that affects 10x scRNA-seq.
+
+#### New flags
 
 - **`--clumpify` opt-in compression mode.** Boolean flag that reorders reads
   inside each gzip member of the trimmed output by canonical 16-mer
@@ -34,9 +40,15 @@
 - **`--high_compression` removed.** Subsumed by the new `--compression <N>`
   flag. Users who previously passed `--high_compression` for level-6
   archival output should switch to `--compression 6` (or
-  `--clumpify --compression 6` to also benefit from reordering). Both
-  flags landed in pre-release development; `--high_compression` was never
-  on a stable release line.
+  `--clumpify --compression 6` to also benefit from reordering).
+  `--high_compression` shipped in v2.1.0 GA — this is a real removal,
+  not a pre-release shim. Existing pipelines that pass it will need to
+  swap; the rewrite is a one-line CLI change.
+
+#### Other changes
+
+- **Integer-arithmetic `max_errors` in adapter alignment** ([#287](https://github.com/FelixKrueger/TrimGalore/pull/287), [#262 Item A](https://github.com/FelixKrueger/TrimGalore/issues/262)). Replaced four call sites of `(max_error_rate * len as f64).floor() as usize` in `find_3prime_adapter` and `myers_proves_no_match` with integer math, eliminating a per-read libm `floor()` call that pprof attributed at 0.21% leaf self-time on the Buckberry fixture. Byte-identical to the float form for any non-negative integer length; determinism is *better* (no f64 rounding-mode dependency). Win: ~0.2% wall — small but it's free, and the parity matrix confirms byte-identity across all 19 flag paths.
+- **Memory & I/O reference data added to the [Threading model](https://www.trimgalore.com/performance/threading/) docs page** ([#287](https://github.com/FelixKrueger/TrimGalore/pull/287)). Memory profile section now contextualises TG v2's <100 MB peak vs Cutadapt 100–300 MB / fastp 100+ MB / BBDuk 1–4 GB, plus a new "I/O and cache behaviour" subsection covering disk-bandwidth-comfortable I/O and the L3-cache-pressure mechanism behind the `--cores ≥ 16` diminishing-returns plateau. Audit-trail data captured by [@an-altosian](https://github.com/an-altosian)'s [#263](https://github.com/FelixKrueger/TrimGalore/issues/263) and [#264](https://github.com/FelixKrueger/TrimGalore/issues/264) characterization reports.
 
 
 ### Version 2.1.0 (Release on 4 May 2026)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,7 +1715,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "trim-galore"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trim-galore"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Fast adapter and quality trimming for NGS data — Oxidized Edition"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Consistent quality and adapter trimming for next-generation sequencing data, wit
 - **NextSeq / 2-colour quality trim** — `--nextseq N` / `--2colour N` applies 2-colour-aware quality trimming (opt-in; replaces `-q`)
 - **Poly-A trimming** — built-in removal of poly-A tails without external tools; recommended for mRNA-seq / poly-A-selected RNA-seq libraries
 - **Parallel processing** — `--cores N` runs trimming and gzip compression in worker threads under an N+4 thread model (N workers + 2 decompressors + 1 batcher + 1 writer); near-linear speedup up to `--cores 8` for paired-end runs, then gzip-output I/O typically becomes binding
+- **Clumpify compression (v2.2+)** — opt-in `--clumpify` reorders reads by canonical 16-mer minimizer so similar reads share gzip dictionary windows; combined with `--compression 1–9` it shrinks output 15–55% on fragment-clustered data (ATAC, Ribo, RRBS, RNA-seq, MiSeq amplicons). Coverage-diverse data (WGBS PE, scRNA-seq R2) regress — see [Clumpy compression](https://www.trimgalore.com/performance/clumpy/) for the per-data-type guidance
 - **FastQC integration** — optional post-trimming quality reports built in via the bundled [fastqc-rust](https://crates.io/crates/fastqc-rust) library; produces FastQC 0.12.1-compatible HTML + ZIP outputs without requiring Java or an external `fastqc` on `$PATH`
 - **MultiQC compatible** — trimming reports parse cleanly in MultiQC dashboards (text + JSON)
 - **Demultiplexing** — 3' inline barcode demultiplexing
@@ -75,7 +76,7 @@ Multi-arch images (amd64 + arm64) are available from GitHub Container Registry:
 docker run --rm -v "$PWD":/data -w /data ghcr.io/felixkrueger/trimgalore:latest trim_galore input.fastq.gz
 ```
 
-FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:latest` (latest stable, currently `v2.1.0`), `:v2.1.0` (pinned to a specific release), `:beta` (latest prerelease — only set during an active beta cycle), and `:dev` (every push to the `dev` branch). See the [docs site install page](https://www.trimgalore.com/install/) for the full table.
+FastQC is built into the binary itself via the bundled fastqc-rust library — no external `fastqc` or Java runtime needed in the image. Tags published: `:latest` (latest stable, currently `v2.2.0`), `:v2.2.0` (pinned to a specific release), `:beta` (latest prerelease — only set during an active beta cycle), and `:dev` (every push to the `dev` branch). See the [docs site install page](https://www.trimgalore.com/install/) for the full table.
 
 ### Prebuilt binaries
 
@@ -91,7 +92,7 @@ trim_galore input.fastq.gz
 trim_galore --paired file_R1.fastq.gz file_R2.fastq.gz
 
 # Parallel processing (recommended for large files)
-# Near-linear speedup up to ~8 cores on v2.1.0-beta.8; beyond that the
+# Near-linear speedup up to ~8 cores on v2.2.0; beyond that the
 # gzip-output I/O on the storage layer typically becomes binding.
 trim_galore --cores 8 --paired file_R1.fastq.gz file_R2.fastq.gz
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -52,8 +52,8 @@ FastQC is built in via the bundled [`fastqc-rust`](https://crates.io/crates/fast
 
 | Tag | Updates |
 | --- | --- |
-| `:latest` | latest stable release (currently v2.1.0) |
-| `:v2.1.0` | pinned to a specific release |
+| `:latest` | latest stable release (currently v2.2.0) |
+| `:v2.2.0` | pinned to a specific release |
 | `:beta` | latest prerelease — only set during an active beta cycle |
 | `:dev` | every push to the `dev` development branch |
 


### PR DESCRIPTION
## Summary

Cuts v2.2.0 — the Clumpify Edition. This PR is the version-bump-and-CHANGELOG commit that gates the release.yml dispatch on master.

\`\`\`diff
- version = \"2.1.0\"
+ version = \"2.2.0\"
\`\`\`

### Scope of v2.2.0 vs v2.1.0 GA

| Area | Source |
|---|---|
| Phil Ewels' \`--clumpify\` / \`--compression\` / \`--memory\` feature trio | #282 |
| WGBS-vs-RRBS perf-data drops backing the per-data-type guidance | #283 |
| \`--high_compression\` flag **removed** (subsumed by \`--compression <N>\`) | #282 |
| Workflow model: dev = canonical truth, master = release pin | #284 → #285 |
| When-to-use bullet list updated: RRBS in low-complexity yes-list, WGBS framing softened to \"may have detrimental impact\" | #286 |
| Integer-arithmetic max_errors in adapter alignment (#262 Item A) | #287 |
| Memory & I/O reference data folded into Threading model docs (#263 + #264) | #287 |

### Release plan after this merges

1. **FF master to dev** — \`git push origin origin/dev:master\`
2. **Trigger \`release.yml\` on master** via workflow_dispatch
3. release.yml fires the GA path on master + version-string \`2.2.0\` → publishes binaries (Linux x86_64/aarch64 + macOS arm64), GHCR \`:latest\` / \`:v2.2.0\` / \`:v2.2\` / \`:v2\`, crates.io publish, GitHub Release with the v2.2.0 tag
4. Bioconda recipe bump (separate PR on bioconda-recipes — \`2.1.0\` → \`2.2.0\` + 3 new sha256s)
5. Optional Discussion #215 announcement

## Test plan

- [x] \`cargo build --release\` clean — version banner reads \`trim_galore 2.2.0 (Oxidized Edition)\`
- [x] \`npm run build\` (docs) clean
- [ ] CI green on this PR (Lint, Rust Tests ubuntu+macos, Coverage, Reproducibility, Validate-vs-Perl, Security audit)
- [ ] After merge to dev + FF master to dev: trigger release.yml; all 12 jobs green
- [ ] Post-release: \`cargo install trim-galore\` resolves to 2.2.0; \`docker pull ghcr.io/felixkrueger/trimgalore:latest\` resolves to v2.2.0 multi-arch image

Closes the v2.2.0 release milestone.