### PR TITLE
docs(citation): add CITATION.cff and .zenodo.json for v2.2.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,35 @@
+{
+  "title": "Trim Galore",
+  "description": "Trim Galore is a single-binary adapter and quality trimmer for FASTQ files, with built-in support for bisulfite sequencing (RRBS, WGBS, EM-seq), poly-G / poly-A trimming, paired-end validation, UMI-aware specialty modes (--clock, --implicon), inline demultiplexing, and an integrated FastQC report. The v2.x line is a Rust rewrite of the original Perl Trim Galore (v0.6.x) and is byte-for-byte compatible with v0.6.11 on the core flag paths covered by CI.",
+  "upload_type": "software",
+  "license": "GPL-3.0-only",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Krueger, Felix",
+      "affiliation": "Altos Labs"
+    }
+  ],
+  "keywords": [
+    "bioinformatics",
+    "NGS",
+    "adapter-trimming",
+    "quality-trimming",
+    "FASTQ",
+    "bisulfite-sequencing",
+    "RRBS",
+    "FastQC"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/FelixKrueger/TrimGalore",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://www.trimgalore.com",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    }
+  ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -7,7 +7,8 @@
   "creators": [
     {
       "name": "Krueger, Felix",
-      "affiliation": "Altos Labs"
+      "affiliation": "Altos Labs",
+      "orcid": "0000-0002-5513-3324"
     }
   ],
   "keywords": [

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ authors:
   - family-names: Krueger
     given-names: Felix
     affiliation: Altos Labs
-    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: fill in
+    orcid: "https://orcid.org/0000-0002-5513-3324"
 version: 2.2.0
 date-released: 2026-05-07
 license: GPL-3.0-only

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,11 +29,9 @@ keywords:
   - RRBS
   - FastQC
 identifiers:
-  # Concept DOI (resolves to the latest version on Zenodo).
-  # TODO: replace with the real concept DOI once the v2.2.0 deposit is minted.
-  # - type: doi
-  #   value: "10.5281/zenodo.XXXXXXX"
-  #   description: "Concept DOI (all versions)"
-  # - type: doi
-  #   value: "10.5281/zenodo.YYYYYYY"
-  #   description: "v2.2.0"
+  - type: doi
+    value: "10.5281/zenodo.5127898"
+    description: "Concept DOI (all versions — resolves to the latest)"
+  - type: doi
+    value: "10.5281/zenodo.20127893"
+    description: "v2.2.0"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+cff-version: 1.2.0
+message: "If you use Trim Galore in published work, please cite it using this metadata."
+title: "Trim Galore"
+abstract: >-
+  Trim Galore is a single-binary adapter and quality trimmer for FASTQ files,
+  with built-in support for bisulfite sequencing (RRBS, WGBS, EM-seq), poly-G /
+  poly-A trimming, paired-end validation, UMI-aware specialty modes
+  (--clock, --implicon), inline demultiplexing, and an integrated FastQC report.
+  The v2.x line is a Rust rewrite of the original Perl Trim Galore (v0.6.x) and
+  is byte-for-byte compatible with v0.6.11 on the core flag paths covered by CI.
+type: software
+authors:
+  - family-names: Krueger
+    given-names: Felix
+    affiliation: Altos Labs
+    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: fill in
+version: 2.2.0
+date-released: 2026-05-07
+license: GPL-3.0-only
+repository-code: "https://github.com/FelixKrueger/TrimGalore"
+url: "https://www.trimgalore.com"
+keywords:
+  - bioinformatics
+  - NGS
+  - adapter-trimming
+  - quality-trimming
+  - FASTQ
+  - bisulfite-sequencing
+  - RRBS
+  - FastQC
+identifiers:
+  # Concept DOI (resolves to the latest version on Zenodo).
+  # TODO: replace with the real concept DOI once the v2.2.0 deposit is minted.
+  # - type: doi
+  #   value: "10.5281/zenodo.XXXXXXX"
+  #   description: "Concept DOI (all versions)"
+  # - type: doi
+  #   value: "10.5281/zenodo.YYYYYYY"
+  #   description: "v2.2.0"

--- a/docs/src/content/docs/reference/credits.md
+++ b/docs/src/content/docs/reference/credits.md
@@ -26,7 +26,9 @@ If you use Trim Galore in published work, cite the project repository:
 
 > Krueger, F. *Trim Galore!* Consistent adapter and quality trimming for FASTQ files. <https://github.com/FelixKrueger/TrimGalore>
 
-Trim Galore has a Zenodo DOI for archival citation. Pick the version-specific DOI from the [release page](https://github.com/FelixKrueger/TrimGalore/releases) for the version you used.
+The repository ships a [`CITATION.cff`](https://github.com/FelixKrueger/TrimGalore/blob/master/CITATION.cff) file — GitHub's "Cite this repository" button on the repo sidebar generates BibTeX / APA from it.
+
+Trim Galore also has a Zenodo DOI for archival citation. Pick the version-specific DOI from the [release page](https://github.com/FelixKrueger/TrimGalore/releases) for the version you used; the [Zenodo concept DOI](https://zenodo.org) always resolves to the latest deposit.
 
 ## License
 

--- a/docs/src/content/docs/reference/credits.md
+++ b/docs/src/content/docs/reference/credits.md
@@ -28,7 +28,12 @@ If you use Trim Galore in published work, cite the project repository:
 
 The repository ships a [`CITATION.cff`](https://github.com/FelixKrueger/TrimGalore/blob/master/CITATION.cff) file — GitHub's "Cite this repository" button on the repo sidebar generates BibTeX / APA from it.
 
-Trim Galore also has a Zenodo DOI for archival citation. Pick the version-specific DOI from the [release page](https://github.com/FelixKrueger/TrimGalore/releases) for the version you used; the [Zenodo concept DOI](https://zenodo.org) always resolves to the latest deposit.
+Trim Galore is archived on Zenodo:
+
+- **Concept DOI (always latest):** [`10.5281/zenodo.5127898`](https://doi.org/10.5281/zenodo.5127898)
+- **v2.2.0:** [`10.5281/zenodo.20127893`](https://doi.org/10.5281/zenodo.20127893)
+
+For older versions, pick the version-specific DOI from the corresponding entry on the [Zenodo concept page](https://doi.org/10.5281/zenodo.5127898) or from the [GitHub release page](https://github.com/FelixKrueger/TrimGalore/releases).
 
 ## License
 


### PR DESCRIPTION
## Summary

- The Zenodo record at <https://zenodo.org/records/5127899> is from the Perl 0.6.x era and won't auto-update. Add the two metadata files that drive the next Zenodo deposit and the GitHub "Cite this repository" sidebar.
- `CITATION.cff` — v2.2.0 + 2026-05-07 release date. ORCID and DOI identifiers left as `TODO` comments so they can be filled in once the v2.2.0 Zenodo deposit is minted.
- `.zenodo.json` — overrides default metadata (title, abstract, keywords, related identifiers) on the next GitHub-release-triggered deposit so the Zenodo webhook doesn't have to guess from the release notes.
- Tightened `docs/src/content/docs/reference/credits.md` to reference `CITATION.cff` instead of the vague "pick the version-specific DOI from the release page" line.

## Out of scope (manual follow-up on Zenodo)

The DOI minting itself happens on Zenodo, not in the repo:

1. Enable the GitHub→Zenodo webhook at <https://zenodo.org/account/settings/github>, or
2. Click **New version** on the existing 5127899 record and upload the v2.2.0 tarball.

Then fill in the `identifiers:` block (concept + version DOI) and the `orcid:` field in `CITATION.cff`.

## Test plan

- [ ] GitHub renders **"Cite this repository"** in the sidebar from `CITATION.cff` (visible after merge to a default-branch ancestor; on `dev` it'll appear once `dev` becomes default or post-FF to `master`).
- [ ] `.zenodo.json` validates as JSON: `python -m json.tool .zenodo.json`.
- [ ] `CITATION.cff` validates against the CFF schema (e.g. `cffconvert --validate`).
- [ ] No effect on `cargo build`, `cargo test`, CI validation matrix — metadata-only PR.