### PR TITLE
docs(citation): forward citation metadata into master

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,36 @@
+{
+  "title": "Trim Galore",
+  "description": "Trim Galore is a single-binary adapter and quality trimmer for FASTQ files, with built-in support for bisulfite sequencing (RRBS, WGBS, EM-seq), poly-G / poly-A trimming, paired-end validation, UMI-aware specialty modes (--clock, --implicon), inline demultiplexing, and an integrated FastQC report. The v2.x line is a Rust rewrite of the original Perl Trim Galore (v0.6.x) and is byte-for-byte compatible with v0.6.11 on the core flag paths covered by CI.",
+  "upload_type": "software",
+  "license": "GPL-3.0-only",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Krueger, Felix",
+      "affiliation": "Altos Labs",
+      "orcid": "0000-0002-5513-3324"
+    }
+  ],
+  "keywords": [
+    "bioinformatics",
+    "NGS",
+    "adapter-trimming",
+    "quality-trimming",
+    "FASTQ",
+    "bisulfite-sequencing",
+    "RRBS",
+    "FastQC"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/FelixKrueger/TrimGalore",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://www.trimgalore.com",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,37 @@
+cff-version: 1.2.0
+message: "If you use Trim Galore in published work, please cite it using this metadata."
+title: "Trim Galore"
+abstract: >-
+  Trim Galore is a single-binary adapter and quality trimmer for FASTQ files,
+  with built-in support for bisulfite sequencing (RRBS, WGBS, EM-seq), poly-G /
+  poly-A trimming, paired-end validation, UMI-aware specialty modes
+  (--clock, --implicon), inline demultiplexing, and an integrated FastQC report.
+  The v2.x line is a Rust rewrite of the original Perl Trim Galore (v0.6.x) and
+  is byte-for-byte compatible with v0.6.11 on the core flag paths covered by CI.
+type: software
+authors:
+  - family-names: Krueger
+    given-names: Felix
+    affiliation: Altos Labs
+    orcid: "https://orcid.org/0000-0002-5513-3324"
+version: 2.2.0
+date-released: 2026-05-07
+license: GPL-3.0-only
+repository-code: "https://github.com/FelixKrueger/TrimGalore"
+url: "https://www.trimgalore.com"
+keywords:
+  - bioinformatics
+  - NGS
+  - adapter-trimming
+  - quality-trimming
+  - FASTQ
+  - bisulfite-sequencing
+  - RRBS
+  - FastQC
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.5127898"
+    description: "Concept DOI (all versions — resolves to the latest)"
+  - type: doi
+    value: "10.5281/zenodo.20127893"
+    description: "v2.2.0"

--- a/docs/src/content/docs/reference/credits.md
+++ b/docs/src/content/docs/reference/credits.md
@@ -26,7 +26,14 @@ If you use Trim Galore in published work, cite the project repository:
 
 > Krueger, F. *Trim Galore!* Consistent adapter and quality trimming for FASTQ files. <https://github.com/FelixKrueger/TrimGalore>
 
-Trim Galore has a Zenodo DOI for archival citation. Pick the version-specific DOI from the [release page](https://github.com/FelixKrueger/TrimGalore/releases) for the version you used.
+The repository ships a [`CITATION.cff`](https://github.com/FelixKrueger/TrimGalore/blob/master/CITATION.cff) file — GitHub's "Cite this repository" button on the repo sidebar generates BibTeX / APA from it.
+
+Trim Galore is archived on Zenodo:
+
+- **Concept DOI (always latest):** [`10.5281/zenodo.5127898`](https://doi.org/10.5281/zenodo.5127898)
+- **v2.2.0:** [`10.5281/zenodo.20127893`](https://doi.org/10.5281/zenodo.20127893)
+
+For older versions, pick the version-specific DOI from the corresponding entry on the [Zenodo concept page](https://doi.org/10.5281/zenodo.5127898) or from the [GitHub release page](https://github.com/FelixKrueger/TrimGalore/releases).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Forwards `dev` into `master` for the single squash commit from PR #291 (`CITATION.cff`, `.zenodo.json`, credits page DOI fill-in).
- Fixes a 404 in the live docs site: `docs/src/content/docs/reference/credits.md` links to `blob/master/CITATION.cff`, which doesn't exist until this lands on master.
- Makes the GitHub **"Cite this repository"** sidebar appear on the repo — the button reads from the default branch (master).

## Why outside the usual release-time FF

Per the workflow model (dev = canonical truth, master = release pin), master normally only FFs from dev at release time. Exception is justified here because:

- The change is **metadata-only** — no source, no test surface, no behavior change. Doesn't affect the v2.2.0 binary or anyone pinning to the v2.2.0 tag.
- Real pinning model is **tag-based** (`v2.2.0`), not branch-tip-based. Tag pinners are unaffected.
- The live docs site (auto-deployed from dev) already advertises both DOIs and links to `CITATION.cff` on master — without this FF the link is broken for users.

## Mechanics

This is a **true fast-forward** — `master` is a strict ancestor of `dev`. No merge commit needed:

```
master..dev:  44444aa docs(citation): add CITATION.cff and .zenodo.json for v2.2.0 (#291)
dev..master:  (empty)
```

Recommend **"Rebase and merge"** to preserve linear history.

## Test plan

- [ ] After merge, https://github.com/FelixKrueger/TrimGalore/blob/master/CITATION.cff loads (no 404).
- [ ] "Cite this repository" button appears in the repo sidebar.
- [ ] The credits page link on https://www.trimgalore.com resolves.
- [ ] No CI surface impact (metadata-only); checks should mirror PR #291's all-green result.