### PR TITLE
chore(deps): route Dependabot to dev + add npm ecosystem for /docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,15 @@
 # Dependabot configuration (v2) — https://docs.github.com/en/code-security/dependabot
 #
-# Tracks two ecosystems:
+# Tracks three ecosystems:
 #   - cargo (direct + transitive dependencies in Cargo.lock)
 #   - github-actions (pinned action versions in .github/workflows/*.yml)
+#   - npm (docs site dependencies in docs/package-lock.json — Astro/Starlight)
+#
+# All updates target the `dev` branch (the work trunk + docs auto-deploy
+# source), not `master` (the release pin). Without an explicit target-branch
+# Dependabot defaults to the repo's default branch (master), which mismatches
+# the workflow model adopted post-PR #285. Routing to dev means dep bumps land
+# on the live docs site automatically and FF to master at release time.
 #
 # Weekly Monday cadence matches a pre-week triage flow.  `open-pull-requests-
 # limit: 5` caps the initial surge when Dependabot first activates; raise if
@@ -13,14 +20,15 @@
 # labels later if we want fine-grained categorisation.
 #
 # Grouping: patch + minor bumps are batched into a single weekly PR per
-# ecosystem (one for cargo, one for github-actions). Major bumps still open
-# as individual PRs so breaking-change reviews stay focused. This collapsed
-# the post-v2.1.0-GA Dependabot inbox from ~9 emails (3 PRs × ~3 events) to
-# 1-2 emails per cycle.
+# ecosystem (one for cargo, one for github-actions, one for npm). Major bumps
+# still open as individual PRs so breaking-change reviews stay focused. This
+# collapsed the post-v2.1.0-GA Dependabot inbox from ~9 emails (3 PRs × ~3
+# events) to 1-2 emails per cycle.
 version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -35,6 +43,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -43,6 +52,21 @@ updates:
       - "FelixKrueger"
     groups:
       github-actions-patch-minor:
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    assignees:
+      - "FelixKrueger"
+    groups:
+      npm-patch-minor:
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
## Summary

Two changes to align Dependabot with the workflow model adopted in #285:

- **Add `target-branch: "dev"` to all ecosystems** so Dependabot opens PRs against `dev` (work trunk + docs auto-deploy source) instead of `master` (release pin). The mismatch was first surfaced by PR #294, which auto-opened against master and left the live docs site on the vulnerable `devalue@5.7.1` until master was manually merged into dev.
- **Add `npm` ecosystem for `/docs`** so the Astro/Starlight docs site dependencies get the same weekly + patch-minor-grouping treatment as `cargo` and `github-actions`. Without this, npm only got Dependabot attention via the security-advisory escape hatch (which is exactly how #294 opened despite zero npm config).

## Effect on future PRs

| Ecosystem | Before | After |
|---|---|---|
| cargo | weekly grouped PRs to master | weekly grouped PRs to **dev** |
| github-actions | weekly grouped PRs to master | weekly grouped PRs to **dev** |
| npm (/docs) | security-advisory-only, to master | weekly grouped PRs to **dev** + security advisories to **dev** |

## Test plan

- [ ] YAML validates (`python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'`) — verified locally.
- [ ] Next Dependabot run (Monday) lands PRs on `dev`, not `master`.
- [ ] No effect on `cargo build`, tests, or CI matrix — config-only.