### PR TITLE
chore(deps): bump astro to 6.1.10 — server-island GHSA fix

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,7 +14,7 @@
         "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@resvg/resvg-js": "^2.6.2",
-        "astro": "^6.1.9",
+        "astro": "^6.1.10",
         "katex": "^0.16.45",
         "rehype-class-names": "^2.0.0",
         "rehype-katex": "^7.0.1",
@@ -2333,9 +2333,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.9",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.9.tgz",
-      "integrity": "sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ==",
+      "version": "6.1.10",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.10.tgz",
+      "integrity": "sha512-jQAIki6c862oxRr7OXXC+h3n4wg1EpmKgCH3vv1FtXM9VFmD2iTjlaxrfb0I6eQCwtUjSBxfJBFBDSXHu7Wing==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,7 +18,7 @@
     "@fontsource/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@resvg/resvg-js": "^2.6.2",
-    "astro": "^6.1.9",
+    "astro": "^6.1.10",
     "katex": "^0.16.45",
     "rehype-class-names": "^2.0.0",
     "rehype-katex": "^7.0.1",


### PR DESCRIPTION
## Summary

Manually picks up the Astro security advisory fix surfaced after PR #294 landed.

- **Vuln**: "Astro: Server island encrypted parameters vulnerable to cross-component replay" (low severity).
- **Fix**: Astro 6.1.10. Within the existing `^6.1.9` caret range, so this is a one-line `package.json` bump + the matching lockfile resolution + integrity hash for the astro entry.
- **Exploitability in our config**: not exploitable — the TrimGalore docs site uses Starlight, which renders statically and doesn't use Astro server islands. Landing the fix anyway to clear the Dependabot alert and keep dependency hygiene clean.
- **Verification**: `npm audit` now reports `found 0 vulnerabilities` (was 1 before).

## Why manual instead of waiting for Dependabot

PR #295 just enabled the npm ecosystem for Dependabot, which would have caught this on next Monday's run automatically. Bumping manually now means the alert disappears from the repo's security tab immediately rather than persisting through the weekend.

## Test plan

- [ ] `cd docs && npm install` — clean install resolves to astro@6.1.10.
- [ ] `cd docs && npm audit` — 0 vulnerabilities (verified locally).
- [ ] `cd docs && npm run build` — Starlight site builds without errors (CI's docs `build` job runs this automatically).
- [ ] Pages deploy succeeds — the docs `deploy` job auto-fires from `dev` and republishes www.trimgalore.com with no visual regression.