### PR TITLE
fix(poly-g): trim R2's 3' poly-G tail (was incorrectly 5' poly-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 
 ### Unreleased (on `dev`)
 
+#### Fixes
+
+- **`--poly_g` now correctly trims the 3' end of Read 2** (was trimming
+  the 5' end as poly-C — wrong location for the 2-colour artifact).
+  Reported by @K81ta in
+  [#321](https://github.com/FelixKrueger/TrimGalore/issues/321).
+  The 2-colour poly-G artifact is sequencer-induced (the instrument
+  calls "no signal" as a high-quality G when it overruns the template),
+  which happens at the 3' end of every read regardless of strand
+  orientation — unlike poly-A, which is a template feature (mRNA tail
+  on the forward strand) and presents at opposite ends of R1 vs R2 in
+  the reverse-complement orientation. The original code copied the
+  poly-A `revcomp = is_r2` pattern, addressing the wrong location on
+  R2. Stat labels and reports also updated from "R2 poly-C" to "R2
+  poly-G".
+
+  Behaviour change: R2 records with 3' poly-G tails are now trimmed
+  (previously untouched); R2 records that happened to start with a
+  poly-C run on their 5' end are no longer trimmed by `--poly_g` (that
+  was the bug). No effect on `--poly_a` / poly-T handling. No effect on
+  R1 / single-end (only the R2 path changed). v0.6.x Perl byte-identity
+  unaffected (`--poly_g` is a v2.x-only feature, no Perl baseline).
+
 #### New input formats
 
 - **uBAM (unaligned BAM) input support**

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Consistent quality and adapter trimming for next-generation sequencing data, wit
 - **Quality trimming** — Phred-based trimming from the 3' end (BWA algorithm)
 - **Paired-end** — single-pass processing of both reads with automatic pair validation
 - **RRBS** — MspI end-repair artifact removal, directional and non-directional libraries
-- **Poly-G trimming** — sequence-based removal of no-signal G-runs at the 3' end of Read 1 (and poly-C at the 5' end of Read 2) from 2-colour instruments (NovaSeq, NextSeq, NovaSeq X). Auto-detected from the data; opt-out with `--no_poly_g`
+- **Poly-G trimming** — sequence-based removal of no-signal G-runs at the 3' end of Read 1 *and* Read 2 from 2-colour instruments (NovaSeq, NextSeq, NovaSeq X). The artifact is sequencer-induced (overrun → "no signal" called as G), so it manifests at the 3' end of every read regardless of strand. Auto-detected from the data; opt-out with `--no_poly_g`
 - **NextSeq / 2-colour quality trim** — `--nextseq N` / `--2colour N` applies 2-colour-aware quality trimming (opt-in; replaces `-q`)
 - **Poly-A trimming** — built-in removal of poly-A tails without external tools; recommended for mRNA-seq / poly-A-selected RNA-seq libraries
 - **Parallel processing** — `--cores N` runs trimming and gzip compression in worker threads under an N+4 thread model (N workers + 2 decompressors + 1 batcher + 1 writer); near-linear speedup up to `--cores 8` for paired-end runs, then gzip-output I/O typically becomes binding

--- a/docs/src/content/docs/modes/poly.md
+++ b/docs/src/content/docs/modes/poly.md
@@ -9,7 +9,7 @@ v2 ships with two built-in poly-X trimmers that the Perl version did not have: *
 
 On 2-colour Illumina instruments (NextSeq, NovaSeq, NovaSeq X), no signal is encoded as a high-quality **G**. This produces spurious G-runs at the 3' end of reads with little signal. They look like high-quality bases to the basecaller but represent dark cycles, not actual G calls.
 
-`--poly_g` scans the 3' end of Read 1 (and the 5' end of Read 2, where the reverse complement reads as poly-C) for these runs and trims them. It is auto-enabled when the data looks 2-colour, based on sequence detection of trailing G-runs.
+`--poly_g` scans the 3' end of **both** Read 1 and Read 2 for these runs and trims them. The artifact is sequencer-induced (overrun → high-quality "G" called for no signal), so it appears at the 3' end of every read regardless of strand orientation — unlike poly-A, which is a template feature and presents at opposite ends of R1 and R2 in the reverse-complement orientation. `--poly_g` is auto-enabled when the data looks 2-colour, based on sequence detection of trailing G-runs.
 
 ```bash
 # Auto-detection runs by default. No flag needed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1089,12 +1089,12 @@ fn run_paired(
     }
     if stats_r2.poly_g_trimmed > 0 {
         eprintln!(
-            "R2 reads with poly-C trimmed:    {:>10} ({:.1}%)",
+            "R2 reads with poly-G trimmed:    {:>10} ({:.1}%)",
             stats_r2.poly_g_trimmed,
             pct(stats_r2.poly_g_trimmed, stats_r2.total_reads)
         );
         eprintln!(
-            "  R2 poly-C bases removed:       {:>10}",
+            "  R2 poly-G bases removed:       {:>10}",
             stats_r2.poly_g_bases_trimmed
         );
     }

--- a/src/report.rs
+++ b/src/report.rs
@@ -42,9 +42,9 @@ pub struct TrimStats {
     pub poly_a_trimmed: usize,
     /// Total bases removed by poly-A/poly-T trimming
     pub poly_a_bases_trimmed: usize,
-    /// Reads with poly-G/poly-C tails trimmed
+    /// Reads with 3' poly-G tails trimmed (2-colour sequencing artifact, both R1 and R2)
     pub poly_g_trimmed: usize,
-    /// Total bases removed by poly-G/poly-C trimming
+    /// Total bases removed by poly-G trimming
     pub poly_g_bases_trimmed: usize,
     /// Reads discarded because no adapter was found (--discard-untrimmed)
     pub discarded_untrimmed: usize,
@@ -288,7 +288,7 @@ pub fn write_report_header<W: Write>(w: &mut W, config: &TrimConfig) -> std::io:
     if config.poly_g {
         writeln!(
             w,
-            "Poly-G trimming enabled: removing poly-G tails from 3' end of R1/SE reads, and poly-C heads from 5' end of R2 reads"
+            "Poly-G trimming enabled: removing poly-G tails from 3' end of both R1 and R2 (2-colour sequencer artifact)"
         )?;
     }
     if config.gzip {

--- a/src/trimmer.rs
+++ b/src/trimmer.rs
@@ -213,23 +213,23 @@ pub fn trim_read(record: &mut FastqRecord, config: &TrimConfig, is_r2: bool) -> 
         }
     }
 
-    // 2.8. Poly-G / Poly-C trimming (2-colour chemistry artifact removal)
-    // R1/SE: trim poly-G from 3' end. R2: trim poly-C from 5' end.
+    // 2.8. Poly-G trimming (2-colour chemistry artifact removal).
+    //
+    // Unlike poly-A (template-side: mRNA poly-A tail on the forward
+    // strand → R1 sees 3' poly-A, R2 sees 5' poly-T), the 2-colour
+    // poly-G artifact is sequencer-induced: the instrument calls "no
+    // signal" as a high-quality G when it overruns the template, which
+    // happens at the 3' end of BOTH reads regardless of strand. So
+    // poly-G must be trimmed at the 3' end on R1 AND R2 — NOT at the
+    // 5' end of R2 (which would address poly-C, the wrong location for
+    // this artifact). See issue #321.
     let mut poly_g_trimmed: usize = 0;
     if config.poly_g && !record.is_empty() {
-        let revcomp = is_r2;
         let seq_len_before = record.seq.len();
-        let idx = quality::homopolymer_trim_index(record.seq.as_bytes(), b'G', revcomp);
-        if revcomp {
-            if idx > 0 {
-                record.clip_5prime(idx);
-                poly_g_trimmed = idx;
-            }
-        } else {
-            if idx < seq_len_before {
-                record.truncate(idx);
-                poly_g_trimmed = seq_len_before - idx;
-            }
+        let idx = quality::homopolymer_trim_index(record.seq.as_bytes(), b'G', false);
+        if idx < seq_len_before {
+            record.truncate(idx);
+            poly_g_trimmed = seq_len_before - idx;
         }
     }
 
@@ -1104,5 +1104,69 @@ mod tests {
 
         assert!(result.had_adapter);
         assert_eq!(result.bp_after_cutadapt, record.seq.len());
+    }
+
+    // ── Poly-G + R2 (issue #321 regression guards) ─────────────────────────
+
+    fn poly_g_config() -> TrimConfig {
+        let mut c = test_config_with_adapters(Vec::<(&str, &str)>::new(), 1);
+        c.poly_g = true;
+        c
+    }
+
+    #[test]
+    fn test_poly_g_r2_trims_3prime_tail() {
+        // Issue #321: 2-colour artifact appears at 3' end of BOTH reads
+        // (sequencer-induced, not template-side). R2 with a 3' poly-G
+        // tail must get trimmed at the 3' end — previously the code
+        // mistakenly looked for 5' poly-C only and left R2 3' tails
+        // untrimmed.
+        let read_seq = "ACGTACGTACGTACGTGGGGGGGGGGGG"; // 16bp signal + 12 G's
+        let config = poly_g_config();
+        let mut record = make_record(read_seq);
+        let result = trim_read(&mut record, &config, true); // is_r2 = true
+
+        assert!(
+            result.poly_g_trimmed >= 12,
+            "expected ≥12 G's trimmed from R2 3' end, got {}",
+            result.poly_g_trimmed
+        );
+        assert_eq!(
+            record.seq.len(),
+            16,
+            "R2 should be trimmed to 16bp (signal only)"
+        );
+        assert!(!record.seq.ends_with('G'));
+    }
+
+    #[test]
+    fn test_poly_g_r1_still_trims_3prime_tail() {
+        // R1 regression guard: the fix must NOT alter R1 behaviour.
+        let read_seq = "ACGTACGTACGTACGTGGGGGGGGGGGG";
+        let config = poly_g_config();
+        let mut record = make_record(read_seq);
+        let result = trim_read(&mut record, &config, false); // is_r2 = false
+
+        assert!(result.poly_g_trimmed >= 12);
+        assert_eq!(record.seq.len(), 16);
+    }
+
+    #[test]
+    fn test_poly_g_r2_does_not_trim_5prime_poly_c() {
+        // After the issue-#321 fix, a 5' poly-C run on R2 is NOT touched
+        // by `--poly_g` (that was the bug — `--poly_g` was incorrectly
+        // attacking the 5' end of R2). The artifact is sequencer-side
+        // 3' poly-G; legitimate 5' content stays intact.
+        let read_seq = "CCCCCCCCCCCCACGTACGTACGTACGT"; // 12 C's at 5' + 16bp signal
+        let config = poly_g_config();
+        let mut record = make_record(read_seq);
+        let result = trim_read(&mut record, &config, true); // is_r2 = true
+
+        assert_eq!(
+            result.poly_g_trimmed, 0,
+            "R2 5' poly-C must NOT be trimmed by --poly_g (issue #321)"
+        );
+        assert_eq!(record.seq.len(), 28, "no length change expected");
+        assert!(record.seq.starts_with('C'));
     }
 }


### PR DESCRIPTION
## Summary

Fix for [#321](https://github.com/FelixKrueger/TrimGalore/issues/321) (reported by @K81ta).

The 2-colour poly-G artifact is **sequencer-induced** (the instrument calls "no signal" as a high-quality G when it overruns the template), and it manifests at the **3' end of every read regardless of strand orientation**. The original code copied the poly-A `revcomp = is_r2` cross-strand pattern — correct for poly-A (template-side: mRNA tail on the forward strand → R1 sees 3' poly-A, R2 sees 5' poly-T in reverse-complement), wrong for poly-G (sequencer-side, hits 3' of both reads).

Net effect of the bug: R2's actual 3' poly-G tail went untrimmed; instead `--poly_g` ate legitimate 5' poly-C content on R2.

## Behaviour change

- ✅ R2 records with 3' poly-G tails are **now trimmed** (previously untouched — this was the bug)
- ✅ R2 records with legitimate 5' poly-C content are **no longer eaten** by \`--poly_g\` (this was the buggy side-effect)
- ✅ R1 / single-end behaviour: **unchanged** (only the R2 path differed)
- ✅ \`--poly_a\` / poly-T behaviour: **unchanged** (still template-side, still cross-strand on R2 — correct as it was)
- ✅ v0.6.x Perl byte-identity: **unaffected** (\`--poly_g\` is a v2.x-only feature; confirmed via \`git show 0.6.11:trim_galore | grep poly_g\` → zero matches)

## Files changed

- \`src/trimmer.rs\` — fix the poly-G branch (drop the \`revcomp = is_r2\` line; always trim 3'); + 3 new lib regression tests
- \`src/main.rs\` — paired summary lines: "R2 reads with poly-C trimmed" → "poly-G"
- \`src/report.rs\` — \`TrimStats\` field docs + report-header text
- \`README.md\` — feature bullet rewritten
- \`docs/src/content/docs/modes/poly.md\` — dedicated prose updated to reflect 3'-both-reads + the why
- \`CHANGELOG.md\` — fix entry under Unreleased

## Test plan

- [x] \`cargo test --release\` — 353 tests pass (+3 over 350 baseline)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --release --all-targets -- -D warnings\` clean
- [x] Manual: \`test_poly_g_r2_trims_3prime_tail\` — R2 with \`...GGGGGGGGGGGG\` 3' tail → 12bp removed from 3'
- [x] Manual: \`test_poly_g_r1_still_trims_3prime_tail\` — R1 regression guard, same outcome
- [x] Manual: \`test_poly_g_r2_does_not_trim_5prime_poly_c\` — confirms the old buggy 5' poly-C eating is gone
- [ ] CI: Perl 0.6.11 byte-identity for the FASTQ output path stays green (sanity — should be unaffected since poly-G is v2-only)
- [ ] CI: existing poly-A / poly-T tests stay green (sanity — only the poly-G branch changed)

Closes #321.