### PR TITLE
chore(deps): bump memmap2 0.9.10 → 0.9.11 (RUSTSEC-2026-0186)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,9 +1010,9 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
## Summary

Single-line transitive-dep bump to clear [RUSTSEC-2026-0186](https://rustsec.org/advisories/RUSTSEC-2026-0186.html) (unchecked pointer offset in `memmap2 0.9.10`'s `advise_range` / `flush_range` functions). Fix released in `memmap2 0.9.11`.

**Dep chain:** \`memmap2 ← fontdb ← usvg ← resvg ← fastqc-rust 1.0.1 ← trim-galore\` — used for FastQC's SVG plot rendering. The exact-pinned \`fastqc-rust = "=1.0.1"\` upstream pin is preserved.

**Practical risk for TrimGalore:** ~zero. The vulnerable functions take attacker-controlled \`offset\`/\`len\` parameters, but no such input flows through TrimGalore's FastQC SVG render path (fonts are bundled/system, not user-supplied). Still worth fixing: clears the \`audit\` CI job red state surfaced by the auto-opened issue #324.

## Diff

\`Cargo.lock\` only — single version-line change for \`memmap2 0.9.10 → 0.9.11\`. No \`Cargo.toml\` change required (the version constraint is a transitive \`^0.9\` floor; the patch update resolves naturally).

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo test --release\` — 353 tests pass (unchanged from v2.3.0)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --release --all-targets -- -D warnings\` clean
- [ ] CI \`audit\` job goes green (previously red on this advisory)
- [ ] All other CI lanes stay green (FASTQ byte-identity vs Perl 0.6.11, etc.)

Refs #324 (will manually close after merge since the auto-close keyword only fires on default-branch merge per [`feedback_auto_close_keyword`](https://github.com/FelixKrueger/TrimGalore/blob/dev/CLAUDE.md))