### PR TITLE
docs(install): Homebrew in Astro + v2.3.0 refs + clippy 1.97 unblock

### DIFF
--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install Trim Galore via cargo, bioconda, Docker, or prebuilt binaries.
+description: Install Trim Galore via cargo, bioconda, Homebrew, Docker, or prebuilt binaries.
 ---
 
 Trim Galore v2 ships as a single static binary. No Python, no Perl, no Cutadapt, no Java, no `igzip`, no `pigz`, no external FastQC. Pick whichever channel fits the rest of your stack.
@@ -17,6 +17,14 @@ cargo install trim-galore
 
 ```bash
 conda install -c bioconda trim-galore
+```
+
+## From Homebrew
+
+Available in [homebrew-core](https://formulae.brew.sh/formula/trim-galore) for macOS and Linux:
+
+```bash
+brew install trim-galore
 ```
 
 ## Build from source
@@ -52,8 +60,8 @@ FastQC is built in via the bundled [`fastqc-rust`](https://crates.io/crates/fast
 
 | Tag | Updates |
 | --- | --- |
-| `:latest` | latest stable release (currently v2.2.0) |
-| `:v2.2.0` | pinned to a specific release |
+| `:latest` | latest stable release (currently v2.3.0) |
+| `:v2.3.0` | pinned to a specific release |
 | `:beta` | latest prerelease — only set during an active beta cycle |
 | `:dev` | every push to the `dev` development branch |
 
@@ -74,7 +82,7 @@ trim_galore --version
 Should print:
 
 ```
-trim_galore 2.1.0
+trim_galore 2.3.0
 <git-hash> — <os>/<arch> — built <ISO-8601-UTC>
 ```
 

--- a/src/clump.rs
+++ b/src/clump.rs
@@ -393,7 +393,7 @@ mod tests {
         // not a quality claim.
         let n_bins = 64;
         let mut counts = vec![0u32; n_bins];
-        let bases = [b'A', b'C', b'G', b'T'];
+        let bases = *b"ACGT";
         let mut rng_state: u64 = 0x9E3779B97F4A7C15;
         let mut next_byte = || {
             rng_state = rng_state

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -1565,7 +1565,7 @@ mod tests {
             let tail: String = (0..40)
                 .map(|j| {
                     let r = i.wrapping_mul(2654435761).wrapping_add(j as u32);
-                    [b'A', b'C', b'G', b'T'][(r >> 28) as usize & 0x3] as char
+                    (*b"ACGT")[(r >> 28) as usize & 0x3] as char
                 })
                 .collect();
             content.push_str(&format!(
@@ -1621,14 +1621,14 @@ mod tests {
             let r1_tail: String = (0..40)
                 .map(|j| {
                     let r = i.wrapping_mul(2654435761).wrapping_add(j as u32);
-                    [b'A', b'C', b'G', b'T'][(r >> 28) as usize & 0x3] as char
+                    (*b"ACGT")[(r >> 28) as usize & 0x3] as char
                 })
                 .collect();
             // R2 sequence different from R1 — mates aren't byte-identical.
             let r2_tail: String = (0..40)
                 .map(|j| {
                     let r = i.wrapping_mul(0x9E3779B1).wrapping_add(j as u32);
-                    [b'A', b'C', b'G', b'T'][(r >> 28) as usize & 0x3] as char
+                    (*b"ACGT")[(r >> 28) as usize & 0x3] as char
                 })
                 .collect();
             r1_content.push_str(&format!(
@@ -1768,7 +1768,7 @@ mod tests {
                 (0..120)
                     .map(|i| {
                         let r = seed.wrapping_mul(2654435761).wrapping_add(i);
-                        [b'A', b'C', b'G', b'T'][(r >> 28) as usize & 0x3] as char
+                        (*b"ACGT")[(r >> 28) as usize & 0x3] as char
                     })
                     .collect()
             })


### PR DESCRIPTION
Follow-up to #336 (`c0328da`, merged into `dev`).

## Summary

- **Docs (Astro):** Adds a `## From Homebrew` section to `docs/src/content/docs/install.md`, mirroring the README change from #336. Live install page at https://www.trimgalore.com/install/ will be consistent with the GitHub README on next docs deploy.
- **Docs staleness fixes** (unrelated to Homebrew, folded in while touching the file):
  - Docker tag table: `currently v2.2.0` → `currently v2.3.0`
  - Pinned tag row: `:v2.2.0` → `:v2.3.0`
  - `--version` example: `trim_galore 2.1.0` → `trim_galore 2.3.0`
  - Frontmatter `description:` adds Homebrew for SEO / OpenGraph.
- **Clippy 1.97.0 unblock** (added after CI reported failure): Rust 1.97.0 promoted `clippy::byte_char_slices` — fires on `&[b'A', b'C', b'G', b'T']` form idiomatic in ACGT test scaffolding. `-D warnings` turns these into hard errors. 5 sites in `#[cfg(test)]` blocks converted to `*b"ACGT"` (byte-identical, same `u8` at every index). Unblocks CI on `dev` (broken since #336's merge — first run against Rust 1.97.0).

## Test plan

- [x] `git diff` reviewed — docs (12 lines), src (10 lines), all intentional
- [x] `cargo clippy --all-targets --release -- -D warnings` passes locally (rustc 1.95.0)
- [x] `cargo fmt --all -- --check` clean
- [ ] Full CI matrix (Rust 1.97.0 stable) passes
- [ ] Astro docs build succeeds
- [ ] Live docs at https://www.trimgalore.com/install/ show the Homebrew section after deploy