### PR TITLE
Print help (exit 0) on bare invocation instead of a required-args error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Trim Galore Changelog
 
 
+### Unreleased
+
+#### Changes
+
+- **`trim_galore` with no arguments now prints the full help and exits 0**,
+  instead of the terse `error: the following required arguments were not
+  provided: <INPUT>...` usage error on stderr with a non-zero status. This
+  matches the convention of most modern CLIs (help to stdout, success exit
+  code). Explicit `--help` / `--version` are unchanged, and genuine usage
+  errors (e.g. an unknown flag, or `--paired` with no input files) still fail
+  loudly on stderr with a non-zero status.
+- **Tidied the `--help` text**: removed developer-internal references (legacy
+  Perl `v0.6.x` version notes and internal `PLAN.md`/`§` pointers) that had
+  leaked into user-facing flag descriptions. No behaviour change.
+
+
 ### Version 2.3.0 (Release on 27 June 2026)
 
 **The Formats Edition.** Both directions of unaligned BAM (uBAM) now ship: TrimGalore reads uBAM transparently (auto-detected by content, paired-interleaved supported via a bounded de-interleaver, BAM aux tags fold into FASTQ headers via `--preserve-tags`) and emits uBAM via `--output-format ubam` (SE → `*_trimmed.bam`, PE → ONE interleaved `*_val.bam` matching samtools/Picard/fgbio convention, aux tags round-trip A/Z/i/f scalars). Pairs with Bismark's uBAM input support ([Bismark#1026](https://github.com/FelixKrueger/Bismark/pull/1026) + [#1027](https://github.com/FelixKrueger/Bismark/pull/1027)) — the cross-tool TrimGalore-emits → Bismark-reads handshake is now first-class, and Bismark's test suite confirms byte-identity between TrimGalore's uBAM output and `samtools fastq` on real BS-seq data (SE + PE), so the transcoder is hermetically guarded at the byte level.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ pub enum OutputFormat {
     /// FASTQ output, mirroring input compression (default).
     #[default]
     Fastq,
-    /// Unaligned BAM output. Always single-threaded in v1; --clumpify,
+    /// Unaligned BAM output. Always single-threaded; --clumpify,
     /// --passthrough, --clock, --implicon, --demux are rejected at validation.
     #[clap(name = "ubam")]
     UBam,
@@ -22,9 +22,9 @@ pub enum OutputFormat {
 
 /// Trim Galore: A fast, single-pass NGS adapter and quality trimmer.
 ///
-/// Drop-in replacement for Trim Galore, rewritten in Rust. Matches v0.6.x outputs
-/// for the core feature set and extends it with poly-G / generic poly-A auto-trimming
-/// and other additions. Compatible with MultiQC and existing pipelines.
+/// Single-binary adapter and quality trimmer for NGS FASTQ data, with poly-G /
+/// generic poly-A auto-trimming and built-in FastQC reporting. Compatible with
+/// MultiQC and existing pipelines.
 #[derive(Parser, Debug)]
 #[clap(
     name = "trim_galore",
@@ -33,7 +33,11 @@ pub enum OutputFormat {
         env!("CARGO_PKG_VERSION"), "\n",
         env!("VERSION_BODY")
     ),
-    about
+    about,
+    // Bare `trim_galore` (no args) prints help and exits 0 rather than a
+    // "required arguments were not provided" usage error, matching the
+    // convention of samtools/git/bwa and friends.
+    arg_required_else_help = true
 )]
 pub struct Cli {
     /// Input FASTQ file(s). For paired-end, provide two files.
@@ -109,7 +113,7 @@ pub struct Cli {
     #[clap(long = "max_n")]
     pub max_n: Option<f64>,
 
-    /// Trim N bases from both ends of reads. Suppressed under --rrbs (matches Perl v0.6.x).
+    /// Trim N bases from both ends of reads. Suppressed under --rrbs.
     #[clap(long = "trim-n", alias = "trim_n")]
     pub trim_n: bool,
 
@@ -155,7 +159,7 @@ pub struct Cli {
 
     /// Do not gzip-compress output files. Forces plain output regardless of
     /// input compression. By default, output compression mirrors the input
-    /// (plain → plain, .gz → .gz; matches Perl v0.6.x behaviour).
+    /// (plain → plain, .gz → .gz).
     #[clap(long = "dont_gzip")]
     pub dont_gzip: bool,
 
@@ -202,16 +206,15 @@ pub struct Cli {
     /// FASTQ header on uBAM input. Tab-separated, samtools `-T`-compatible.
     /// Each tag must be a 2-char SAM tag name (`[A-Za-z][A-Za-z0-9]`).
     /// Ignored for FASTQ input. The `ALL` keyword is reserved for a future
-    /// release and rejected in v1. See PLAN §3.2.5.
+    /// release and is currently rejected.
     #[clap(long = "preserve-tags", value_delimiter = ',', value_parser = parse_sam_tag_name)]
     pub preserve_tags: Vec<String>,
 
     /// Output container format. Default `fastq` keeps existing behaviour
     /// (input-compression-mirroring FASTQ); `ubam` emits unaligned BAM with
     /// aux tags propagated from uBAM inputs (when `--preserve-tags` is set).
-    /// uBAM output is always single-threaded in v1; see the rejection rules
-    /// in `Cli::validate` for incompatible combinations.
-    /// See `plans/06252026_pluggable-io-formats/phase1-trimgalore-formats/PLAN.md`.
+    /// uBAM output is always single-threaded; some flag combinations are
+    /// rejected (see `--help` and the startup diagnostics for details).
     #[clap(long = "output-format", value_enum, default_value_t = OutputFormat::Fastq)]
     pub output_format: OutputFormat,
 
@@ -816,6 +819,25 @@ mod tests {
                 "expected even-number error, got: {err}"
             );
         }
+    }
+
+    #[test]
+    fn test_no_args_displays_help_not_missing_arg_error() {
+        // Running `trim_galore` with no arguments should print the help text
+        // and exit 0 (like samtools/git/bwa), NOT bail with a "required
+        // arguments were not provided" usage error. clap signals the former
+        // with ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand, which
+        // renders to stdout and exits with a success code.
+        use clap::CommandFactory;
+        use clap::error::ErrorKind;
+        let err = Cli::command()
+            .try_get_matches_from(["trim_galore"])
+            .unwrap_err();
+        assert_eq!(
+            err.kind(),
+            ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+            "no-args invocation should show help, got: {err}"
+        );
     }
 
     // ── parse_sam_tag_name (PLAN §5 step 4.3, T16) ──────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,27 @@ fn main() -> Result<()> {
     env_logger::init();
 
     // Pre-parse rewrite for Perl-era `-r1`/`-r2` short flags before clap sees them.
-    let cli = Cli::parse_from(rewrite_perl_short_flags(std::env::args()));
+    // A bare `trim_galore` (no args) prints the full help to stdout and exits 0,
+    // like most modern CLIs, rather than a non-zero "missing arguments" error.
+    // clap surfaces the help/version outcomes as `Err`, so intercept those three
+    // kinds and route them to stdout with a success code; genuine usage errors
+    // keep clap's default stderr + non-zero behaviour.
+    let cli = match Cli::try_parse_from(rewrite_perl_short_flags(std::env::args())) {
+        Ok(cli) => cli,
+        Err(err) => {
+            use clap::error::ErrorKind::{
+                DisplayHelp, DisplayHelpOnMissingArgumentOrSubcommand, DisplayVersion,
+            };
+            if matches!(
+                err.kind(),
+                DisplayHelp | DisplayHelpOnMissingArgumentOrSubcommand | DisplayVersion
+            ) {
+                print!("{err}");
+                std::process::exit(0);
+            }
+            err.exit();
+        }
+    };
     cli.validate()?;
 
     // Command-line as seen by the user (pre-clap-rewrite). Used by the

--- a/tests/integration_no_args_help.rs
+++ b/tests/integration_no_args_help.rs
@@ -1,0 +1,45 @@
+//! Binary-driven integration test for the bare-invocation help path.
+//!
+//! Running `trim_galore` with no arguments should behave like most modern
+//! CLIs: print the full help to **stdout** and exit **0**, rather than emit a
+//! terse "the following required arguments were not provided" usage error to
+//! stderr with a non-zero status. See `main.rs` (the `try_parse_from` handler
+//! that routes clap's help/version outcomes to stdout + success) and
+//! `cli.rs` (`arg_required_else_help = true`).
+//!
+//! `CARGO_BIN_EXE_trim_galore` is auto-set by cargo for integration tests.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_trim_galore"))
+}
+
+#[test]
+fn bare_invocation_prints_help_to_stdout_and_exits_zero() {
+    let out = Command::new(binary())
+        .output()
+        .expect("failed to run trim_galore with no args");
+
+    assert!(
+        out.status.success(),
+        "bare `trim_galore` should exit 0, got {:?}",
+        out.status.code()
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // Full help lands on stdout: usage line plus the options list.
+    assert!(
+        stdout.contains("Usage: trim_galore") && stdout.contains("--adapter"),
+        "expected help text on stdout, got: {stdout}"
+    );
+
+    // No error message, and nothing on stderr for a bare invocation.
+    assert!(
+        !stdout.contains("error:") && stderr.is_empty(),
+        "bare invocation should not emit an error; stderr was: {stderr:?}"
+    );
+}


### PR DESCRIPTION
## Problem

Running `trim_galore` with no arguments currently fails with clap's terse required-argument error on **stderr** and a **non-zero** exit:

```
$ trim_galore
error: the following required arguments were not provided:
  <INPUT>...

Usage: trim_galore <INPUT>...

For more information, try '--help'.
```

Most modern CLIs (samtools, git, bwa, cargo, docker…) instead print their full help on a bare invocation. This PR makes `trim_galore` do the same.

## Change

- Set `arg_required_else_help = true` so clap resolves the no-args case to a help outcome rather than a missing-argument error.
- Route clap's help/version outcomes (including this one) to **stdout** with **exit 0** via a `try_parse_from` handler in `main`. Genuine usage errors (unknown flag, `--paired` with no input files, etc.) still fail loudly on **stderr** with a **non-zero** exit.

```
$ trim_galore            # now: full help on stdout, exit 0
$ echo $?
0
```

- Also tidied the `--help` text: dropped developer-internal references (legacy Perl `v0.6.x` version notes and internal `PLAN.md` / section pointers) that had leaked into user-facing flag descriptions. No behaviour change.

## Tests

- A clap-layer unit test (`cli.rs`) locks the no-args → help outcome.
- A binary-driven integration test (`tests/integration_no_args_help.rs`) asserts exit 0 + help on stdout + empty stderr end-to-end.
- Full suite green (`cargo test`: 331 unit + integration), `cargo fmt --check` and `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)