### PR TITLE
chore(dependabot): ignore noodles (exact-pinned for byte-identity)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,14 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    # noodles is exact-pinned (`=0.88.0`) in Cargo.toml for byte-identity of
+    # uBAM I/O. In the pre-1.0 (0.x) series, minor bumps carry no wire-format
+    # or API compat guarantees, and any noodles change here is coordinated
+    # against Bismark's cross-tool byte-identity CI (src/bam.rs + noodles both
+    # need scoped human review). Dependabot has already tried 0.88 → 0.109 in
+    # PR #326 (5 CI failures, closed with rationale) — silence future attempts.
+    ignore:
+      - dependency-name: "noodles"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Closes the review loop on #326.

## Why

\`noodles\` is exact-pinned to \`=0.88.0\` in \`Cargo.toml\` for byte-identity of the uBAM I/O path. The crate's pre-1.0 (0.x) semver doesn't guarantee wire-format or API stability across minor bumps, and any real noodles migration would need scoped human review coordinated with Bismark's cross-tool byte-identity CI (per \`src/bam.rs\` + Bismark's own pin).

Dependabot proposed \`0.88.0 → 0.109.0\` in #326 despite the exact-pin (Dependabot ignores pin operators when proposing bumps). Result: 5 failed CI checks (Rust Tests × 2, Reproducibility, Lint, Coverage — all compile/API errors), \`Validate vs Perl TrimGalore\` and \`Validate uBAM input\` skipped as downstream. The pin is doing its job; Dependabot's weekly re-proposal isn't.

## Change

Adds an \`ignore\` entry to the cargo ecosystem block:

\`\`\`yaml
ignore:
  - dependency-name: "noodles"
\`\`\`

All other cargo deps continue to flow through the \`cargo-patch-minor\` group as before.

## Test plan

- [x] YAML parses (git diff looks clean, indentation matches surrounding block)
- [ ] Next Monday's Dependabot run does not re-propose \`noodles\` (observational — no immediate CI signal since dependabot.yml is only exercised by scheduled runs)