### PR TITLE
ci(audit): add rustybuzz to unmaintained-ignore list (closes #344)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,15 @@ jobs:
           # ttf-parser successor, part of the `fontations` project). Nothing
           # we can do at this level; revisit when fastqc-rust or resvg
           # switches.
-          ignore: RUSTSEC-2024-0436, RUSTSEC-2026-0192
+          #
+          # RUSTSEC-2026-0206 — `rustybuzz` no longer maintained.
+          # Transitive four levels deep:
+          #   trim-galore → fastqc-rust → resvg → usvg → rustybuzz
+          # Same upstream story as ttf-parser: sits under the resvg/usvg
+          # font-and-text stack, `harfbuzz` team announced end-of-maintenance
+          # on the pure-Rust port. Revisit when fastqc-rust or resvg swaps in
+          # a maintained text-shaping crate.
+          ignore: RUSTSEC-2024-0436, RUSTSEC-2026-0192, RUSTSEC-2026-0206
 
   # #247 item 4: line/branch coverage reporting via `cargo-llvm-cov`.
   # Generates an LCOV file as an artifact (downloadable from the Actions


### PR DESCRIPTION
Closes #344 (RUSTSEC-2026-0206 — \`rustybuzz\` unmaintained, filed by \`rustsec/audit-check\` on 2026-07-13).

## Rationale

Adds \`RUSTSEC-2026-0206\` to the \`rustsec/audit-check\` ignore list, alongside the existing \`RUSTSEC-2024-0436\` (\`paste\`) and \`RUSTSEC-2026-0192\` (\`ttf-parser\`) entries.

\`rustybuzz 0.20.1\` is transitive four levels deep — \`trim-galore → fastqc-rust → resvg → usvg → rustybuzz\` — sitting alongside \`ttf-parser\` under the same resvg/usvg font-and-text stack. The \`harfbuzz\` team announced end-of-maintenance on the pure-Rust port. Nothing we can fix at this level; needs upstream migration at resvg or fastqc-rust to a maintained text-shaping crate.

Matches the existing policy: **suppress only \`unmaintained\` warnings where the fix has to land in an upstream crate; CVE-class advisories remain loud.**

## The pattern

This is the third RUSTSEC \`unmaintained\` advisory to fire off the same resvg/usvg subtree in a short window — first ttf-parser (yesterday's #331), now rustybuzz. Worth noting as a signal that this subtree's maintenance risk is growing, but no action beyond the ignore list makes sense until either fastqc-rust or resvg upstream ships a maintained replacement.

## Test plan

- [x] YAML format matches yesterday's successful #342 (comma-separated per \`rustsec/audit-check\`'s input schema)
- [ ] Security audit passes on this PR