### PR TITLE
fix(ubam): run FastQC on --output-format ubam output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -847,6 +847,35 @@ jobs:
             echo "SKIP: ubam_test_with_tags.bam not committed; aux-tag round-trip covered by lib tests"
           fi
 
+      - name: Validate SE uBAM-out — --fastqc produces a report
+        # Guards against the uBAM-output path silently skipping FastQC.
+        # fastqc-rust reads BAM natively; the zip must appear alongside the
+        # BAM output, matching the FASTQ path's contract.
+        if: ${{ !cancelled() }}
+        run: |
+          mkdir -p /tmp/ubam_out_se_fqc
+          ./target/release/trim_galore --output-format ubam --fastqc \
+            -o /tmp/ubam_out_se_fqc test_files/ubam_test.bam
+          test -f /tmp/ubam_out_se_fqc/ubam_test_trimmed.bam
+          test -f /tmp/ubam_out_se_fqc/ubam_test_trimmed_fastqc.zip
+          test -f /tmp/ubam_out_se_fqc/ubam_test_trimmed_fastqc.html
+          unzip -l /tmp/ubam_out_se_fqc/ubam_test_trimmed_fastqc.zip | grep -q fastqc_data.txt
+
+      - name: Validate PE uBAM-out — --fastqc produces one report for the interleaved BAM
+        # PE uBAM output is ONE interleaved BAM, so exactly ONE FastQC zip
+        # is expected (not two). Regression guard against a "call twice"
+        # symmetry mistake with the FASTQ paired path.
+        if: ${{ !cancelled() }}
+        run: |
+          mkdir -p /tmp/ubam_out_pe_fqc
+          ./target/release/trim_galore --paired --output-format ubam --fastqc \
+            -o /tmp/ubam_out_pe_fqc test_files/ubam_paired_test.bam
+          test -f /tmp/ubam_out_pe_fqc/ubam_paired_test_val.bam
+          test -f /tmp/ubam_out_pe_fqc/ubam_paired_test_val_fastqc.zip
+          # Exactly one zip: guard against accidentally calling fastqc twice.
+          ZIP_COUNT=$(ls /tmp/ubam_out_pe_fqc/*_fastqc.zip 2>/dev/null | wc -l | tr -d ' ')
+          [ "$ZIP_COUNT" = "1" ] || { echo "Expected 1 fastqc zip, got $ZIP_COUNT"; ls /tmp/ubam_out_pe_fqc; exit 1; }
+
       - name: Upload uBAM validation outputs on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -829,6 +829,10 @@ jobs:
           grep -q "20 .* paired in sequencing" /tmp/ubam_out_pe.flagstat
 
       - name: Validate uBAM-out aux-tag preservation
+        # NOTE: deliberately NOT `set -o pipefail` — the `samtools view | head -1`
+        # below SIGPIPEs the producer, which pipefail would surface as step
+        # failure. Adjacent fastqc steps DO use pipefail; the asymmetry is
+        # intentional.
         if: ${{ !cancelled() }}
         run: |
           # Skip gracefully if the with-tags fixture isn't present (it's
@@ -854,13 +858,25 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
-          mkdir -p /tmp/ubam_out_se_fqc
+          rm -rf /tmp/ubam_out_se_fqc && mkdir -p /tmp/ubam_out_se_fqc
           ./target/release/trim_galore --output-format ubam --fastqc \
             -o /tmp/ubam_out_se_fqc test_files/ubam_test.bam
           test -f /tmp/ubam_out_se_fqc/ubam_test_trimmed.bam
           test -f /tmp/ubam_out_se_fqc/ubam_test_trimmed_fastqc.zip
           test -f /tmp/ubam_out_se_fqc/ubam_test_trimmed_fastqc.html
-          unzip -l /tmp/ubam_out_se_fqc/ubam_test_trimmed_fastqc.zip | grep -q fastqc_data.txt
+          # Tempfile split rather than `unzip -l | grep -q` — under pipefail,
+          # `grep -q` closes the pipe on first match and SIGPIPEs unzip
+          # (~1% flake rate observed on real fixtures). Listing lands in the
+          # failure artifact for free (globbed by /tmp/ubam_out_*).
+          unzip -l /tmp/ubam_out_se_fqc/ubam_test_trimmed_fastqc.zip \
+            > /tmp/ubam_out_se_fqc/ziplist.txt
+          grep -q fastqc_data.txt /tmp/ubam_out_se_fqc/ziplist.txt
+          # Content assertion: guard against a structurally-valid but empty
+          # report (e.g. from an upstream regression that yields zero
+          # sequences). The 10-read fixture must produce Total Sequences=10.
+          unzip -p /tmp/ubam_out_se_fqc/ubam_test_trimmed_fastqc.zip \
+            '*fastqc_data.txt' > /tmp/ubam_out_se_fqc/fastqc_data.txt
+          grep -qE '^Total Sequences\s+10\s*$' /tmp/ubam_out_se_fqc/fastqc_data.txt
 
       - name: Validate PE uBAM-out (interleaved BAM in) — --fastqc produces one report
         # PE uBAM output is ONE interleaved BAM, so exactly ONE FastQC zip
@@ -869,11 +885,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
-          mkdir -p /tmp/ubam_out_pe_fqc
+          rm -rf /tmp/ubam_out_pe_fqc && mkdir -p /tmp/ubam_out_pe_fqc
           ./target/release/trim_galore --paired --output-format ubam --fastqc \
             -o /tmp/ubam_out_pe_fqc test_files/ubam_paired_test.bam
           test -f /tmp/ubam_out_pe_fqc/ubam_paired_test_val.bam
           test -f /tmp/ubam_out_pe_fqc/ubam_paired_test_val_fastqc.zip
+          test -f /tmp/ubam_out_pe_fqc/ubam_paired_test_val_fastqc.html
           # Exactly one zip: guard against accidentally calling fastqc twice.
           # `|| true` keeps the zero-match branch alive under pipefail so we
           # can emit the friendly diagnostic instead of aborting silently.
@@ -886,12 +903,13 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           set -euo pipefail
-          mkdir -p /tmp/ubam_out_pe_fastq_fqc
+          rm -rf /tmp/ubam_out_pe_fastq_fqc && mkdir -p /tmp/ubam_out_pe_fastq_fqc
           ./target/release/trim_galore --paired --output-format ubam --fastqc \
             -o /tmp/ubam_out_pe_fastq_fqc \
             test_files/BS-seq_10K_R1.fastq.gz test_files/BS-seq_10K_R2.fastq.gz
           test -f /tmp/ubam_out_pe_fastq_fqc/BS-seq_10K_R1_val.bam
           test -f /tmp/ubam_out_pe_fastq_fqc/BS-seq_10K_R1_val_fastqc.zip
+          test -f /tmp/ubam_out_pe_fastq_fqc/BS-seq_10K_R1_val_fastqc.html
           ZIP_COUNT=$(ls /tmp/ubam_out_pe_fastq_fqc/*_fastqc.zip 2>/dev/null | wc -l | tr -d ' ' || true)
           [ "$ZIP_COUNT" = "1" ] || { echo "Expected 1 fastqc zip, got $ZIP_COUNT"; ls /tmp/ubam_out_pe_fastq_fqc; exit 1; }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -849,10 +849,11 @@ jobs:
 
       - name: Validate SE uBAM-out — --fastqc produces a report
         # Guards against the uBAM-output path silently skipping FastQC.
-        # fastqc-rust reads BAM natively; the zip must appear alongside the
-        # BAM output, matching the FASTQ path's contract.
+        # fastqc-rust dispatches on file EXTENSION (not content), so this
+        # relies on output paths ending in `.bam`.
         if: ${{ !cancelled() }}
         run: |
+          set -euo pipefail
           mkdir -p /tmp/ubam_out_se_fqc
           ./target/release/trim_galore --output-format ubam --fastqc \
             -o /tmp/ubam_out_se_fqc test_files/ubam_test.bam
@@ -861,20 +862,38 @@ jobs:
           test -f /tmp/ubam_out_se_fqc/ubam_test_trimmed_fastqc.html
           unzip -l /tmp/ubam_out_se_fqc/ubam_test_trimmed_fastqc.zip | grep -q fastqc_data.txt
 
-      - name: Validate PE uBAM-out — --fastqc produces one report for the interleaved BAM
+      - name: Validate PE uBAM-out (interleaved BAM in) — --fastqc produces one report
         # PE uBAM output is ONE interleaved BAM, so exactly ONE FastQC zip
         # is expected (not two). Regression guard against a "call twice"
         # symmetry mistake with the FASTQ paired path.
         if: ${{ !cancelled() }}
         run: |
+          set -euo pipefail
           mkdir -p /tmp/ubam_out_pe_fqc
           ./target/release/trim_galore --paired --output-format ubam --fastqc \
             -o /tmp/ubam_out_pe_fqc test_files/ubam_paired_test.bam
           test -f /tmp/ubam_out_pe_fqc/ubam_paired_test_val.bam
           test -f /tmp/ubam_out_pe_fqc/ubam_paired_test_val_fastqc.zip
           # Exactly one zip: guard against accidentally calling fastqc twice.
-          ZIP_COUNT=$(ls /tmp/ubam_out_pe_fqc/*_fastqc.zip 2>/dev/null | wc -l | tr -d ' ')
+          # `|| true` keeps the zero-match branch alive under pipefail so we
+          # can emit the friendly diagnostic instead of aborting silently.
+          ZIP_COUNT=$(ls /tmp/ubam_out_pe_fqc/*_fastqc.zip 2>/dev/null | wc -l | tr -d ' ' || true)
           [ "$ZIP_COUNT" = "1" ] || { echo "Expected 1 fastqc zip, got $ZIP_COUNT"; ls /tmp/ubam_out_pe_fqc; exit 1; }
+
+      - name: Validate PE uBAM-out (FASTQ pair in) — --fastqc produces one report
+        # Covers run_ubam_output_paired_two_files (FASTQ+FASTQ → interleaved BAM),
+        # the driver not exercised by the interleaved-BAM step above.
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/ubam_out_pe_fastq_fqc
+          ./target/release/trim_galore --paired --output-format ubam --fastqc \
+            -o /tmp/ubam_out_pe_fastq_fqc \
+            test_files/BS-seq_10K_R1.fastq.gz test_files/BS-seq_10K_R2.fastq.gz
+          test -f /tmp/ubam_out_pe_fastq_fqc/BS-seq_10K_R1_val.bam
+          test -f /tmp/ubam_out_pe_fastq_fqc/BS-seq_10K_R1_val_fastqc.zip
+          ZIP_COUNT=$(ls /tmp/ubam_out_pe_fastq_fqc/*_fastqc.zip 2>/dev/null | wc -l | tr -d ' ' || true)
+          [ "$ZIP_COUNT" = "1" ] || { echo "Expected 1 fastqc zip, got $ZIP_COUNT"; ls /tmp/ubam_out_pe_fastq_fqc; exit 1; }
 
       - name: Upload uBAM validation outputs on failure
         if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@
   Perl `v0.6.x` version notes and internal `PLAN.md`/`§` pointers) that had
   leaked into user-facing flag descriptions. No behaviour change.
 
+#### Fixes
+
+- **`--fastqc` now runs on `--output-format ubam` output** for both single-end
+  and paired-end runs. The uBAM-output path previously silently skipped the
+  bundled FastQC pass even when `--fastqc` (or `--fastqc_args`) was requested;
+  the FASTQ-output path already honoured it. `fastqc-rust` reads BAM natively,
+  so the report is generated directly from the trimmed `*_trimmed.bam` (SE) or
+  the single interleaved `*_val.bam` (PE) — one FastQC report per output BAM,
+  covering both mates in the PE case.
+
 
 ### Version 2.3.0 (Release on 27 June 2026)
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ trim_galore --preserve-tags CB,UB sample.bam
 # input `@HD`/`@PG` chain is propagated and a trim_galore `@PG` line is
 # appended. Paired output is ONE interleaved BAM (`<stem>_val.bam`) with
 # FREAD1/FREAD2 flag bits per record (samtools/Picard/fgbio convention).
+# `--fastqc` works on uBAM output too; paired mode produces ONE report per
+# pair covering both mates pooled (a consequence of the interleaved shape —
+# you lose the per-mate R1 vs R2 quality curve you'd get from FASTQ output).
 trim_galore --output-format ubam sample.bam
 trim_galore --paired --output-format ubam interleaved.bam
 

--- a/docs/src/content/docs/guide/outputs.md
+++ b/docs/src/content/docs/guide/outputs.md
@@ -59,6 +59,8 @@ Gzip-compressed input produces gzip-compressed output by default. Pass `--dont_g
 
 ## FastQC
 
-`--fastqc` runs the bundled [`fastqc-rust`](https://crates.io/crates/fastqc-rust) library on the trimmed output files after pair validation, producing FastQC 0.12.1-compatible HTML + ZIP reports alongside the trimmed FASTQ. No Java or external `fastqc` install needed.
+`--fastqc` runs the bundled [`fastqc-rust`](https://crates.io/crates/fastqc-rust) library on the trimmed output files after pair validation, producing FastQC 0.12.1-compatible HTML + ZIP reports alongside the trimmed output. Works on both FASTQ output (default) and uBAM output (`--output-format ubam`) — `fastqc-rust` reads `.bam` natively, so no intermediate conversion. No Java or external `fastqc` install needed.
+
+For paired-end runs, FastQC is invoked once per output file — so PE FASTQ produces two reports (one per mate), while PE uBAM produces a **single** report per pair (uBAM PE output is one interleaved BAM, and the report covers both mates pooled).
 
 `--fastqc_args "..."` passes a subset of FastQC flags through. Currently supported: `--nogroup`, `--expgroup`, `--quiet`, `--svg`, `--nano`, `--nofilter`, `--casava`, `-t`/`--threads`, `-o`/`--outdir`. Other flags emit a warning and are ignored.

--- a/src/fastqc.rs
+++ b/src/fastqc.rs
@@ -8,10 +8,13 @@
 //! runtime dependencies, completing the "single static binary, zero
 //! deps" story for the v2.x rewrite.
 //!
-//! Public entry point: [`run`]. The two callers in `src/main.rs` (one
-//! per single-end output, two per paired-end output) invoke it with the
-//! trimmed FASTQ path; output `*_fastqc.html` and `*_fastqc.zip` land
-//! in the trim-galore `--output_dir` (or current dir if unset).
+//! Public entry point: [`run`]. Callers in `src/main.rs` invoke it with a
+//! trimmed output path — FASTQ on the default path, BAM on the
+//! `--output-format ubam` path (`fastqc-rust` dispatches on file
+//! extension and reads `.bam` natively). Output `*_fastqc.html` and
+//! `*_fastqc.zip` land in the trim-galore `--output_dir` (or, when unset,
+//! the parent directory of the input file, which is where the trimmed
+//! output already lives).
 
 use std::path::Path;
 
@@ -20,14 +23,15 @@ use fastqc_rust::{config::FastQCConfig, runner};
 
 /// Run FastQC on a single trimmed output file.
 ///
-/// `output_path` — the FASTQ to analyse (one of the trimmed outputs).
+/// `output_path` — the trimmed output to analyse (FASTQ, or BAM when
+///                 `--output-format ubam` is in effect).
 /// `fastqc_args` — raw user-supplied `--fastqc_args` string. A subset
 ///                 of common FastQC CLI flags is translated to
 ///                 [`FastQCConfig`] mutations; unknown flags emit a
 ///                 warning and are ignored.
 /// `output_dir`  — where the `*_fastqc.html` / `*_fastqc.zip` artifacts
-///                 land. `None` means current directory (FastQC's
-///                 default).
+///                 land. `None` falls back to the input file's parent
+///                 directory (fastqc-rust's default).
 /// `cores`       — threading budget for `fastqc-rust`'s internal rayon
 ///                 pool. Always at least 1.
 pub fn run(

--- a/src/fastqc.rs
+++ b/src/fastqc.rs
@@ -30,7 +30,7 @@ use fastqc_rust::{config::FastQCConfig, runner};
 ///                 [`FastQCConfig`] mutations; unknown flags emit a
 ///                 warning and are ignored.
 /// `output_dir`  — where the `*_fastqc.html` / `*_fastqc.zip` artifacts
-///                 land. `None` falls back to the input file's parent
+///                 land. `None` falls back to the analysed file's parent
 ///                 directory (fastqc-rust's default).
 /// `cores`       — threading budget for `fastqc-rust`'s internal rayon
 ///                 pool. Always at least 1.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1634,6 +1634,16 @@ fn run_ubam_output_single(
         eprintln!("JSON report: {}", json_path.display());
     }
 
+    // Run FastQC if requested (bundled fastqc-rust reads BAM natively).
+    if cli.fastqc || cli.fastqc_args.is_some() {
+        fastqc::run(
+            &output_path,
+            cli.fastqc_args.as_deref(),
+            output_dir,
+            cli.cores,
+        )?;
+    }
+
     Ok(())
 }
 
@@ -1760,6 +1770,17 @@ fn run_ubam_output_paired_two_files(
         )?;
     }
 
+    // Run FastQC if requested (bundled fastqc-rust reads BAM natively).
+    // PE uBAM output is a single interleaved BAM, so one call covers both mates.
+    if cli.fastqc || cli.fastqc_args.is_some() {
+        fastqc::run(
+            &output_path,
+            cli.fastqc_args.as_deref(),
+            output_dir,
+            cli.cores,
+        )?;
+    }
+
     Ok(())
 }
 
@@ -1867,6 +1888,17 @@ fn run_ubam_output_paired_single_file(
             adapters_r1,
             adapters_r2,
             None,
+        )?;
+    }
+
+    // Run FastQC if requested (bundled fastqc-rust reads BAM natively).
+    // PE uBAM output is a single interleaved BAM, so one call covers both mates.
+    if cli.fastqc || cli.fastqc_args.is_some() {
+        fastqc::run(
+            &output_path,
+            cli.fastqc_args.as_deref(),
+            output_dir,
+            cli.cores,
         )?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,8 +219,9 @@ fn main() -> Result<()> {
         if cli.cores > 1 {
             eprintln!(
                 "NOTE: --output-format ubam uses single-threaded compression in v1; \
-                 --cores {} is ignored. For high-throughput uBAM output, run \
-                 multiple invocations in parallel.",
+                 --cores {} is ignored for BAM writing (FastQC, if requested, still \
+                 uses it). For high-throughput uBAM output, run multiple invocations \
+                 in parallel.",
                 cli.cores
             );
         }
@@ -1634,7 +1635,8 @@ fn run_ubam_output_single(
         eprintln!("JSON report: {}", json_path.display());
     }
 
-    // Run FastQC if requested (bundled fastqc-rust reads BAM natively).
+    // Run FastQC if requested. fastqc-rust dispatches on file EXTENSION
+    // (not content), so this relies on output_path ending in `.bam`.
     if cli.fastqc || cli.fastqc_args.is_some() {
         fastqc::run(
             &output_path,
@@ -1770,7 +1772,8 @@ fn run_ubam_output_paired_two_files(
         )?;
     }
 
-    // Run FastQC if requested (bundled fastqc-rust reads BAM natively).
+    // Run FastQC if requested. fastqc-rust dispatches on file EXTENSION
+    // (not content), so this relies on output_path ending in `.bam`.
     // PE uBAM output is a single interleaved BAM, so one call covers both mates.
     if cli.fastqc || cli.fastqc_args.is_some() {
         fastqc::run(
@@ -1891,7 +1894,8 @@ fn run_ubam_output_paired_single_file(
         )?;
     }
 
-    // Run FastQC if requested (bundled fastqc-rust reads BAM natively).
+    // Run FastQC if requested. fastqc-rust dispatches on file EXTENSION
+    // (not content), so this relies on output_path ending in `.bam`.
     // PE uBAM output is a single interleaved BAM, so one call covers both mates.
     if cli.fastqc || cli.fastqc_args.is_some() {
         fastqc::run(

--- a/tests/integration_ubam_out.rs
+++ b/tests/integration_ubam_out.rs
@@ -534,3 +534,66 @@ fn ubam_out_preserve_tags_all_fastq_rejected() {
         stderr
     );
 }
+
+// ─── --fastqc regression guards ─────────────────────────────────────────
+// The uBAM-output drivers previously skipped fastqc::run silently; these
+// tests portable-guard the fix at the cargo-test layer so a regression is
+// caught locally, not only in CI. fastqc-rust reads .bam natively (it
+// dispatches on file extension), so the report is produced directly from
+// the trimmed BAM output.
+
+#[test]
+fn ubam_out_se_fastqc_produces_report() {
+    let dir = fresh_tmpdir("tg_int_ubam_out_se_fastqc");
+    let status = Command::new(binary())
+        .args(["--output-format", "ubam", "--fastqc"])
+        .arg("test_files/ubam_test.bam")
+        .arg("-o")
+        .arg(&dir)
+        .status()
+        .expect("trim_galore failed to run");
+    assert!(status.success(), "trim_galore exited non-zero");
+
+    assert!(
+        dir.join("ubam_test_trimmed.bam").exists(),
+        "output BAM missing"
+    );
+    assert!(
+        dir.join("ubam_test_trimmed_fastqc.zip").exists(),
+        "FastQC zip missing — --fastqc silently skipped on the uBAM-output path"
+    );
+    assert!(
+        dir.join("ubam_test_trimmed_fastqc.html").exists(),
+        "FastQC html missing"
+    );
+}
+
+#[test]
+fn ubam_out_pe_fastqc_produces_exactly_one_report() {
+    // PE uBAM output is a SINGLE interleaved BAM, so exactly ONE FastQC
+    // report is expected (not two, as in the FASTQ paired path).
+    let dir = fresh_tmpdir("tg_int_ubam_out_pe_fastqc");
+    let status = Command::new(binary())
+        .args(["--paired", "--output-format", "ubam", "--fastqc"])
+        .arg("test_files/ubam_paired_test.bam")
+        .arg("-o")
+        .arg(&dir)
+        .status()
+        .expect("trim_galore failed to run");
+    assert!(status.success(), "trim_galore exited non-zero");
+
+    assert!(
+        dir.join("ubam_paired_test_val_fastqc.zip").exists(),
+        "FastQC zip missing"
+    );
+
+    let zips = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().ends_with("_fastqc.zip"))
+        .count();
+    assert_eq!(
+        zips, 1,
+        "expected exactly 1 FastQC zip for interleaved PE output, got {zips}"
+    );
+}


### PR DESCRIPTION
## Summary

The `run_ubam_output_*` driver functions in `src/main.rs` never called `fastqc::run`, so `--fastqc` was silently a no-op on `--output-format ubam`. The FASTQ-output path already honoured `--fastqc`. This PR wires the same guarded `fastqc::run` invocation into all three uBAM-output drivers (SE, PE two-file, PE interleaved) so the flag composes as any reader would expect.

`fastqc-rust` reads `.bam` natively (verified against the crate's `runner.rs` — `.bam`/`.ubam`/`.sam` extensions are dispatched to the BAM reader), so the report is produced directly from the trimmed BAM output. No intermediate conversion.

- SE uBAM output → one `*_trimmed_fastqc.zip` next to `*_trimmed.bam`
- PE uBAM output (single interleaved BAM) → one `*_val_fastqc.zip` next to `*_val.bam`, covering both mates. Unlike the FASTQ paired path which calls FastQC twice (once per output file), the uBAM paired path calls it once — regression-guarded by an explicit "exactly 1 zip" assertion.

## Context

Called out in the session handoff from the `--clump_only` v2 work (PR #356) as a pre-existing bug — v2's clump-only uBAM-output path correctly wires FastQC in, whereas the older trim uBAM output path did not. This closes the gap.

Independent of PRs #355 and #356 (which touch the same file); safe to merge in any order. Untouched by clump-only work — it's a defect in the trim uBAM output path that predates that feature.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [x] `cargo test` — 355 tests, 0 failed
- [x] Local smoke: `--output-format ubam --fastqc test_files/ubam_test.bam` → produces `ubam_test_trimmed_fastqc.zip` + `.html`
- [x] Local smoke: `--paired --output-format ubam --fastqc test_files/ubam_paired_test.bam` → produces exactly one `ubam_paired_test_val_fastqc.zip`
- [ ] CI `validation-ubam` job: two new smoke steps (SE + PE with `--fastqc`) assert the zip is produced and PE emits exactly one