### PR TITLE
docs: plain technical register on the index and performance pages

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -62,7 +62,7 @@ Same CLI, same output filenames, same report format — with a few capabilities 
   <div class="tg-news-item">
     <div class="num">05</div>
     <h3>Built-in FastQC</h3>
-    <p>FastQC reports run in-process via the bundled <code>fastqc-rust</code> library. No Java, no external <code>fastqc</code> binary. Pass <code>--fastqc</code> and it just works.</p>
+    <p>FastQC reports run in-process via the bundled <code>fastqc-rust</code> library. No Java, no external <code>fastqc</code> binary — <code>--fastqc</code> is the only flag required.</p>
   </div>
 </div>
 

--- a/docs/src/content/docs/performance/clumpy.md
+++ b/docs/src/content/docs/performance/clumpy.md
@@ -8,7 +8,7 @@ description: Reorder reads in the trimmed FASTQ output to make .fq.gz files sign
 `--compression <N>` sets the gzip level independently (1–9, default 1). Combine the two for maximum effect: `--clumpify --compression 9` reorders reads **and** runs gzip at its slowest/smallest level.
 
 :::note[Reorder without trimming: `--clump_only`]
-If you want the clumping compression win **without** any trimming — e.g. for lossless archival recompression — see [Clump-only (lossless reorder)](/modes/clump-only/). It uses the same clumping mechanism but skips the trim pipeline entirely, producing output records that are byte-identical to the input (header + sequence + quality untouched; only file order changes).
+For the clumping compression benefit **without** any trimming — for example, lossless archival recompression — see [Clump-only (lossless reorder)](/modes/clump-only/). It uses the same clumping mechanism but skips the trim pipeline entirely, producing output records that are byte-identical to the input (header + sequence + quality untouched; only file order changes).
 :::
 
 ## When to use it
@@ -16,7 +16,7 @@ If you want the clumping compression win **without** any trimming — e.g. for l
 ### Clumpify
 
 - ✅ Low complexity data: yes (ATAC-seq, ChIP-seq, Ribo-Seq, RNA-Seq, RRBS, high sequencing depth WES)
-- ❌ High complexity data: no (whole-genome sequencing, WGBS) - may have detrimental impact (flowcell ordering wins)
+- ❌ High complexity data: no (whole-genome sequencing, WGBS) - may degrade compression, since the native flowcell ordering already groups similar reads more effectively
 - ❌ Long reads: no (Oxford Nanopore) - has no effect
 - ❌ Unusual paired-end formats: no - can have deleterious effect
 
@@ -26,7 +26,7 @@ Whether to push up `--compression` level or not depends on what the trimmed FAST
 
 - **Pipeline intermediates** (trimmed FASTQ is ephemeral, deleted after the pipeline finishes)
     - Leave as compression level 1, but can still use `--clumpify`.
-    - The reorder is essentially free (1.0–1.4× slowdown on most data) and the smaller output makes the *next* step (typically an aligner) read less from disk — net I/O win for the whole pipeline.
+    - The reorder is essentially free (1.0–1.4× slowdown on most data) and the smaller output makes the *next* step (typically an aligner) read less from disk — a net I/O reduction across the pipeline.
 - **Long-term storage or disk-constrained workdirs**
     - Add `--compression 6` (or `--compression 9` for archival)
     - `--clumpify --compression 6` can halve output file sizes (15–50% less) but makes the run time 4–6× slower.
@@ -40,11 +40,11 @@ Whether to push up `--compression` level or not depends on what the trimmed FAST
 | **Ribo-seq (paired)** | ~45% | ✅ **Strong yes**: short ribosome-protected fragments are highly clustered |
 | **MiSeq amplicon / CRISPR / sgRNA** | 30–37% | ✅ **Strong yes**: explicit amplification produces lots of duplicates |
 | **RRBS (paired)** | ~24% at default `--memory 1G`; up to ~31% at `--memory 4G+` | ✅ **Yes**: MspI cut sites concentrate reads at fragment ends; minimizer co-clusters them. Bigger `--memory` budget gives substantial extra saving — atypical for paired-end data (most types saturate at default memory). |
-| **WGBS (paired)** | +9% — but plain `--compression 6` alone gets +19% | ❌ **No**: coverage-diverse reads, no fragment-level clustering. R2 disruption beats the R1 win at every gzip level — same mechanism as 10x scRNA-seq. Use `--compression 6` without `--clumpify` for ~19% saving |
+| **WGBS (paired)** | +9% — but plain `--compression 6` alone gets +19% | ❌ **No**: coverage-diverse reads, no fragment-level clustering. the R2 disruption outweighs the R1 gain at every gzip level — same mechanism as 10x scRNA-seq. Use `--compression 6` without `--clumpify` for ~19% saving |
 | **ChIP-seq (single-end)** | ~24% | ✅ **Yes**: peaks generate clustered reads |
 | **RNA-seq (paired)** | 16–30% | ✅ **Yes**: highly-expressed transcripts create dense clusters; bigger savings at higher gzip levels |
 | **WES / WGS (paired)** | 6–22% | 🟡 **Modest**: diverse coverage gives less clustering |
-| **scRNA-seq (10x Chromium)** | negative — output grows | ❌ **No**: R1 (cell barcode + UMI) reorders cleanly, but R2 (cDNA) follows R1's order to preserve pair lockstep and ends up scrambled vs the natural flowcell-cluster order. R2 disruption beats the R1 win. Use `--compression 6` without `--clumpify` for ~17% saving |
+| **scRNA-seq (10x Chromium)** | negative — output grows | ❌ **No**: R1 (cell barcode + UMI) reorders cleanly, but R2 (cDNA) follows R1's order to preserve pair lockstep and ends up scrambled vs the natural flowcell-cluster order. The R2 disruption outweighs the R1 gain. Use `--compression 6` without `--clumpify` for ~17% saving |
 | **Long-read (ONT, PacBio)** | ~0% | ❌ **No**: long reads are mostly unique fragments; clumpify doesn't help and adds wall time |
 | **Variable-length / mixed amplicon** | ~0% | ❌ **Skip**: diversity defeats minimizer clustering |
 
@@ -60,7 +60,7 @@ trim_galore --clumpify --compression 9 <input>
 # Compose for archival storage: max compression with extra memory
 trim_galore --clumpify --compression 9 --memory 4G <input>
 
-# Higher gzip without reordering (gzip-only win, no clumping cost)
+# Higher gzip without reordering (gzip-only saving, no clumping cost)
 trim_galore --compression 6 <input>
 ```
 

--- a/docs/src/content/docs/performance/threading.md
+++ b/docs/src/content/docs/performance/threading.md
@@ -7,7 +7,7 @@ description: Why the Rust rewrite is faster. Single-pass paired-end, worker-pool
 
 **The bottleneck is gzip, not trimming.** The actual trimming logic (adapter alignment, quality clipping) is ~5% of runtime; the other 95% is gzip compression (~60%) and decompression (~30%). Rust's speed advantage over Perl/Python only applies to that 5%.
 
-The real wins come from **architectural differences**.
+The remaining speedup is therefore architectural rather than language-level. Three changes account for it.
 
 ## 1. Single-pass vs three-pass
 
@@ -45,7 +45,7 @@ For reference, the contrast against the legacy Perl 0.6.x model at the same `-j 
 
 At Perl `-j 8` vs v2.x `--cores 8`: up to ~27 vs exactly 12 threads, yet **4.54× faster** wall and **5.93× less CPU** on the 84M-read Buckberry fixture (v2.1.0-beta.7).
 
-Parallel efficiency at Buckberry scale: 100% (cores=1) → 72% (cores=8) → 34% (cores=16) → 22% (cores=24). Scaling is near-linear up to `--cores 8`; beyond that, gzip-output I/O on the storage layer typically becomes binding before workers run out of useful per-read work, so adding cores helps progressively less. **`--cores 8` is the sweet spot for nf-core / Snakemake / CWL workflows** — also the saturation point.
+Parallel efficiency at Buckberry scale: 100% (cores=1) → 72% (cores=8) → 34% (cores=16) → 22% (cores=24). Scaling is near-linear up to `--cores 8`; beyond that, gzip-output I/O on the storage layer typically becomes binding before workers run out of useful per-read work, so adding cores helps progressively less. **`--cores 8` is the recommended setting for nf-core / Snakemake / CWL workflows**, and is also the saturation point.
 
 ## Memory profile
 
@@ -66,7 +66,7 @@ For context, mainstream multi-threaded FASTQ trimmers typically use a lot more R
 
 The pipeline is comfortably under disk-bandwidth limits at every reasonable core count. At `--cores 8` on Buckberry, total throughput is ~33 MB/s in + ~33 MB/s out (~7% of a typical SSD ceiling, trivially within spinning-disk capability), with `BufReader` averaging ~33 KB per read syscall and `BufWriter` ~114 KB per write syscall. Neither saturates kernel I/O machinery; disk is not the bottleneck for any realistic deployment.
 
-**L3 cache pressure shows up at high core counts.** Each worker's hot working set (deflate sliding window + hash chain + output batch buffer) is ~200 KB; aggregate through `--cores 16` fits comfortably within typical 16-32 MB L3, but `--cores 32` starts to press at ~13 MB combined. This is one of the contributing mechanisms behind the diminishing-returns plateau past `--cores 8` — alongside the gzip-output I/O bottleneck and the single-threaded reader/main-collector serialisation. **Stay at `--cores 8` for the sweet spot; `--cores 16` is the upper end of useful parallelism on typical x86 servers.**
+**L3 cache pressure shows up at high core counts.** Each worker's hot working set (deflate sliding window + hash chain + output batch buffer) is ~200 KB; aggregate through `--cores 16` fits comfortably within typical 16-32 MB L3, but `--cores 32` starts to press at ~13 MB combined. This is one of the contributing mechanisms behind the diminishing-returns plateau past `--cores 8` — alongside the gzip-output I/O bottleneck and the single-threaded reader/main-collector serialisation. **`--cores 8` remains the recommended setting; `--cores 16` is the upper end of useful parallelism on typical x86 servers.**
 
 ## Beyond speed
 


### PR DESCRIPTION
## Summary

Register cleanup on three pages: conversational and marketing phrasing replaced with direct statements. **No measurement, recommendation, or mechanism claim is altered** — this is wording only.

## Changes

**`index.mdx`** — the FastQC card read "Pass `--fastqc` and it just works", which is marketing copy sitting directly beside a precise technical claim (in-process, no Java, no external binary). Now states the actual requirement.

**`performance/threading.md`**
- "The real wins come from **architectural differences**" → states that the remaining speedup is architectural rather than language-level, and that three changes account for it (which the numbered sections immediately below then enumerate).
- "`--cores 8` is the **sweet spot**" (×2) → "the recommended setting".

**`performance/clumpy.md`**
- "clumping compression **win**" → "benefit"; "net I/O **win**" → "net I/O reduction"; "gzip-only **win**" → "gzip-only saving".
- "(flowcell ordering **wins**)" was carrying real explanatory load behind a colloquialism — "wins" meant *prevails over minimizer reordering*. Now spelled out: the native flowcell ordering already groups similar reads more effectively.
- "R2 disruption **beats** the R1 **win**" (×2) → "the R2 disruption outweighs the R1 gain". Same fragment-clustering-vs-coverage-diversity discriminator, stated plainly.

## Deliberately out of scope

- **`rrbs/*.md`** — carries scientific prose ported from the Perl-era README. Author's voice, left alone.
- **`reference/changelog.md`** — a synced copy of `CHANGELOG.md`; editing it desyncs the pair.
- **`modes/clump-only.md`** and **`README.md`** — same cleanup applied, but on the #356 branch, which already rewrites both files. Doing it here too would conflict.
- **Standard tech-doc headings** left as-is by request: `## When to use this` (hardtrim), `## When to use which` (poly), `## When NOT to use --rrbs`, `## What's not supported in v1` (passthrough), `## What's logged` (quality), `## What stays the same` / `## What's new in v2` (migration). These are conventional documentation headings rather than the chatty-question form.

## Test plan

- [x] `BAM\1 magic` deliberately retained — that is the correct term for a format magic number, not filler
- [x] "Shape A"/"Shape B" retained — defined terms for the two paired-end uBAM input topologies
- [ ] Astro build passes (CI)