### PR TITLE
fix(cli): distinguish mixed FASTQ+BAM pairs from two-BAM pairs (#363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,46 @@
   only fires when *every* byte is `0xFF`. Such bytes are now mapped to
   `'!'` per byte, matching the all-`0xFF` path, and any other out-of-spec
   value is clamped to the SAM maximum of 93.
+- **A `--paired` pair containing one FASTQ and one uBAM is now diagnosed
+  correctly** ([#363](https://github.com/FelixKrueger/TrimGalore/issues/363)).
+  The guard reported *"--paired with two BAM files is not supported"* for any
+  pair containing at least one BAM, and offered the single-interleaved-file
+  remediation. For a mixed pair both statements were false, and the advice was
+  misdirection: the cause is usually a mis-typed filename or an intent to pass
+  two FASTQ files, neither of which is fixed by interleaving. Mixed pairs now
+  report which input is which format and are not offered that remediation; a
+  genuine two-BAM pair keeps the message, now naming both files.
+
+  The check also moved into input validation, ahead of dispatch. Three
+  consequences on rejected runs, all improvements but all observable:
+
+  - `--output_dir` is no longer created. This applies to every affected mode.
+  - On the ordinary trimming path, adapter auto-detection no longer runs
+    first. It previously scanned up to 1 M reads per input before the
+    guaranteed rejection. The `--output-format ubam` and `--clump_only` paths
+    already rejected before detection, or perform none at all.
+  - **Multi-pair runs on the trimming and `--clump_only` FASTQ paths now fail
+    before any pair is processed.** The check previously sat inside the
+    per-pair loop there, so pairs preceding the offending one were fully
+    trimmed and their `*_val_{1,2}.fq.gz` files and trimming reports written
+    to disk. A pipeline that consumed whatever pairs succeeded before the
+    failure now gets nothing. The `--output-format ubam` paths already
+    validated every pair up-front.
+
+  The two-BAM message now also names a command that combines the two files:
+  `samtools merge -n -o interleaved.bam r1.bam r2.bam`, verified to produce a
+  mate-adjacent file TrimGalore accepts. Previously the message said only that
+  an interleaved file was expected, without saying how to make one. Note that
+  `samtools collate` is not the tool for this — it takes a single input and
+  treats its second argument as a temp-file prefix, so `collate -O r1.bam
+  r2.bam` exits successfully having written only the first file's records.
+
+  `--clump_only` on the FASTQ-output path keeps its own diagnosis (uBAM input
+  requires `--output-format ubam`, because the FASTQ output path would drop
+  aux tags): there the fix is a flag, not a re-shaped input. Behaviour is
+  unchanged for `--hardtrim5/3`, which process each input independently and so
+  are unaffected by a mixed pair, and for `--clock` / `--implicon`, which
+  continue to report their own (separate) error on such input.
 
 
 ### Version 2.3.0 (Release on 27 June 2026)

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -54,7 +54,7 @@ FastQC is built in via the bundled `fastqc-rust` library: no Java or external `f
 
 ## Unaligned BAM (uBAM)
 
-uBAM input is auto-detected — no flag needed. Paired reads may come as two BAM files or a single interleaved BAM (samtools `sort -n` / `collate` / Picard / fgbio order):
+uBAM input is auto-detected — no flag needed. Paired reads must arrive as a single interleaved BAM with mates adjacent (samtools `sort -n` / `collate` / Picard / fgbio all produce this order). Two separate BAM files are not supported and are rejected before any output is written:
 
 ```bash
 # uBAM in → FASTQ out (default)

--- a/plans/mixed-format-pair-message/PLAN.md
+++ b/plans/mixed-format-pair-message/PLAN.md
@@ -1,0 +1,536 @@
+# PLAN v2 — Accurate per-pair format rejection (#363)
+
+**Issue:** [#363](https://github.com/FelixKrueger/TrimGalore/issues/363) — *Mixed FASTQ+BAM pair under `--paired` reports "two BAM files" when only one input is a BAM*
+**Branch:** `fix/mixed-format-pair-message` off `dev`
+**Reviews incorporated:** `PLAN_review_reviewer-A.md`, `PLAN_review_reviewer-B.md` (dual independent, both verified against the code and by running the binary)
+
+**Scope decisions taken with the user:**
+
+- Message **and** guard placement, not message-only.
+- Specialty modes (`--hardtrim5/3`, `--clock`, `--implicon`) **excluded**; follow-up issue instead.
+- **Not** release-gated — the v2.4.0 cut is parked pending feedback on the usefulness of `--clump_only`.
+- Reviewer A's **mode enum** adopted over Reviewer B's minimal `fmt_flag` fix (§10 R1).
+- Already-dead code at `main.rs:498-512` **retired** in the same pass (§4 Step 7).
+
+See §12 for the revision history and what v1 got wrong.
+
+---
+
+## 1. Goal
+
+Two user-visible outcomes:
+
+1. **Correct diagnosis per input shape.** A pair containing exactly one BAM must be told that both inputs of a pair have to share a format, naming which input is which, and must *not* be offered the single-interleaved-file remediation. A pair of two BAMs keeps that remediation, because for it the advice is right. `--clump_only` on the FASTQ-output path must keep its own, better diagnosis (the problem there is BAM-on-a-FASTQ-path, not heterogeneity).
+2. **Reject before doing work.** The rejection must fire in the cheap-validation window — before adapter auto-detection, before the trimming banner, before the output directory is created, and before any pair is processed.
+
+Non-goal: changing *whether* mixed pairs are rejected. Rejection is right. Only the diagnosis and its timing change.
+
+---
+
+## 2. Context
+
+### 2.1 The two defective sites
+
+Both loop over the pair's inputs and `bail!` on the **first** BAM encountered, so the two-BAM message is emitted for any pair containing at least one BAM:
+
+| Site | Path | Reached by |
+|---|---|---|
+| `src/main.rs:1268-1278` | `run_paired` — trim, FASTQ output | `--paired <fastq> <bam>` |
+| `src/main.rs:1750-1762` | `run_ubam_output` — paired Shape A | `--paired --output-format ubam <fastq> <bam>` |
+
+Reproduced on `dev` @ `a4ffd47`, both argument orders. On the trim path the error arrives only after adapter auto-detection has run, poly-G detection has run, the banner has printed planned output paths, and the output directory has been created. Both reviewers reproduced this independently.
+
+On the uBAM-output path (`:1750`) the error fires earlier — only `ensure_output_dir` and the uBAM startup NOTEs precede it. v1 generalised one site's stderr to both; corrected here.
+
+### 2.2 The issue mis-attributes a third site
+
+`#363` lists `src/main.rs:543` as a cause site. It is not — it is the **reference implementation**. The block at `main.rs:536-558` already branches correctly, with `bail!` calls at `:542` (two-BAM) and `:551` (mixed):
+
+```rust
+if r1_is_bam && r2_is_bam { anyhow::bail!("--clump_only --paired with two BAM files …") }   // :542
+if r1_is_bam != r2_is_bam { anyhow::bail!("--clump_only --paired requires both input …") }  // :551
+```
+
+Confirmed live by both reviewers and by me. It also has regression coverage (§2.5). **The fix therefore touches two defective sites, not three**, and this one becomes redundant once the guard is hoisted (§4 Step 5). The issue will be corrected with a comment rather than silently.
+
+### 2.3 Where the new guard goes, and why there
+
+Target: `src/main.rs`, immediately after the N=1 uBAM check at `:257-263`, before the `gzip`/`output_dir` block at `:265-277`.
+
+Four properties of that position, each load-bearing:
+
+- **`input_formats` already exists.** `:182-186` detects every input's format once, explicitly so validation and dispatch can share it. The guard needs no new I/O — and removes some, since two of the three replaced guards each re-called `detect_input_format` (§6).
+- **It is the established home for format-dependent validation.** The `--phred64` guard at `:211` sits here for the reason documented at `:206-210`: *"validate() runs before input format detection and cannot see `any_bam`."* Same constraint.
+- **Preconditions are already proven.** By `:264`, `Cli::validate()` has enforced an even input count (`cli.rs:506`) and R1≠R2 per pair (`cli.rs:513`), and `main.rs:257` has rejected `--paired` + N=1 + non-BAM. So the guard sees either N=1 (a proven uBAM, correctly exempt) or an even N≥2 with distinct members.
+- **It precedes every write.** `naming::ensure_output_dir` is at `:277`; dispatch branches are all below it — hardtrim5 `:321`, clump-only `:409`, uBAM-out `:653`, paired trim `:675`. Nothing is *created* when the guard runs.
+
+Note (corrected from v1): the guard is **not** the first thing to touch the disk. `sanity_check_any(&cli.input[0])` reads at `:176` and `detect_input_format` reads every input at `:182-186`. Only the *created-nothing* half of the claim is load-bearing. A mixed pair whose R1 is an empty BAM therefore still reports the empty-BAM error, which is correct precedence.
+
+### 2.4 New precedence the hoist establishes
+
+The guard now runs ahead of all three output-collision pre-flights — paired trim (`:683`), clump-only (`:559`), uBAM-out (`:1763`). For an input that is *both* collision-prone and format-mixed, the reported error changes from the collision to the format. That is the right precedence (format is the more fundamental error) but it is a change, and it is why V8's command had to be rewritten (§9).
+
+`--passthrough` keeps its own precedence: `main.rs:251-256` rejects it against *any* BAM input, i.e. **before** `:264`. So `--paired --passthrough pt.fq <fq> <bam>` keeps its more specific message. Correct as-is; documented so a future "consistency" fix does not undo it.
+
+### 2.5 Existing test coverage, and two gaps
+
+| Test | Asserts stderr contains | Exercises |
+|---|---|---|
+| `integration_clump_only_ubam.rs:363` `rejects_two_bam_paired` | `"single interleaved"` ∨ `"uBAM paired mode expects"` | clump-only uBAM, two distinct BAMs |
+| `integration_clump_only_ubam.rs:594` `rejects_mixed_format_paired` | `"same format"` ∨ `"mixed"` | clump-only uBAM, mixed pair |
+| `integration_ubam_out.rs:443` `ubam_out_two_bam_pair_rejected` | `"two BAM files is not supported"` ∨ `"interleaved file"` | site `:1750`, two distinct BAMs |
+
+All three assert on loose substrings, which is what makes a consolidated guard viable: §3.4's message set retains every one, so **no existing test needs editing**. If any requires a change, the wording drifted too far — treat it as a review finding, not a test to update. §3.4 additionally reflows the text so no pinned substring straddles a Rust line-continuation (§3.5).
+
+**Gap 1:** nothing covers site `:1268` — plain `--paired <bam> <bam>` without `--output-format ubam`.
+**Gap 2 (the one that made v1 wrong):** nothing covers `--clump_only --paired` on the **FASTQ-output** path. `integration_clump_only.rs:303 rejects_ubam_input_without_ubam_output` looks like the guard but is **single-end**, so it exercises `clump_only.rs:265`, not `:403`.
+
+### 2.6 Explicitly out of scope
+
+Both to be filed as a separate issue, not fixed here:
+
+- `--hardtrim5 10 --paired <fastq> <bam>` **silently accepts** the mixed pair and writes output. Mechanism confirmed: `main.rs:321-345` loops `for input in &cli.input` and never consults `cli.paired`, so pairing is genuinely inert there.
+- `--clock --paired <fastq> <bam>` fails with `Paired-end files have different numbers of reads!`, misleading in the same way, and would have *proceeded* had the record counts matched.
+
+The guard must therefore **not** fire for the four specialty modes; those invocations work today and this change must not remove them. See §8 A4 for the sharpened justification.
+
+---
+
+## 3. Behavior
+
+### 3.1 Guard activation
+
+Runs when **all** hold:
+
+- `cli.paired`
+- `cli.input.len() > 1` — N=1 is single-file interleaved uBAM, already validated at `:257-263`
+- no specialty mode active: `cli.hardtrim5.is_none() && cli.hardtrim3.is_none() && !cli.clock && cli.implicon.is_none()`
+
+`cli.clump_only` is **not** excluded; it is handled by its own shape (§3.2). Field types verified: `hardtrim5`/`hardtrim3`/`implicon` are `Option<usize>` (`cli.rs:372`, `:377`, `:391`), `clock`/`clump_only`/`paired` are `bool` (`:383`, `:208`, `:89`). `cli.rs:805-814` additionally makes `--clump_only` mutually exclusive with all four specialty modes, so the exemption cannot accidentally swallow clump-only.
+
+### 3.2 Shape determination and per-pair decision
+
+The rejection differs by mode, so the helper takes a shape enum resolved once by the caller:
+
+| Shape | Condition |
+|---|---|
+| `ClumpOnlyUbamOut` | `cli.clump_only && output_format == UBam` |
+| `ClumpOnlyFastqOut` | `cli.clump_only` (FASTQ output) |
+| `TrimUbamOut` | `output_format == UBam` |
+| `Trim` | otherwise |
+
+For each `chunk` of 2 over the paired inputs, with `n_bam` = count of `InputFormat::UnalignedBam`:
+
+**`ClumpOnlyFastqOut` — predicate is `n_bam >= 1`, not mismatch.** The user's problem in this mode is BAM input on a FASTQ-output path, whether one input or both is a BAM. Emits the aux-tag message (§3.4), preserving today's behaviour exactly. This is the case v1 got wrong.
+
+**All other shapes:**
+
+| `n_bam` | Action |
+|---|---|
+| 0 | continue — all-FASTQ pair |
+| 1 | mixed-format message |
+| 2 | two-BAM message |
+
+First offending pair wins; iteration stops there. The message names the 1-based pair index **when there is more than one pair** — "Pair 1 of 1" is noise on the common case.
+
+### 3.3 Critical: the predicate is BAM-count, not format equality
+
+`InputFormat` has **three** variants (`format.rs:25-34`): `FastqPlain`, `FastqGz`, `UnalignedBam`. A naive `formats[0] != formats[1]` would reject a plain+gzipped FASTQ pair, which works today — verified: `--paired plainR1.fastq R2.fastq.gz` exits 0 and writes `plainR1_val_1.fq` + `BS-seq_10K_R2_val_2.fq`.
+
+The helper is therefore named for the BAM-count predicate, not for format equality, and §9 V12 pins the plain+gz acceptance.
+
+### 3.4 Message text
+
+Format names are rendered by a promoted `input_format_label` (§4 Step 2) — `InputFormat` has no `Display`, so `{:?}` would leak `FastqGz`/`UnalignedBam` into user-facing text. Substrings pinned by existing tests are marked ✚.
+
+**Two BAM files** (`Trim`, `TrimUbamOut`, `ClumpOnlyUbamOut`) — semantics unchanged, plus both paths and a *verified* remediation:
+
+```
+{mode} with ✚two BAM files is not supported.
+✚uBAM paired mode expects a ✚single interleaved file:
+`trim_galore {mode}{fmt_flag} interleaved.bam`.
+{Pair i of n is }two BAM files: {r1} and {r2}.
+Combine them into one mate-adjacent file first:
+`samtools merge -n -o interleaved.bam {r1} {r2}`.
+```
+
+Retains ✚`two BAM files is not supported`, ✚`single interleaved`, ✚`uBAM paired mode expects`. Names **both** files, replacing v1's *"one of them is {R1}"* — naming a single file when both are BAM was never informative.
+
+**The `samtools` command is verified, not inferred.** v1 proposed `samtools collate -O r1.bam r2.bam`, copied from `bam.rs:52-58`'s `GROUPED_INPUT_ERR`. Tested on samtools 1.21 with two 10 000-record uBAMs: it exits **0** and emits **10 000** records — `collate`'s second positional is the temp-file *prefix*, so `r2.bam` is silently consumed as a prefix and half the library is dropped with no warning. `samtools merge -n -o interleaved.bam r1.bam r2.bam` produces all 20 000 records, mate-adjacent (flags 69/133 alternating), and TrimGalore accepts the result. Reviewer A's `merge -n | collate` pipeline also works; `merge -n` alone is simpler and sufficient, because `merge -n` presumes name-sorted inputs and any FASTQ-derived uBAM is name-sorted. If a future report shows non-name-sorted inputs in the wild, `| samtools collate -O - tmp` is the verified fallback.
+
+**Mixed format** (`Trim`, `TrimUbamOut`, `ClumpOnlyUbamOut`) — the new case:
+
+```
+{mode} requires both inputs of a pair to be the ✚same format.
+{Pair i of n is }✚mixed: {r1} is {fmt1} and {r2} is {fmt2}.
+Pass two FASTQ files, or a single interleaved uBAM.
+If you meant two FASTQ files, check for a mis-typed filename.
+```
+
+Retains ✚`same format` and ✚`mixed`. Deliberately **no** bare interleaved-file imperative — for a mis-typed filename that advice misdirects, which is the substance of #363. §9 V14 pins its absence.
+
+The sentence attributes the rejection to BAM-vs-FASTQ only, so a plain-vs-gzip pair can never read as an error (§3.3).
+
+**`ClumpOnlyFastqOut`** — preserve today's text from `clump_only.rs:403-409` verbatim:
+
+```
+uBAM input under --clump_only requires --output-format ubam
+(using the FASTQ output path with uBAM input would drop aux tags).
+Input: {first_bam}
+```
+
+Verbatim preservation is deliberate: it means this mode's observable behaviour is unchanged except for firing earlier, so the new tests in §9 V13 pin today's message and would fail under v1's design.
+
+Wording constraint from a shipped feature: mixed formats *across a batch* are deliberately allowed (`integration_ubam_out.rs:340`, single-end). Hence "both inputs of **a pair**" throughout. Register per `feedback_docs_register`: plain statements, no filler, no second-person scolding.
+
+### 3.5 Rust line-continuation hazard
+
+`\` + newline in a Rust string literal consumes the newline **and all leading whitespace on the next line**. A break between `"a single"` and `"interleaved file"` therefore yields `"a singleinterleaved file"`, silently breaking `rejects_two_bam_paired`'s pinned substring. Existing code avoids this by ending each line with a space before the `\` (`main.rs:1271-1274`).
+
+**Implementation rule:** none of the four pinned substrings — `two BAM files is not supported`, `single interleaved`, `uBAM paired mode expects`, `same format` — may straddle a source-line break. V9 is the backstop, not the primary defence.
+
+### 3.6 Side effects
+
+None. No reader opened, no adapter detection, no trimming banner, no output directory, no pair processed. The version banner at `main.rs:172-174` prints unconditionally on every run and is unaffected. Exit is non-zero via `anyhow::bail!`.
+
+---
+
+## 4. Implementation outline
+
+1. **Add the shape enum and helper to `src/format.rs`** (not `main.rs` — §10 Q2 resolved). `format.rs` owns `InputFormat`, already has a unit-test module including the load-bearing bgzip-vs-BAM case, and a pure decision function over `&[InputFormat]` is its remit. `main.rs` has **zero** `#[cfg(test)]` modules (verified), so a first bin-target unit test would be off-convention. `anyhow` is a normal dependency (`Cargo.toml:32`), so the `Result` signature ports unchanged.
+
+2. **Promote `input_format_label`** from `clump_only.rs:685` (currently private) to `format.rs`, or add `impl Display for InputFormat`. Update `clump_only.rs`'s use site. This is what keeps enum variant names out of user-facing text.
+
+3. **Call the helper at `src/main.rs:264`**, after the N=1 check, before the `gzip` binding at `:272`. Gate per §3.1, resolve the shape per §3.2. Comment it in the register of the `--phred64` guard above: why here (formats known, nothing created yet), and why specialty modes are exempt.
+
+4. **Replace the defective site at `:1268-1278` with an enforced internal-invariant check**, not a bare comment. The default `--cores 1` path at `:1311` hard-codes `FastqReader::open(input_r1)`, and a BGZF BAM handed to `FastqReader` decompresses to binary and parses as FASTQ — silent wrong output, not an error. Use internal-invariant wording (e.g. *"internal error: uBAM input reached run_paired; the format guard in main() should have rejected it"* — note the enclosing function is `main.rs::run_paired`, **not** `trimmer::run_paired_end`) so §11's `grep -n 'two BAM files' src/` completion check still returns exactly one hit.
+
+5. **Delete the defective site at `:1750-1762` and the now-redundant clump-only branch at `:536-558`**, each replaced by a pointer to the hoisted guard. Keep a cheap belt-and-braces check at the two leaf functions that read the source header from **R1 only** and then open each side independently — `run_ubam_output_paired_two_files` (`main.rs:1993-1995`) and `clump_only_paired_to_bam_one_pair` Shape A (`clump_only.rs:946-958`). A mixed pair reaching either would emit a BAM mixing FASTQ-derived records (no aux tags, no source header) with BAM-derived ones, silently. The project's own convention supports this: `clump_only.rs:920-928` already carries a *"Belt-and-braces guard: main.rs::dispatch should have caught this"* check.
+
+6. **Update all four stale comments**, not the two v1 listed:
+   - `main.rs:1266-1267` — *"handled in main() before this fn is called"* (aspirational in v1; the hoist makes it true — state where).
+   - `main.rs:1309-1310` — *"paired-BAM rejected above, so both are FastqReader"* — "above" ceases to exist.
+   - `main.rs:1993-1994` — *"At this point both inputs are FASTQ"* — an invariant now maintained ~1 700 lines away.
+   - `clump_only.rs:942-945` — cites *"Format-guards in main.rs::dispatch"*; the location changes.
+
+7. **Retire the dead check at `main.rs:498-512`** (user-approved). Its condition — `clump_only ∧ UBam ∧ paired ∧ N=1 ∧ ¬BAM` — is a strict subset of `main.rs:257-263`'s, so it is already unreachable. Same family of redundancy this change retires, one branch from code already being edited.
+
+8. **Unit tests in `format.rs`'s test module** (no fixtures needed): all-FASTQ pair passes; plain+gz pair passes (§3.3); mixed rejected in both orders with the mixed message; two-BAM rejected with the two-BAM message; `ClumpOnlyFastqOut` rejects on `n_bam == 1` *and* `n_bam == 2` with the aux-tag message; multi-pair offence reports the right index; single-pair omits the index.
+
+9. **Integration tests** per §9, covering both §2.5 gaps.
+
+10. **Verify the three existing tests pass unedited.** Any failure means the wording drifted — fix the wording, not the test.
+
+11. **CHANGELOG.md** — append to the **existing** `#### Fixes` block under `### Unreleased` (`CHANGELOG.md:84`); do not add a second. Cite #363. Cover: the wording change, the earlier firing, that no output directory is created on rejection, and that **multi-pair runs no longer write partial output for pairs preceding the offending one** (§7).
+
+12. **File the follow-up issue** for §2.6 (specialty modes on mixed pairs), cross-referencing #363.
+
+---
+
+## 5. Signature
+
+```rust
+/// Which paired-input shape is being validated. Determines both the predicate
+/// and the remediation, which differ by mode: `ClumpOnlyFastqOut` rejects any
+/// BAM in the pair (its problem is BAM-on-a-FASTQ-path, not heterogeneity),
+/// while the others reject only a format mismatch or a two-BAM pair.
+pub enum PairedShape {
+    /// `--paired`, FASTQ output.
+    Trim,
+    /// `--paired --output-format ubam`.
+    TrimUbamOut,
+    /// `--clump_only --paired`, FASTQ output. Must keep the aux-tag diagnosis
+    /// from `clump_only.rs:403-409`: for this mode the fix is a flag, not a
+    /// re-shaped input, and suggesting `--paired interleaved.bam` produces a
+    /// command that `main.rs:426-432` rejects.
+    ClumpOnlyFastqOut,
+    /// `--clump_only --paired --output-format ubam`.
+    ClumpOnlyUbamOut,
+}
+
+/// Reject paired inputs whose two members disagree on being BAM.
+///
+/// The predicate is a **BAM count per pair**, not format equality:
+/// `InputFormat` has three variants, and a `FastqPlain` + `FastqGz` pair is
+/// legal (verified). Only BAM-vs-FASTQ within one pair is an error.
+///
+/// Operates on the formats detected once in `main()` (`input_formats`), so it
+/// performs no I/O and runs before any output directory is created — which is
+/// the point: the sites this replaces fired only after adapter auto-detection
+/// had scanned the inputs, the output directory existed, and (on multi-pair
+/// input) earlier pairs had already been written.
+///
+/// Callers must skip specialty modes (`--hardtrim5/3`, `--clock`,
+/// `--implicon`), which accept mixed pairs today, and must not call this for
+/// `N == 1` (single-file interleaved uBAM, validated at `main.rs:257-263`).
+///
+/// Assumes `Cli::validate()` has already enforced an even input count
+/// (`cli.rs:506`) and R1 != R2 per pair (`cli.rs:513`), and that
+/// `inputs.len() == formats.len()` — the last is `debug_assert`ed, since the
+/// `chunks(2)` indexing depends on it.
+pub fn reject_bam_format_mismatch_in_pair(
+    inputs: &[std::path::Path],
+    formats: &[InputFormat],
+    shape: PairedShape,
+) -> anyhow::Result<()>
+```
+
+The shape enum replaces v1's two opaque `&str` parameters. That is not merely tidier: it is what makes the `ClumpOnlyFastqOut` remediation expressible at all, and it removes the risk of a caller passing a `mode` string that disagrees with the actual flags.
+
+---
+
+## 6. Efficiency
+
+No measurable cost: one pass over an already-materialised `Vec<InputFormat>` of a handful of `Copy` elements, with early exit. O(N/2).
+
+Strictly *less* work than today, in three ways — the third is a correctness argument, not a performance one:
+
+1. **On rejected runs**, the whole adapter-detection scan (up to 1 M reads, `adapter.rs`) is skipped, along with poly-G detection and `ensure_output_dir`.
+2. **On all runs**, two of the three replaced guards re-called `detect_input_format` (`:1752`, `:537-538`) — a file open plus a BGZF-block decompress, twice per pair — on inputs already classified at `:182`. The third (`:1269`) is **retained** as an internal-invariant backstop (§4 Step 4), so the ordinary paired FASTQ path still pays two detections per pair. That is the deliberate trade for enforcing the invariant rather than documenting it, and the cost is per pair, not per read.
+3. **The single classification at `:182` becomes authoritative** for both validation and reader dispatch. The guard and the reader can no longer disagree about a file's format. This is the strongest argument for the hoist; v1 rested on line count.
+
+On multi-pair input the largest saving is behavioural: earlier pairs are no longer processed before the failure (§7).
+
+---
+
+## 7. Integration
+
+**Reads:** `cli.input`, `cli.paired`, the specialty flags, `cli.clump_only`, `cli.output_format`, and the pre-computed `input_formats`. **Writes:** nothing.
+
+**Order:** after `Cli::validate()`, after `sanity_check_any` (`:176`), after format detection (`:182`), after the `--phred64` (`:211`), `--preserve-tags` (`:233`), `--passthrough` (`:251`) and N=1 (`:257`) guards — before `ensure_output_dir` (`:277`), before all three collision pre-flights (§2.4), and before every dispatch branch.
+
+**Behaviour changes visible to users:**
+
+1. Mixed pairs get an accurate message instead of a false one — the point of the fix.
+2. **Multi-pair runs no longer write partial output.** Today the trim-path guard is *inside* the per-pair loop, so earlier pairs complete first. Verified on `dev`: `--paired R1.fq.gz R2.fq.gz R2.fq.gz ubam_test.bam` leaves pair 1's `BS-seq_10K_R{1,2}_val_{1,2}.fq.gz` **and both trimming reports** on disk before failing on pair 2. After the hoist that run produces nothing. Fail-fast is right — failing in a second beats failing after hours on pair 97 of 100 — but a pipeline that consumed whatever pairs succeeded now gets nothing. This is the largest change and belongs in the CHANGELOG.
+3. Rejected paired runs no longer create the output directory or run adapter detection.
+4. Rejection errors lose the `processing pair N of M` context wrapper, replaced by an explicit pair index inside the message (omitted when there is one pair).
+5. For input that is both collision-prone and format-mixed, the reported error changes from collision to format (§2.4).
+
+No accepted invocation changes. Specialty modes are untouched. `--passthrough` keeps its own earlier rejection.
+
+**No `-D warnings` exposure from the deletions:** the `format::{InputFormat, detect_input_format}` import at `main.rs:16` remains used at `:28`, `:49`, `:66`, `:185`, `:257`, `:502`, `:1851`, `:1995`.
+
+---
+
+## 8. Assumptions
+
+- **A1.** `detect_input_format` is authoritative and content-based (`format.rs:40-77`), so `bgzip`-framed FASTQ classifies as FASTQ, not BAM — guarded by `detect_bgzipped_fastq_is_fastq_not_bam`. The guard adds no format logic of its own. Fixed rule.
+- **A2.** `Cli::validate()` guarantees an even input count for paired mode (`cli.rs:506`) with the N=1 carve-out (`cli.rs:503`), and R1≠R2 per pair (`cli.rs:513`). Reachability also verified: `validate_paired_input("Paired-end")` is invoked at `cli.rs:596` under plain `if self.paired`, so it covers `--clump_only --paired` too — which the guard's coverage of clump-only depends on.
+- **A3.** `--paired` + N=1 is legal only for uBAM and is rejected otherwise at `main.rs:257-263`. Verified: `--paired <interleaved.bam>` with FASTQ output succeeds, so §3.4's "or a single interleaved uBAM" hint is valid on the trim path. It is **not** valid on the clump-only FASTQ path (`main.rs:426-432` rejects it), which is why `ClumpOnlyFastqOut` exists.
+- **A4.** Excluding specialty modes is a user-confirmed departure from #362's *"rejected uniformly rather than per-mode"* reasoning, and the justification differs by mode:
+  - `--hardtrim5/3` — genuinely harmless. `main.rs:321-370` never consults `cli.paired`, so pairing is inert and each file is processed independently. Confirmed live.
+  - `--clock` / `--implicon` — **not** harmless. These do pair, and `--clock` today fails with a misleading read-count error and would have proceeded on equal counts. Their exemption is *"out of scope for this PR"*, not *"correct as-is"*. The follow-up issue (§4 Step 12) is doing real work and is not optional.
+- **A5.** Existing loose `contains` assertions (§2.5) are satisfied by §3.4's wording — verified by substring inspection, and re-verified by running (V9), not by re-reading the strings. §3.5 is the specific way this can still fail.
+- **A6.** Rejection remains correct for mixed pairs, and the accepting path is further from working than v1 implied. Both `FastqReader` and `BamReader` implement `RecordSource`, but only the `--cores > 1` branch is format-polymorphic (`:1283-1284` `open_threaded_reader`); the **default** serial branch hard-codes `FastqReader::open` (`:1311`). And both two-file leaf functions take the source header from R1 alone, so a mixed pair "processed" would mean a BAM with a header from one arbitrary side. Rejection is not merely the likelier-intent call — the accepting path does not exist in a correct form. This is also the argument for Step 5's belt-and-braces checks. Worded carefully so no future reader takes A6 as "it nearly works already".
+- **A7.** `inputs.len() == formats.len()`. This is what the `chunks(2)` indexing actually relies on, and it was unstated in v1. `debug_assert_eq!` in the helper.
+
+---
+
+## 9. Validation
+
+Run from the crate root; `cargo build --release` first — `cargo clippy` leaves the binary stale (handoff §5). Note `CARGO_BIN_EXE_trim_galore` (`integration_clump_only_ubam.rs:16`) means `cargo test` always builds the binary it exercises, so V9/V10 cannot pass against a stale build; the manual V1–V8 runs are what need the explicit build.
+
+| # | Verify | How | Expected |
+|---|---|---|---|
+| V1 | Mixed pair, both orders, gets the mixed message | `--paired <fq> <bam>` and `--paired <bam> <fq>` | Non-zero; "both inputs of a pair"/"same format"; names both files with their formats |
+| V2 | Two distinct BAMs keep the two-BAM message | `--paired <bam1> <bam2>` | Non-zero; "two BAM files is not supported" + interleaved remediation + the `samtools merge -n` hint |
+| V3 | **No side effects on rejection** — the §1 outcome most easily lost in a refactor | Automated: pass `-o <fresh_tmpdir>/nested`, assert `!nested.exists()`. **Gotcha:** `fresh_tmpdir` (`integration_ubam_out.rs:28-32`) does `create_dir_all`, so passing it directly guarantees existence and the check would be vacuous | Directory absent; stderr shows no adapter-detection, poly-G, or trimming-banner lines |
+| V4 | uBAM-output path fixed too | V1 and V2 with `--output-format ubam` | Same messages, mode-appropriate remediation |
+| V5 | clump-only **uBAM-output** messages did not regress after deleting `:536-558` | `--clump_only --paired --output-format ubam` with mixed, then two BAMs | Mixed → mixed message; two-BAM → two-BAM message; remediation names `--clump_only --paired --output-format ubam` |
+| V6 | Legal invocations unaffected | Paired FASTQ pair; `--paired one.bam`; multi-pair FASTQ (N=4, distinct paths) | All succeed, output unchanged |
+| V7 | Specialty modes untouched | `--hardtrim5 10 --paired <fq> <bam>`; `--clock --paired <fq> <bam>` | Byte-identical to `dev` — hardtrim writes output and exits 0; clock still reports its read-count error |
+| V8 | Multi-pair offence names the right pair | `--paired R1.fq.gz R2.fq.gz R2.fq.gz <bam>`. The property that matters is **distinct output paths**, not distinct inputs: v1's `<fq> <fq> <fq> <bam>` collided on output and tripped the collision pre-flight first, so post-fix it would have flipped to the guard and been recorded as a pass while actually testing precedence, not indexing. Reusing `R2.fq.gz` as pair 1's R2 and pair 2's R1 is fine — the four outputs differ and within-pair R1≠R2 holds | Rejected naming **pair 2 of 2** |
+| V9 | Existing tests pass **unedited** | `cargo test rejects_two_bam_paired rejects_mixed_format_paired ubam_out_two_bam_pair_rejected` | 3 passed, zero diff in `tests/` for these three |
+| V10 | Full suite + lint | `cargo test`; `cargo fmt --all -- --check`; `cargo clippy --all-targets --release -- -D warnings` | 421 + new tests pass; zero warnings |
+| V11 | Validation matrix untouched | md5 the PE (`BS-seq_10K_R{1,2}_val_{1,2}.fq.gz`), SE, hardtrim5 and clock outputs **before** touching code; re-compare after | Identical md5s. The guard only ever rejects, so this is belt-and-braces — but V11 is on the do-not-skip list, so make it a measurement, not an inspection |
+| **V12** | **Plain+gz FASTQ pair still accepted** — the §3.3 regression a naive `formats[0] != formats[1]` would cause | `--paired plainR1.fastq R2.fastq.gz` | Exit 0; `plainR1_val_1.fq` + `BS-seq_10K_R2_val_2.fq` written (verified working on `dev`) |
+| **V13** | **`--clump_only` FASTQ-output paired keeps today's diagnosis** — closes §2.5 gap 2 and is the test that would have failed under v1 | `--clump_only --paired <fq> <bam>` and `--clump_only --paired <bam1> <bam2>`, both **without** `--output-format ubam` | Non-zero; stderr contains `--output-format ubam` and `drop aux tags`; must **not** suggest `--paired interleaved.bam` |
+| **V14** | **The absent substring is pinned** — #363's substance | Mixed-pair test asserts `!stderr.contains("uBAM paired mode expects")` | Passes. Without this, the two messages can silently re-converge in a later refactor |
+| **V15** | **No partial multi-pair output** | Run V8's command with `-o <fresh>/nested`; assert no `_val_*` and no `*_trimming_report.txt` for pair 1 | None present (they *are* present on `dev` — verified) |
+| **V16** | Format labels are human-readable | Any mixed-pair stderr | Contains `uBAM`; does **not** contain `UnalignedBam` or `FastqGz` |
+| **V17** | Site `:1268` covered — closes §2.5 gap 1 | `--paired <bam1> <bam2>` **without** `--output-format ubam`, as an integration test | Non-zero with the two-BAM message |
+
+V3, V9, V11, V13, V15 are the ones that would quietly stop holding. Do not mark any of them "doesn't apply" — if a check appears not to apply, run it down. That discipline is what surfaced FastQC-Rust#6 and, this round, the silently-destructive `samtools` hint.
+
+---
+
+## 10. Questions or ambiguities
+
+**Resolved since v1:**
+
+- **R1 — fix shape for the Critical.** Reviewer A's mode enum adopted over Reviewer B's `fmt_flag` derivation (user-confirmed). B's version produces a *valid* command but still leads with "your pair is heterogeneous" when the user's actual problem is BAM-on-a-FASTQ-path — a point B's own report concedes while recommending otherwise. The enum preserves the aux-tag *reason*, which is the actionable part.
+- **R2 — helper placement (v1 Q2).** `src/format.rs`. `main.rs` has zero `#[cfg(test)]` modules (verified), so a first bin-target unit test would be off-convention; `format.rs` owns `InputFormat` and has an existing test module.
+- **R3 — `{fmt}` rendering.** Promote `input_format_label` (`clump_only.rs:685`) to `format.rs`. `{:?}` would leak enum variant names.
+- **R4 — the `samtools` hint.** Replaced with `samtools merge -n`, verified end-to-end on samtools 1.21. v1's `collate` form silently drops half the library (§3.4).
+- **R5 — dead code at `main.rs:498-512`.** Retired in this pass (user-approved).
+
+**Open (assumption taken, no blocker):**
+
+1. **Whether the mixed message distinguishes plain from gzipped FASTQ.** Taken: label them distinctly (`FASTQ (plain)` / `FASTQ (gzip)`) since `input_format_label` already does, but attribute the rejection to BAM-vs-FASTQ in the sentence so a plain+gz pair can never read as an error. V12 + V16 guard both halves.
+2. **Pair index on single-pair runs.** Taken: omit when `n == 1`. House style at `main.rs:772-780` does print it, so either choice is defensible; "Pair 1 of 1" is noise on the common case.
+3. **`Cli::validate_formats(&self, &[InputFormat])` as the eventual home** for all five format-dependent guards now inline in `main.rs` (`:211`, `:233`, `:251`, `:257`, and this one). `main.rs` is ~2 400 lines and validation logic is what a maintainer looks for in `cli.rs`. Out of scope here; recorded as the direction of travel.
+
+**Critical:** none outstanding.
+
+---
+
+## 11. Self-Review
+
+**Efficiency.** No hot path touched. Strictly less work on rejected runs, less I/O on all runs, and a correctness gain from single-source format classification (§6).
+
+**Logic.** Traced against every paired entry point: trim FASTQ (`:1268`), trim uBAM output (`:1750`), clump-only uBAM (`:536-558`), clump-only FASTQ (`:426` N=1 + `clump_only.rs:399-410` N≥2), and the four specialty modes (exempt). Non-applicable paths checked rather than assumed: `--demux` is rejected with `--paired` at CLI level; `--passthrough` is rejected against any BAM at `:251-256`, i.e. earlier; `--retain_unpaired` has no format interaction. `run_paired` and `run_ubam_output` each have exactly one caller.
+
+**Edge cases.** N=1 interleaved uBAM (exempt, A3); N=1 non-BAM (rejected at `:257`); odd N (rejected at `cli.rs:506`); R1==R2 (rejected at `cli.rs:513` — which is why `rejects_two_bam_paired` copies its fixture, per its own comment); **plain+gz pair (V12 — the regression a naive predicate would cause)**; multi-pair offence in a later pair (V8, V15); mixed in both argument orders (V1); `bgzip`-framed FASTQ (A1); empty `cli.input` (unreachable — `:176` indexes `[0]` first); empty BAM as R1 (keeps the empty-BAM error, correct precedence, §2.3).
+
+**Integration.** Five user-visible changes enumerated in §7, up from three in v1; the multi-pair partial-output change is the largest and was missing.
+
+**Remaining risks.**
+
+- *Low:* wording drift breaks an existing test. Mitigated by V9, §3.5's line-break rule, and the fix-the-wording-not-the-test rule.
+- *Low:* a future addition to §3.1's exemption list reopens the silent-wrong-output path at the two R1-header leaf functions. Mitigated by Step 5's belt-and-braces checks — which is why they are not optional.
+- *Very low:* an unenumerated paired entry point still carries a stale guard. Mitigated by V5–V7 and by `grep -n 'two BAM files' src/` returning exactly one hit afterwards (Step 4's internal-invariant wording keeps that grep meaningful).
+
+---
+
+## 12. Revision history
+
+### v2 — 2026-07-26, after dual independent plan review
+
+**One Critical, from both reviewers independently, against v1's own claim.** v1 §11 recorded having traced the clump-only FASTQ-output path as *"unaffected — confirmed live, case D"*. Only the **N=1** shape is unaffected. For N≥2 the hoisted guard preempts `clump_only.rs:403-409` and replaces a correct, actionable message with a remediation `main.rs:426-432` rejects — the exact failure mode #363 is about, recreated in another mode. v1's live check exercised N=1 and generalised. Fixed by the `PairedShape` enum (§3.2, §5); pinned by V13, which had zero coverage before.
+
+**Corrections to v1's own claims:**
+
+| v1 said | Actually |
+|---|---|
+| clump-only FASTQ path "unaffected" | Only N=1; N≥2 was preempted (the Critical) |
+| `samtools collate -O r1.bam r2.bam` interleaves two BAMs | Exits 0 and emits **half** the records — `collate`'s 2nd positional is the temp prefix. Replaced with verified `samtools merge -n` |
+| §7 listed three behaviour changes | Five. The missing one — multi-pair runs no longer write partial output — is the largest |
+| "Nothing has been created or read when the guard runs" | `sanity_check_any` and `detect_input_format` both read first; only "created" is load-bearing |
+| Helper named for format equality | Predicate is BAM *count*; `InputFormat` has 3 variants and plain+gz pairs are legal (V12) |
+| V8's `<fq> <fq> <fq> <bam>` tests pair indexing | Repeated path trips the collision pre-flight; post-fix it would flip to the guard and pass while testing the wrong thing |
+| A6: "a mixed pair could be processed" | Only on `--cores > 1`; the default serial path is `FastqReader`-only |
+| A4: specialty modes are harmless | True for hardtrim; `--clock`/`--implicon` do pair and are merely out of scope |
+| Two stale comments to update | Four (`main.rs:1309-1310` and `:1993-1994` were missed) |
+| Q2 (helper placement) open | Resolved: `format.rs`; `main.rs` has no test module |
+| Line refs `:543`/`:552`, "~:300", `clump_only.rs:940-944` | `:542`/`:551`, `:321`, `clump_only.rs:942-945` |
+
+**Added:** `PairedShape` enum; promoted `input_format_label`; enforced internal-invariant checks at three callees instead of comments; §2.4 pre-flight precedence; §3.5 Rust line-continuation rule; A7; V12–V17; retirement of dead code at `:498-512`.
+
+### v1 — 2026-07-25
+
+Initial plan. Correct on the core diagnosis (two defective sites, not the three the issue names), the guard position, and `Cli::validate()`'s preconditions — all independently confirmed by both reviewers.
+
+---
+
+## 13. Implementation notes
+
+**Implemented 2026-07-26** on branch `fix/mixed-format-pair-message` off `dev` @ `a4ffd47`. All 12 outline steps done except Step 12 (follow-up issue), which is outward-facing and awaiting the user's go-ahead.
+
+### What was built
+
+| File | Change |
+|---|---|
+| `src/format.rs` | `PairedShape` enum + `reject_bam_format_mismatch_in_pair` + promoted `pub fn input_format_label`; 9 unit tests |
+| `src/main.rs` | Guard wired in after the N=1 check; two defective sites replaced (one by an internal-invariant backstop, one deleted); dead Shape-B check retired; belt-and-braces check at `run_ubam_output_paired_two_files`; 3 stale comments rewritten |
+| `src/clump_only.rs` | Private `input_format_label` removed in favour of the promoted one; belt-and-braces check + comment rewrite on Shape A |
+| `tests/integration_paired_format_guard.rs` | **New**, 11 tests |
+| `CHANGELOG.md` | Appended to the existing `#### Fixes` block |
+
+Net: 441 tests, up from 421.
+
+### Deviations from the plan
+
+1. **Signature — `&[PathBuf]`, not `&[Path]`.** §5 specified `inputs: &[std::path::Path]`, which cannot compile: `Path` is unsized, so `[Path]` is not a valid slice element type. Used `&[std::path::PathBuf]`, which is what `cli.input` already is. Mechanical correction, no design impact.
+
+2. **Pair prefix reads `"Got "` on a single pair, not `""`.** §3.2 said to omit the index when there is one pair. Implemented literally first, and the smoke test showed the result reads as a fragment: *"…`interleaved.bam`. two BAM files: A and B."* The clause needs a subject, so a single pair now yields *"Got two BAM files: A and B"* / *"Got mixed: …"* and multi-pair yields *"Pair 2 of 3 is …"*. Caught by reading the output rather than by a test — worth noting, since no assertion would have failed.
+
+3. **Both defective sites did not get identical treatment.** §4 Step 4/5 anticipated this, but to be explicit: `run_paired`'s site was *replaced* with an enforced internal-invariant `bail!` (the sequential path below it hard-codes `FastqReader::open`, and `--cores 1` is the default), while `run_ubam_output`'s was *deleted* outright — its downstream leaf already receives an equivalent check.
+
+4. **`grep -n 'two BAM files' src/` returns 4 lines, not 1.** §11's completion check expected one hit. All four are inside `format.rs`: one comment, two in the single message literal, one test assertion. The intent — no stale copy of the message outside the shared helper — holds; the literal count was mis-stated in the plan.
+
+### Validation results
+
+| Check | Result |
+|---|---|
+| V1 mixed message, both orders | Pass — names both inputs with `FASTQ (plain)` / `uBAM` labels |
+| V2 two-BAM message + hint | Pass — `samtools merge -n`, both files named |
+| V3 no side effects | Pass — output dir absent, no adapter-detection or banner lines. Automated |
+| V4 uBAM-output path | Pass |
+| V5 clump-only uBAM messages | Pass — remediation echoes `--clump_only --paired --output-format ubam` |
+| V6 legal invocations | Pass — PE pair, single interleaved uBAM, multi-pair N=4 (4 outputs) |
+| V7 specialty modes | Pass — hardtrim writes output and exits 0; `--clock` still reports its own read-count error |
+| V8 multi-pair index | Pass — *"Pair 2 of 2 is mixed"*; three distinct input paths yielding four distinct outputs (see §13 deviation 5) |
+| V9 existing tests unedited | Pass — 3/3, and `git diff --stat tests/` is empty |
+| V10 suite + fmt + clippy | Pass — 441 tests, `fmt --check` clean, `clippy -D warnings` clean |
+| V11 validation matrix | Pass — all 6 baseline outputs (PE ×2, SE, hardtrim5, clock ×2) byte-identical to pre-change md5s |
+| V12 plain+gz accepted | Pass — unit + integration |
+| V13 clump-only FASTQ diagnosis | Pass — all three shapes keep the aux-tag message; no `interleaved.bam` suggestion |
+| V14 absent substring pinned | Pass — `!contains("uBAM paired mode expects")` on the mixed message |
+| V15 no partial multi-pair output | Pass — output dir absent after an N=4 rejection |
+| V16 human-readable labels | Pass — `uBAM` present, `UnalignedBam`/`FastqGz` absent |
+| V17 site `:1268` covered | Pass — `two_bam_pair_keeps_interleave_remediation` |
+
+### Iteration log
+
+**#1 — `samtools` hint verified before shipping (pre-implementation).** The plan flagged v1's `samtools collate -O r1.bam r2.bam` as wrong on Reviewer A's reading that `collate` cannot take two inputs. Tested on samtools 1.21 against two 10 000-record uBAMs: it exits **0** and emits **10 000** records, silently consuming `r2.bam` as the temp prefix — worse than the error A predicted. `samtools merge -n -o interleaved.bam r1.bam r2.bam` yields all 20 000 records, mate-adjacent (flags 69/133), and TrimGalore accepts the result. An earlier attempt at this check was itself invalid: both fixtures were built with `samtools import -1`, so both claimed READ1 and TrimGalore rejected the merge for non-adjacent mates. Rebuilt with `-1`/`-2` before concluding anything.
+
+**#2 — single-pair message read as a fragment.** See deviation 2. Changed the empty prefix to `"Got "`; re-verified all seven shapes by hand.
+
+**#3 — `cargo fmt` reflowed three assertions in `format.rs`.** Cosmetic; clippy was already clean. Re-ran the full suite after formatting — 441 still passing.
+
+### Follow-ups
+
+- **Not done: Step 12**, the follow-up issue for `--hardtrim5/3` silently accepting mixed pairs and `--clock` reporting a misleading read-count error (§2.6). Awaiting go-ahead — filing an issue is outward-facing.
+- **Not done:** the correcting comment on #363 itself, noting that `main.rs:542` was the reference implementation rather than a third defect (§2.2). Same reason.
+- Nothing committed or pushed.
+
+---
+
+## 14. Verification round — dual code review + coverage audit
+
+Ran 2026-07-26 after implementation: two independent code reviewers plus a plan-manager coverage audit, all in fresh contexts, each told to treat §13 as a claim to verify.
+
+- `CODE_review_reviewer-A.md`, `CODE_review_reviewer-B.md`, `COVERAGE.md`.
+- **Coverage verdict: INCOMPLETE — 1 item**, that item being Step 12 (the user-gated follow-up issue). 45 items audited: 42 DONE, 0 PARTIAL, 1 MISSING, 2 DEVIATED (both already documented). Every §9 check was independently re-run and matched §13 in every row.
+- **V11 was upgraded from deductive to empirical.** Reviewer A built `dev` @ `a4ffd47` in a throwaway worktree with a separate `--target-dir` and md5-compared 15 outputs across PE, SE, `--hardtrim5`, `--clock`, `--demux` and `--clump_only`: identical. That closes the gap the coverage audit had declared (it could not reach the pre-change baselines).
+
+### Defects found in the implementation, and fixed
+
+| # | Found by | Defect |
+|---|---|---|
+| 1 | **Both** | **The CHANGELOG asserted a bug that never shipped.** The entry claimed the old two-BAM message "suggested `samtools collate -O r1.bam r2.bam`". It never did — `git show a4ffd47:src/main.rs` shows all three shipped two-BAM messages ending at *"Got two BAM files; one of them is {}"* with **no** `samtools` command. The destructive two-input `collate` form existed only in this plan's v1 draft, corrected before implementation. Shipping the paragraph would have told users TrimGalore once printed a silently-lossy command, and could have cast doubt on the *correct* one-input `collate` hint in `bam.rs:57`. Rewritten to describe what actually changed. Reviewer A also caught a second false claim in the same paragraph — that `--clock`/`--implicon` "accept mixed pairs today", which they do not |
+| 2 | **Both** | The internal-invariant message named `run_paired_end`; the enclosing function is `run_paired` (`trimmer::run_paired_end` is a different function named in `CLAUDE.md`). §4 Step 4 specified the wrong name verbatim, so the plan carried it in. Corrected in both plan and code |
+| 3 | B | **A fifth stale comment**, missed by Step 6's list of four: `run_ubam_output_paired_two_files` still carried *"Two-file paired-BAM rejection lives up-front in `run_ubam_output`"* — pointing at the loop this change deletes, three lines above the new backstop comment that says the opposite. Deleted |
+| 4 | B | `multi_pair_names_the_offending_pair_and_writes_nothing` asserted `contains("Pair 2 of 2")`, which the per-pair progress banner `=== Pair 2 of 2 ===` also satisfies — so a regression where the guard stopped firing and the run *proceeded* would still have matched. Tightened to `"Pair 2 of 2 is mixed"`, which only the guard can produce |
+
+### Recommendations adopted
+
+| # | Found by | Change |
+|---|---|---|
+| 5 | **Both** | `debug_assert_eq!` → `anyhow::ensure!` + `chunks_exact(2)`. Release builds set no `debug-assertions`, so the assert compiled out of every shipped binary, and Reviewer A identified the worse of the two failure modes: a short `formats` makes `zip` truncate, so later pairs go unexamined and the function returns `Ok(())` **without having checked** — a validation guard that silently passes, precisely the failure class it exists to prevent. Now also checks evenness. Deviates from §5/A7, which specified `debug_assert` |
+| 6 | **Both** | Both leaf backstops widened from *mismatch* to *any BAM*. The code they replaced rejected any BAM; narrowing to a mismatch check half-met the stated intent, since a two-BAM pair reaching either leaf would silently discard R2's `@HD`/`@PG` chain and tag dictionary — the same "header from R1 only" hazard the backstops exist for. `n_bam == 0` is the invariant main()'s guard actually establishes for those shapes |
+| 7 | A | The negative `samtools` assertion pinned the full `collate -O <fixture> <fixture>` string — a spelling that never existed and that a fixture rename would have turned into a tautology. Now asserts the property: `!contains("samtools collate")` |
+| 8 | B | The CHANGELOG's three consequences were stated as applying to all four shapes. Only `--output_dir` does. Adapter detection ran before the old rejection **only** on the ordinary trim path, and the no-partial-output change applies to trim and `--clump_only` FASTQ but not the two uBAM-out paths, which already validated every pair up-front. Scoped per bullet. **Same generalisation error §2.1 records as one of v1's, recurring in a different file** |
+| 9 | A | `anyhow::bail!` → `bail!` in `clump_only.rs`, which imports `bail` and uses the bare form in the adjacent Shape B backstop |
+
+### Plan-text corrections from this round
+
+`{fmt_hint}` removed from §3.4 (a placeholder the plan never defined; the implementation renders it empty — flagged by both reviewers *and* the coverage audit); §2.1/§4/§11/§13 `run_paired_end` → `run_paired`; §9 V8's "four distinct paths" restated as the property that actually matters, distinct **output** paths (the test passes three distinct inputs, and Reviewer A independently confirmed with four genuinely distinct paths that the index is still correct, so no test change was needed); §2.3/§6's "three deleted re-detections" corrected to two of three, since `:1269`'s was deliberately retained as the backstop.
+
+### Deviations added to the §13 list
+
+5. **`{fmt_hint}` dropped** from the mixed message (§3.4). Harmless — both legal alternatives are already named for every shape that emits the message — but it was an undocumented divergence from the plan text.
+6. **`anyhow::ensure!` instead of `debug_assert`** (§5, A7). See item 5 above; the plan's choice would have compiled out of release builds.
+7. **Leaf backstops enforce `n_bam == 0`, not mismatch** (§4 Step 5). See item 6 above.
+
+### Not adopted, surfaced to the maintainer instead
+
+- **`docs/src/content/docs/quickstart.md:57` states *"Paired reads may come as two BAM files"*, which is false** — the binary rejects it, and this change makes the rejection more emphatic. Pre-existing on `dev` and outside this diff, so Reviewer A deliberately did not touch it. #363 is arguably the right issue to close it under.
+- **Multi-pair `ClumpOnlyFastqOut` omits the pair index** (B Low-3): `pair_prefix` is computed but that arm bails before using it. A direct consequence of §3.4's decision to preserve the message verbatim, which is what makes V13 a pure regression test. Left as-is deliberately; changing it would weaken that property.
+- Editorial nits: `Got mixed:` → `Got a mixed pair:` (A), `Pair 2 of 2 is two BAM files` → `contains two BAM files` (B). Both grammatical as they stand; the shared prefix makes the second awkward to apply.
+- **`Cli::validate_formats(&self, &[InputFormat])`** as the eventual home for all five format-dependent guards now inline in `main.rs` (§10 open item 3). Still out of scope.
+
+### Process note
+
+Both reviewers edited the same working tree concurrently; two of B's `Edit` calls collided with A's, and one fix was applied by both. Reviewer B correctly warned that neither report is a complete account of the tree. Every fix above was therefore re-verified directly against the working tree rather than taken from either report, and the full suite, `fmt`, `clippy` and the V11 md5 comparison were re-run after the final edit: **441 tests passing, fmt and clippy clean, all 6 baseline outputs still byte-identical.** For future rounds, dual reviewers should either review read-only or work on separate worktrees.

--- a/src/clump_only.rs
+++ b/src/clump_only.rs
@@ -48,7 +48,7 @@ use crate::clump::{
 };
 use crate::fastq::{FastqReader, FastqRecord, RecordSource};
 use crate::fastqc;
-use crate::format::{InputFormat, detect_input_format};
+use crate::format::{InputFormat, detect_input_format, input_format_label};
 use crate::io as naming;
 use noodles::sam::Header as BamHeader;
 
@@ -681,15 +681,6 @@ pub fn expected_output_paths_paired(
 // dispatcher as v1, and on flush write mate-adjacent records via
 // paired_side=None (SE) or paired_side=Some(1)/Some(2) (PE interleaved).
 
-/// Format label for the report (`"FASTQ (plain)"` / `"FASTQ (gzip)"` / `"uBAM"`).
-fn input_format_label(fmt: InputFormat) -> &'static str {
-    match fmt {
-        InputFormat::FastqPlain => "FASTQ (plain)",
-        InputFormat::FastqGz => "FASTQ (gzip)",
-        InputFormat::UnalignedBam => "uBAM",
-    }
-}
-
 /// True iff the input format is compression-quantifiable (`gzip` or `BGZF`).
 fn input_is_compressed(fmt: InputFormat) -> bool {
     matches!(fmt, InputFormat::FastqGz | InputFormat::UnalignedBam)
@@ -939,13 +930,34 @@ pub fn clump_only_paired_to_bam_one_pair(
             input_bytes_total: in_bytes,
         }
     } else {
-        // Shape A: two files. Format-guards in main.rs::dispatch reject
-        // two-BAM Shape A and mixed-format Shape A; this function assumes
-        // both files share a compatible format (both FASTQ, or both uBAM
-        // — though the latter is currently rejected upstream).
+        // Shape A: two files. `format::reject_bam_format_mismatch_in_pair`,
+        // called from main() before dispatch, rejects two-BAM Shape A and
+        // mixed-format Shape A, so both files share a compatible format here.
+        //
+        // Internal-invariant backstop (#363): the header below comes from R1
+        // alone while each side is opened by its own per-file detection, so any
+        // BAM reaching this two-file branch is wrong output rather than an error.
+        // A mixed pair would emit a BAM silently mixing FASTQ-derived records
+        // (no aux tags, no source header) with BAM-derived ones; a two-BAM pair
+        // would silently discard R2's @HD/@PG chain and tag dictionary. The
+        // enforced predicate is therefore "no BAM at all", matching the invariant
+        // main()'s guard actually establishes for Shape A — and matching the
+        // breadth of the code this replaced. Interleaved single-BAM input is
+        // legal and takes the Shape B branch above, not this one.
         let r1_path = &inputs[0];
         let r2_path = &inputs[1];
         let fmt = detect_input_format(r1_path)?;
+        let fmt_r2 = detect_input_format(r2_path)?;
+        if matches!(fmt, InputFormat::UnalignedBam) || matches!(fmt_r2, InputFormat::UnalignedBam) {
+            bail!(
+                "internal error: uBAM input reached clump_only_paired_to_bam_one_pair \
+                 Shape A ({} and {}); the paired format guard in main() should have \
+                 rejected it. Please report this at \
+                 https://github.com/FelixKrueger/TrimGalore/issues",
+                r1_path.display(),
+                r2_path.display()
+            );
+        }
         let header = if matches!(fmt, InputFormat::UnalignedBam) {
             Some(peek_header(r1_path)?)
         } else {

--- a/src/format.rs
+++ b/src/format.rs
@@ -33,6 +33,173 @@ pub enum InputFormat {
     UnalignedBam,
 }
 
+/// Human-readable label for an input format, for use in user-facing messages.
+///
+/// `InputFormat` deliberately has no `Display` impl: `{:?}` would put internal
+/// variant names (`FastqGz`, `UnalignedBam`) into error text. Promoted here
+/// from `clump_only.rs` so every module renders formats the same way.
+pub fn input_format_label(fmt: InputFormat) -> &'static str {
+    match fmt {
+        InputFormat::FastqPlain => "FASTQ (plain)",
+        InputFormat::FastqGz => "FASTQ (gzip)",
+        InputFormat::UnalignedBam => "uBAM",
+    }
+}
+
+/// Which paired-input shape is being validated. Determines both the predicate
+/// and the remediation, which differ by mode: `ClumpOnlyFastqOut` rejects any
+/// BAM in the pair (its problem is BAM-on-a-FASTQ-path, not heterogeneity),
+/// while the others reject only a format mismatch or a two-BAM pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairedShape {
+    /// `--paired`, FASTQ output.
+    Trim,
+    /// `--paired --output-format ubam`.
+    TrimUbamOut,
+    /// `--clump_only --paired`, FASTQ output. Keeps the aux-tag diagnosis that
+    /// `clump_only.rs` uses for this shape: the fix here is a *flag*, not a
+    /// re-shaped input, and suggesting `--paired interleaved.bam` would print a
+    /// command that `main.rs`'s clump-only N=1 guard rejects.
+    ClumpOnlyFastqOut,
+    /// `--clump_only --paired --output-format ubam`.
+    ClumpOnlyUbamOut,
+}
+
+impl PairedShape {
+    /// The mode flags to echo back in a remediation command.
+    fn mode(self) -> &'static str {
+        match self {
+            PairedShape::Trim | PairedShape::TrimUbamOut => "--paired",
+            PairedShape::ClumpOnlyFastqOut | PairedShape::ClumpOnlyUbamOut => {
+                "--clump_only --paired"
+            }
+        }
+    }
+
+    /// The output-format flag to echo back, so a pasted remediation reproduces
+    /// the user's own mode.
+    fn fmt_flag(self) -> &'static str {
+        match self {
+            PairedShape::TrimUbamOut | PairedShape::ClumpOnlyUbamOut => " --output-format ubam",
+            PairedShape::Trim | PairedShape::ClumpOnlyFastqOut => "",
+        }
+    }
+}
+
+/// Reject paired inputs whose two members disagree on being BAM.
+///
+/// The predicate is a **BAM count per pair**, not format equality:
+/// `InputFormat` has three variants, and a `FastqPlain` + `FastqGz` pair is
+/// legal. Only BAM-vs-FASTQ within one pair is an error.
+///
+/// Operates on the formats detected once in `main()`, so it performs no I/O and
+/// runs before any output directory is created — which is the point. The sites
+/// this replaces fired only after adapter auto-detection had scanned the
+/// inputs, the output directory existed, and (on multi-pair input) earlier
+/// pairs had already been written to disk.
+///
+/// Callers must skip the specialty modes (`--hardtrim5/3`, `--clock`,
+/// `--implicon`), which accept mixed pairs today, and must not call this for
+/// `N == 1` (single-file interleaved uBAM, validated separately in `main()`).
+///
+/// Assumes `Cli::validate()` has already enforced an even input count and
+/// R1 != R2 per pair. `inputs.len() == formats.len()` is `debug_assert`ed,
+/// since the `chunks(2)` indexing depends on it.
+pub fn reject_bam_format_mismatch_in_pair(
+    inputs: &[std::path::PathBuf],
+    formats: &[InputFormat],
+    shape: PairedShape,
+) -> Result<()> {
+    // A hard check, not a `debug_assert`: release builds set no
+    // `debug-assertions`, so a debug-only assert would compile out of every
+    // shipped binary — and both violations fail badly. A short `formats` makes
+    // `zip` truncate, so later pairs go unexamined and this returns `Ok(())`
+    // *without having checked*: a validation guard that silently passes, which
+    // is the failure class this whole function exists to prevent. An odd length
+    // would panic on `paths[1]` instead of erroring. Neither is reachable today
+    // (`input_formats` is built by mapping over `cli.input`, and
+    // `Cli::validate` rejects odd N for every paired mode), so this is
+    // defence-in-depth for future callers of a `pub` function.
+    anyhow::ensure!(
+        inputs.len() == formats.len() && inputs.len().is_multiple_of(2),
+        "internal error: reject_bam_format_mismatch_in_pair got {} inputs and {} formats \
+         (must be equal and even). Please report this at \
+         https://github.com/FelixKrueger/TrimGalore/issues",
+        inputs.len(),
+        formats.len()
+    );
+
+    let total_pairs = inputs.len() / 2;
+    let is_bam = |f: &InputFormat| matches!(f, InputFormat::UnalignedBam);
+
+    for (pair_idx, (paths, fmts)) in inputs
+        .chunks_exact(2)
+        .zip(formats.chunks_exact(2))
+        .enumerate()
+    {
+        let n_bam = fmts.iter().filter(|f| is_bam(f)).count();
+        if n_bam == 0 {
+            continue;
+        }
+
+        // "Pair 3 of 5 is " when there are several pairs, plain "Got " when
+        // there is one — "Pair 1 of 1" is noise on the common case, but the
+        // clause still needs a subject to read as a sentence.
+        let pair_prefix = if total_pairs > 1 {
+            format!("Pair {} of {} is ", pair_idx + 1, total_pairs)
+        } else {
+            "Got ".to_string()
+        };
+        let (r1, r2) = (paths[0].display(), paths[1].display());
+
+        // --clump_only with FASTQ output: any BAM in the pair is the error,
+        // regardless of whether the other side is a BAM too. The user's
+        // problem is BAM input on a FASTQ-output path, so the actionable
+        // information is the flag to add — not the shape of the input.
+        if matches!(shape, PairedShape::ClumpOnlyFastqOut) {
+            let first_bam = if is_bam(&fmts[0]) { r1 } else { r2 };
+            bail!(
+                "uBAM input under --clump_only requires --output-format ubam \
+                 (using the FASTQ output path with uBAM input would drop aux tags). \
+                 Input: {first_bam}"
+            );
+        }
+
+        let (mode, fmt_flag) = (shape.mode(), shape.fmt_flag());
+
+        // Pinned-substring note: the three existing rejection tests assert on
+        // "two BAM files is not supported", "uBAM paired mode expects",
+        // "single interleaved" and "same format". Rust's `\`-continuation eats
+        // the newline AND the next line's leading whitespace, so each of those
+        // phrases must stay on one source line and every break must carry its
+        // space BEFORE the backslash.
+        if n_bam == 2 {
+            bail!(
+                "{mode} with two BAM files is not supported. \
+                 uBAM paired mode expects a single interleaved file: \
+                 `trim_galore {mode}{fmt_flag} interleaved.bam`. \
+                 {pair_prefix}two BAM files: {r1} and {r2}. \
+                 Combine them into one mate-adjacent file first: \
+                 `samtools merge -n -o interleaved.bam {r1} {r2}`."
+            );
+        }
+
+        // Exactly one BAM. Deliberately NOT offered the single-interleaved-file
+        // remediation: this is overwhelmingly a mis-typed filename, and issue
+        // #363 is precisely about that advice pointing the wrong way.
+        bail!(
+            "{mode} requires both inputs of a pair to be the same format. \
+             {pair_prefix}mixed: {r1} is {} and {r2} is {}. \
+             Pass two FASTQ files, or a single interleaved uBAM. \
+             If you meant two FASTQ files, check for a mis-typed filename.",
+            input_format_label(fmts[0]),
+            input_format_label(fmts[1])
+        );
+    }
+
+    Ok(())
+}
+
 /// Peek the first bytes of `path` and classify by content (NOT by filename).
 ///
 /// See module-level docs for the algorithm and the rationale for the
@@ -202,5 +369,163 @@ mod tests {
         std::fs::write(&p, b"").unwrap();
         let r = detect_input_format(&p);
         assert!(r.is_err());
+    }
+
+    // ── reject_bam_format_mismatch_in_pair (#363) ──────────────────────
+    //
+    // Pure decision logic over pre-detected formats, so these need no
+    // fixtures. The end-to-end messages are covered by
+    // tests/integration_paired_format_guard.rs.
+
+    fn paths(n: usize) -> Vec<std::path::PathBuf> {
+        (0..n)
+            .map(|i| std::path::PathBuf::from(format!("in{i}.fq")))
+            .collect()
+    }
+
+    fn err(fmts: &[InputFormat], shape: PairedShape) -> String {
+        let p = paths(fmts.len());
+        reject_bam_format_mismatch_in_pair(&p, fmts, shape)
+            .expect_err("expected rejection")
+            .to_string()
+    }
+
+    #[test]
+    fn pair_guard_accepts_all_fastq() {
+        for shape in [
+            PairedShape::Trim,
+            PairedShape::TrimUbamOut,
+            PairedShape::ClumpOnlyFastqOut,
+            PairedShape::ClumpOnlyUbamOut,
+        ] {
+            let fmts = [InputFormat::FastqGz, InputFormat::FastqGz];
+            assert!(
+                reject_bam_format_mismatch_in_pair(&paths(2), &fmts, shape).is_ok(),
+                "all-FASTQ pair must be accepted for {shape:?}"
+            );
+        }
+    }
+
+    /// The predicate is BAM *count*, not format equality. `InputFormat` has
+    /// three variants, and a plain+gzip pair is legal — naming the helper for
+    /// "format mismatch" invites `formats[0] != formats[1]`, which would
+    /// reject this working invocation.
+    #[test]
+    fn pair_guard_accepts_plain_plus_gzip_fastq() {
+        let fmts = [InputFormat::FastqPlain, InputFormat::FastqGz];
+        assert!(
+            reject_bam_format_mismatch_in_pair(&paths(2), &fmts, PairedShape::Trim).is_ok(),
+            "plain + gzipped FASTQ is a legal pair and must not be rejected"
+        );
+    }
+
+    #[test]
+    fn pair_guard_rejects_mixed_in_both_orders() {
+        for fmts in [
+            [InputFormat::FastqPlain, InputFormat::UnalignedBam],
+            [InputFormat::UnalignedBam, InputFormat::FastqPlain],
+        ] {
+            let msg = err(&fmts, PairedShape::Trim);
+            assert!(msg.contains("same format"), "got: {msg}");
+            assert!(msg.contains("mixed"), "got: {msg}");
+            // The substance of #363: the mixed case must NOT be offered the
+            // single-interleaved-file remediation.
+            assert!(
+                !msg.contains("uBAM paired mode expects"),
+                "mixed-pair message must not carry the two-BAM remediation; got: {msg}"
+            );
+            // Labels, not enum variant names.
+            assert!(msg.contains("uBAM"), "got: {msg}");
+            assert!(!msg.contains("UnalignedBam"), "got: {msg}");
+            assert!(!msg.contains("FastqPlain"), "got: {msg}");
+        }
+    }
+
+    #[test]
+    fn pair_guard_rejects_two_bam_with_interleave_remediation() {
+        let fmts = [InputFormat::UnalignedBam, InputFormat::UnalignedBam];
+        let msg = err(&fmts, PairedShape::Trim);
+        assert!(msg.contains("two BAM files is not supported"), "got: {msg}");
+        assert!(msg.contains("uBAM paired mode expects"), "got: {msg}");
+        assert!(msg.contains("single interleaved"), "got: {msg}");
+        // Verified remediation: `samtools collate` cannot combine two files —
+        // its second positional is the temp prefix, so it silently emits only
+        // the first file's records.
+        assert!(msg.contains("samtools merge -n"), "got: {msg}");
+        // Both files named, not just one.
+        assert!(
+            msg.contains("in0.fq") && msg.contains("in1.fq"),
+            "got: {msg}"
+        );
+    }
+
+    /// `--clump_only` with FASTQ output rejects on ANY BAM in the pair, not on
+    /// mismatch: the problem is BAM-on-a-FASTQ-path. Suggesting a single
+    /// interleaved uBAM there would print a command the binary rejects.
+    #[test]
+    fn pair_guard_clump_only_fastq_out_keeps_aux_tag_diagnosis() {
+        for fmts in [
+            [InputFormat::FastqGz, InputFormat::UnalignedBam],
+            [InputFormat::UnalignedBam, InputFormat::FastqGz],
+            [InputFormat::UnalignedBam, InputFormat::UnalignedBam],
+        ] {
+            let msg = err(&fmts, PairedShape::ClumpOnlyFastqOut);
+            assert!(msg.contains("--output-format ubam"), "got: {msg}");
+            assert!(msg.contains("drop aux tags"), "got: {msg}");
+            assert!(
+                !msg.contains("interleaved.bam"),
+                "clump-only FASTQ output must not suggest an interleaved uBAM \
+                 (main() rejects that invocation); got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn pair_guard_clump_only_fastq_out_names_the_bam_side() {
+        let fmts = [InputFormat::FastqGz, InputFormat::UnalignedBam];
+        assert!(err(&fmts, PairedShape::ClumpOnlyFastqOut).contains("in1.fq"));
+        let fmts = [InputFormat::UnalignedBam, InputFormat::FastqGz];
+        assert!(err(&fmts, PairedShape::ClumpOnlyFastqOut).contains("in0.fq"));
+    }
+
+    #[test]
+    fn pair_guard_reports_the_offending_pair_index() {
+        // N=6: pairs 1 and 3 are clean, pair 2 is mixed.
+        let fmts = [
+            InputFormat::FastqGz,
+            InputFormat::FastqGz,
+            InputFormat::FastqGz,
+            InputFormat::UnalignedBam,
+            InputFormat::FastqGz,
+            InputFormat::FastqGz,
+        ];
+        let msg = err(&fmts, PairedShape::Trim);
+        assert!(msg.contains("Pair 2 of 3"), "got: {msg}");
+        assert!(
+            msg.contains("in2.fq") && msg.contains("in3.fq"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn pair_guard_omits_index_for_a_single_pair() {
+        let fmts = [InputFormat::FastqGz, InputFormat::UnalignedBam];
+        let msg = err(&fmts, PairedShape::Trim);
+        assert!(msg.contains("Got mixed"), "got: {msg}");
+        assert!(!msg.contains("Pair 1 of 1"), "got: {msg}");
+    }
+
+    #[test]
+    fn pair_guard_remediation_echoes_the_users_mode() {
+        let two_bam = [InputFormat::UnalignedBam, InputFormat::UnalignedBam];
+        assert!(
+            err(&two_bam, PairedShape::TrimUbamOut)
+                .contains("trim_galore --paired --output-format ubam interleaved.bam")
+        );
+        assert!(
+            err(&two_bam, PairedShape::ClumpOnlyUbamOut)
+                .contains("trim_galore --clump_only --paired --output-format ubam interleaved.bam")
+        );
+        assert!(err(&two_bam, PairedShape::Trim).contains("trim_galore --paired interleaved.bam"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,9 @@ use trim_galore::demux;
 use trim_galore::fastq::{FastqReader, FastqWriter, RecordSource};
 use trim_galore::fastqc;
 use trim_galore::filters::{MaxNFilter, UnpairedLengths};
-use trim_galore::format::{InputFormat, detect_input_format};
+use trim_galore::format::{
+    InputFormat, PairedShape, detect_input_format, reject_bam_format_mismatch_in_pair,
+};
 use trim_galore::io as naming;
 use trim_galore::parallel;
 use trim_galore::report;
@@ -262,6 +264,42 @@ fn main() -> Result<()> {
         );
     }
 
+    // Issue #363 — both inputs of a `--paired` pair must agree on being BAM.
+    //
+    // Sited here for the same reason as the `--phred64` guard above: the
+    // decision needs `input_formats`, which `Cli::validate()` cannot see. The
+    // position matters beyond that, though — this is the last point before
+    // `ensure_output_dir` (below), the three output-collision pre-flights, and
+    // every dispatch branch. The three guards this replaces all sat *past* that
+    // line: the trim-path one fired only after adapter auto-detection had
+    // scanned up to 1M reads, the banner had printed, the output directory
+    // existed, and on multi-pair input earlier pairs had already been written.
+    //
+    // Specialty modes are exempt: `--hardtrim5/3` never consult `cli.paired`
+    // (each file is processed independently, so a mixed pair is genuinely
+    // harmless there), and `--clock`/`--implicon` are left alone only because
+    // changing them is out of scope for #363 — they pair for real and today
+    // report a misleading read-count error on mixed input.
+    //
+    // N == 1 is excluded: that is single-file interleaved uBAM, validated
+    // directly above.
+    if cli.paired
+        && cli.input.len() > 1
+        && cli.hardtrim5.is_none()
+        && cli.hardtrim3.is_none()
+        && !cli.clock
+        && cli.implicon.is_none()
+    {
+        let ubam_out = matches!(cli.output_format, trim_galore::cli::OutputFormat::UBam);
+        let shape = match (cli.clump_only, ubam_out) {
+            (true, true) => PairedShape::ClumpOnlyUbamOut,
+            (true, false) => PairedShape::ClumpOnlyFastqOut,
+            (false, true) => PairedShape::TrimUbamOut,
+            (false, false) => PairedShape::Trim,
+        };
+        reject_bam_format_mismatch_in_pair(&cli.input, &input_formats, shape)?;
+    }
+
     // Output gzip mode. Mirror Perl: by default the output's compression
     // matches the input's (plain `.fastq` → plain `.fq`, gzipped `.fastq.gz`
     // → gzipped `.fq.gz`). `--dont_gzip` overrides to always-plain. The
@@ -496,20 +534,11 @@ fn main() -> Result<()> {
                 // step 2 + §Behavior "PE steps".
                 if cli.paired {
                     if cli.input.len() == 1 {
-                        // Shape B: single interleaved uBAM. Cli::validate allowed
-                        // N=1 through; enforce "must be BAM" here at dispatch time.
-                        if !matches!(
-                            detect_input_format(&cli.input[0])?,
-                            InputFormat::UnalignedBam
-                        ) {
-                            anyhow::bail!(
-                                "--clump_only --paired --output-format ubam with a single \
-                                 input file requires an interleaved uBAM. Got a FASTQ file \
-                                 at {}. For two-file paired-end FASTQ input, pass R1 and R2 \
-                                 as separate arguments.",
-                                cli.input[0].display()
-                            );
-                        }
+                        // Shape B: single interleaved uBAM. The "must be BAM"
+                        // check that used to live here was already unreachable —
+                        // its condition is a strict subset of the `--paired`
+                        // N=1 non-BAM guard in main() — and was retired with
+                        // #363. Retained note so the absence is intentional.
                         let planned = naming::clumped_paired_bam_output_name(
                             &cli.input[0],
                             None,
@@ -532,30 +561,13 @@ fn main() -> Result<()> {
                         )?;
                     } else {
                         // Shape A: two-file paired (multi-pair supported for N=2, 4, 6, …).
-                        // Reject two-BAM Shape A + mixed-format Shape A up-front.
-                        for chunk in cli.input.chunks(2) {
-                            let fmt_r1 = detect_input_format(&chunk[0])?;
-                            let fmt_r2 = detect_input_format(&chunk[1])?;
-                            let r1_is_bam = matches!(fmt_r1, InputFormat::UnalignedBam);
-                            let r2_is_bam = matches!(fmt_r2, InputFormat::UnalignedBam);
-                            if r1_is_bam && r2_is_bam {
-                                anyhow::bail!(
-                                    "--clump_only --paired with two BAM files is not supported. \
-                                     uBAM paired mode expects a single interleaved file: \
-                                     `trim_galore --clump_only --paired --output-format ubam \
-                                     interleaved.bam`. Got two BAM files; one of them is {}.",
-                                    chunk[0].display()
-                                );
-                            }
-                            if r1_is_bam != r2_is_bam {
-                                anyhow::bail!(
-                                    "--clump_only --paired requires both input files to be the \
-                                     same format. Got mixed: {} and {}.",
-                                    chunk[0].display(),
-                                    chunk[1].display()
-                                );
-                            }
-                        }
+                        // Two-BAM and mixed-format Shape A are rejected by
+                        // `reject_bam_format_mismatch_in_pair` in main(), which
+                        // runs before this dispatch (and before the pre-flight
+                        // below). This branch previously carried its own copy of
+                        // that check — the only one of the three that got the
+                        // two-BAM-vs-mixed distinction right, and the model for
+                        // the shared helper (#363).
                         // Multi-pair collision pre-flight (case-folded per issue #216).
                         let mut planned: Vec<std::path::PathBuf> = Vec::new();
                         for chunk in cli.input.chunks(2) {
@@ -1263,15 +1275,21 @@ fn run_paired(
         (None, None)
     };
 
-    // Two-file paired-uBAM is rejected per PLAN §3.3 — paired uBAM expects
-    // a single interleaved file (handled in main() before this fn is called).
+    // Internal-invariant backstop, NOT the user-facing rejection. Any BAM in a
+    // two-file pair is rejected by `reject_bam_format_mismatch_in_pair` in
+    // main(), which produces the shape-appropriate message (#363).
+    //
+    // This stays as an enforced check rather than a comment because the
+    // sequential path below hard-codes `FastqReader::open` — and `--cores 1` is
+    // the default. A BGZF BAM handed to `FastqReader` decompresses to binary and
+    // parses as FASTQ, i.e. silent wrong output rather than an error. Deliberately
+    // worded so it cannot be mistaken for the user-facing message.
     for p in [input_r1, input_r2] {
         if matches!(detect_input_format(p)?, InputFormat::UnalignedBam) {
             anyhow::bail!(
-                "--paired with two BAM files is not supported. \
-                 uBAM paired mode expects a single interleaved file: \
-                 `trim_galore --paired interleaved.bam`. \
-                 Got two BAM files; one of them is {}.",
+                "internal error: uBAM input reached run_paired ({}); the paired \
+                 format guard in main() should have rejected it. Please report this at \
+                 https://github.com/FelixKrueger/TrimGalore/issues",
                 p.display()
             );
         }
@@ -1306,8 +1324,12 @@ fn run_paired(
             clump_layout,
         )?
     } else {
-        // Sequential path (--cores 1) — paired-BAM rejected above, so both
-        // are FastqReader.
+        // Sequential path (--cores 1, the default) — hard-codes FastqReader,
+        // which is safe only because uBAM input is rejected by
+        // `reject_bam_format_mismatch_in_pair` in main() and re-checked by the
+        // internal-invariant backstop at the top of this function. Do not
+        // remove that backstop: a BGZF BAM handed to FastqReader parses as
+        // FASTQ rather than erroring.
         let mut reader_r1 = FastqReader::open(input_r1)?;
         let mut reader_r2 = FastqReader::open(input_r2)?;
         let level = config.gzip_level;
@@ -1742,24 +1764,11 @@ fn run_ubam_output(cli: &Cli, output_dir: Option<&Path>, command_line: &str) -> 
     }
 
     if cli.paired {
-        // Two-file paired-BAM input is rejected per PLAN §3.3 — uBAM paired
-        // mode expects a single interleaved file (handled in the
-        // input.len() == 1 branch above). Mirror the FASTQ-path rejection
-        // and fail up-front BEFORE the collision pre-flight runs.
-        // Code-review round-2 B-NIT-1 consolidation.
-        for chunk in cli.input.chunks(2) {
-            for p in [&chunk[0], &chunk[1]] {
-                if matches!(detect_input_format(p)?, InputFormat::UnalignedBam) {
-                    anyhow::bail!(
-                        "--paired with two BAM files is not supported. \
-                         uBAM paired mode expects a single interleaved file: \
-                         `trim_galore --paired interleaved.bam`. \
-                         Got two BAM files; one of them is {}.",
-                        p.display()
-                    );
-                }
-            }
-        }
+        // Two-file paired-BAM input (and mixed FASTQ+BAM pairs) are rejected by
+        // `reject_bam_format_mismatch_in_pair` in main(), which runs before this
+        // dispatch and before the pre-flight below, and which distinguishes the
+        // two-BAM case from the mixed case (#363). The per-pair loop that used to
+        // stand here emitted the two-BAM message for either.
         // Pre-flight: one BAM output per pair; collision on case-folded path.
         let mut out_paths: std::collections::HashMap<String, std::path::PathBuf> =
             std::collections::HashMap::new();
@@ -1979,10 +1988,6 @@ fn run_ubam_output_paired_two_files(
     let output_path =
         naming::paired_bam_output_name(input_r1, input_r2, output_dir, cli.basename.as_deref());
 
-    // Two-file paired-BAM rejection lives up-front in `run_ubam_output`
-    // (code-review round-2 B-NIT-1) — both inputs are guaranteed FASTQ
-    // here.
-
     eprintln!("Trimming (paired-end, interleaved uBAM):");
     eprintln!("  R1:     {}", input_r1.display());
     eprintln!("  R2:     {}", input_r2.display());
@@ -1990,9 +1995,30 @@ fn run_ubam_output_paired_two_files(
 
     // Source header from R1 if it's uBAM; R2's header is ignored (R1's @PG
     // chain is the canonical lineage — R2 is just the mate stream).
-    // (At this point both inputs are FASTQ; the BAM-input case is handled
-    // separately by run_ubam_output_paired_single_file.)
-    let source_header = match detect_input_format(input_r1)? {
+    //
+    // Internal-invariant backstop (#363). Because the header comes from R1 alone
+    // while each side is opened by its own per-file detection below, any BAM
+    // reaching this two-file path is wrong output rather than an error: a mixed
+    // pair would emit a BAM silently mixing FASTQ-derived records (no aux tags,
+    // no source header) with BAM-derived ones, and a two-BAM pair would silently
+    // discard R2's @HD/@PG chain and tag dictionary. So the enforced predicate is
+    // "no BAM at all", matching the invariant that
+    // `reject_bam_format_mismatch_in_pair` in main() actually establishes for
+    // this shape — the guard is ~1700 lines away, hence enforcing rather than
+    // documenting. (The code this replaced also rejected any BAM; narrowing it
+    // to a mismatch check would have half-met the stated intent.)
+    let fmt_r1 = detect_input_format(input_r1)?;
+    let fmt_r2 = detect_input_format(input_r2)?;
+    if matches!(fmt_r1, InputFormat::UnalignedBam) || matches!(fmt_r2, InputFormat::UnalignedBam) {
+        anyhow::bail!(
+            "internal error: uBAM input reached run_ubam_output_paired_two_files \
+             ({} and {}); the paired format guard in main() should have rejected it. \
+             Please report this at https://github.com/FelixKrueger/TrimGalore/issues",
+            input_r1.display(),
+            input_r2.display()
+        );
+    }
+    let source_header = match fmt_r1 {
         InputFormat::UnalignedBam => Some(trim_galore::bam::peek_header(input_r1)?),
         InputFormat::FastqPlain | InputFormat::FastqGz => None,
     };

--- a/tests/integration_paired_format_guard.rs
+++ b/tests/integration_paired_format_guard.rs
@@ -1,0 +1,440 @@
+//! Binary-driven integration tests for the `--paired` per-pair format guard
+//! (issue [#363](https://github.com/FelixKrueger/TrimGalore/issues/363)).
+//!
+//! Before #363, a pair containing exactly *one* BAM was reported as "two BAM
+//! files" and offered the single-interleaved-file remediation — advice that does
+//! not apply when the real cause is a mis-typed filename. The guard now
+//! distinguishes the shapes, and runs in the cheap-validation window in `main()`
+//! rather than inside the per-pair worker.
+//!
+//! Three properties are pinned here that unit tests cannot reach:
+//!
+//! 1. The rejection has **no side effects** — no output directory, no adapter
+//!    auto-detection, and on multi-pair input no partial output from earlier
+//!    pairs. All three happened before #363.
+//! 2. `--clump_only` on the FASTQ-output path keeps its own aux-tag diagnosis.
+//!    This path had zero coverage and is where the first draft of the fix
+//!    regressed: it would have printed `--clump_only --paired interleaved.bam`,
+//!    a command the binary itself rejects.
+//! 3. A plain+gzip FASTQ pair is still **accepted** — the guard keys on BAM
+//!    count, not format equality.
+//!
+//! Fixtures: `phred64_test.fastq` (plain FASTQ), `BS-seq_10K_R{1,2}.fastq.gz`
+//! (gzipped FASTQ), `ubam_test.bam` / `ubam_paired_test.bam` (two distinct
+//! uBAMs — distinct matters, since `Cli::validate` rejects R1 == R2 first).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_trim_galore"))
+}
+
+/// A pre-created scratch directory. Note that tests asserting the *absence* of
+/// an output directory must pass a `nested` child of this (see
+/// [`nonexistent_out`]) — handing this path to `-o` would make the check
+/// vacuous, because it already exists.
+fn tempdir(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir().join(format!("tg_pfg_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+/// A path under `dir` that does not exist yet, so `!exists()` after a rejected
+/// run is a real assertion about `ensure_output_dir` never having run.
+fn nonexistent_out(dir: &Path) -> PathBuf {
+    let p = dir.join("nested_out");
+    assert!(!p.exists(), "precondition: {} must not exist", p.display());
+    p
+}
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from("test_files").join(name)
+}
+
+/// Run the binary and return (success, stderr).
+fn run(args: &[&str]) -> (bool, String) {
+    let out = Command::new(binary())
+        .args(args)
+        .output()
+        .expect("failed to run trim_galore");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+// ── mixed FASTQ + BAM within one pair ──────────────────────────────────
+
+/// The reported bug: one BAM in the pair must not be described as two, and must
+/// not be offered the interleaving remediation.
+#[test]
+fn mixed_pair_reports_format_mismatch_not_two_bams() {
+    for (r1, r2) in [
+        (fixture("phred64_test.fastq"), fixture("ubam_test.bam")),
+        (fixture("ubam_test.bam"), fixture("phred64_test.fastq")),
+    ] {
+        let dir = tempdir("mixed");
+        let (ok, stderr) = run(&[
+            "--paired",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "-o",
+            nonexistent_out(&dir).to_str().unwrap(),
+        ]);
+        assert!(!ok, "a mixed FASTQ+BAM pair must be rejected");
+        assert!(
+            stderr.contains("same format") && stderr.contains("mixed"),
+            "expected a format-mismatch message; got: {stderr}"
+        );
+        // #363's substance. Without this assertion the two messages can
+        // silently re-converge in a later refactor.
+        assert!(
+            !stderr.contains("uBAM paired mode expects"),
+            "mixed pair must not be told to pass a single interleaved file; got: {stderr}"
+        );
+        assert!(
+            !stderr.contains("two BAM files"),
+            "mixed pair must not be described as two BAM files; got: {stderr}"
+        );
+        // Both inputs named, with human-readable format labels.
+        assert!(
+            stderr.contains("phred64_test.fastq") && stderr.contains("ubam_test.bam"),
+            "both inputs should be named; got: {stderr}"
+        );
+        assert!(stderr.contains("uBAM"), "got: {stderr}");
+        assert!(
+            !stderr.contains("UnalignedBam") && !stderr.contains("FastqPlain"),
+            "internal enum names must not leak into user-facing text; got: {stderr}"
+        );
+    }
+}
+
+/// The rejection must happen before anything is created or scanned. Before
+/// #363 this run auto-detected adapters over the inputs, printed the trimming
+/// banner, and created the output directory before failing.
+#[test]
+fn mixed_pair_rejection_has_no_side_effects() {
+    let dir = tempdir("noside");
+    let out = nonexistent_out(&dir);
+    let (ok, stderr) = run(&[
+        "--paired",
+        fixture("phred64_test.fastq").to_str().unwrap(),
+        fixture("ubam_test.bam").to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(!ok);
+    assert!(
+        !out.exists(),
+        "a rejected run must not create the output directory: {}",
+        out.display()
+    );
+    assert!(
+        !stderr.contains("Auto-detecting adapter"),
+        "adapter auto-detection must not run before a guaranteed rejection; got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Trimming (paired-end)"),
+        "the trimming banner must not print before a guaranteed rejection; got: {stderr}"
+    );
+}
+
+// ── two BAM files within one pair ──────────────────────────────────────
+
+/// The genuine two-BAM case keeps its message and its remediation. This also
+/// closes a coverage gap: the plain trim path (no `--output-format ubam`) had
+/// no test at all.
+#[test]
+fn two_bam_pair_keeps_interleave_remediation() {
+    let dir = tempdir("twobam");
+    let (ok, stderr) = run(&[
+        "--paired",
+        fixture("ubam_test.bam").to_str().unwrap(),
+        fixture("ubam_paired_test.bam").to_str().unwrap(),
+        "-o",
+        nonexistent_out(&dir).to_str().unwrap(),
+    ]);
+    assert!(
+        !ok,
+        "two distinct BAM files under --paired must be rejected"
+    );
+    assert!(
+        stderr.contains("two BAM files is not supported"),
+        "got: {stderr}"
+    );
+    assert!(
+        stderr.contains("uBAM paired mode expects") && stderr.contains("single interleaved"),
+        "got: {stderr}"
+    );
+    // `samtools collate` cannot combine two files — its second positional is
+    // the temp-file prefix, so it exits 0 having emitted only the first file's
+    // records. The suggested command must be one that actually works.
+    assert!(
+        stderr.contains("samtools merge -n"),
+        "expected a verified combine command; got: {stderr}"
+    );
+    // Asserts the property, not one literal spelling of its violation: an
+    // earlier draft pinned the full `collate -O <fixture> <fixture>` string,
+    // which a fixture rename would have quietly turned into a tautology.
+    assert!(
+        !stderr.contains("samtools collate"),
+        "collate takes one input — it must never be suggested for combining two \
+         files on this path; got: {stderr}"
+    );
+    // Both files named, not just one.
+    assert!(
+        stderr.contains("ubam_test.bam") && stderr.contains("ubam_paired_test.bam"),
+        "got: {stderr}"
+    );
+}
+
+/// Same rejection on the uBAM-output path, with the remediation echoing the
+/// user's own mode so it can be pasted.
+#[test]
+fn two_bam_pair_rejected_with_ubam_output_and_echoes_mode() {
+    let dir = tempdir("twobam_ubamout");
+    let (ok, stderr) = run(&[
+        "--paired",
+        "--output-format",
+        "ubam",
+        fixture("ubam_test.bam").to_str().unwrap(),
+        fixture("ubam_paired_test.bam").to_str().unwrap(),
+        "-o",
+        nonexistent_out(&dir).to_str().unwrap(),
+    ]);
+    assert!(!ok);
+    assert!(
+        stderr.contains("trim_galore --paired --output-format ubam interleaved.bam"),
+        "remediation should reproduce the user's mode; got: {stderr}"
+    );
+}
+
+#[test]
+fn mixed_pair_rejected_with_ubam_output() {
+    let dir = tempdir("mixed_ubamout");
+    let (ok, stderr) = run(&[
+        "--paired",
+        "--output-format",
+        "ubam",
+        fixture("phred64_test.fastq").to_str().unwrap(),
+        fixture("ubam_test.bam").to_str().unwrap(),
+        "-o",
+        nonexistent_out(&dir).to_str().unwrap(),
+    ]);
+    assert!(!ok);
+    assert!(
+        stderr.contains("same format") && !stderr.contains("uBAM paired mode expects"),
+        "got: {stderr}"
+    );
+}
+
+// ── --clump_only, FASTQ output ─────────────────────────────────────────
+
+/// LOAD-BEARING. This path had zero coverage, and the first draft of the #363
+/// fix regressed it: the hoisted guard preempted the aux-tag diagnosis and
+/// printed `trim_galore --clump_only --paired interleaved.bam` instead — a
+/// command `main()` rejects outright, so the user would paste it and get a
+/// second error, having lost the one piece of information they needed.
+///
+/// In this mode the predicate is "any BAM in the pair", not "the pair
+/// disagrees": both a mixed pair and two BAMs are the same user error, namely
+/// BAM input on a FASTQ-output path.
+#[test]
+fn clump_only_fastq_output_keeps_aux_tag_diagnosis() {
+    let cases: [(PathBuf, PathBuf); 3] = [
+        (fixture("BS-seq_10K_R1.fastq.gz"), fixture("ubam_test.bam")),
+        (fixture("ubam_test.bam"), fixture("BS-seq_10K_R1.fastq.gz")),
+        (fixture("ubam_test.bam"), fixture("ubam_paired_test.bam")),
+    ];
+    for (r1, r2) in cases {
+        let dir = tempdir("clump_fq");
+        let (ok, stderr) = run(&[
+            "--clump_only",
+            "--paired",
+            r1.to_str().unwrap(),
+            r2.to_str().unwrap(),
+            "-o",
+            nonexistent_out(&dir).to_str().unwrap(),
+        ]);
+        assert!(
+            !ok,
+            "uBAM input on the clump-only FASTQ path must be rejected"
+        );
+        assert!(
+            stderr.contains("--output-format ubam"),
+            "must name the flag that fixes it; got: {stderr}"
+        );
+        assert!(
+            stderr.contains("drop aux tags"),
+            "must give the reason, not just the flag; got: {stderr}"
+        );
+        assert!(
+            !stderr.contains("interleaved.bam"),
+            "must not suggest an interleaved uBAM — `--clump_only --paired \
+             interleaved.bam` is itself rejected; got: {stderr}"
+        );
+    }
+}
+
+/// The clump-only uBAM-output path had the only correct implementation of this
+/// distinction before #363; confirm it survived being replaced by the shared
+/// helper, including the mode-specific remediation.
+#[test]
+fn clump_only_ubam_output_distinguishes_mixed_from_two_bam() {
+    let dir = tempdir("clump_ubam_mixed");
+    let (ok, stderr) = run(&[
+        "--clump_only",
+        "--paired",
+        "--output-format",
+        "ubam",
+        fixture("BS-seq_10K_R1.fastq.gz").to_str().unwrap(),
+        fixture("ubam_test.bam").to_str().unwrap(),
+        "-o",
+        nonexistent_out(&dir).to_str().unwrap(),
+    ]);
+    assert!(!ok);
+    assert!(stderr.contains("same format"), "got: {stderr}");
+    assert!(
+        !stderr.contains("uBAM paired mode expects"),
+        "got: {stderr}"
+    );
+
+    let dir = tempdir("clump_ubam_two");
+    let (ok, stderr) = run(&[
+        "--clump_only",
+        "--paired",
+        "--output-format",
+        "ubam",
+        fixture("ubam_test.bam").to_str().unwrap(),
+        fixture("ubam_paired_test.bam").to_str().unwrap(),
+        "-o",
+        nonexistent_out(&dir).to_str().unwrap(),
+    ]);
+    assert!(!ok);
+    assert!(
+        stderr.contains("two BAM files is not supported"),
+        "got: {stderr}"
+    );
+    assert!(
+        stderr.contains("trim_galore --clump_only --paired --output-format ubam interleaved.bam"),
+        "remediation should reproduce the user's mode; got: {stderr}"
+    );
+}
+
+// ── multi-pair ─────────────────────────────────────────────────────────
+
+/// The offending pair is named by index, and — the larger behaviour change —
+/// no earlier pair is processed. Before #363 the guard lived inside the per-pair
+/// loop, so pair 1's `_val_*` files and trimming reports were written to disk
+/// before pair 2 failed.
+///
+/// The four arguments must yield four *distinct output* paths. `BS-seq_10K_R2`
+/// appears twice, which is fine — as pair 1's R2 and pair 2's R1 it produces
+/// `..._val_2` and `..._val_1` respectively. What must not happen is an output
+/// collision, because the pre-flight that detects one now runs *after* the
+/// guard: the test would still fail, but on precedence rather than on pair
+/// indexing.
+#[test]
+fn multi_pair_names_the_offending_pair_and_writes_nothing() {
+    let dir = tempdir("multipair");
+    let out = nonexistent_out(&dir);
+    let (ok, stderr) = run(&[
+        "--paired",
+        fixture("BS-seq_10K_R1.fastq.gz").to_str().unwrap(),
+        fixture("BS-seq_10K_R2.fastq.gz").to_str().unwrap(),
+        fixture("BS-seq_10K_R2.fastq.gz").to_str().unwrap(),
+        fixture("ubam_test.bam").to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(!ok);
+    // "Pair 2 of 2 is mixed", not bare "Pair 2 of 2" — the per-pair progress
+    // banner prints `=== Pair 2 of 2 ===`, so the looser substring would also
+    // be satisfied by a run that got as far as processing pair 2.
+    assert!(
+        stderr.contains("Pair 2 of 2 is mixed"),
+        "the offending pair should be identified by index; got: {stderr}"
+    );
+    assert!(
+        !out.exists(),
+        "no pair may be processed before the rejection — pair 1's outputs and \
+         trimming reports were written here before #363"
+    );
+}
+
+// ── invocations that must keep working ─────────────────────────────────
+
+/// The guard keys on BAM count, not format equality. `InputFormat` has three
+/// variants, so a naive `formats[0] != formats[1]` would reject this — a pair
+/// that works today.
+#[test]
+fn plain_plus_gzip_fastq_pair_is_still_accepted() {
+    let dir = tempdir("plainplusgz");
+    let plain = dir.join("plain_R1.fastq");
+    {
+        use std::io::Write;
+        let f = std::fs::File::open(fixture("BS-seq_10K_R1.fastq.gz")).unwrap();
+        let mut dec = flate2::read::MultiGzDecoder::new(f);
+        let mut buf = Vec::new();
+        std::io::Read::read_to_end(&mut dec, &mut buf).unwrap();
+        std::fs::File::create(&plain)
+            .unwrap()
+            .write_all(&buf)
+            .unwrap();
+    }
+    let out = dir.join("out");
+    let (ok, stderr) = run(&[
+        "--paired",
+        plain.to_str().unwrap(),
+        fixture("BS-seq_10K_R2.fastq.gz").to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(
+        ok,
+        "a plain + gzipped FASTQ pair is legal and must not be rejected; stderr: {stderr}"
+    );
+    assert!(out.join("plain_R1_val_1.fq").exists(), "R1 output missing");
+}
+
+/// Single-file interleaved uBAM under `--paired` is the supported shape and
+/// must not be caught by a guard aimed at two-file pairs.
+#[test]
+fn single_interleaved_ubam_still_accepted() {
+    let dir = tempdir("interleaved");
+    let out = dir.join("out");
+    let (ok, stderr) = run(&[
+        "--paired",
+        fixture("ubam_paired_test.bam").to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(
+        ok,
+        "single interleaved uBAM under --paired must be accepted; stderr: {stderr}"
+    );
+}
+
+/// `--hardtrim5` processes each input independently and never consults
+/// `--paired`, so a mixed pair is harmless there. Left working deliberately;
+/// see the #363 follow-up for whether the specialty modes should change.
+#[test]
+fn hardtrim_still_accepts_a_mixed_pair() {
+    let dir = tempdir("hardtrim");
+    let out = dir.join("out");
+    let (ok, stderr) = run(&[
+        "--hardtrim5",
+        "10",
+        "--paired",
+        fixture("phred64_test.fastq").to_str().unwrap(),
+        fixture("ubam_test.bam").to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(
+        ok,
+        "the paired format guard must not fire for --hardtrim5; stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
Fixes the misleading rejection reported in #363, and moves the check into input validation so a guaranteed-to-fail run stops before doing any work.

Refs #363. (Not `Closes` — this targets `dev`, where auto-close does not fire; #363 needs a manual close after merge.)

## The reported defect

Two sites looped over a `--paired` pair and bailed on the **first** BAM found, so any pair containing at least one BAM got the two-BAM message:

```console
$ trim_galore --paired sample.fastq sample.bam
Error: --paired with two BAM files is not supported. … Got two BAM files;
       one of them is sample.bam.
```

Only one input is a BAM, so both statements are false — and the remediation it offers (pass a single interleaved BAM) is not what the user wants: the cause is usually a mis-typed filename, or an intent to pass two FASTQ files.

## After

| Input | Message |
|---|---|
| one BAM in the pair | `--paired requires both inputs of a pair to be the same format. Got mixed: A is FASTQ (plain) and B is uBAM. Pass two FASTQ files, or a single interleaved uBAM. If you meant two FASTQ files, check for a mis-typed filename.` |
| two BAM files | existing message, now naming **both** files, plus a verified combine command |
| `--clump_only`, FASTQ output | unchanged — uBAM input there requires `--output-format ubam`, because the FASTQ path would drop aux tags |

## Two things the issue got wrong

**`main.rs:543` was not a third cause site.** It already branched two-BAM vs mixed correctly and had regression coverage, so it was the *reference implementation* for this fix. It is now redundant and removed.

**"Diagnostic quality only" understates it.** On the trimming path the check sat *inside* the per-pair worker, so before the error appeared a rejected run had already auto-detected adapters over up to 1 M reads per input, printed the banner, created `--output_dir`, and — on multi-pair input — **fully trimmed and written every pair preceding the offending one**, including their `_val_{1,2}.fq.gz` files and trimming reports. A pipeline consuming whatever pairs succeeded now gets nothing. That is a real behaviour change and is called out in the CHANGELOG.

## Design

One guard, `format::reject_bam_format_mismatch_in_pair`, dispatched by a `PairedShape` enum and called once from `main()` beside the `--phred64` guard — it consumes the `input_formats` vector already computed there, so it needs no I/O. It runs ahead of `ensure_output_dir`, all three output-collision pre-flights, and every dispatch branch.

Three points worth flagging for review:

1. **The predicate is a BAM *count*, not format equality.** `InputFormat` has three variants and a plain+gzip FASTQ pair is legal. Naming the helper for "mismatch" invites `formats[0] != formats[1]`, which breaks a working invocation — pinned by a test.

2. **`--clump_only` with FASTQ output is asymmetric by design**: it rejects on *any* BAM in the pair, not on disagreement, because there the problem is BAM-on-a-FASTQ-path whether one input or both is a BAM. The actionable information is a flag, not a re-shaped input. The first draft of this fix got that wrong and would have printed `trim_galore --clump_only --paired interleaved.bam` — a command the binary itself rejects. That path had zero coverage; it does now.

3. **Three call sites keep an *enforced* internal-invariant check, not a comment.** `run_paired`'s sequential `--cores 1` path (the default) hard-codes `FastqReader::open`, and a BGZF BAM handed to `FastqReader` parses as FASTQ rather than erroring. The two two-file leaves take the source header from R1 alone, so any BAM reaching them is silent wrong output — a mixed pair blends FASTQ-derived and BAM-derived records, a two-BAM pair discards R2's `@PG` chain. Hoisting a guard converts local invariants into one remote one, so the leaves assert rather than document.

## Remediation verified, not inferred

The two-BAM message now names a command that combines two files. The obvious candidate is wrong in a dangerous way: `samtools collate -O r1.bam r2.bam` **exits 0 having written only r1's records**, because `collate`'s second positional is the temp-file prefix. Measured on samtools 1.21 — 10 000 of 20 000 records, no warning. The message uses `samtools merge -n`, verified end-to-end to produce a mate-adjacent file TrimGalore accepts.

## Also in this change

- Retires an already-unreachable check in the `--clump_only` uBAM N=1 branch (its condition was a strict subset of `main()`'s N=1 guard).
- Promotes `input_format_label` out of `clump_only.rs`, so error text never shows internal enum names (`FastqGz`, `UnalignedBam`).
- Corrects `docs/quickstart.md`, which stated paired reads "may come as two BAM files" — the binary rejects that. Verified it was the only such claim across `docs/src` and `README.md`.

## Scope

Unchanged for `--hardtrim5/3`, `--clock` and `--implicon`. `--hardtrim5/3` never consult `--paired`, so a mixed pair is genuinely harmless there; `--clock`/`--implicon` do pair and currently report a misleading read-count error whose firing is incidental on record counts. Tracked in #364 rather than folded in, since the two mode groups need opposite decisions and applying uniformity would remove working invocations for no correctness gain.

## Verification

- **Tests 421 → 441** — 9 unit tests in `format.rs`, 11 integration tests in the new `tests/integration_paired_format_guard.rs`.
- The three pre-existing rejection tests pass **unedited** (`git diff tests/` empty for them) — their loose substring assertions were a design constraint on the new wording, not something to update.
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --release -- -D warnings` clean.
- **Byte-identity against Perl 0.6.11 confirmed unmoved** on all five CI matrix paths (SE, PE, hardtrim5, clock, demux) plus `--clump_only`, by md5-comparing 15 outputs against a build of `dev` @ `a4ffd47` in a separate worktree.
- Reviewed by two independent code reviewers and a coverage audit before this PR: 4 defects found and fixed, 5 recommendations adopted. The most serious was a CHANGELOG paragraph asserting a bug that never shipped — it claimed the old message suggested the destructive `collate` form, which it never did; that form existed only in a plan draft. Full record in `plans/mixed-format-pair-message/PLAN.md` §14.
