### PR TITLE
fix(input): reject non-restartable input with an accurate diagnostic (#379)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+# A blocked `File::open` on a FIFO cannot be interrupted by the test harness,
+# so bound it here as well as at the job level.
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 4 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # A FIFO test with no writer blocks rather than fails, so bound the job.
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,36 @@
 
 #### Fixes
 
+- **Piped and stream input is now rejected with an accurate message**
+  ([#379](https://github.com/FelixKrueger/TrimGalore/issues/379)). Trim Galore
+  reads each input more than once — format detection, the initial sanity check
+  and adapter auto-detection each open it independently — so it requires a
+  regular file. Streams previously failed as though the *data* were at fault:
+  `<(zcat reads.fq.gz)` reported `doesn't seem to be in FastQ format`, a
+  gzipped pipe reported `Failed to decompress first block`, and a named FIFO
+  hung indefinitely with no message at all. All three now fail immediately,
+  naming the real constraint and giving the remedy (`zcat reads.fq.gz >
+  reads.fq` first).
+
+  This is a diagnostic change, not a capability change — piped input did not
+  work before and still does not. No input that previously succeeded is
+  affected: restartability is a property every working run already had.
+
+  Two cases are worth calling out. `--passthrough <stream>` was previously
+  unguarded on every layer, so a FIFO there hung *after* the R1/R2 output
+  files had been created, leaving partial output on disk; it is now rejected
+  before any output file is written. And `trim_galore /dev/stdin` typed at an
+  interactive terminal still waits for input rather than erroring — that is a
+  terminal, not a pipe, and telling them apart needs `isatty`.
+
+  Two smaller behaviour changes come with it. A `--demux` barcode file that is
+  a pipe or FIFO is now rejected: it is only read once, so restartability does
+  not apply, but a FIFO with no writer blocked with no message *after* trimming
+  and reporting had finished. And `--passthrough <uBAM>` is now rejected up
+  front rather than failing mid-run with `stream did not contain valid UTF-8`
+  — the existing uBAM rejection only inspected the R1/R2 inputs, never the
+  passthrough file.
+
 - **Documentation site: `$` in prose is no longer eaten as maths.** The docs
   pipeline enables `remark-math`, which by default treats single dollars as
   inline-maths delimiters. Prices in the changelog and benchmark pages were

--- a/plans/08032026_reject-non-restartable-input/CODE_REVIEW_A.md
+++ b/plans/08032026_reject-non-restartable-input/CODE_REVIEW_A.md
@@ -1,0 +1,290 @@
+# CODE REVIEW A — Reject non-restartable input (#379)
+
+**Reviewer:** A (fresh context, no shared state with Reviewer B)
+**Target:** uncommitted working-tree diff on `dev` @ `40f77ec` — `src/format.rs`, `src/cli.rs`, `src/main.rs`, `.github/workflows/ci.yml`, `CHANGELOG.md`, new `tests/integration_non_restartable_input.rs`, new `.config/nextest.toml`
+**Spec:** `PLAN.md` v3 (§12 deviations D1–D3)
+**Mode:** report only — no files modified. Every recommendation below carries the exact edit.
+
+---
+
+## 1. Summary
+
+The three-layer guard is sound and, on everything I could construct, correct. Layer 1 covers **more** surfaces than the plan's own inventory claims: I verified rejection through `--paired` (R2 position), `--hardtrim5`, `--clump_only` and `--passthrough`, not just plain single-end. The §3.4 edge-case table reproduces exactly, row for row. The message renders with the intended wrapping and 4-space command indent. `read_filled` is correct. The empty-file message still wins for a regular file. `fmt` and `clippy --all-targets --release -D warnings` are clean (re-run, not taken on trust), and the suite is 467/467 under nextest with a 4.9 s slowest test.
+
+One **High** finding: the layer-0 edit at `src/main.rs:770` (`FastqReader::sanity_check` → `sanity_check_any`) makes a **uBAM `--passthrough` file pass a check it previously failed**, so that run now fails *after* three output files exist instead of before any. I verified this against a purpose-built `HEAD` worktree binary. `PLAN.md` §3.2 asserts this arm is unreachable; §2.4 of the same document already records why it is not.
+
+Two **Medium** findings, both about diagnostics in a change whose entire purpose is diagnostics: the unit-test bound reports an assertion failure as a hang (proven with a standalone repro), and layer 1 discards the `stat` errno so `EACCES`/`EMFILE` are reported as "Input file not found".
+
+The claim I probed hardest and could **not** break: *no input that previously succeeded now fails*. I could not construct a counterexample.
+
+### Verified claims (challenged, not accepted)
+
+| Claim | Result |
+|---|---|
+| fmt + clippy clean | Re-ran both. Clean. |
+| 375 unit + 92 integration, 0 failures | `cargo nextest run`: **467 tests, 467 passed**, 9.1 s total, slowest 4.87 s. Matches. |
+| No test hangs | New integration file: 5 passed in 0.38 s. `format::tests` #379 rows: 0.01 s. No nextest LEAK reports despite three detached threads. |
+| Mutation test fails in 10 s rather than hanging | Mechanism confirmed by inspection: with the type check dead, the writer thread has already returned, so `reopen_restarts`' second `File::open` blocks and `bounded` fires. Structurally sound. |
+| `terminate-after = 4` (240 s) is a safe backstop | ~50× margin over the slowest observed test. Safe. |
+| A4 — `detect_input_format` is on no hot path | Confirmed: every call site in `adapter.rs`, `specialty.rs`, `clump_only.rs`, `main.rs` is per-file setup. None per-record or per-chunk. |
+| §3.4 edge-case table | Reproduced exactly for empty / 1-byte / `/dev/null` / `/dev/zero` / `/dev/urandom` / directory / symlink-to-FIFO / missing file. |
+| Not-found strings preserved | Byte-identical to the `exists()` versions; `cli.rs:1764` (`--passthrough file not found`) still passes. |
+
+---
+
+## 2. Issues by area
+
+### 2.1 Logic
+
+**H1 — `sanity_check_any` on `--passthrough` accepts a uBAM the old check rejected, and defers the failure past output creation.** `src/main.rs:770`
+
+`PLAN.md` §3.2 states: *"`--passthrough` + uBAM is rejected at `main.rs:253`, so `sanity_check_any`'s BAM arm is unreachable here and harmless."* That is false, and §2.4 of the same plan says why:
+
+> the `--passthrough` + uBAM rejection at `main.rs:253` keys off `any_bam`, computed from `cli.input`, so the passthrough file's container format is never inspected anywhere either.
+
+FASTQ R1/R2 with a uBAM passthrough leaves `any_bam == false`, so `main.rs:253` does not fire and `sanity_check_any(pt_path)` takes the `UnalignedBam` arm, opens a `BamReader`, reads one record and returns `Ok(())`. Measured, same fixture (`test_files/ubam_test.bam`) both sides:
+
+```
+HEAD (FastqReader::sanity_check)        working tree (sanity_check_any)
+─────────────────────────────────      ──────────────────────────────────────────
+Error: stream did not contain          … Passthrough: pt.bam → outw/pt_passthrough.fq
+valid UTF-8                            Error: processing pair 1 of 1 (R1=r1.fq, R2=r2.fq)
+                                       Caused by: stream did not contain valid UTF-8
+files in output dir: (none)            files in output dir: pt_passthrough.fq
+                                                            r1_val_1.fq
+                                                            r2_val_2.fq
+```
+
+So the change moves this failure from "before any output file" to "after three output files", which is the exact shape §2.4 identifies as the thing to eliminate (*"it hangs with partial output on disk. Exactly the failure mode §1 says this plan removes"*). The configuration is odd — FASTQ mates with a uBAM index read — but it is reachable, it is a regression against `HEAD`, and the fix is small. **High**, not Critical: it still errors, and no wrong output is produced.
+
+**L1 — `reopen_restarts` silently answers `false` for `first.len() > PEEK_LEN`.** `src/format.rs:304-306`
+
+```rust
+let want = first.len().min(again.len());
+let n = read_filled(&mut file, &mut again[..want]).with_context(ctx)?;
+Ok(n == first.len() && &again[..n] == first)
+```
+
+With `first.len() > PEEK_LEN`, `want` clamps to 4, so `n ≤ 4 < first.len()` and the function reports **not restartable** for a perfectly good regular file. Only the sole caller keeps this unreachable (`&peek[..n]`, `n ≤ 4`); the `.min()` makes the function *look* as though it handles a longer slice, which is the trap. The doc comment states the FIFO precondition but not the length one. Reject-direction only — it cannot wrongly accept. **Low**, but the mis-answer is silent, which is what makes it worth a line.
+
+**L2 — `--demux <writer-less FIFO>` still hangs with no message, after the full output is on disk.** `src/cli.rs:942-944` (D1)
+
+Measured:
+
+```
+$ mkfifo f5; trim_galore -o outd --demux f5 r1.fq      # bounded by alarm(8)
+…
+JSON report: outd/r1.fq_trimming_report.json
+Trimming complete, starting demultiplexing procedure (based on 3' barcodes supplied as per file >f5<)
+*** blocked in File::open until killed at 8 s ***
+```
+
+D1's rationale — *"`read_barcode_file` opens the barcode file once … a FIFO barcode file works today, and rejecting it would be an unjustified regression"* — is true **only with a live writer**. Without one, `demux::read_barcode_file` (`main.rs:1265`) blocks in `File::open` with no message, after trimming, FastQC and the JSON report have all completed. That is not a restartability violation, so D1 is right that layer 2's invariant does not apply; it is a *blocking-open* hang, which layer 1 would have closed for free. V10's "every input-bearing CLI surface reaches a guard" is falsified here. Pre-existing, not a regression. **Low** — but either take the guard or amend D1 to record the writer-less case.
+
+**L3 — `-a2 file:<stream>` is a second-open surface and is unguarded.** `src/cli.rs:972` + `src/main.rs:1017`
+
+`Cli::validate` quiet-parses `--a2` (which reads a `file:` FASTA), and `main.rs:1017` parses it again. That is a genuine two-open path on a user-supplied file, outside every layer. Confirmed empirically: with a three-shot FIFO writer, `--a2 file:<fifo>` completes; with a single-shot writer the second parse would see EOF. Nobody streams an adapter FASTA, so this is **Low** — but it is the second counterexample to V10, and V10's stated purpose was *"the next flag that takes a path should be caught by a test rather than by a reviewer"*.
+
+**L4 — D2's `is_ok_and` fall-through re-opens A2's residual, narrowly.** `src/format.rs:299`
+
+D2 is the right call and is strictly less aggressive than the plan, as advertised. Worth recording precisely what it costs: on any handle whose `stream_position()` **errors**, the byte comparison becomes the sole condition, and the byte comparison is exactly what A2 was retired for (a repeating 4-byte prefix defeats it). No real input reaches that state — `lseek` fails with `ESPIPE` for pipes, FIFOs and sockets, and all three are rejected by the type check at `format.rs:322` before `reopen_restarts` is called, leaving only regular files and character devices, for which `stream_position()` succeeds. So this is a documentation point, not a defect. Consider adding "A2's residual returns on this branch" to D2.
+
+**No hole found in `read_filled`.** `Ok(0)` → EOF; `Interrupted` retried; every other error propagated with `.with_context`. The `Interrupted` arm can in principle spin forever, but that is `std::io::Read::read_exact`'s own contract, not a new risk. It does harden the pre-existing `n >= 3` gzip test as A8 claims.
+
+**No hole found in the `n == 0` / new-check interaction.** For a regular file the empty check still precedes the second open, verified end to end (`Input file 'empty.fq' is empty`, no restartability text). D3's strengthened `detect_empty_file_errors` pins both halves.
+
+### 2.2 Errors and error-path quality
+
+**M2 — layer 1 discards the `stat` errno, so `EACCES`/`EMFILE`/`ELOOP` are reported as "Input file not found".** `src/cli.rs:488-489`
+
+```rust
+let meta =
+    std::fs::metadata(path).map_err(|_| anyhow::anyhow!("{not_found}: {}", path.display()))?;
+```
+
+Measured with a file inside a `chmod 000` directory (`stat` → `EACCES`):
+
+```
+Error: Input file not found: locked/hidden.fq
+```
+
+This is *identical* to the old `exists()` behaviour, so it is not a regression — but it is the same wrong-blame the plan rules out one layer down. `PLAN.md` §10 Q3, on `reopen_restarts`:
+
+> **`Err`** … `Ok(false)` would report `EMFILE` or `EACCES` as "your input is a pipe" — the same wrong-blame this plan exists to remove, one layer down.
+
+Layer 1 now does precisely that, one layer up, at a site the change touched and where the `io::Error` was in hand. `reopen_restarts` honours Q3 correctly (`with_context`, path named). **Medium** on the strength of the plan's own principle, and because it is three lines.
+
+**No mis-blame found in layer 2.** `detect_input_format`'s three fallible steps each carry distinct context (`Failed to open input file`, `Failed to stat input file`, `Failed to read from`), and `reopen_restarts` carries `Failed to re-open input file '…' for the restartability check` on both the open and the read, exactly as §4 specifies. A transient `EMFILE` on the second open surfaces as itself, not as "your input is a pipe".
+
+### 2.3 Tests — can any of them hang CI, and do the bounds bound what they claim?
+
+**M1 — `bounded()` reports an assertion failure inside the body as "blocked; it must fail, not hang".** `src/format.rs:510-513`
+
+```rust
+match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+    Ok(v) => v,
+    Err(_) => panic!("{what} blocked; it must fail, not hang"),
+}
+```
+
+`Err(_)` conflates `Timeout` with `Disconnected`. If the body panics — e.g. `detect_input_format` returns `Ok`, so `expect_err("a FIFO must be rejected")` fires — the sender drops, `recv_timeout` returns `Disconnected` **immediately**, and the reported failure is a hang. Standalone repro (`rustc -O --edition 2021`):
+
+```
+thread '<unnamed>' panicked at probe_bounded.rs:18:13:
+a FIFO must be rejected: Err value not returned
+thread 'main' panicked at probe_bounded.rs:10:19:
+detect_input_format on a FIFO blocked; it must fail, not hang  [real recv error: Disconnected]
+--- outcome after 203.334µs
+```
+
+So the one failure mode this harness exists to distinguish — hang versus reject — is reported backwards for the *other* regression, the one where the FIFO is silently accepted. The inner panic is still visible in libtest's captured output, so a careful reader recovers the truth; the headline does not. In §5.3's own terms this is the mirror image of "a blocked test looks like a slow job". **Medium.**
+
+**Nothing here can hang CI.** Checked directly:
+
+- `bounded` panics on the test thread; the blocked body thread is detached, never joined, and dies with the process. libtest exits via `process::exit` and does not wait on non-main threads, so neither `cargo test --release` nor nextest can wedge on it.
+- `spawn_fifo_writer` returns a `JoinHandle` bound to `_writer` (a real binding, not `_`), which is dropped-and-detached at scope end, not joined. No self-deadlock: the writer's `O_WRONLY` open rendezvous with the reader's open, and it cannot exit before the reader's open has returned, so the ordering the test relies on is guaranteed rather than raced. `write_all` is `let _ =`, so the expected `EPIPE` is swallowed (rule 3).
+- `run_bounded` (integration, `tests/…:60-91`) drains stderr on its own thread, so a chatty child cannot deadlock against the wait loop; the 20 s deadline `kill()`s then `wait()`s; the post-exit `recv_timeout(5 s)` degrades to an empty string rather than blocking. For the `sh -c "cat … | trim_galore …"` rows, `sh` reaps both pipeline members before exiting, so stderr reaches EOF.
+- No nextest LEAK reports across the whole suite, despite three detached threads.
+- All 10 temp-dir slugs are unique (`tg_format_fifo_detect`, `tg_format_fifo_stat`, `tg_format_reopen`, `tg_format_devfd`, `tg_format_devfd_repeat`, `tg_379_fifo_in`, `tg_379_stdin_plain`, `tg_379_stdin_gz`, `tg_379_passthrough`, `tg_379_control`) — rule 5 honoured, and the 19-slug audit recorded at `ci.yml:52-56` still holds.
+
+**The bounds do not cover setup — which is safe here, but the comment says otherwise.** `src/format.rs:501-502` claims *"each bounds its body"*. `bounded()` wraps only the call under test; `make_fifo` and `spawn_fifo_writer` run unbounded on the test thread, and the integration tests bound only the child process, not `fresh_dir`/`make_fifo`. `PLAN.md` §5.3 rule 2 asked for the whole body *"setup included"*, because the measured wedge (Shape B, `child.wait()` on a writer) was in setup. It is fine as written — the writer's blocking `open` is on its own thread, and `mkfifo(1)`, `remove_dir_all`, `create_dir_all` and `fs::write` cannot block — but that is a property worth stating rather than a bound. **Low**, comment accuracy only.
+
+**L8 — `spawn_fifo_writer` swallows an open failure, then the reader blocks and the panic blames the guard.** `src/format.rs:540`. `if let Ok(mut f) = …open(&p)` discards the error; if the write-only open ever fails, no writer arrives, the reader's `File::open` blocks and `bounded` panics with "blocked; it must fail, not hang" — pointing at the guard when the fault is in the harness. That is the class rule 4 guards against for `mkfifo`, unguarded one line later. **Low.**
+
+**L5 — the `/dev/urandom` negative is nondeterministic at 2⁻³².** `src/format.rs:601`. Four random bytes could match; the plan chose this knowingly. Noting only so it is not mistaken for a deterministic control.
+
+**Coverage note (informational).** `detect_rejects_dev_fd_when_the_leading_bytes_repeat` is the only test isolating the offset condition — v3's central design change — and it is `#[cfg(target_os = "macos")]`. On `ubuntu-latest` reverting `stream_position()` fails nothing. The matrix does include `macos-latest`, so CI covers it; there is just no redundancy, and §12 already records this as the Darwin-only leg.
+
+### 2.4 CI
+
+**L6 — `timeout-minutes: 30` may be tight on a cold cache.** `.github/workflows/ci.yml:32`. `lto = true` + `codegen-units = 1` means every one of the now-**ten** release test binaries gets its own full LTO link. Measured locally (M-series, warm registry, cold `target`): `cargo build --release` 1 m 12 s; `cargo test --release --no-run` a further **1 m 00 s wall / 175 s CPU**. Scaling 175 CPU-seconds to a 2-vCPU `ubuntu-latest` and adding a cold `cargo install cargo-nextest --locked`, the debug build, and both test runs puts a cold-cache job in the 15–22 minute band — a 1.4–2× margin, not the 10× the number implies. The bound's stated job is to turn a 360-minute wedge into a fast red, and the debug leg is already bounded at 240 s per test by nextest, so only a release-profile-only hang depends on this number; 45 buys the same protection with room. **Low.**
+
+`.config/nextest.toml` is correctly placed (workspace-root `.config/`), not gitignored, and `[profile.default]` is the profile `cargo nextest run` uses with no `--profile` flag. Note for the record that `terminate-after` does **not** cover the `cargo test --release` step (`ci.yml:74`) — the job bound is the only backstop there, which is what §5.2 says.
+
+### 2.5 Structure and style
+
+Against `CLAUDE.md`'s "one line, state the fact" rule, the new comments sit inside a file whose existing register is far more discursive, and they are consistent with it. One exception:
+
+`.github/workflows/ci.yml:30-31` — *"A test that opens a FIFO with no writer blocks instead of failing; without a bound that is a 6-hour job, not a red X."* The second clause is evidence and colour; `CLAUDE.md` puts that in the commit message. One line would do.
+
+`.config/nextest.toml`'s two-line comment states the fact and earns its second line. The `read_filled` and `reopen_restarts` doc comments carry rationale, which is what doc comments in this crate do. The rewritten `format.rs:346-347` is a genuine improvement — four lines to two, and it now says the true thing.
+
+`make_fifo` and `fresh_tmpdir`/`fresh_dir` are duplicated between `src/format.rs`'s test module and the integration file. Unavoidable across crate boundaries without a test-support crate, and `fresh_tmpdir` duplication is already the repo idiom in five places. No action.
+
+The `REJECTION` constant in the integration file is the right call — it is the one substring both message variants share, so a wording drift fails in one place.
+
+### 2.6 Efficiency
+
+One `fstat` on an already-open handle plus, for regular files, one extra `open` + `stream_position()` + ≤4-byte `read` per `detect_input_format` call. Peak concurrent handles rise from 1 to 2 (3 on the gzip branch). Against the five-plus opens and full-file read per input this is unmeasurable, and A4 holds — no call site is per-record. Layer 1 is genuinely zero extra syscalls: `Path::exists()` is `fs::metadata(path).is_ok()`, so the replacement is the same call. Nothing to raise.
+
+### 2.7 Byte-identity invariant
+
+Nothing in the diff touches quality trimming, adapter alignment, filtering, naming or writing. Every new code path terminates in `bail!` or falls through unchanged. The plan's V2 result (6 outputs + 6 reports byte-identical to a `HEAD` build with a firing sentinel control) is the right test and I see no path by which it could be wrong. V3 (Perl 0.6.11) still needs the CI `validation` / `validation-ubam` run before merge, as §12 says.
+
+---
+
+## 3. Fixes recommended
+
+Ordered by priority. None applied — reporting only, per the review brief.
+
+### High
+
+**F1 — reject a uBAM `--passthrough` file on its own detected format (H1).** `src/main.rs`, immediately after the existing block at `:253-258` and therefore before `ensure_output_dir` at `:315`:
+
+```rust
+    // `any_bam` above is computed from `cli.input`; the passthrough file is a
+    // separate surface and needs its own format check.
+    if let Some(ref pt) = cli.passthrough
+        && matches!(detect_input_format(pt)?, InputFormat::UnalignedBam)
+    {
+        anyhow::bail!(
+            "--passthrough is not supported with uBAM input in this release. \
+             Either convert the uBAM to FASTQ via `samtools fastq` first, or drop --passthrough."
+        );
+    }
+```
+
+This restores the fail-before-any-output-file property, reuses the existing wording verbatim, and makes `main.rs:770`'s BAM arm genuinely unreachable — which is what §3.2 assumed. It also runs the #379 guard on the passthrough file earlier than `main.rs:770` does. Worth a regression test asserting no output file exists after a uBAM passthrough is rejected; `test_files/ubam_test.bam` is a ready fixture.
+
+### Medium
+
+**F2 — distinguish `Timeout` from `Disconnected` in `bounded` (M1).** `src/format.rs:510-513`:
+
+```rust
+        match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+            Ok(v) => v,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                panic!("{what} blocked; it must fail, not hang")
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("{what} panicked; see the panic above")
+            }
+        }
+```
+
+**F3 — keep the errno at layer 1 (M2).** `src/cli.rs:488-489`:
+
+```rust
+    let meta = std::fs::metadata(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            anyhow::anyhow!("{not_found}: {}", path.display())
+        } else {
+            anyhow::Error::new(e).context(format!("Cannot stat input file: {}", path.display()))
+        }
+    })?;
+```
+
+`cli.rs:1764` and the "Input file not found" wording are preserved for the `NotFound` case, which is the only case any test asserts on.
+
+### Low
+
+**F4 — pin `reopen_restarts`' length precondition (L1).** `src/format.rs`, before line 303, and add the precondition to the doc comment alongside the FIFO one:
+
+```rust
+    debug_assert!(
+        first.len() <= PEEK_LEN,
+        "reopen_restarts compares at most PEEK_LEN bytes"
+    );
+```
+
+**F5 — either guard the `--demux` barcode file or amend D1 (L2).** The guard is one line, `src/cli.rs:942-944`:
+
+```rust
+            check_restartable_input(demux_file, "Barcode file not found")?;
+```
+
+My recommendation is to take it. D1 correctly observes that the restartability invariant does not apply, but the blocking-open hang does, and the working configuration it would break — a live-writer FIFO as a two-column barcode TSV — has no plausible user, whereas the hang leaves a completed trim run wedged with no message. If you decline, add the writer-less case to D1 so the deviation records what it costs, and drop V10's "every input-bearing CLI surface" to the two surfaces it actually covers.
+
+**F6 — record `-a2 file:` as an unguarded second-open surface (L3).** No code change needed for this release; V10's enumeration should name it, or it will be rediscovered as a bug report.
+
+**F7 — surface a failed writer open in `spawn_fifo_writer` (L8).** `src/format.rs:540`:
+
+```rust
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&p)
+                .expect("FIFO writer must open");
+```
+
+A panic on this thread disconnects the channel; with F2 applied, `bounded` then says "panicked", not "blocked" — the two fixes compose.
+
+**F8 — raise the CI job bound (L6).** `.github/workflows/ci.yml:32`: `timeout-minutes: 45`.
+
+**F9 — trim the ci.yml comment to the fact (style).** `.github/workflows/ci.yml:30-31`:
+
+```yaml
+    # A FIFO test with no writer blocks rather than fails, so bound the job.
+```
+
+**F10 — correct `src/format.rs:501-502`** from "each bounds its body" to what is true: each bounds the call under test, and no setup step can block.
+
+---
+
+## 4. Plan-text corrections worth folding into §12
+
+Not code, but they are claims a future reader will rely on:
+
+1. **§3.2 is wrong** that `sanity_check_any`'s BAM arm is unreachable for `--passthrough`. §2.4 already contains the refutation.
+2. **V10 is falsified** by two surfaces: `--demux` (D1, deliberate) and `-a2 file:` (not considered).
+3. **D1's rationale is incomplete** — it addresses restartability but not the writer-less blocking open, which is the failure the plan is named after.
+4. **D2 should note** that A2's repeating-prefix residual returns on the `stream_position()`-error branch, even though nothing real reaches it.

--- a/plans/08032026_reject-non-restartable-input/CODE_REVIEW_B.md
+++ b/plans/08032026_reject-non-restartable-input/CODE_REVIEW_B.md
@@ -1,0 +1,526 @@
+# CODE_REVIEW_B — Reject non-restartable input (#379)
+
+**Reviewer:** B (independent, fresh context)
+**Target:** uncommitted working-tree diff on `dev` @ `40f77ec` — `src/format.rs`, `src/cli.rs`, `src/main.rs`, `.github/workflows/ci.yml`, `CHANGELOG.md`, `tests/integration_non_restartable_input.rs` (new), `.config/nextest.toml` (new)
+**Spec:** `plans/08032026_reject-non-restartable-input/PLAN.md` v3
+**Constraint honoured:** no file was modified. Every fix below is given as an exact edit for the author to apply.
+
+---
+
+## 1. Summary
+
+The three-layer guard is **behaviourally correct**. I probed all twelve §3.4 edge-case rows that are reachable on Darwin and every one lands where the plan says it should — including the four that the plan's own reviewers argued about (`/dev/null` → `is empty`, `/dev/zero` → not-recognised, `/dev/urandom` → Reopen message, `/dev/stdin` from a regular-file redirect → Reopen message). I found no input that is wrongly accepted, and no input that terminates in neither direction other than the tty residual the plan already books as a known case.
+
+I also confirmed the guard's testing is not self-satisfied: **both** layers have a test that fails if the layer is deleted, in the fast direction, not the wedge direction.
+
+One finding is material and I would not merge without it:
+
+> **H1 — the layer-0 swap at `src/main.rs:770` makes `--passthrough <uBAM>` strictly worse.** `sanity_check_any` *accepts* a BAM passthrough file (it routes to `BamReader`), where `FastqReader::sanity_check` rejected it. The run then proceeds, creates the R1/R2 and passthrough output files, and dies with `stream did not contain valid UTF-8`. Reproduced. The plan's justification for this being safe (§3.2: "`--passthrough` + uBAM is rejected at `main.rs:253`") is false, and §2.4 of the same plan says why.
+
+Everything else is Medium or below: a test helper that reports assertion failures as hangs, an errno thrown away at layer 1, and a latent precondition in `reopen_restarts`.
+
+### Claims I re-ran rather than accepted
+
+| Claim | Verdict |
+|---|---|
+| `cargo fmt --check` clean | Confirmed. |
+| `cargo clippy --all-targets --release -D warnings` clean | Confirmed (cache replay, no warnings). |
+| Full suite, 0 failures | Confirmed. `cargo nextest run`: **467 tests, 467 passed, 8.727 s**. `cargo test --release`: exit 0. |
+| "a mutation makes the FIFO test fail in 10 s rather than hang" | Sound, and stronger than stated — it fails on **either** branch of the race. If the second open blocks, `bounded` times out; if the writer is still alive so the second open succeeds, `reopen_restarts` reads mid-stream, returns `false`, and the `is a pipe or FIFO` assertion fails outright. |
+| Byte-identity vs `HEAD` for 6 outputs + 6 reports | Not re-run; out of practical scope for this review. No writer path is touched by the diff, which is consistent. V3 (Perl 0.6.11) is correctly still booked as CI-only. |
+| §5.3 rule 5 (one `fresh_tmpdir` slug per FIFO test) | Confirmed. All five new unit slugs and all five new integration slugs are unique, and no other test file uses a `tg_379_*` or `tg_format_fifo*` / `tg_format_devfd*` / `tg_format_reopen` slug. |
+
+### What I verified end to end
+
+Run against `./target/release/trim_galore` built from the working tree, each bounded with `perl -e 'alarm N; exec @ARGV'`:
+
+| Input | Result | Plan row |
+|---|---|---|
+| writer-less FIFO | `is a pipe or FIFO`, exit 1, prompt, no output dir | §3.4 "no writer at all" ✓ |
+| `cat f \| … /dev/stdin` | `is a pipe or FIFO`, exit 1 | §1 row 2 ✓ |
+| `<(cat f)` → `/dev/fd/63` | `is a pipe or FIFO`, exit 1 | §1 row 1 ✓ |
+| `/dev/stdin < f` (macOS row B) | `…opening it a second time did not return to the beginning of the data` | §2.2.1 row B ✓ |
+| `/dev/null` | `Input file '/dev/null' is empty` | §3.4 ✓ |
+| `/dev/zero` | `is not recognised as FASTQ …` | §3.4 ✓ |
+| `/dev/urandom` | Reopen message | §3.4 ✓ |
+| directory | `Failed to read from <dir>` / `Is a directory (os error 21)` | §3.4 ✓ (unchanged) |
+| `--passthrough <pipe>` | `is a pipe or FIFO`, **no output dir created** | §2.4 fixed ✓ |
+| `--passthrough /dev/stdin < f` | Reopen message | the case layer 0 uniquely buys (see L3) |
+
+The rendered message is correct, including the `\x20   ` indent trick surviving the `\`-continuations:
+
+```
+Error: Input '/tmp/.../stream.fq' is a pipe or FIFO, not a regular file, so it cannot be re-read from the start.
+
+Trim Galore reads each input more than once — format detection, the initial
+sanity check, and adapter auto-detection each open it independently — so it
+requires a regular file.
+
+Common causes are pipes, FIFOs, process substitution such as
+`<(zcat reads.fq.gz)`, and /dev/stdin. Write the stream to a file first:
+
+    zcat reads.fq.gz > reads.fq && trim_galore [options] reads.fq
+```
+
+---
+
+## 2. Issues by area
+
+### 2.1 Logic
+
+#### H1 — `--passthrough <uBAM>` now passes the sanity check and fails deep, with partial output on disk
+
+`src/main.rs:763-771`:
+
+```rust
+// `sanity_check_any`, not `FastqReader::sanity_check`, so the
+// passthrough path reaches the #379 restartability guard.
+if pair_idx == 0
+    && let Some(ref pt_path) = cli.passthrough
+{
+    sanity_check_any(pt_path)?;
+}
+```
+
+`sanity_check_any` (`src/main.rs:29-42`) dispatches on `detect_input_format`, and its `UnalignedBam` arm opens a `BamReader` and returns `Ok(())`. The passthrough file is then read, unconditionally and on both paths, by `FastqReader` — `src/main.rs:1346` (`open_threaded`) and `src/main.rs:1385` (`open`).
+
+The plan asserts this arm is unreachable:
+
+> §3.2: "`--passthrough` + uBAM is rejected at `main.rs:253`, so `sanity_check_any`'s BAM arm is unreachable here and harmless."
+
+`src/main.rs:253` is `if cli.passthrough.is_some() && any_bam`, and `any_bam` is built at `src/main.rs:184-191` by mapping over **`cli.input`**. The passthrough file is not in `cli.input` — which is the whole premise of §2.4, and which §2.4 states in terms:
+
+> "the `--passthrough` + uBAM rejection at `main.rs:253` keys off `any_bam`, computed from `cli.input`, so the passthrough file's container format is never inspected anywhere either."
+
+So §3.2 contradicts §2.4, and the implementation followed §3.2. Reproduced on the working-tree binary:
+
+```
+$ trim_galore --paired -o $D/out --passthrough test_files/ubam_test.bam $D/r1.fastq $D/r2.fastq
+  Passthrough: test_files/ubam_test.bam → …/out/ubam_test_passthrough.fq
+Error: processing pair 1 of 1 (R1=…/r1.fastq, R2=…/r2.fastq)
+
+Caused by:
+    stream did not contain valid UTF-8
+exit 1
+
+$ ls $D/out
+r1_val_1.fq  r2_val_2.fq  ubam_test_passthrough.fq      # three empty files
+```
+
+Before the change, `FastqReader::sanity_check` read the BGZF bytes as text at that same line and errored **before** `run_paired`, so nothing was created. The diff therefore moves one `--passthrough` case from "errors before any output" to "errors after three output files exist, with an opaque message" — the exact failure shape the CHANGELOG entry claims this change removes for `--passthrough`.
+
+This is not a reason to revert the layer-0 swap: it is the only thing that catches the *Reopen* class on the passthrough path (`--passthrough /dev/stdin` — verified rejected, no output dir). The fix is to give the passthrough file the BAM rejection that `cli.input` gets.
+
+**Exact fix** — `src/main.rs:767-771`, replace:
+
+```rust
+            if pair_idx == 0
+                && let Some(ref pt_path) = cli.passthrough
+            {
+                sanity_check_any(pt_path)?;
+            }
+```
+
+with:
+
+```rust
+            if pair_idx == 0
+                && let Some(ref pt_path) = cli.passthrough
+            {
+                // main.rs:253 rejects passthrough + uBAM from `any_bam`, which is
+                // built from cli.input only — the passthrough file needs its own check.
+                if matches!(detect_input_format(pt_path)?, InputFormat::UnalignedBam) {
+                    anyhow::bail!(
+                        "--passthrough is not supported with uBAM input in this release. \
+                         Either convert '{}' to FASTQ via `samtools fastq` first, or drop \
+                         --passthrough.",
+                        pt_path.display()
+                    );
+                }
+                sanity_check_any(pt_path)?;
+            }
+```
+
+`detect_input_format` is idempotent and cheap here (§6/A4), and running it twice keeps the restartability guard as the first thing the passthrough file meets. Both symbols are already imported at `src/main.rs:16-18`.
+
+Add a test alongside the others in `tests/integration_non_restartable_input.rs`, or better in `tests/integration_passthrough.rs` next to its siblings:
+
+```rust
+#[test]
+fn passthrough_ubam_is_rejected_before_output() {
+    let dir = fresh_dir("tg_379_passthrough_ubam");
+    let (r1, r2) = (dir.join("r1.fastq"), dir.join("r2.fastq"));
+    write_fastq(&r1);
+    write_fastq(&r2);
+    let out = dir.join("out");
+
+    let mut cmd = Command::new(binary());
+    cmd.arg("--paired").arg("-o").arg(&out)
+        .arg("--passthrough").arg("test_files/ubam_test.bam")
+        .arg(&r1).arg(&r2);
+    let (ok, stderr) = run_bounded(cmd, "trim_galore --passthrough on a uBAM");
+
+    assert!(!ok, "a uBAM passthrough must be rejected; stderr was: {stderr}");
+    assert!(stderr.contains("not supported with uBAM input"), "unexpected message: {stderr}");
+    assert!(
+        !stderr.contains("valid UTF-8"),
+        "must not fail deep in the reader: {stderr}"
+    );
+    assert!(!out.join("r1_val_1.fq").exists(), "must reject before writing output");
+}
+```
+
+Priority: **High**. Exotic invocation, but it is a diagnostic regression inside the change whose sole purpose is diagnostics, and it leaves partial output where none was left before.
+
+#### M3 — `reopen_restarts`'s `PEEK_LEN` clamp answers silently and wrongly outside its unstated precondition
+
+`src/format.rs:303-306`:
+
+```rust
+    let mut again = [0u8; PEEK_LEN];
+    let want = first.len().min(again.len());
+    let n = read_filled(&mut file, &mut again[..want]).with_context(ctx)?;
+    Ok(n == first.len() && &again[..n] == first)
+```
+
+Two silent answers outside `1 <= first.len() <= PEEK_LEN`:
+
+- `first.len() > PEEK_LEN` → `want == 4`, so `n <= 4 < first.len()` and the function returns `Ok(false)` **always**, i.e. "not restartable" for a perfectly good regular file. It cannot return `true`.
+- `first.len() == 0` → `want == 0`, `read_filled` returns `Ok(0)` without reading, and `0 == 0 && [] == []` returns `Ok(true)` vacuously.
+
+Neither is reachable today: the sole caller is `src/format.rs:334`, which passes `&peek[..n]` with `1 <= n <= PEEK_LEN` (the `n == 0` bail at `:330` guarantees the lower bound). But the doc comment at `:278-287` states only the FIFO precondition, so the next caller has nothing to read. This is the "silently produce wrong results" class that `CLAUDE.md` asks code to fail loudly on.
+
+The `.min()` is what hides it: it converts an out-of-contract argument into a plausible-looking answer instead of a compile or runtime error.
+
+**Exact fix** — `src/format.rs:288`, extend the doc block and assert. Add after the existing `Callers must reject FIFOs first:` paragraph:
+
+```rust
+/// `first` must be the 1..=`PEEK_LEN` bytes the first handle actually returned.
+```
+
+and replace `:303-304`:
+
+```rust
+    let mut again = [0u8; PEEK_LEN];
+    let want = first.len().min(again.len());
+```
+
+with:
+
+```rust
+    debug_assert!(
+        (1..=PEEK_LEN).contains(&first.len()),
+        "reopen_restarts: `first` must be 1..={PEEK_LEN} bytes, got {}",
+        first.len()
+    );
+    let mut again = [0u8; PEEK_LEN];
+    let want = first.len().min(PEEK_LEN);
+```
+
+Note the tension the author will hit: this file already argues at `:119-128` that a `debug_assert` "would compile out of every shipped binary". That argument was about a `pub` function reachable from a release build; this is a private helper with one caller, so a `debug_assert` plus the doc line is proportionate. If you disagree, a plain `assert!` costs one comparison per `detect_input_format` call, which is nothing against the extra `open` it already does.
+
+Priority: **Medium** (latent, not live).
+
+#### Not a hole — the `is_ok_and` fall-through (D2)
+
+`src/format.rs:299`:
+
+```rust
+    if file.stream_position().is_ok_and(|pos| pos != 0) {
+        return Ok(false);
+    }
+```
+
+I probed for a gap here and did not find one. The three ways `stream_position` can fail to be decisive all land safely:
+
+- `Err(ESPIPE)` on a pipe → falls through to the byte comparison, which would read from the stream. Unreachable: `is_non_restartable_type` at `:322` has already bailed, on both the path (`cli.rs:490`) and the handle. The doc comment at `:286-287` states the precondition and both callers honour it.
+- `Err(_)` on an exotic character device → falls through, byte comparison decides. `/dev/zero` (accept) and `/dev/urandom` (reject) both verified end to end, and both go through the byte half regardless because their offset is `Ok(0)`.
+- `Ok(0)` on a `dup`-shared handle whose offset happens to be 0 → the byte comparison is the backstop, and `detect_rejects_dev_fd_when_the_leading_bytes_repeat` is the test that keeps the offset half honest in the other direction.
+
+D2 is strictly more conservative than the plan (`Err` → defer rather than propagate), and I agree with the deviation for the reason given: propagating would turn a class that falls through today into a hard error.
+
+`read_filled` (`:265-276`) is also correct. `Ok(0)` breaks on EOF, `Interrupted` retries, `n` is monotone so it terminates, and `Ok(n)` with `n < buf.len()` is a genuine short read the caller can distinguish. The only unbounded case is an unending `Interrupted` storm, which is what `std::io::Read::read_exact` does too.
+
+The `n == 0` empty check at `:330` correctly precedes the reopen check at `:334`, so an empty regular file keeps its own message — asserted in both directions by the strengthened `detect_empty_file_errors` (D3), which is the right strengthening.
+
+### 2.2 Errors and diagnostics
+
+#### M2 — layer 1 throws away the errno it now has in hand
+
+`src/cli.rs:487-489`:
+
+```rust
+fn check_restartable_input(path: &std::path::Path, not_found: &str) -> anyhow::Result<()> {
+    let meta =
+        std::fs::metadata(path).map_err(|_| anyhow::anyhow!("{not_found}: {}", path.display()))?;
+```
+
+`map_err(|_| …)` collapses every `io::Error` into "not found" and drops the source, so `EACCES` on a parent directory, `ELOOP` on a symlink cycle and `EMFILE` under fd pressure all print `Input file not found: reads.fq`.
+
+This is byte-for-byte the behaviour of the `Path::exists()` it replaces (`exists()` is `fs::metadata(path).is_ok()`), so it is not a regression — but it is the one site in this diff that acquired the errno and discarded it, and the plan rejects exactly this pattern one layer down:
+
+> §10 Q3: "`Ok(false)` would report `EMFILE` or `EACCES` as 'your input is a pipe' — the same wrong-blame this plan exists to remove, one layer down."
+
+The same reasoning applies to reporting `EACCES` as "not found" one layer *up*. `src/cli.rs:1764` asserts on `--passthrough file not found`, so the `NotFound` wording must stay.
+
+**Exact fix** — replace `src/cli.rs:488-489` with:
+
+```rust
+    let meta = std::fs::metadata(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            anyhow::anyhow!("{not_found}: {}", path.display())
+        } else {
+            anyhow::Error::new(e).context(format!("Failed to stat input '{}'", path.display()))
+        }
+    })?;
+```
+
+This keeps `test_passthrough_rejects_missing_file` (`src/cli.rs:1753-1765`) green and matches the `Failed to stat input file` wording already used at `src/format.rs:319-321`.
+
+Priority: **Medium**.
+
+#### L2 — the pipe message never names a socket
+
+`src/format.rs:210-212` documents `NotRestartable::Pipe` as "A pipe, FIFO **or socket**, named by its file type", and `is_non_restartable_type` (`:249-253`) matches `is_fifo() || is_socket()`. The message at `:222-226` says only:
+
+> `Input 'X' is a pipe or FIFO, not a regular file, so it cannot be re-read from the start.`
+
+The plan spends a paragraph (§3.3) on v2's noun being wrong for the majority case; a socket gets the same treatment here, in the same change. It is still an improvement — before this, a socket path reached `File::open` and returned a bare `ENXIO` — so this is cosmetic.
+
+**Exact fix** (optional): add a `Socket` variant to `NotRestartable`, have `is_non_restartable_type` return which one, and give it `"Input '{}' is a socket, not a regular file, so it cannot be re-read from the start."`. Cheaper alternative, which keeps the `is a pipe or FIFO` substring the two tests assert on: leave it, and drop "or socket" from the `:210` doc so the code and the message agree.
+
+Priority: **Low**.
+
+#### L1 — the Reopen class leaves an empty output directory
+
+`naming::ensure_output_dir(output_dir)` runs at `src/main.rs:315`, ahead of every layer-2 site (`sanity_check_any` at `:760`/`:762`/`:770`). So the pipe/FIFO class, caught by layer 1 inside `Cli::validate()` at `src/main.rs:166`, creates nothing — verified, and asserted by `fifo_input_is_rejected_and_creates_no_output` and `passthrough_fifo_is_rejected_and_creates_no_output`. The Reopen class does not:
+
+```
+$ trim_galore --paired -o $D/o1 --passthrough /dev/stdin r1 r2 < idx.fastq
+Error: Input '/dev/stdin' cannot be re-read from the start: …
+$ ls -la $D/o1
+total 0            # created, empty
+```
+
+The CHANGELOG says of `--passthrough`, "it is now rejected before anything is written". True for the class the entry is about (a FIFO), not for `/dev/fd`-shaped input. An empty directory is harmless; the claim is the thing to soften.
+
+**Exact fix**: no code change. In `CHANGELOG.md`, change "it is now rejected before anything is written" to "it is now rejected before any output file is written".
+
+Priority: **Low**.
+
+### 2.3 Tests — can any of them hang CI, and do the bounds bound what they claim?
+
+Short answer: **no new test can hang CI**, and the bounds are real. Longer answer, per mechanism:
+
+**`bounded()` (`src/format.rs:505-514)`.** The body runs on a detached thread, `recv_timeout(10 s)` bounds the wait, and a panic on the harness thread is a test failure. The leaked body thread cannot hold the process open — the Rust test harness returns from `main`, which exits the process regardless of live threads. Under nextest each test is its own process, so it is moot there too. Correct.
+
+**`spawn_fifo_writer()` (`src/format.rs:537-545)`.** Correct, and correct for the non-obvious reason: the write-only `open` is off the main thread, so it rendezvous with the reader's `open` instead of self-deadlocking (§5.3 rule 1 + the trap the plan calls out). `if let Ok(mut f) = …` and `let _ = f.write_all(…)` give rule 3 (EPIPE tolerance) without an `unwrap`. The handle is bound to `_writer`, not `_`, so it is not dropped at the end of the statement — that distinction matters here and is easy to break in a later edit, though nothing depends on the handle actually being joined.
+
+**`make_fifo()` (`src/format.rs:517-530` and `tests/…:46-57`).** Implements rule 4 exactly: `mkfifo` exit status *and* a positive `is_fifo()` assertion on the created node. This is the check that stops a `$PATH` failure from being reported as a guard bug.
+
+**`run_bounded()` (`tests/integration_non_restartable_input.rs:60-91`).** Implements rule 6 correctly and for the right reason — `spawn()` not `output()`, stderr drained on its own thread so a chatty child cannot deadlock the `try_wait` loop, `kill()` then `wait()` on the 20 s deadline. Two rough edges, both reachable only in the regression case:
+
+- **L5a**: the `panic!` at `:84` fires *before* `rx.recv_timeout` at `:89`, so the failure message carries no stderr at all — on the one failure that matters most, you get `trim_galore on a FIFO never exited; it must fail, not hang` and nothing about what the binary said. Fix: drain first.
+- **L5b**: for the two `sh -c "… | trim_galore …"` tests, `child.kill()` signals only `sh`. A wedged `trim_galore` and its `cat` survive as orphans still holding the inherited stderr pipe, so nextest's `leak-timeout` (default 100 ms) would add a LEAK on top of the failure. Still red, just noisier.
+
+**Exact fix for L5a** — `tests/integration_non_restartable_input.rs:80-85`, replace:
+
+```rust
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("{what} never exited; it must fail, not hang");
+            }
+```
+
+with:
+
+```rust
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let stderr = rx.recv_timeout(Duration::from_secs(5)).unwrap_or_default();
+                panic!("{what} never exited; it must fail, not hang. stderr was: {stderr}");
+            }
+```
+
+Priority: **Low**.
+
+#### M1 — `bounded()` reports an assertion failure as a hang
+
+`src/format.rs:510-513`:
+
+```rust
+        match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+            Ok(v) => v,
+            Err(_) => panic!("{what} blocked; it must fail, not hang"),
+        }
+```
+
+`recv_timeout` has two error variants and `Err(_)` swallows the distinction. If the body panics — `expect_err("a FIFO must be rejected")` firing because a regression made `detect_input_format` *succeed* on a FIFO, or `expect("stat must not block")` firing because the fixture vanished — the sender drops without sending, `recv_timeout` returns `Disconnected` immediately, and the test reports `detect_input_format on a FIFO blocked; it must fail, not hang`. It did not block. It failed in 200 µs, for a different reason.
+
+The body's own panic message does reach the captured output via the default hook, so the information is recoverable — but the headline is wrong, and the wrong headline is "the design decision this whole plan is about has regressed into a hang", which is the most alarming possible misdiagnosis. In a change whose thesis is *do not describe the failure inaccurately*, the harness describes the failure inaccurately.
+
+**Exact fix** — `src/format.rs:506-514`, replace the body of `bounded` with:
+
+```rust
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(body());
+    });
+    use std::sync::mpsc::RecvTimeoutError;
+    match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(RecvTimeoutError::Timeout) => panic!("{what} blocked; it must fail, not hang"),
+        Err(RecvTimeoutError::Disconnected) => {
+            panic!("{what} panicked; see the panic message above")
+        }
+    }
+```
+
+Priority: **Medium**.
+
+#### L3 — the layer-0 change is the only edit with no test that fails if it is reverted
+
+Delete-one-thing check, run by inspection over all four edits:
+
+| Reverted | What fails |
+|---|---|
+| layer 1 (`cli.rs:949`/`:902`) | `fifo_input_is_rejected_and_creates_no_output` and `passthrough_fifo_is_rejected_and_creates_no_output` — the binary blocks in `File::open` on the writer-less FIFO, `run_bounded` kills at 20 s and panics. Fails in 20 s, not 6 hours. ✓ |
+| layer 2 type check (`format.rs:322`) | `detect_rejects_a_fifo_with_the_pipe_message`, in ≤10 s, on either branch of the writer race. ✓ |
+| layer 2 offset condition (`format.rs:299`) | `detect_rejects_dev_fd_when_the_leading_bytes_repeat` (macOS leg). ✓ |
+| layer 2 byte condition (`format.rs:306`) | `reopen_restarts_false_for_a_streaming_char_device`. ✓ |
+| **layer 0 (`main.rs:770`)** | **Nothing.** `passthrough_fifo_is_rejected_and_creates_no_output` uses a writer-less FIFO, which layer 1 already rejects inside `Cli::validate` — long before line 770 runs. |
+
+So the edit that H1 shows to be actively harmful is also the only one with no test defending it. What layer 0 uniquely buys is the *Reopen* class on the passthrough path, which I verified by hand (`--passthrough /dev/stdin < f` → Reopen message, no output dir) and which nothing asserts.
+
+**Exact fix**: fold into H1's new test, and add a macOS-only companion so the Reopen class on the passthrough surface is covered:
+
+```rust
+/// The class layer 1 cannot see: a `/dev/fd`-shaped passthrough is a regular
+/// file to `stat`, so only `sanity_check_any` at main.rs:770 rejects it.
+#[cfg(target_os = "macos")]
+#[test]
+fn passthrough_dev_stdin_is_rejected() {
+    let dir = fresh_dir("tg_379_passthrough_devfd");
+    let (r1, r2, idx) = (dir.join("r1.fastq"), dir.join("r2.fastq"), dir.join("idx.fastq"));
+    write_fastq(&r1);
+    write_fastq(&r2);
+    write_fastq(&idx);
+    let out = dir.join("out");
+
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(format!(
+        "'{}' --paired -o '{}' --passthrough /dev/stdin '{}' '{}' < '{}'",
+        binary().display(), out.display(), r1.display(), r2.display(), idx.display()
+    ));
+    let (ok, stderr) = run_bounded(cmd, "trim_galore --passthrough /dev/stdin");
+    assert!(!ok, "stderr was: {stderr}");
+    assert!(stderr.contains(REJECTION), "unexpected message: {stderr}");
+}
+```
+
+Priority: **Low** as a coverage gap in its own right; the substance is H1.
+
+#### L4 — the per-test bound covers only one of the two CI test legs
+
+`.config/nextest.toml` sets `[profile.default] slow-timeout = { period = "60s", terminate-after = 4 }`, which applies to `cargo nextest run` (`ci.yml:71`). The **release** leg, `cargo test --release` (`ci.yml:74`), has no per-test bound — libtest has none to give. A wedge there is caught only by `timeout-minutes: 30`, and reports as a job timeout rather than a named test failure.
+
+The plan's §5.2 says the job bound is "the one backstop that survives an implementer forgetting every rule in §5.3", and that is exactly right — I raise this only so the asymmetry is on the record, not as a defect. `timeout-minutes: 30` is the load-bearing bound; `terminate-after` is a nicety on one leg.
+
+On the blast radius of a repo-wide `terminate-after = 4` (240 s kill): measured margin is ~52x. Slowest test on this machine is `integration_adapter2::a2_wins_on_every_resolution_path` at **4.579 s**; whole suite 8.727 s for 467 tests. Even a 10x-slower cold runner has room. No existing test is at risk.
+
+Priority: **Low** (informational).
+
+#### L6 — `/dev/urandom` negative control is probabilistic
+
+`reopen_restarts_false_for_a_streaming_char_device` (`src/format.rs:599-608`) asserts that four random bytes differ from four other random bytes. False-pass probability 2⁻³² ≈ 2.3 × 10⁻¹⁰ per run. Recording it rather than recommending a change — there is no better portable non-restartable source that cannot block, which the plan established (V7), and reading more bytes only changes the exponent.
+
+Priority: **Low** (informational, no action).
+
+### 2.4 Does the CLI-layer change preserve existing behaviour?
+
+Yes. Checked all three `exists()` sites named in the prompt:
+
+| Site | Message | Status |
+|---|---|---|
+| `cli.rs:902` (`--passthrough`) | `--passthrough file not found: {}` | Preserved verbatim. Asserted by `src/cli.rs:1764` (`test_passthrough_rejects_missing_file`) — still green. |
+| `cli.rs:949` (`cli.input`) | `Input file not found: {}` | Preserved verbatim. No test asserts it (the identical string at `src/fastq.rs:281`, `src/bam.rs:168` and `:352` is unrelated and untouched). |
+| `cli.rs:942` (`--demux` barcode file) | `Barcode file not found: {}` | **Unchanged** — deliberately, per D1. |
+
+**D1 verified independently.** `demux::read_barcode_file` (`src/demux.rs:31-34`) opens once and streams with a `BufReader`, and `grep` shows exactly one call site (`src/main.rs:1265`). So a FIFO barcode file does work today and rejecting it would have been an unjustified regression. D1 is the right call and its stated reason is accurate.
+
+Ordering is unchanged too: `check_restartable_input` sits where the `exists()` it replaced sat, so the `--passthrough` case-fold collision check (1.ix, `cli.rs:903-919`) still runs after the existence check, and the `cli.input` loop still runs after the `--demux` block.
+
+#### L7 — a third multi-read input surface exists that neither the plan nor D1 mentions
+
+V10 claims "**Every** input-bearing CLI surface reaches a guard", narrowed by D1 to `cli.input` + `cli.passthrough`. There is one more: an adapter FASTA given as `-a file:adapters.fa` / `-a2 file:…`.
+
+`adapter::parse_adapter_spec_inner` (`src/adapter.rs:313-316`) calls `read_fasta_adapters(path)` on every invocation, and the file is read once per call — but the call happens more than once: `Cli::validate` runs `parse_adapter_specs_quiet` for the `-a2` #369 pre-validation, and `setup_trimming` runs `parse_adapter_specs` again, **per pair**. So a FIFO adapter FASTA is read 2+ times and would block or come back empty on the second.
+
+Out of #379's scope (the issue is about read input), and I would not add a guard for it — an adapter FASTA from a stream is not a thing anyone does. The point is the documentation claim: V10's "every" should be narrowed the way D1 narrowed it, so the next reader does not treat V10 as proof that no surface is left.
+
+**Exact fix**: append to D1 in `PLAN.md` §12, or add a D4:
+
+> **D4 — an adapter FASTA (`-a file:x.fa`) is also read more than once** (`adapter.rs:314`, once in `Cli::validate` for the `-a2` pre-check and again per pair in `setup_trimming`) and is **not** guarded. Deliberate: out of scope for #379, and a streamed adapter FASTA is not a real invocation. V10's enumeration is `cli.input` + `cli.passthrough`, not "every path-valued flag".
+
+Priority: **Low** (documentation accuracy).
+
+### 2.5 Efficiency
+
+No concerns. `detect_input_format` gains one `fstat` on an already-open handle plus, for a regular file, one `open` + one `lseek` + a ≤4-byte `read`. §6's accounting is accurate and A4 (not a hot path) holds — the call count is per input file, not per record. The `[u8; 4]` probe buffer allocates nothing. `read_filled` replacing a single `read` is free in the common case (one syscall either way).
+
+The declined optimisation in §6 (inspect the gzip branch's existing second handle) is the right call for the reason given: it would split the predicate across two sites and make it conditional on the branch taken.
+
+### 2.6 Structure and style
+
+**Comments, against `CLAUDE.md`'s "one line, state the fact":** mostly compliant, and the ones that are two lines earn it by pinning an ordering constraint that the code cannot show. Specifically good:
+
+- `src/format.rs:317-318` — "Before the first `read`: a FIFO with a live writer but no data yet blocks there, and a second open with no writer blocks forever." Two facts, each of which is why the statement is *there* rather than three lines down. Keep.
+- `src/main.rs:765-766` — "`sanity_check_any`, not `FastqReader::sanity_check`, so the passthrough path reaches the #379 restartability guard." Names a non-obvious call choice. Keep. (Its claim is what H1 disputes, but the comment itself is the right shape.)
+- `src/format.rs:346-347` — the reworded gzip comment is 2 lines where the original was 4, and drops the now-false "not required for correctness". Exactly what §5.1 step 7 asked for.
+
+Two I would trim:
+
+- `src/format.rs:297-298` — "An inherited offset is the exact signal. A device that cannot report a position falls through to the byte comparison below." The second sentence narrates the next four lines, which is the thing `CLAUDE.md` names. One line does it: `// An inherited offset is the exact signal; anything else defers to the bytes.`
+- `.github/workflows/ci.yml:30-31` — "without a bound that is a 6-hour job, not a red X" is the evidence, not the fact. `# A blocked FIFO open would otherwise burn GitHub's 360-minute ceiling.` One line. That said, this file's neighbouring comments run to 20 lines (`ci.yml:56-70`), so by "read like the surrounding code" the current form is in keeping — take or leave it.
+
+Doc comments (`///`) are longer, and that is fine: they carry preconditions (`reopen_restarts`' FIFO rule, `is_non_restartable_type`'s reason for taking `Metadata`) that a caller cannot derive. The one gap is the one M3 names — `first`'s length contract is missing from the doc that documents everything else about it.
+
+**Naming.** `is_non_restartable_type`, `not_restartable_message`, `reopen_restarts`, `read_filled`, `check_restartable_input` all read correctly and none of them lies about what it does. `reopen_restarts` returning `bool` (not `Result<()>`) keeps the "unexpected error is `Err`, not `false`" distinction that Q3 turns on. Good.
+
+**Duplication.** `not_restartable_message` shared between `cli.rs` and `format.rs` is the right factoring — the plan wanted the wording unable to drift, and `pub(crate)` is the minimum visibility that achieves it. The `#[cfg(unix)]` / `#[cfg(not(unix))]` pair on `is_non_restartable_type` correctly avoids the bare `use FileTypeExt` that A7 identified as a hard break for a non-Unix library consumer.
+
+One structural note, no action: on non-Unix, `is_non_restartable_type` returns `false` for everything, so a Windows named pipe would reach `reopen_restarts`, whose `File::open` can block. There is no `cfg(unix)` elsewhere in `src/`, CI is Ubuntu + macOS only, and the crate does not claim Windows support — so this is theoretical. Worth knowing if Windows is ever targeted.
+
+---
+
+## 3. Fixes recommended
+
+None applied (per the override in my brief). In priority order:
+
+| # | Priority | File:line | Fix |
+|---|---|---|---|
+| H1 | **High** | `src/main.rs:767-771` | Reject a uBAM `--passthrough` file before `sanity_check_any`, plus an integration test. Exact code in §2.1. Without it, `--passthrough <ubam>` regresses from a pre-output error to `stream did not contain valid UTF-8` with three empty output files on disk. |
+| M1 | Medium | `src/format.rs:510-513` | Split `RecvTimeoutError::Timeout` from `Disconnected` in `bounded()` so a panicking body is not reported as a hang. |
+| M2 | Medium | `src/cli.rs:488-489` | Keep the `NotFound` message for `NotFound` only; propagate other `io::Error`s with `Failed to stat input '{}'`. |
+| M3 | Medium | `src/format.rs:288, 303-304` | Document `first`'s 1..=`PEEK_LEN` contract and `debug_assert!` it, so an out-of-contract call cannot silently answer `false` (or vacuously `true`). |
+| L1 | Low | `CHANGELOG.md` | "before anything is written" → "before any output file is written" (`ensure_output_dir` at `main.rs:315` precedes the Reopen-class rejection). |
+| L2 | Low | `src/format.rs:210` or `:222-226` | Either add a `Socket` variant with its own noun, or drop "or socket" from the `NotRestartable::Pipe` doc so code and message agree. |
+| L3 | Low | `tests/integration_non_restartable_input.rs` | Add the macOS `--passthrough /dev/stdin` test so the layer-0 edit has a test that fails when it is reverted. |
+| L5 | Low | `tests/integration_non_restartable_input.rs:80-85` | Drain stderr before the timeout `panic!` so the hang message carries what the binary said. |
+| L7 | Low | `PLAN.md` §12 | Add D4: the `-a file:x.fa` adapter FASTA is a third multi-read surface, deliberately unguarded; narrow V10's "every input-bearing CLI surface" accordingly. |
+| L8 | Low | `src/format.rs:297-298`, `.github/workflows/ci.yml:30-31` | Trim two 2-line comments to 1 line each. Optional. |
+
+No Critical findings. H1 is the only one I would block a merge on.
+
+---
+
+## 4. What is right, and worth not losing in a refactor
+
+Recording these so a later change does not undo them by accident:
+
+1. **The layer ordering inside `detect_input_format` is load-bearing** — `fstat` before the first `read` (`:319-324` before `:327`), and `n == 0` before the second open (`:330` before `:334`). Moving either breaks a documented case, and the second one silently: an empty file would start reporting as non-restartable. D3's strengthened `detect_empty_file_errors` is what catches that, and it catches it because it asserts the *absence* of the new message, not just `is_err()`.
+2. **`reopen_restarts` interrogates the second handle, not the first.** A future reader will be tempted to "simplify" it to a seekability probe on the handle already open. That is #379's own proposal and it accepts macOS row B. The doc comment at `:282-284` says so; keep it attached to the code.
+3. **`bounded` + `run_bounded` are the reason a dead guard fails instead of wedging.** The wedge is the failure mode this design is most exposed to, and it is the one that costs 6 hours of CI rather than showing a red X. Do not replace `run_bounded` with `Command::output()`, and do not move the write-only FIFO `open` onto the main thread.
+4. **Layer 1 is what makes a writer-less FIFO diagnosable at all.** `fs::metadata` never blocks where `File::open` blocks forever — that asymmetry is the entire mechanism, and it is why `check_restartable_input` must stay a `stat` and never become an open.

--- a/plans/08032026_reject-non-restartable-input/COVERAGE.md
+++ b/plans/08032026_reject-non-restartable-input/COVERAGE.md
@@ -1,0 +1,235 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs. plan)
+**Plan:** `plans/08032026_reject-non-restartable-input/PLAN.md` (v3)
+**Implementation spec:** §5 (5.1–5.4) + §9; requirements audited from §3, §3.4, §8, §12
+**Repo:** `/Users/fkrueger/Github/TrimGalore`, branch `dev`, uncommitted working tree
+**Date:** 2026-08-04
+**Verdict:** **COMPLETE** — 0 items MISSING, 0 PARTIAL. 4 DEVIATED (all documented, all justifications verified). 1 validation row (V3) is CI-gated and cannot be run locally.
+
+## Summary
+
+| Status | Count |
+|---|---|
+| Total items | 62 |
+| DONE | 55 |
+| PARTIAL | 0 |
+| MISSING | 0 |
+| DEVIATED | 4 |
+| DEFERRED (CI-gated) | 1 |
+| N/A (retired / out of scope by the plan) | 2 |
+
+Test run: `cargo test --release` from the crate root, **exit 0, 375 unit + 92 integration, 0 failed**
+(`integration_non_restartable_input`: 5 passed in 0.06 s). `cargo fmt --all -- --check` clean;
+`cargo clippy --all-targets --release -- -D warnings` clean. All 14 tests named below were observed
+running and passing by name — none is reported as verified on inspection alone.
+
+Files audited: `src/format.rs`, `src/cli.rs`, `src/main.rs`, `src/demux.rs`,
+`tests/integration_non_restartable_input.rs`, `.config/nextest.toml`,
+`.github/workflows/ci.yml`, `CHANGELOG.md`.
+
+---
+
+## A. §5.1 Source changes (10 items)
+
+| # | Item | Source | Status | Notes |
+|---|---|---|---|---|
+| S1a | Layer 1: replace the `cli.input` `path.exists()` loop with an `fs::metadata()` match | §5.1.1 | DONE | `cli.rs:947-950` → `check_restartable_input(path, "Input file not found")`; helper at `cli.rs:482-495`. Loop is **unconditional** inside `Cli::validate`, so every mode is covered |
+| S1b | Layer 1 at `--passthrough` | §5.1.1 | DONE | `cli.rs:900-902`, replaces `if !pt.exists()` |
+| S1c | Layer 1 at the `--demux` barcode file | §5.1.1 | DEVIATED | Not applied; `cli.rs:942` still `if !demux_file.exists()`. Documented as **D1** — justification independently verified, see §H |
+| S2 | `main.rs:768` `FastqReader::sanity_check` → `sanity_check_any` | §5.1.2 | DONE | `main.rs:763-771`. `sanity_check_any` (`main.rs:29-43`) dispatches through `detect_input_format` then still calls `FastqReader::sanity_check` on the FASTQ arms, exactly as §3.2 specified. Grep confirms **no** `FastqReader::sanity_check` call remains on any passthrough path |
+| S3 | Layer-2 type check after `File::open`, **before** the read; `#[cfg(unix)]`-gated with a `#[cfg(not(unix))]` no-op | §5.1.3 | DONE | `format.rs`: `is_non_restartable_type` has both cfg arms; called in `detect_input_format` between the open and `read_filled`. Ordering verified in the diff. Minor form difference: the `use std::os::unix::fs::FileTypeExt` sits inside the cfg-gated fn rather than at module scope — equivalent, and no bare unix `use` escapes a cfg gate anywhere in the change |
+| S4 | Loop the first read until 4 bytes or EOF, retrying `Interrupted` | §5.1.4 | DONE | `read_filled()`; used for **both** reads |
+| S5 | Add `reopen_restarts`, private, above `detect_input_format`, per §4 | §5.1.5 / §4 | DONE | Signature `fn reopen_restarts(path: &Path, first: &[u8]) -> Result<bool>` matches §4 exactly; private; placed above `detect_input_format`; §4's doc comment reproduced; `.with_context()` on the second open carries the §4 wording verbatim |
+| S6 | Call it after the `n == 0` check and before the `peek[0] == b'@'` branch | §5.1.6 | DONE | Verified in the diff; empirically confirmed by the empty-file and short-file probes below |
+| S7 | Reword the `format.rs:227-230` comment ("not required for correctness" is now false) | §5.1.7 | DONE | Now: "Re-open rather than seek: sidesteps a `MultiGzDecoder` interaction with the consumed prefix, and non-restartable input is rejected above." Two lines, per CLAUDE.md |
+| S8 | CHANGELOG entry under `#### Fixes` in `Unreleased` | §5.1.8 | DONE | `CHANGELOG.md:86`, inside `### Unreleased` (line 4) → `#### Fixes` (line 84). Covers the three reproductions, the `--passthrough` case, and the tty residual §11 asked to be mentioned |
+
+**Undocumented but benign form deviation.** §4 said "the type checks stay **inline** … each is two lines".
+The implementation factors them into `format::is_non_restartable_type` + `format::not_restartable_message`
+(both `pub(crate)`) plus `cli::check_restartable_input`. This is not in §12's deviation list, but it
+*serves* §3.3's stated requirement that the two layers' wording "cannot drift", and has no behavioural
+consequence. Recorded, not counted as a gap.
+
+## B. §5.2 CI backstop (2 items)
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| C1 | `timeout-minutes: 30` on the `rust-tests` job | DONE | `ci.yml:32`, on the matrix job that runs both `cargo nextest run` (`:70`) and `cargo test --release` (`:77`) — the four job-steps §5.2 identified |
+| C2 | `.config/nextest.toml` with `slow-timeout = { period = "60s", terminate-after = 4 }` | DONE | New file, byte-for-byte the value §5.2 specified, under `[profile.default]` (the profile CI actually uses) |
+
+## C. §5.3 FIFO test construction — the six rules (6 items)
+
+| # | Rule | Status | Notes |
+|---|---|---|---|
+| R1 | A writer must open the FIFO, spawned before the call | DONE | `spawn_fifo_writer` (`format.rs` test mod) opens write-only **on a spawned thread**, precisely the trap §5.3 warns about. Used by `detect_rejects_a_fifo_with_the_pipe_message`. Correctly *not* used by the layer-1 test or the integration tests, which need writer-less FIFOs |
+| R2 | Bound the whole test body, setup included; thread + `mpsc::recv_timeout`; no `timeout(1)` | DONE | `bounded()` uses a thread + `recv_timeout(10s)` and panics; `run_bounded()` uses `try_wait` + a 20 s deadline. No `timeout(1)` anywhere. **Form deviation:** setup (`fresh_tmpdir`, `make_fifo`, `spawn_fifo_writer`) sits *outside* the bound. Substance holds — the wedge shape R2 was written against (Shape B, `child.wait()` on the writer) does not exist here: `mkfifo` exits immediately, the writer's blocking `open` runs on a detached thread, and the `JoinHandle` is never joined. No setup operation can block on the calling thread |
+| R3 | The writer must tolerate `EPIPE` | DONE | `if let Ok(mut f) = …open(&p)` and `let _ = f.write_all(…)` — neither the open nor the write is unwrapped. No spawned `cat` has `.success()` asserted (the two `sh -c` pipe tests assert `!ok` on the *binary*, and `sh` reports the last pipeline member's status) |
+| R4 | Assert the fixture is a FIFO (`mkfifo` exit status **and** `is_fifo()`) | DONE | Both `make_fifo` implementations (unit + integration) check `st.success()` *and* `fs::metadata(path).file_type().is_fifo()`. This is also what satisfies V9 |
+| R5 | One `fresh_tmpdir` slug per FIFO test | DONE | Repo-wide sweep of all 99 `temp_dir().join(…)` / `fresh_tmpdir(…)` / `fresh_dir(…)` sites: **zero duplicate slugs**. The new slugs are `tg_format_fifo_detect`, `tg_format_fifo_stat`, `tg_format_reopen`, `tg_format_devfd`, `tg_format_devfd_repeat`, `tg_379_fifo_in`, `tg_379_stdin_plain`, `tg_379_stdin_gz`, `tg_379_passthrough`, `tg_379_control` |
+| R6 | Integration recipe: `spawn()`, keep the `Child`, `kill()` then `wait()` on timeout — never `output()` | DONE | `run_bounded()` at `tests/integration_non_restartable_input.rs:60-91`: `spawn()`, stderr drained on a separate thread (so a chatty child cannot deadlock the wait loop), `try_wait` poll to a deadline, then `kill()` + `wait()` + panic. No `output()` in the file. The "kill the writer child" clause is moot — the integration tests use writer-less FIFOs and spawn no writer child |
+
+**Harness proven capable of failing (independently, without touching source).** §12 records a mutation
+check; because this audit must not modify source, I verified the two bounding mechanisms directly by
+compiling standalone `rustc` programs that replicate `bounded()` and `run_bounded()` verbatim in shape
+and point them at a writer-less FIFO:
+
+```
+bounded()      → panicked after 3.004 s  ("blocked; it must fail, not hang")
+run_bounded()  → killed the child + panicked after 3.042 s
+```
+
+Both convert a genuine indefinite `open(2)` block into a failure. V5's structural claim holds.
+
+## D. §5.4 Tests (10 items)
+
+All ten confirmed present **and observed passing by name** in the `cargo test --release` run.
+
+| # | Required test | Status | Test name / location |
+|---|---|---|---|
+| T1 | A regular plain FASTQ is accepted (happy-path regression guard) | DONE | `detect_fastq_plain_from_at_sign` (pre-existing; now also guards the new code) |
+| T2 | A regular gzipped FASTQ is accepted | DONE | `detect_fastq_gz_from_plain_gzip` |
+| T3 | A FIFO is rejected with the pipe message — **one** test | DONE | `detect_rejects_a_fifo_with_the_pipe_message`. Exactly one, per §5.3; asserts both `cannot be re-read from the start` **and** `is a pipe or FIFO` |
+| T4 | An empty regular file still produces the *empty* error, not either new message | DONE | `detect_empty_file_errors`, strengthened per **D3** |
+| T5 | `reopen_restarts(&regular_fq, b"@rea")? == true` | DONE | `reopen_restarts_answers_both_directions` |
+| T6 | `reopen_restarts(&regular_fq, b"XXXX")? == false` | DONE | same test |
+| T7 | `reopen_restarts("/dev/urandom", …)? == false` | DONE | `reopen_restarts_false_for_a_streaming_char_device` |
+| T8 | `/dev/fd/N` over a 4-byte file rejected, `#[cfg(target_os = "macos")]` | DONE | `detect_rejects_dev_fd_over_a_four_byte_file` |
+| T9 | Integration: FIFO, `/dev/stdin` from a pipe, `--passthrough <fifo>`; non-zero exit + `cannot be re-read from the start` | DONE | `fifo_input_is_rejected_and_creates_no_output`, `dev_stdin_from_a_plain_pipe_is_rejected`, `dev_stdin_from_a_gzipped_pipe_is_rejected`, `passthrough_fifo_is_rejected_and_creates_no_output`. Two of the three surfaces additionally assert `!out.exists()` |
+| T10 | Do **not** assert on `/dev/stdin` redirected from a *regular* file (row B, platform-divergent) | DONE | No such assertion exists. Verified by reading the whole file |
+
+**Beyond the plan (both verified running and passing):**
+- `path_stat_names_a_fifo_without_opening_it` — isolates layer 1's decisive property (`fs::metadata`
+  does not block where `File::open` would) and asserts `is_non_restartable_type` in **both** directions.
+- `detect_rejects_dev_fd_when_the_leading_bytes_repeat` — the test §12 says retires A2. Confirmed it
+  isolates the start-offset condition: with `@a@a@a@a`, the byte comparison alone would return
+  restartable, so only the offset check can reject it.
+- `regular_file_still_runs` (integration) — the positive control without which every rejection
+  assertion would pass on a build that rejected everything.
+
+## E. §3.4 Edge cases (12 items)
+
+Each row checked for the **guard or branch**, not merely the function. Rows marked "probed" were
+confirmed against the built `target/release/trim_galore`.
+
+| # | Case | Required handling | Status | Evidence |
+|---|---|---|---|---|
+| E1 | Empty regular file | Existing `is empty`, unchanged | DONE | Probed: `Error: Input file '…/zero.fq' is empty`. `n == 0` precedes the second-open call in `detect_input_format`. Test T4 asserts the restartability message is **absent** |
+| E2 | File shorter than 4 bytes | Length-aware compare; regular short file falls through; the same file via `/dev/fd/N` now **rejected** | DONE | Probed both directions: `@` (1 B) → `Truncated FASTQ: missing sequence line after @`; `@abc` (4 B) → same class; `X` (1 B) → `is not recognised as FASTQ…`. The **same 4-byte file via `/dev/fd/9`** → `cannot be re-read from the start: opening it a second time did not return to the beginning`. That is the row-B-shaped input that fstats as *regular*, so it proves the offset condition is load-bearing in production, not only in the macOS unit tests |
+| E3 | Empty FIFO (writer opened, wrote nothing, exited) | **Behaviour change:** pipe message, previously `is empty` | DONE | Realised by construction: the type check precedes `read_filled`, verified in the diff. No test isolates this specific row — noted, but §5.4 asked for one FIFO test and the code path is identical to T3's |
+| E4 | FIFO with **no writer at all** | Rejected by layer 1 without opening (v2's Medium residual) | DONE | Probed: rejected promptly, no output dir. Covered by `path_stat_names_a_fifo_without_opening_it` (unit) and `fifo_input_is_rejected_and_creates_no_output` (integration, writer-less by design) |
+| E5 | Socket | Rejected by layer 2 step 2, or layer 1 | DONE (inspection) | `ft.is_socket()` present in `is_non_restartable_type`, which both layers call. Empirical check not possible here: the sandbox denies `AF_UNIX` `bind` (`PermissionError: Operation not permitted`). Flagged as a harness limitation, not a finding |
+| E6 | `/dev/null` | Char device, `n == 0` → existing `is empty` | DONE | Probed: `Error: Input file '/dev/null' is empty` |
+| E7 | `/dev/zero` | Offset 0, bytes equal → falls through → existing not-recognised error | DONE | Probed: `Error: Input '/dev/zero' is not recognised as FASTQ (plain or gzipped) or unaligned BAM` |
+| E8 | `/dev/urandom` | Offset 0, bytes differ → the **new** re-open message | DONE | Probed: exactly the §3.3 re-open message. Also T7 |
+| E9 | `/dev/stdin` at an interactive terminal | Residual, out of scope; §11 asked for a CHANGELOG sentence | DONE | Not fixed (correct — §11 declared it out of scope for option A) and named in the CHANGELOG entry, with the `isatty` reason |
+| E10 | Directory | `read` fails with `EISDIR` — unchanged | DONE | Probed: `Failed to read from …` / `Is a directory (os error 21)`. Layer 1's `fs::metadata` succeeds for a directory exactly as `exists()` did, so nothing shifted |
+| E11 | Second open fails with an unexpected `io::Error` | Propagated as itself **with context**, not as non-restartable (§10 Q3) | DONE (inspection) | `File::open(path).with_context(ctx)?` in `reopen_restarts`, and `reopen_restarts(…)?` at the call site propagates `Err` rather than treating it as `false`. Context string matches §4 verbatim |
+| E12 | Regular file being concurrently appended | Restartable; out of scope | N/A | Explicitly out of scope in the plan |
+
+## F. §9 Validation table (10 items)
+
+The brief flagged V5, V6, V7 and V10 as the rows most likely to "quietly not hold". All four were
+checked against something capable of failing.
+
+| # | Row | Status | Evidence |
+|---|---|---|---|
+| V1 | Three #379 reproductions say the right thing, and each **stops saying its own wrong thing** | DONE | All three reproduced against the release binary: `<(cat plain.fastq)` → `Input '/dev/fd/11' is a pipe or FIFO…`; `gzip -c … \| trim_galore /dev/stdin` → `Input '/dev/stdin' is a pipe or FIFO…`; `mkfifo f; cat small.fq > f & trim_galore f` → pipe message, promptly. Per-row negative controls are in the integration tests (`doesn't seem to be in FastQ format` for the plain row, `Failed to decompress first block` for the gz row) — i.e. the vacuous-pass defect v2 had is fixed. **Note:** the automated suite substitutes a plain pipe for `<(…)`, because `<(…)` is not POSIX `sh`; I verified the process-substitution form manually and it is caught by layer 1 |
+| V2 | Regular files unaffected; outputs byte-identical to `dev` | DONE | Full suite green (467 tests, including the output-content integration suites). Diff inspection confirms **no** transformation, writer or report code is touched — every added branch is a pre-reader rejection. §12 records the 6-output + 6-report byte-identity comparison against a `HEAD` worktree build across SE-gz / SE-plain / PE `--cores 1` / PE `--cores 4`, with a sentinel negative control that demonstrably fired (iteration log item 3). **I did not re-run that md5 comparison**; it is recorded, not re-derived |
+| V3 | Byte-identity against Perl 0.6.11 | **DEFERRED — CI-gated** | Requires the CI `validation` / `validation-ubam` jobs; cannot run locally. §12 already records this as the one outstanding pre-merge check. Not an implementation gap |
+| V4 | The empty-file error still wins | DONE | Probed (`Input file '…' is empty`, no restartability message) and asserted in both directions by T4 (D3's strengthening) |
+| V5 | **No FIFO test hangs**, and nothing can hang for long | DONE | New integration file completes in **0.06 s**, whole suite in seconds. Both CI bounds in place (C1, C2). And the bounding mechanisms were **proven capable of firing** — standalone replicas of `bounded()` and `run_bounded()` pointed at a writer-less FIFO panicked/killed at 3.00 s and 3.04 s rather than hanging. This is the structural claim §5.2 exists to protect, and it holds |
+| V6 | The writer-exited FIFO — the case that hangs on `dev` today | DONE | Probed both variants: live-writer FIFO (`cat small.fq > f &`) and **writer-less** FIFO — both rejected promptly with the pipe message and no output. The writer-less case is the strictly harder one (it is what used to hang forever), and is what the integration test uses. §12's "one thing the plan did not anticipate" correctly explains why the literal `cat x > f &` shape cannot be used inside a harness now: layer 1 never opens the FIFO, so the writer blocks in `open` forever |
+| V7 | Every guard can fail, in **both** directions | DONE | Layer 1: writer-less FIFO rejected without opening (`path_stat_names_a_fifo_without_opening_it`, observed passing) / regular file proceeds (same test asserts `!is_non_restartable_type`, plus `regular_file_still_runs` end-to-end). Layer 2 type check: FIFO → pipe message (T3) / regular → passes (T1, T2). Second-open check: `true` for `b"@rea"`, `false` for `b"XXXX"`, `false` for `/dev/urandom`, `false` for macOS `/dev/fd/N` over 4 bytes, `false` for the repeating-prefix case. Additionally the `/dev/fd/9` probe shows the offset condition rejecting real production input, so this predicate is no longer "only ever observed passing" |
+| V8 | uBAM input still detected | DONE | `detect_unaligned_bam_via_decompressed_magic`, `detect_paired_ubam_via_decompressed_magic`, `detect_bgzipped_fastq_is_fastq_not_bam` all pass, plus `integration_ubam` (8) and `integration_ubam_out` (23) and `integration_clump_only_ubam` (15). Every added layer is format-agnostic |
+| V9 | The Linux mechanism is measured, not assumed | DONE (code); Linux leg CI-gated | The required assertion exists in **both** `make_fifo` helpers: `fs::metadata(path).file_type().is_fifo()` on the fixture immediately before it is handed to the binary, plus the `mkfifo` exit-status check. Green on Darwin here. The `ubuntu-latest` leg is the first CI run, as the plan intended — that is by design, not a gap. Row B correctly left unasserted (T10) |
+| V10 | **Every** input-bearing CLI surface reaches a guard | DEVIATED | `cli.input` and `cli.passthrough` are each asserted rejected for a FIFO by their own integration test. The third surface, the `--demux` barcode file, is argued out rather than covered — **D1**, justification verified (§H). Two observations: (a) the enumeration is *by test*, not *by mechanism*, so V10's forward-looking intent — "the next flag that takes a path should be caught by a test rather than by a reviewer" — is not structurally met; nothing fails if a new path-bearing flag is added unguarded. (b) A writer-less FIFO passed to `--demux` still blocks in `File::open` with no message. That is not a restartability defect and not a regression (it predates this change), but it is the one remaining "hang with no message" on an input-bearing flag |
+
+## G. §8 Assumptions (9 items)
+
+| # | Assumption | Status | Evidence |
+|---|---|---|---|
+| A1 | Every currently-working input is restartable; nothing in `tests/`, `.github/`, `justfile` uses `/dev/stdin`, `mkfifo` or process substitution | DONE | Re-verified by grep over `tests/ .github/ justfile`: **zero** hits outside the new `integration_non_restartable_input.rs`. Positive control run (the pattern does match the new file) so the negative is trustworthy |
+| A2 | *Retired in v3* | N/A | Retired by the offset condition. §12's extra test `detect_rejects_dev_fd_when_the_leading_bytes_repeat` is what makes the retirement testable, and it passes |
+| A3 | `File::open` on a writer-less FIFO blocks | DONE | Re-confirmed a fourth time here: the standalone `bounded()` replica blocked until the 3 s bound fired |
+| A4 | `detect_input_format` is on no hot path | DONE | Unchanged by this work; call-site inventory intact |
+| A5 | For a regular file the `n == 0` check still precedes the second-open check | DONE | Verified in code order and probed (E1). For a FIFO the type check wins instead, as §3.4 intends (E3) |
+| A6 | `fstat` names a FIFO as a FIFO on both platforms | DONE (Darwin) | Verified on Darwin by test and probe. Linux leg is V9's CI run, which is how the plan chose to discharge it |
+| A7 | Unix-only — "handled rather than flagged" | **DONE — claim verified** | `is_non_restartable_type` has a `#[cfg(unix)]` arm and a `#[cfg(not(unix))]` no-op returning `false`. Every unix-only `use` is inside a cfg-gated item: `FileTypeExt` inside the gated fn and inside `#[cfg(unix)] fn make_fifo`; `AsRawFd` inside the two `#[cfg(target_os = "macos")]` tests. The integration file carries a file-level `#![cfg(unix)]`. `cli::check_restartable_input` is portable. No bare unix `use` at module scope, so the `src/lib.rs` compile-break §5.1.3 warned about does not exist |
+| A8 | Both reads must return everything asked for — "handled by the looped reads, not assumed" | **DONE — claim verified** | `read_filled()` loops to buffer-full-or-EOF and retries `ErrorKind::Interrupted`; it is used for **both** the first read in `detect_input_format` and the second read in `reopen_restarts`. The comparison is length-aware (`n == first.len() && &again[..n] == first`), closing the ≤4-byte prefix hole — probed live via `/dev/fd/9` over a 4-byte file. The claim that the same loop hardens the pre-existing `n >= 3` gzip test also holds: that branch now sees a filled `peek` |
+| A9 | No input-bearing CLI surface bypasses the guard — "asserted by V10 rather than by inspection" | **DONE for the two live surfaces; see V10/D1** | Layer 1's loop is unconditional inside `Cli::validate`, and `cli.validate()` has exactly **one** call site (`main.rs:166`) ahead of all dispatch — so every mode (paired, SE, specialty, clump-only, uBAM-out) inherits it for `cli.input`. `cli.passthrough` covered at `cli.rs:900`. The `--demux` barcode file is the one surface *not* covered, deliberately (D1) |
+
+## H. §12 Deviations — are they deviations, or gaps relabelled? (3 items)
+
+| # | Deviation | Verdict | Why |
+|---|---|---|---|
+| D1 | The `--demux` barcode file is **not** checked; V10's enumeration drops from three surfaces to two | **DEVIATED — justification holds** | Verified independently against `src/demux.rs`. `read_barcode_file` (`demux.rs:31-34`) performs exactly **one** `File::open` and streams the file with `BufReader::lines()` in a single pass. Grep confirms exactly one production call site (`main.rs:1265`), and `demux::demultiplex` receives already-parsed `BarcodeEntry` values — it never re-opens the path. So the invariant this guard enforces ("re-opening yields the same bytes from the start") genuinely does not apply, and D1's conclusion that rejecting a FIFO barcode file would be an unjustified regression is correct. This narrows §3.0/§5.1's stated scope, and the narrowing is sound. **One residual worth recording** (not a gap against this plan): a *writer-less* FIFO barcode file still blocks in `File::open` with no message — a hang, but not a restartability failure, and identical to `dev` today |
+| D2 | A `stream_position()` error falls through to the byte comparison instead of propagating | **DEVIATED — justification holds** | `if file.stream_position().is_ok_and(\|pos\| pos != 0) { return Ok(false); }`. Strictly less aggressive than §3.1 step 5, as claimed: only a *successfully read* non-zero offset is decisive. This is what preserves §3.4's `/dev/null` and `/dev/zero` rows, both of which I probed and both of which land where §3.4 predicted. It does not weaken §10 Q3, which concerns the second `open` failing — that still propagates with context (E11) |
+| D3 | The pre-existing `detect_empty_file_errors` test was **strengthened**, not merely left alone | **DONE — a genuine improvement, correctly recorded** | It previously asserted only `is_err()`, which would have passed if an empty file had started being reported as non-restartable. It now asserts `is empty` is present **and** `cannot be re-read` is absent — which is exactly what V4 demands. Observed passing |
+
+---
+
+## Gaps (detail)
+
+None. No item is MISSING and none is PARTIAL.
+
+The four DEVIATED rows are two underlying decisions, each recorded in §12 with a justification that
+this audit verified against the code:
+
+- **S1c / D1 / V10** — one decision, seen from three angles: the `--demux` barcode file is excluded
+  because it is read once, not re-read. Verified in `src/demux.rs`.
+- **D2** — a `stream_position()` error defers to the byte comparison rather than becoming a new hard
+  error for exotic character devices. Verified by probe against `/dev/null`, `/dev/zero`, `/dev/urandom`.
+
+## Outstanding before merge (not implementation gaps)
+
+1. **V3 — Perl 0.6.11 byte-identity.** Needs the CI `validation` and `validation-ubam` jobs; not
+   runnable locally. §12 flags it as the invariant that must not move. Evidence that it will hold is
+   strong (no writer or transformation path is touched, and V2's local byte-identity comparison
+   passed with a firing sentinel control) — but it is unverified until CI runs.
+2. **V9 / A6 — the Linux leg.** The `ubuntu-latest` matrix entry is the measurement the plan chose
+   for A6. Deliberate, and the fixture assertion that makes a platform surprise name itself is in
+   place.
+3. **#374 merge order.** §7.1 recommends merging Benjamin Demaille's PR first and re-checking the
+   `main.rs` line references. This work was implemented against `dev` @ `40f77ec`; the one changed
+   `main.rs` line (`:770`) is not among the lines #374 edits, and layer 1 lives in `cli.rs`, which
+   #374 does not touch.
+
+## Verification commands run for this audit
+
+```
+cargo test --release                                  # exit 0 — 375 unit + 92 integration, 0 failed
+cargo fmt --all -- --check                            # clean
+cargo clippy --all-targets --release -- -D warnings   # clean
+```
+
+Plus, against `target/release/trim_galore`: the three #379 reproductions (process substitution,
+gzipped pipe → `/dev/stdin`, live-writer FIFO), a writer-less FIFO, `/dev/null`, `/dev/zero`,
+`/dev/urandom`, an empty regular file, a directory, 1- and 4-byte regular files, and the same 4-byte
+file via `/dev/fd/9`. Plus two standalone `rustc` programs replicating `bounded()` and `run_bounded()`
+to prove each converts a real indefinite block into a failure.
+
+Not verifiable in this environment: a Unix-socket input (sandbox denies `AF_UNIX bind`), and
+`/dev/stdin` at an interactive terminal (no tty).
+
+## Verdict
+
+**COMPLETE.**
+
+Every item in §5.1–§5.4, §5.2's CI backstop, §5.3's six FIFO rules, §3.4's twelve edge cases and
+§9's validation table is implemented as specified or deviates for a reason recorded in §12 and
+confirmed here against the code. Nothing is missing; nothing is partial.
+
+The four rows the brief singled out as most likely to "quietly not hold" all hold, and each was
+checked against something capable of failing rather than merely observed passing:
+
+- **V5** — the two bounding harnesses were proven to fire on a real `open(2)` block (3.00 s, 3.04 s).
+- **V6** — both FIFO variants rejected promptly, including the writer-less case that used to hang forever.
+- **V7** — all six directions exercised, and the offset predicate additionally caught real production
+  input (`/dev/fd/9` over a 4-byte file), so it is no longer a check only ever seen to pass.
+- **V10** — two of three surfaces asserted; the third excluded on a justification verified against
+  `src/demux.rs`. The residual is that the enumeration is by test, not by mechanism, so a *future*
+  path-bearing flag added unguarded would not fail anything.
+
+One verification remains genuinely open and cannot be closed locally: **V3** (Perl 0.6.11
+byte-identity), which needs the CI `validation` / `validation-ubam` jobs before merge.

--- a/plans/08032026_reject-non-restartable-input/MEASUREMENTS_reopen_probe.md
+++ b/plans/08032026_reject-non-restartable-input/MEASUREMENTS_reopen_probe.md
@@ -1,0 +1,88 @@
+# Measurements — re-open behaviour and FIFO open semantics
+
+Taken during manual review of `PLAN.md`, 2026-08-04, kernel Darwin 25.5.0 / macOS 26.5.1, arm64, rustc from `~/.cargo/bin`. **Every row below is Darwin**; the plan's Linux claims are reasoned, not measured, and PLAN §9 V9 makes CI measure the one that matters.
+Probe sources: `probe.rs` (two opens + byte compare) and `probe2.rs` (fstat of the first handle), reproduced at the end.
+
+Both probes mirror `format::detect_input_format`: open, `read` up to 4 bytes, then — **still holding the first handle**, as `format.rs:231` does — open again. `probe.rs` runs the second open on a thread with `recv_timeout(3s)` so a blocking open is reported rather than hanging.
+
+## 1. Does re-opening restart? (`probe.rs`)
+
+| # | input | open1 | open2 | restarts |
+|---|---|---|---|---|
+| A | regular file | `@MS2` | `@MS2` | **true** |
+| B | `/dev/stdin` redirected from a regular file | `@MS2` | `_rea` | false |
+| C | `/dev/stdin` from a pipe | `@MS2` | `_rea` | false |
+| D | `<(cat reg.fq)` process substitution (bash) | `@MS2` | `_rea` | false |
+| E | named FIFO, **writer exited** after writing | `@MS2` | *blocked >3 s* | **HANG** |
+| F | named FIFO, writer still open | `@MS2` | `_rea` | false |
+
+A–D reproduce PLAN §2.2 exactly, including the seekable-but-non-restarting case B. A is the positive control: the comparison can return `true`.
+
+**E is new.** POSIX `open(O_RDONLY)` on a FIFO blocks until a writer opens; an existing reader holding the fd does not satisfy it. So the probe's own second open blocks indefinitely when the writer has exited — which is the common shape (`mkfifo f; cat small.fq > f &`).
+
+E vs F is decided by whether the writer is still alive at second-open time, i.e. by payload size against the pipe buffer (64 KiB). A test using a small fixture is a scheduler coin-flip.
+
+## 2. Can the file type be named without a second open? (`probe2.rs`)
+
+| # | input | `File::metadata()` (fstat) | `fs::metadata(path)` |
+|---|---|---|---|
+| A | regular file | regular | regular |
+| B | `/dev/stdin` from a regular file | **regular** | regular |
+| C | `/dev/stdin` from a pipe | FIFO/pipe | FIFO/pipe |
+| D | process substitution | FIFO/pipe | FIFO/pipe |
+| E | named FIFO | FIFO/pipe | FIFO/pipe |
+
+fstat on the handle already open in `detect_input_format` names every pipe and FIFO (C, D, E) — the three cases where a second open either consumes stream bytes or blocks. It reports **regular** for B, confirming PLAN §2.2: a type check alone cannot catch the shared-offset case, so it cannot replace the byte probe.
+
+`std::os::unix::fs::FileTypeExt::is_fifo()` is std — no new dependency.
+
+## 3. Consequences for the plan
+
+1. Reject `is_fifo()` / `is_socket()` on the first handle **before** attempting a second open. Removes case E's hang, avoids consuming stream bytes, and leaves the byte probe to do the only job a type check cannot (case B).
+2. A3/V5's risk is **flakiness**, not a deterministic hang: make the FIFO test's writer outlive the second open (or exceed the pipe buffer) and give the test an in-process timeout. `timeout(1)` is absent on Darwin and on GitHub's `macos-latest` leg, and the CI matrix is `[ubuntu-latest, macos-latest]`.
+
+## 4. Probe sources
+
+```rust
+// probe.rs — two opens, byte compare, second open on a timed thread
+use std::fs::File; use std::io::Read; use std::sync::mpsc; use std::thread;
+use std::time::Duration;
+fn main() {
+    let path = std::env::args().nth(1).unwrap();
+    let mut f1 = File::open(&path).unwrap();
+    let mut b1 = [0u8; 4];
+    let n1 = f1.read(&mut b1).unwrap();
+    let p2 = path.clone();
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let r = (|| -> std::io::Result<(usize, [u8; 4])> {
+            let mut g = File::open(&p2)?;
+            let mut b = [0u8; 4];
+            let n = g.read(&mut b)?;
+            Ok((n, b))
+        })();
+        let _ = tx.send(r);
+    });
+    match rx.recv_timeout(Duration::from_secs(3)) {
+        Ok(Ok((n2, b2))) => println!("restarts={}", b1[..n1] == b2[..n2]),
+        Ok(Err(e)) => println!("second-open-failed: {e}"),
+        Err(_) => println!("HANG"),
+    }
+    drop(f1);
+    std::process::exit(0);
+}
+```
+
+```rust
+// probe2.rs — file type of the already-open handle vs the path
+use std::fs::File; use std::os::unix::fs::FileTypeExt;
+fn main() {
+    let path = std::env::args().nth(1).unwrap();
+    let f = File::open(&path).unwrap();
+    let ft = f.metadata().unwrap().file_type();
+    println!("fifo={} sock={} chardev={} regular={}",
+             ft.is_fifo(), ft.is_socket(), ft.is_char_device(), ft.is_file());
+}
+```
+
+Harness notes: `nice(5) failed` lines in the FIFO runs are the sandbox refusing to renice a background job; they do not affect the result. Each FIFO used a fresh `$$`-suffixed name rather than being cleared.

--- a/plans/08032026_reject-non-restartable-input/PLAN.md
+++ b/plans/08032026_reject-non-restartable-input/PLAN.md
@@ -1,0 +1,594 @@
+# PLAN — Reject non-restartable input with an accurate diagnostic
+
+**Issue:** [#379](https://github.com/FelixKrueger/TrimGalore/issues/379)
+**Branch:** `fix/reject-non-restartable-input` off `dev`
+**Scope decision:** option **A** of three. This does **not** add pipe support — it replaces a misleading error with a correct one. See §10 for what B and C would have cost.
+
+**Revision history**
+
+| v | What changed |
+|---|---|
+| v1 | Byte-comparison probe alone. |
+| v2 | Measurement showed that probe **hangs** on the commonest FIFO shape (`MEASUREMENTS_reopen_probe.md` §1 row E). Added a non-blocking `fstat` pre-filter in front of it. |
+| **v3** | Dual plan review (`PLAN_REVIEW_A.md`, `PLAN_REVIEW_B.md`). Both reviewers independently found the guard **misses `--passthrough` entirely** (§2.4) and that the FIFO test specification was self-contradictory and unbounded (§5.3). Adds a path-level check in `Cli::validate` that also closes v2's Medium residual; swaps the byte comparison for an **offset-or-bytes** predicate; folds in the now-merged shape of [#374](https://github.com/FelixKrueger/TrimGalore/pull/374) (§7). |
+
+---
+
+## 1. Goal
+
+When the input cannot be re-read from the start, fail immediately with a message that says so and explains what to do. Today such input fails with one of three wrong outcomes:
+
+| Input | Today |
+|---|---|
+| `<(cat plain.fastq)` | `doesn't seem to be in FastQ format (first line doesn't start with '@')` — `fastq.rs:485` |
+| `cat reads.fq.gz \| … /dev/stdin` | `Failed to decompress first block of '…' for format detection` — `format.rs:236` |
+| `mkfifo f; cat reads.fq > f &` | **hangs**, no message |
+
+All three blame the user's data, or say nothing, for a limitation of ours.
+
+Non-goal: making pipes, FIFOs, process substitution or `/dev/stdin` work. That is a capability change (§10).
+
+---
+
+## 2. Context
+
+### 2.1 Why the input is read more than once
+
+Trim Galore opens each input at least **five times** for a gzipped file, and reads the first million records twice:
+
+| Pass | Site | Opens | Consumes |
+|---|---|---|---|
+| Format detection | `format.rs:208`, `:231` | 2 | 4 bytes, then one decompressed block |
+| Sanity check | `fastq.rs:474` (`FastqReader::sanity_check`) | 1 | 1 record, then **drops the reader** |
+| Adapter auto-detection | `adapter.rs:115` / `:268` via `open_sync_reader` | 1 | up to `MAX_SCAN_READS = 1_000_000` (`adapter.rs:84`) |
+| Trim pass | `format.rs:256`/`:273` factories | 1 | everything |
+
+The true count is higher and rising: `detect_input_format` runs at *every* one of those sites; `cli.input[0]` passes through it twice before any reader is built (`main.rs:178` → `:30`, then the all-inputs map at `:187`); and after #374 the bare `FastqReader::open` / `open_threaded` / `sanity_check` entry points each perform **two** opens rather than one, because `sniff_gzip` opens the path to read three magic bytes and then the stream is opened again (§7).
+
+The exact number does not matter. What matters is that it is greater than one, at every layer, and that each pass opens the path afresh. That is fine for a regular file and wrong for anything else.
+
+### 2.2 The invariant that breaks, and the guards that do not test it
+
+`format.rs:227-230` states the assumption explicitly:
+
+> Re-open from byte 0 (cheaper than seeking and sidesteps any interaction between `MultiGzDecoder` and the already-consumed prefix; the alternative `PeekReader` wrapper in PLAN §5 step 2.3 is a documented future optimization, **not required for correctness**).
+
+The real invariant is **re-opening the path yields the same bytes from the start**. Measured on Darwin (kernel 25.5.0, macOS 26.5.1, arm64 — `MEASUREMENTS_reopen_probe.md` §1), with the first handle still open, as `format.rs:231` leaves it:
+
+| # | input | open1 | open2 | restarts |
+|---|---|---|---|---|
+| A | regular file | `@MS2` | `@MS2` | **yes** |
+| B | `/dev/stdin` redirected from a regular file | `@MS2` | `_rea` | no |
+| C | `/dev/stdin` from a pipe | `@MS2` | `_rea` | no |
+| D | `<(cat reg.fq)` process substitution | `@MS2` | `_rea` | no |
+| E | named FIFO, **writer exited** after writing | `@MS2` | *blocked >3 s* | **hangs** |
+| F | named FIFO, writer still open | `@MS2` | `_rea` | no |
+
+Row A is the positive control: the comparison is capable of returning true. Both reviewers reproduced row E independently.
+
+**A seekability probe** (`lseek(fd, 0, SEEK_CUR)` on the *first* handle) accepts row B — that fd *is* seekable — which then fails with the original misleading message. On Darwin `/dev/stdin` is `fd/0`, and opening `/dev/fd/N` is `dup(N)`, so the second open shares the file offset. This is what killed the approach #379 proposes. Note the distinction from §3's actual predicate, which interrogates the **second** handle (§2.2.2).
+
+**A file-type check cannot replace it** either: row B fstats as a *regular file* (§2.2.1).
+
+**And the byte-level check cannot stand alone**, because row E shows its own second open blocking indefinitely. POSIX `open(O_RDONLY)` on a FIFO waits for a *writer*; the reader we are already holding does not satisfy it. `mkfifo f; cat reads.fq > f &` is the commonest FIFO shape, and its writer exits as soon as the payload fits the 64 KiB pipe buffer. A guard whose purpose is to print a message would print nothing and wedge.
+
+Rows E and F differ only in whether the writer is still alive when the second open happens — i.e. in payload size against the pipe buffer. That is a race, not a property of the input, and §5.3 is written around it.
+
+### 2.2.1 The file-type checks
+
+`File::metadata()` on the handle `detect_input_format` already holds (`MEASUREMENTS_reopen_probe.md` §2):
+
+| # | input | `fstat` on the open handle |
+|---|---|---|
+| A | regular file | regular |
+| B | `/dev/stdin` from a regular file | **regular** |
+| C | `/dev/stdin` from a pipe | FIFO/pipe |
+| D | process substitution | FIFO/pipe |
+| E, F | named FIFO | FIFO/pipe |
+
+`is_fifo()` names every case where a second open would block (E) or consume stream bytes (C, D, F), and reports *regular* for B — which is why it guards the second-open check rather than replacing it. `std::os::unix::fs::FileTypeExt` is std; no new dependency. Reviewer B measured that `File::metadata` follows a symlink to its target's type, so a symlink to a FIFO is caught and there is no TOCTOU window on a handle-level check.
+
+`is_socket()` **is** included, on Reviewer B's recommendation. v2 excluded it as unreachable (`File::open` on a socket path failing first), but that claim was never measured — the measurement file has no socket row — and on Linux a socket reached through `/proc/self/fd/N` returns `ENXIO`, which §10 Q3's `Err` decision would surface as a bare OS error. The check costs one `||` and removes a dependency on an unmeasured claim.
+
+`is_char_device()` is **not** included: `/dev/null` is a character device and *is* restartable, so rejecting the class would be wrong. Character devices fall through, and §3.2 records where each one lands.
+
+The argument against a type check in v1 ("it is platform-dependent") was aimed at the wrong target. The *behaviour* is platform-dependent: Linux resolves `/dev/stdin` through `/proc/self/fd/0` and may genuinely restart, Darwin `dup`s and cannot. Only a behavioural check accepts what works on each platform and rejects what does not. A pipe, by contrast, is a pipe on both — so the type filter is safe to layer underneath.
+
+### 2.2.2 The second-layer predicate: offset, then bytes
+
+v2 compared the leading bytes of the two opens. Reviewer B showed that predicate has a hole and a sharper replacement.
+
+The hole: with a single `read` and a prefix comparison — the natural reading of v2's wording — a `/dev/fd/N` over a **≤4-byte** file is *wrongly accepted*, because the second read returns 0 bytes and an empty prefix compares equal. Measured:
+
+| file size | n1 | n2 | prefix compare | length-aware compare |
+|---|---|---|---|---|
+| 4 B | 4 | 0 | **true — wrongly accepted** | false |
+| 1 B | 1 | 0 | **true — wrongly accepted** | false |
+| 5 B | 4 | 1 | false | false |
+
+The replacement: `Seek::stream_position()` on the **second** handle. `0` means a genuine fresh open; non-zero means the open inherited an offset, which is exactly what rows B, D and F are. Measured by Reviewer B:
+
+| input | second open `stream_position()` | offset verdict |
+|---|---|---|
+| regular 4 B / 6 B / 40 B | `Ok(0)` | restartable |
+| `/dev/fd/N` over 4 B | `Ok(4)` | **not restartable** (the byte compare missed this) |
+| `/dev/fd/N` over 6 B / 40 B | `Ok(4)` | not restartable |
+| `/dev/null`, `/dev/zero` | `Ok(0)` | restartable |
+| `/dev/urandom` | `Ok(0)` | restartable |
+
+This is std, needs no `libc`, and needs no second `read`. It is **not** the seekability probe §2.2 rejects: that one asks the *first* handle "are you seekable" and accepts row B; this asks the *second* "did you start at zero", which is the property that actually differs.
+
+**Decision: take both conditions, OR'd** — not restartable if `stream_position() != 0` **or** the length-aware byte comparison fails. Rationale:
+
+- The offset condition is exact, so it retires A2's pathological-repeating-prefix residual and closes the ≤4-byte hole.
+- Keeping the byte condition preserves v2's treatment of a *streaming* character device: `/dev/urandom` is `Ok(0)` on offset but differs on bytes, so it stays rejected. Dropping the byte half would silently change that to the not-FASTQ error.
+- Neither condition can fire on a genuine regular file (measured, both directions).
+
+### 2.3 Placement, and what the v2 inventory got wrong
+
+`format::detect_input_format` is the function every **`cli.input`** path passes through: the two factories (`format.rs:256`, `:273`), `main::sanity_check_any` (`main.rs:30`) and its siblings at `:51`/`:68`, the all-inputs map at `main.rs:187`, `clump_only.rs:265`/`:402`/`:747`/`:910`/`:949`/`:950`, `specialty.rs:128`/`:180`, and `main.rs:1328`/`:1900`/`:2050`/`:2051`.
+
+v2 claimed this covered "every input path" and stamped it **Verified**. That was verified against `cli.input`, not against every input-bearing CLI surface. Corrections, all confirmed against source:
+
+| v2 claim | Correction |
+|---|---|
+| `specialty.rs:531` is a call site | It is inside `#[cfg(test)] mod tests` (module opens at `:508`) — a `read_fastq` helper, not a production path |
+| `demux.rs:170` is downstream of a detect | It opens Trim Galore's **own trimming output** (name derived at `demux.rs:129`). Safe because we wrote it, not because a detect preceded it. This is also why #374's `sniff_gzip` deliberately avoids `detect_input_format` (§7) |
+| `main.rs:1373`/`:1374`/`:1383` are all downstream of a detect | `:1373`/`:1374` are R1/R2 and are. **`:1383` is the `--passthrough` file and is not** (§2.4) |
+| "the guard fires first in every flow" | False. See §2.4 |
+
+The three `clump_only.rs` pairs do check out — `:290` is preceded by `:265`, and `:430`/`:432` by `:402`, on the same paths — and none of `clump_only`'s detect sites is on a self-created intermediate.
+
+### 2.4 The hole both reviewers found: `--passthrough`
+
+`cli.passthrough` is a separate `Option<PathBuf>` (`cli.rs:282`), not an element of `cli.input`, so it is in none of the inventories above. Its whole lifecycle:
+
+| Step | Site | What it does |
+|---|---|---|
+| 1 | `cli.rs:884` | `if !pt.exists()` — a `stat`; a FIFO satisfies it |
+| 2 | `main.rs:768` | `FastqReader::sanity_check(pt_path)` — **not** `sanity_check_any`, so no `detect_input_format`. One record, then drops the reader |
+| 3 | `main.rs:1344` (parallel) / `main.rs:1383` (serial) | `FastqReader::open_threaded(p)` / `open(p)` |
+
+The internal-invariant loop at `main.rs:1327` iterates `[input_r1, input_r2]` only. So the passthrough file is opened twice — four times after #374, which adds a sniff open to each bare entry point — with **no guard at any layer**. Consequences if this plan shipped without covering it:
+
+- **`--passthrough <writer-exited FIFO>` still hangs with no message**, and by then `ensure_output_dir` has run and the R1/R2 writers exist — so it hangs *with partial output on disk*. Exactly the failure mode §1 says this plan removes.
+- **`--passthrough <live-writer FIFO or /dev/fd/N>` desyncs**: step 2 consumes a record, step 3 resumes mid-stream, and the three-way header sync check at `parallel.rs:640` fires with a message about a truncated or desynced passthrough — blaming the user's data for a limitation of ours, one flag over.
+
+Reviewer B found the same gap is structural rather than incidental: the `--passthrough` + uBAM rejection at `main.rs:253` keys off `any_bam`, computed from `cli.input`, so the passthrough file's container format is never inspected anywhere either.
+
+---
+
+## 3. Behavior
+
+Two placements, deliberately. Both fail closed; each covers what the other cannot.
+
+### 3.0 Layer 1 — `Cli::validate` (path level, never opens)
+
+`cli.rs:933` already stats every input unconditionally (`if !path.exists()`), reached from `main.rs:166` before any dispatch branch. Reviewer A measured the decisive property: **`fs::metadata` on a writer-less FIFO returns promptly while `File::open` blocks.**
+
+```
+FIFO, no writer ever:   Path::exists = true
+                        fs::metadata = Ok(fifo=true)
+                        File::open   = *** BLOCKED >3s ***
+regular file (control): fs::metadata = Ok(fifo=false);  File::open returned
+```
+
+So replacing that `exists()` with an `fs::metadata()` match costs **zero extra syscalls** and buys three things v2 could not:
+
+1. It closes v2's Medium residual. `trim_galore fifo` with no writer blocked at the first open with no message, and v2 called that unfixable without opening every input `O_NONBLOCK`. `stat(2)` never opens, so the FIFO is named and rejected before anything can block.
+2. It covers `--passthrough` (`cli.rs:884`) and the `--demux` barcode file (`cli.rs:926`) at the same site.
+3. It fires earliest, so nothing is created before the message.
+
+It does **not** replace layer 2: `Cli::validate` is bypassed by a library consumer calling e.g. `clump_only::clump_only_single` without a `Cli`, and a path stat is a TOCTOU proxy where layer 2's `fstat` is not. Two cheap checks that fail closed.
+
+### 3.1 Layer 2 — `detect_input_format` (handle level)
+
+The order is load-bearing:
+
+1. Open the path (unchanged).
+2. **New:** `fstat` the handle. If `is_fifo() || is_socket()`, bail with the §3.3 pipe message. This precedes the `read`, so a FIFO with a live writer and no data yet is rejected instead of blocking in `read`.
+3. Read up to 4 bytes into `peek`, **looping** until the buffer is full or EOF and retrying `ErrorKind::Interrupted` (§8 A8).
+4. `n == 0` → the existing empty-input error (unchanged).
+5. **New:** open the path a second time. Not restartable if `stream_position() != 0`, or if a looped read of `n` bytes does not return exactly `n` bytes equal to `peek[..n]`. On not-restartable, bail with the §3.3 re-open message.
+6. Everything from here is untouched: `@` → `FastqPlain`; gzip magic → decompress a block and probe for `BAM\1`; anything else → the existing "not recognised as FASTQ" error.
+
+### 3.2 Layer 0 — route `--passthrough` through the guard
+
+`main.rs:768`: `FastqReader::sanity_check(pt_path)` → `sanity_check_any(pt_path)`.
+
+`sanity_check_any` dispatches through `detect_input_format` (`main.rs:30`) and then calls `FastqReader::sanity_check` for the FASTQ arms, so the existing check still runs. Two notes:
+
+- **This does not undo #374.** Both `detect_input_format` and #374's `sniff_gzip` are content-based, so a `.bgz` passthrough file keeps working; the run simply gains one redundant content check.
+- The empty-input message changes from `seems to be completely empty` (`fastq.rs:478`) to `is empty` (`format.rs:216`) for an empty passthrough file. Both are errors, both are accurate, and an empty passthrough would desync R1/R2 anyway.
+
+~~`--passthrough` + uBAM is rejected at `main.rs:253`, so `sanity_check_any`'s BAM arm is unreachable here and harmless.~~
+
+**Corrected in the fix round (§13, H1) — this was false, and §2.4 above already said why.** `main.rs:253` tests `any_bam`, computed from `cli.input`, so a uBAM *passthrough* file never reached it. `sanity_check_any`'s BAM arm therefore **accepted** the file (it opens a `BamReader` and returns `Ok`) where `FastqReader::sanity_check` had rejected it, and the run went on to die in the FASTQ reader with three empty output files on disk. Both code reviewers found this independently. The arm is genuinely unreachable now, because §13's fix adds a passthrough-specific format check beside `main.rs:253` — i.e. the claim was made true rather than merely asserted.
+
+### 3.3 The messages
+
+Two openings, one shared tail. Both contain the substring **`cannot be re-read from the start`**, so a single assertion covers either path.
+
+Pipe or FIFO (layer 1, and layer 2 step 2):
+
+```
+Input 'X' is a pipe or FIFO, not a regular file, so it cannot be re-read from
+the start.
+```
+
+v2 said "named pipe (FIFO)". Reviewer B pointed out that two of the three #379 reproductions — `<(zcat reads.fq.gz)` and `cat x | trim_galore /dev/stdin` — are **anonymous** pipes, so v2's noun was wrong for the majority case, in a plan whose premise is that we should not describe the user's input inaccurately. Nothing caught it, because V1 asserts only the shared tail.
+
+Re-open mismatch (layer 2 step 5):
+
+```
+Input 'X' cannot be re-read from the start: opening it a second time did not
+return to the beginning of the data.
+```
+
+Shared tail:
+
+```
+Trim Galore reads each input more than once — format detection, the initial
+sanity check, and adapter auto-detection each open it independently — so it
+requires a regular file.
+
+Common causes are pipes, FIFOs, process substitution such as
+`<(zcat reads.fq.gz)`, and /dev/stdin. Write the stream to a file first:
+
+    zcat reads.fq.gz > reads.fq && trim_galore [options] reads.fq
+```
+
+"Common causes are" rather than "This affects", because the list is not exhaustive — a streaming character device reaches the same message (§3.4). Per `CLAUDE.md`, the reasoning lives here and in the commit message rather than in a source comment.
+
+### 3.4 Edge cases
+
+| Case | Handling |
+|---|---|
+| Empty regular file | Existing `Input file 'X' is empty` (`format.rs:216`), unchanged — a regular file passes both type checks and `n == 0` precedes the second-open check |
+| File shorter than 4 bytes | Length-aware comparison (§2.2.2); a 1-byte regular file is restartable and falls through to the existing format errors. The same file via `/dev/fd/N` is now correctly **rejected** — v2 would have accepted it |
+| Empty FIFO (writer opened, wrote nothing, exited) | **Behaviour change:** the pipe message, previously `is empty`. Both true; naming the pipe is more useful, and step 2 must precede the read to avoid blocking |
+| FIFO with **no writer at all** | Rejected by layer 1 without opening. This was v2's Medium residual |
+| Socket | Rejected by layer 2 step 2, or by layer 1 |
+| `/dev/null` | Character device, `n == 0` → existing `is empty` ✓ |
+| `/dev/zero` | Character device, offset 0 and bytes equal → falls through → existing not-recognised error ✓ |
+| `/dev/urandom` | Character device, offset 0 but bytes differ → the **new** re-open message. Accurate (it genuinely cannot be re-read), and the tail no longer claims to be exhaustive |
+| `/dev/stdin` **at an interactive terminal** | Character device; neither type check fires, and the first `read` blocks with no message. Residual — see §11 |
+| Directory | `read` fails with `EISDIR` — unchanged from today |
+| Second open fails with an unexpected `io::Error` | Propagated as itself with context, **not** reported as non-restartable — §10 Q3 |
+| Regular file being concurrently appended | Restartable; out of scope, and no worse than today |
+
+---
+
+## 4. Signature
+
+```rust
+/// True iff opening `path` a second time returns to the beginning of the data.
+///
+/// Trim Galore opens each input several times (format detection, sanity check,
+/// adapter auto-detection, the trim pass), so a path whose re-open does not
+/// restart cannot be processed. `/dev/fd/N` shares the file offset on some
+/// platforms even though it is seekable, which is why this interrogates the
+/// second handle rather than probing the first for seekability.
+///
+/// Callers must reject FIFOs before calling this: a second open on a FIFO with
+/// no live writer blocks indefinitely.
+fn reopen_restarts(path: &Path, first: &[u8]) -> Result<bool>
+```
+
+Private to `format.rs`. Takes the bytes already read so the caller does not read twice from the first handle.
+
+- `Ok(false)` means *opened successfully and did not restart* — a non-zero start offset, or a length-aware byte mismatch.
+- An unexpected `io::Error` is `Err`, carrying `.with_context(|| format!("Failed to re-open input file '{}' for the restartability check", path.display()))` in the style of `format.rs:209`/`:213`. Without that context the improvement Q3 bought is only half-delivered: a bare `Too many open files (os error 24)` with no path is still a bad diagnostic.
+
+The type checks stay **inline** — layer 1 in `Cli::validate`, layer 2 in `detect_input_format`. Each is two lines and layer 2 needs the open handle, which no helper has. §9 V7 exercises them through their callers.
+
+---
+
+## 5. Implementation outline
+
+### 5.1 Source
+
+1. **`Cli::validate` (layer 1).** Replace the `path.exists()` check at `cli.rs:933` with an `fs::metadata()` match: `Err` → the existing not-found error; `Ok(m)` where `m.file_type().is_fifo() || is_socket()` → the §3.3 pipe message; otherwise proceed. Apply the same at `cli.rs:884` (`--passthrough`) and `cli.rs:926` (`--demux` barcode file). No new syscalls — these sites already stat.
+2. **`main.rs:768` (layer 0).** `FastqReader::sanity_check(pt_path)` → `sanity_check_any(pt_path)`.
+3. **`detect_input_format` type check (layer 2 step 2).** After the `File::open` at `format.rs:208` and **before** the `read` at `:211`. `use std::os::unix::fs::FileTypeExt;` at module scope, `#[cfg(unix)]`-gated with a `#[cfg(not(unix))]` no-op (§8 A7) — the crate ships a `src/lib.rs`, so a bare `use` is a hard compile break for any non-Unix consumer.
+4. **Loop the first read** at `format.rs:211` until 4 bytes or EOF, retrying `Interrupted`.
+5. **Add `reopen_restarts`**, private, above `detect_input_format`, per §4.
+6. **Call it** after the `n == 0` check at `format.rs:215-217` and before the `peek[0] == b'@'` branch at `:219`.
+7. **Reword the comment at `format.rs:227-230`** — "not required for correctness" is now false in the general case and true only because the guard rejects the inputs where it would matter. One line.
+8. **CHANGELOG** entry under `#### Fixes` in `Unreleased`. Reviewer B checked `docs/`, `README.md` and `--help` for `/dev/stdin`, `mkfifo` and `… | trim_galore` and found nothing, so the CHANGELOG is the entire documentation surface.
+
+### 5.2 CI backstop — do this first, not last
+
+Neither exists today. Both reviewers filed it, and Reviewer B gave the argument that makes it structural rather than hygiene: **if the layer-2 type check is ever accidentally dead** — placed after the `read`, or the predicate inverted — the FIFO test does not fail, it *hangs*, because the second open blocks (row E). The plan's central design decision fails, if it fails, in the one mode the plan itself calls hardest to notice.
+
+```yaml
+# .github/workflows/ci.yml — rust-tests job
+timeout-minutes: 30
+```
+
+```toml
+# .config/nextest.toml — no such file today
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 4 }
+```
+
+Verified: `grep -rn "timeout-minutes" .github/workflows/` returns nothing, there is no `.config/`, and the job runs `cargo nextest run` (`ci.yml:67`) **and** `cargo test --release` (`:74`) on both matrix legs. An escaped wedge therefore burns GitHub's default 360-minute ceiling on four job-steps. This is the one backstop that survives an implementer forgetting every rule in §5.3.
+
+### 5.3 FIFO test construction — the part v2 got wrong
+
+v2 asked for "both writer states — writer exited, and writer still open". **Drop that.** Reviewer A measured why it is not a specification anyone can implement:
+
+```
+Shape A  writer held open in-process for the whole call  -> message in 144 µs   deterministic
+Shape B  child.wait() for the writer BEFORE the call     -> *** BLOCKED >3s ***  in SETUP
+Shape C  spawn writer, then call immediately             -> message in 28 ms     deterministic
+Shape D  v1's second open, writer gone                   -> *** BLOCKED >3s ***  (row E)
+```
+
+"Writer exited" is **unreachable as a pre-condition**: a writer's `open(O_WRONLY)` blocks until a reader opens, and the only reader is the call under test, so Shape B blocks in `child.wait()`. What row E observed was a writer exiting *between* the first and second open — which v2's pre-filter deletes by construction. And Reviewer B showed v2's own rule 2 ("payload under 64 KiB so the writer exits") *contradicted* the writer-still-open case, making it the scheduler race the measurement file identifies. With the pre-filter, both states traverse identical code: there is one test.
+
+**The construction.** Hold the write end open on a spawned thread inside the test process:
+
+```rust
+let w = { let p = fifo.clone(); thread::spawn(move || {
+    let f = std::fs::OpenOptions::new().write(true).open(&p).unwrap();
+    std::thread::park();            // hold the writer open
+    drop(f);
+}) };
+```
+
+The write-only `open` rendezvous with our reader's `open`, so both complete. **It must not be on the main thread** — a write-only `open` on a FIFO blocks until a reader appears, so doing it before `detect_input_format` on the same thread self-deadlocks. That is the obvious way to write this test and it is a trap.
+
+**Rules, each from a measured failure mode.** Every one of these replaced or corrected a v2 rule:
+
+1. **A writer must open the FIFO**, or the *first* open blocks (§3.4). Spawn it before the call; its `open` blocks until ours succeeds, so there is no race.
+2. **Bound the whole test body, setup included** — not "the call". v2 bounded the call; the measured wedge (Shape B) is in setup, outside that bound. Run the body on a thread and `mpsc::recv_timeout`. Do **not** rely on `timeout(1)`: absent on Darwin and on GitHub's `macos-latest` runner.
+3. **The writer must tolerate `EPIPE`.** The guard bails and drops the reader before the writer's `write_all` lands, so an in-process writer must not `unwrap()` its write, and a spawned `cat` must not have `.success()` asserted — it is killed by `SIGPIPE`, payload-size-dependently. (This is the real reason v2's payload rule was needed; the reason v2 gave was already stale.)
+4. **Assert the fixture is a FIFO.** Check `mkfifo`'s exit status and `assert!(fs::metadata(&f)?.file_type().is_fifo())`. If `mkfifo` fails, `cat x > f` creates a regular file, `detect_input_format` returns `FastqPlain`, and the test fails pointing at the guard when the fault is in the harness.
+5. **One `fresh_tmpdir` slug per FIFO test.** `fresh_tmpdir` opens with `remove_dir_all`, and the debug leg is process-per-test under nextest, so a shared slug lets one process unlink another's FIFO while a writer is blocked on it. `ci.yml:52-56` records an audit that all 19 existing `temp_dir().join(…)` sites use unique slugs — do not be the first exception.
+6. **Integration tests get their own recipe.** The repo idiom is `Command::new(binary()).output()` (`tests/integration_no_args_help.rs:21-24` and every `integration_clump_only*` case). `output()` reads both pipes to EOF and cannot be interrupted, so a child blocked in `open` holds them open and `output()` never returns. Use `spawn()`, keep the `Child`, and on timeout `kill()` then `wait()`. Give the writer child `Stdio::null()` and kill it in cleanup — a leaked child holding output handles trips nextest's `leak-timeout` (default 100 ms) and is reported LEAK.
+
+### 5.4 Tests
+
+**Unit, in `src/format.rs`'s existing `mod tests`** (which already has `fresh_tmpdir`):
+
+- a regular plain FASTQ is accepted; a regular gzipped FASTQ is accepted (happy-path regression guards);
+- a FIFO is rejected with the pipe message — **one** test, per §5.3;
+- an empty regular file still produces the *empty* error, not either new message;
+- `reopen_restarts(&regular_fq, b"@rea")? == true` — positive direction;
+- `reopen_restarts(&regular_fq, b"XXXX")? == false` — negative direction, portable (see V7);
+- `reopen_restarts(Path::new("/dev/urandom"), …)? == false` — negative direction against a real non-restartable source that cannot block;
+- a `/dev/fd/N` over a 4-byte file is rejected, `#[cfg(target_os = "macos")]` — the case v2 would have accepted (§2.2.2).
+
+**FIFO creation:** `std::process::Command::new("mkfifo")` (confirmed at `/usr/bin/mkfifo` on Darwin, present on both runners). Correcting v2's stated rationale, which both reviewers flagged: dev-dependencies are `serde_json`, `tempfile` **and `bstr`** (`Cargo.toml:50-56`), not "tempfile only", and `libc 0.2.184` is **already in `Cargo.lock`** transitively via `rustix`/`tempfile` — so `libc::mkfifo` would add one dev-dep line and *zero* new compiled crates. The honest comparison is "a `$PATH` dependency with a failure mode that masquerades as a guard bug (rule 4)" versus "one dev-dep line on a crate already in the graph, and an immediate errno". `Command` is chosen for needing no `unsafe`; the trade-off is close.
+
+**Integration** `tests/integration_non_restartable_input.rs`: invoke the built binary with a FIFO, with `/dev/stdin` from a pipe, and with `--passthrough <fifo>`; assert non-zero exit and stderr containing `cannot be re-read from the start`. Rules 1–6 apply. Do **not** assert on `/dev/stdin` redirected from a *regular file* — that is row B, whose correct outcome is platform-divergent (§2.2.1).
+
+---
+
+## 6. Efficiency
+
+Per input:
+
+- **Layer 1:** zero extra syscalls. `cli.rs:884`/`:926`/`:933` already stat; `fs::metadata` replaces `exists()`, which is the same call.
+- **Layer 2, FIFO or socket:** one `fstat` on an already-open handle, then bail. No extra open.
+- **Layer 2, regular file:** one `fstat`, one extra `open`, one `stream_position()`, and a ≤4-byte `read`.
+
+`detect_input_format` runs several times per input (§2.1), so the regular-file cost is one extra open per *call*, not per input; on the gzip branch a call now performs **three** opens (`:208`, the probe, `:231`). Against five-plus opens and a full-file read this is unmeasurable. No allocation — the probe buffer is a `[u8; 4]` on the stack.
+
+An optimisation exists and is **not** taken: the gzip branch already re-opens at `:231`, so its handle's offset could be inspected for free, making the check zero-cost there and paid only on the plain branch. That would split the check across two sites and make it conditional on the branch taken. One `open` is not worth that. (Reviewer A's ALT-4 — memoising detection per path — would remove the redundant opens altogether and make this moot, but it collides with #374 and is a larger change than this plan wants.)
+
+---
+
+## 7. Integration
+
+**Reads:** the input path. **Writes:** nothing.
+
+**Order:** layer 1 in `Cli::validate` (`main.rs:166`), before any dispatch; layer 2 inside `detect_input_format`, before any reader is constructed. Only one call site changes (`main.rs:768`).
+
+**Downstream:** an input that previously failed later with a wrong message — or hung with no message — now fails immediately with a right one. No input that previously *succeeded* can newly fail: restartability is exactly the property every existing successful run already had (§8 A1).
+
+### 7.1 #374 — no longer "not at all"
+
+v2 asserted the two changes do not interact. That was true of v2's shape and is now wrong in three specific ways. Benjamin Demaille (`@BenjaminDEMAILLE`) pushed `16d47ca` and `a293a1b` on 2026-08-04, and the PR now takes the content-sniff route:
+
+1. **`FastqReader`'s bare entry points gain an open each.** `is_gz_filename` becomes `sniff_gzip`, and `open` / `open_threaded` / `sanity_check` each call it with a path, so each performs its own `File::open` for three magic bytes before the stream is opened. That is a **new instance of the very invariant this plan guards** — on a pipe the sniff consumes three bytes and the stream open loses them; on a writer-exited FIFO the sniff's open blocks. `sniff_gzip` swallows every error by design (`.is_ok_and(…)`, "any failure here answers 'not gzip'"), so it cannot report either. This makes §2.4's unguarded passthrough path strictly worse — four opens, no guard — and is an additional argument for layer 0 and layer 1, which stop the input before `FastqReader` ever sees it.
+2. **`detect_input_format` itself is untouched**, so layer 2's edit site is conflict-free. But #374 does edit `src/format.rs` (`:258`, `:278`, `:296`) and deletes 37 lines from `src/main.rs` — the duplicate `open_sync_reader`/`open_threaded_reader`, i.e. two of §2.3's inventory entries (`main.rs:51`, `:68`) cease to exist. **Every `main.rs` line number in this plan shifts.** Benjamin's own description already cites the post-merge numbers for the passthrough sites: `main.rs:743`/`1319`/`1358`, against this plan's `768`/`1344`/`1383`.
+3. **`sniff_gzip` deliberately avoids `detect_input_format` because it bails on empty input**, since `demux.rs:170` reads back a trimmed output that is legitimately empty when every read was filtered. Record this: it is a standing reason the guard cannot later be pushed down into `FastqReader`, and it independently confirms §2.3's correction about `demux.rs:170`.
+
+**Merge order: #374 first.** It is complete, green (468 tests) and an external contributor's; this plan should absorb the churn rather than impose it. Then rebase, correct the `main.rs` references, and re-verify §2.4's three sites. Note that layer 1 lives in `cli.rs`, which #374 does not touch at all — so the part of this change that closes the most cases cannot conflict with it either way.
+
+---
+
+## 8. Assumptions
+
+- **A1.** Every currently-working input is restartable. Follows from all the passes in §2.1 already depending on it. Nothing in `tests/`, `.github/` or `justfile` uses `/dev/stdin`, `mkfifo` or process substitution; **re-verified** by grep with a positive control, and with a tighter pattern than v2 used — a bare `<(` matches Rust tuple syntax (`Vec<(…)>`) throughout `tests/`. Reviewer A adds a sharpening: on Linux, row B genuinely restarts, so `trim_galore /dev/stdin < reads.fq` works on `ubuntu-latest` today and continues to, because the offset check returns 0 there. No regression on either platform. Exactly true only once A8 lands.
+- **A2.** *Retired.* v2 assumed comparing ≤4 bytes was sufficient and accepted a pathological repeating-prefix residual. The offset condition (§2.2.2) is exact, so the residual is gone.
+- **A3.** `File::open` on a FIFO with no writer blocks. **Verified** three times — `MEASUREMENTS_reopen_probe.md` §1 row E, and independently by both reviewers.
+- **A4.** `detect_input_format` is on no hot path — a handful of times per input file, never per record. Confirmed by the call-site inventory (§2.3) and independently by Reviewer B.
+- **A5.** For a **regular** file the `n == 0` empty check still precedes the second-open check, so empty-file behaviour is unchanged. Fixed by construction in §3.1 steps 4–5. For a FIFO the type check now wins instead (§3.4, deliberate).
+- **A6.** `fstat` names a FIFO as a FIFO on both target platforms. **Verified on Darwin; reasoned on Linux.** The POSIX `S_IFIFO` guarantee covers *named* FIFOs (rows E, F); rows C and D on Linux go through `/proc/self/fd/N`, a different mechanism. Reviewer A's kernel-level reading: re-opening a pipefs inode yields `S_IFIFO`, and `fifo_open`'s partner-wait is gated on `!is_pipe`, so an anonymous pipe does not block on re-open while a named FIFO does — matching row E on both platforms. V9 makes CI prove this rather than assume it.
+- **A7.** Unix-only. `FileTypeExt` does not exist on Windows, and there is no `cfg(unix)` anywhere in `src/`, `tests/` or `build.rs` today. Handled rather than flagged: §5.1 step 3 gates it, because the crate ships a `src/lib.rs` and a bare `use` would be the first hard compile break for a non-Unix consumer.
+- **A8.** *New.* Both reads must return everything asked for, or the comparison is wrong in both directions: a short second read wrongly rejects a good regular file (NFS, FUSE, `EINTR` surfacing as `ErrorKind::Interrupted` rather than being retried), and a prefix reading of the comparison wrongly *accepts* `/dev/fd/N` over a ≤4-byte file. Handled by the looped reads in §3.1 steps 3 and 5, not assumed. The same loop hardens the pre-existing `n >= 3` gzip test at `format.rs:226`, which today misclassifies a gzip file on a short first read.
+- **A9.** *New, and the load-bearing one.* No input-bearing CLI surface bypasses the guard. v2 assumed this implicitly and was wrong (§2.4). Now covered by layer 1, which sees every path `Cli::validate` sees, and asserted by V10 rather than by inspection.
+
+---
+
+## 9. Validation
+
+| # | Verify | How | Expected |
+|---|---|---|---|
+| V1 | The three #379 reproductions say the right thing, and **each stops saying its own wrong thing** | Per row: `<(cat plain.fastq)`, `cat reads.fq.gz \| … /dev/stdin`, `mkfifo f; cat small.fq > f &` | All: non-zero exit, stderr contains `cannot be re-read from the start`. Per-row negative control — row 1 must not contain `doesn't seem to be in FastQ format` (`fastq.rs:485`); row 2 must not contain `Failed to decompress first block` (`format.rs:236`); row 3 must return promptly, since today it produces no stderr at all. v2 asserted only row 1's string for all three, which passes vacuously on rows 2 and 3 — it would have passed on unpatched `dev` |
+| V2 | Regular files are unaffected | Full `cargo test`; plus a trim of `10K_150bp.fastq.gz` and its uncompressed twin | All pass; outputs byte-identical to `dev`. **Prove the comparison can fail** by diffing against a sentinel-appended copy |
+| V3 | Byte-identity against Perl 0.6.11 holds | CI `validation` and `validation-ubam` jobs | Green. The guard adds no transformation, but this is the invariant that must not move |
+| V4 | The empty-file error still wins | `trim_galore` on a 0-byte regular file | Stderr contains `Input file` … `is empty` (`format.rs:216`), **not** either §3.3 message. Not `seems to be completely empty` — that is `fastq.rs:478`, pre-empted at `main.rs:30` |
+| V5 | **No FIFO test hangs**, and nothing can hang for long | New tests bounded per §5.3 rule 2; plus §5.2's `timeout-minutes` and nextest `terminate-after` in place | Complete in seconds. Structural, not lucky: for a FIFO the second open never happens, and if that regresses the CI bound turns a 6-hour wedge into a fast failure |
+| V6 | The writer-exited FIFO — the case that hangs on `dev` today | `mkfifo f; cat small.fq > f & trim_galore f` | The pipe message, promptly. On `dev` this hangs at `fastq.rs:474`; v1 of this plan would have hung inside the guard |
+| V7 | Every guard can fail, in both directions | Layer 1: `fs::metadata` on a writer-less FIFO → rejected without opening; on a regular file → proceeds. Layer 2 type check: FIFO → pipe message; regular → passes through. Second-open check: `reopen_restarts(&regular, b"@rea")` → `true`, `(&regular, b"XXXX")` → `false`, `/dev/urandom` → `false`, and (macOS only) `/dev/fd/N` over 4 bytes → `false` | All exercised. v2 specified `/dev/stdin` from a pipe as the negative case; both reviewers showed that is not constructible — a unit test cannot control its own fd 0, it blocks on a terminal, it never reaches the check anyway because the type filter catches it first, and on `ubuntu-latest` the negative branch would run **zero** times. Record in §9 that `/dev/fd/N` is not a portable substitute (dup on Darwin, fresh open on Linux) and that this predicate has no portable real-world negative reproduction |
+| V8 | uBAM input still detected | Existing uBAM tests, plus a real `.bam` and a `bgzip`-ed FASTQ | Formats unchanged; every layer is format-agnostic |
+| V9 | The Linux mechanism is measured, not assumed | Integration test asserts `fs::metadata(…).file_type().is_fifo()` on the descriptor it is about to hand the binary, before invoking it | Green on `ubuntu-latest` **and** `macos-latest`. The first CI run becomes the Linux measurement for A6, and a platform surprise names itself instead of appearing as a message mismatch. Row B stays unasserted (§5.4) |
+| V10 | **Every input-bearing CLI surface reaches a guard** | Enumerate them — `cli.input`, `cli.passthrough`, the `--demux` barcode file — and assert each is rejected for a FIFO. Not "exercise one of them" | All rejected. This is the row whose absence hid §2.4: nine rows of input-shape testing could not see a whole flag being unguarded, and the next flag that takes a path should be caught by a test rather than by a reviewer |
+
+V5, V6, V7 and V10 are the ones that would quietly not hold: V5/V6 because a hanging test looks like a slow job, V7 because a check only ever observed passing is not a check, V10 because it tests the plan's placement claim rather than its mechanism.
+
+---
+
+## 10. Questions or ambiguities
+
+**Resolved before writing (scope):** three targets were costed and **A** chosen.
+
+- **A — reject accurately** (this plan). ~70 lines plus tests, across `cli.rs`, `main.rs` (one line) and `format.rs`. Fixes the diagnostic, not the capability.
+- **B — pipes when `-a` is given.** Requires threading a reader rather than a path through `format.rs`, `fastq.rs`, `bam.rs` and `main.rs`, folding `sanity_check` into the trim pass, and forbidding adapter auto-detection on streams. Benjamin's #374 review independently reached the same conclusion — "whoever takes it will want to hand a reader downstream instead of a path" — and confirmed a `bool` verdict is neither a step toward it nor an obstacle.
+- **C — full single-pass front end.** All of B plus buffering the `MAX_SCAN_READS` window: ~200 MB at 65 bp, to be reconciled with `--memory` and `--clumpify`.
+
+**Note for whoever attempts B:** this guard is in the way by construction. All three layers reject the exact inputs B would enable, and the second-open check consumes ≤4 bytes from a stream before rejecting it. They must come out, not be worked around.
+
+**Open (assumption taken):**
+
+1. **Should the message name workarounds per input type?** Taken: one generic remedy in a shared tail, with only the first sentence varying (§3.3). Enumerating FIFO vs `/dev/fd` vs `/dev/stdin` fixes is longer and each reduces to "write it to a file".
+2. **How much of the stream should the second-open check compare?** Taken: none of it, primarily — the start offset is exact and length-insensitive (§2.2.2). The ≤4-byte comparison is retained only as a second reject condition, to keep streaming character devices rejected.
+3. **`Ok(false)` vs `Err` when the second open fails.** **`Err`**, changed in v2 and kept. `Ok(false)` would report `EMFILE` or `EACCES` as "your input is a pipe" — the same wrong-blame this plan exists to remove, one layer down. With `.with_context` (§4) so the path is named.
+4. **Whitelist or blacklist the file type?** Taken: blacklist (`is_fifo() || is_socket()`). Reviewer A costed the whitelist (`is_file() || is_char_device()`), which would also give sockets and directories an accurate message instead of a raw `errno`. Declined: it is a behaviour change for input classes nobody has complained about (block devices), and it converts "unknown file type" from *fall through and let the format check decide* into a hard error. Conservative is right for a diagnostic-only fix.
+5. **Compare `(st_dev, st_ino)` across the two handles?** Declined, and recorded because it is the obvious third idea. On Darwin `open("/dev/fd/N")` is a `dup`, so the second handle reports the same device and inode. The offset is the only thing that differs — i.e. Q2.
+
+**Critical:** none.
+
+---
+
+## 11. Self-Review
+
+**Logic.** Three layers test one invariant, at the three points where an input can enter: `Cli::validate` (every path the binary is given), `detect_input_format` (every path a library consumer detects), and the one call site that had neither. Each covers what the others cannot — the path stat cannot be TOCTOU-proof but never blocks; the handle `fstat` is exact but requires an open; the offset check is the only thing that catches a `dup`-ed regular file. The ordering constraints are pinned in §3.1: type check before the `read`, empty check before the second open.
+
+**What review changed, three times over.**
+
+*Before v1:* I intended a seekability probe, which is what #379 proposes. Measurement killed it — row B is seekable and does not restart.
+
+*Manual review of v1:* the byte comparison alone **hangs** on row E, the commonest FIFO shape and one of the three input classes the message names. v1 recorded this only as a test-hygiene risk. It was a design defect, and the fix was the type check v1 had dismissed on an axis that did not matter.
+
+*Dual agent review of v2:* two independent reviewers both found, as their Critical, that the guard **misses `--passthrough` entirely** — and that v2 stamped the claim "Verified" when it had been verified against `cli.input` only. Both also found the FIFO test specification unbuildable: v2 asked for a writer state that cannot exist, bounded the wrong scope, and contradicted itself between two adjacent rules. Neither finding touched the mechanism; both touched claims I had marked as settled. The pattern is the same each time — a check verified against a narrower set than it names.
+
+**Edge cases.** §3.4, expanded from six rows to twelve: the two new type-check classes, three character devices with three different outcomes, the terminal case, the ≤4-byte `/dev/fd/N` case v2 would have accepted, and the FIFO-with-no-writer case v2 called unfixable.
+
+**Efficiency.** Zero extra syscalls at layer 1; one `fstat` and (regular files only) one open per `detect_input_format` call at layer 2. The available optimisation is declined in §6 with a reason.
+
+**Integration.** One call site changes. #374's interaction is now specified rather than denied (§7.1), with a merge order and the reason.
+
+**Remaining risks.**
+
+- *Medium:* `trim_galore /dev/stdin` **at an interactive terminal** is a character device, so no type check fires and the first `read` blocks with no message. Distinguishing a tty needs `isatty`, i.e. `libc`. It is a plausible thing for someone who has just read #379 to try, and `/dev/stdin` is named in our own remedy text — so this is the residual most likely to generate a follow-up issue. Out of scope for A; worth a sentence in the CHANGELOG entry.
+- *Medium:* the FIFO tests remain the most delicate part of the change. §5.3's six rules and §5.2's CI bound are what keep them honest; the bound is the only one that survives an implementer skipping the rules.
+- *Low:* three layers is more surface than one. Mitigated by all of them emitting the same two messages and by V7 exercising each in both directions.
+- *Low:* layer 1 is bypassed by a library consumer that never builds a `Cli`. That is what layer 2 is for.
+- *Very low:* an exotic filesystem where a regular file does not restart. Would already be broken today.
+
+---
+
+## 12. Implementation notes
+
+Implemented 2026-08-04 on `dev` (uncommitted at time of writing). `.github/workflows/ci.yml`, `.config/nextest.toml` (new), `src/cli.rs`, `src/format.rs`, `src/main.rs`, `CHANGELOG.md`, `tests/integration_non_restartable_input.rs` (new) — 340 insertions, 19 deletions.
+
+### Deviations from the plan
+
+**D1 — the `--demux` barcode file is *not* checked.** ~~§3.0 and §5.1 step 1 said to apply layer 1 at `cli.rs:926` as well.~~ **Reversed in the fix round (§13).** The reasoning below is correct about *restartability* and was silent about *blocking*: Reviewer A measured that a writer-less FIFO barcode file blocks in `File::open` with no message **after** trimming, FastQC and the JSON report have all completed. Layer 1 closes that for one line, and the working configuration it removes — a live-writer FIFO used as a barcode TSV — has no plausible user. The check is now applied, so layer 1 covers all three surfaces.
+
+The original reasoning, retained because it is why the *restartability* argument alone did not justify the guard: `read_barcode_file` (`demux.rs:31-34`) opens the barcode file **once** and streams it with a `BufReader`; there is no second open. So the invariant this guard enforces genuinely does not hold there — the guard is justified by the blocking open, not by restartability.
+
+**D2 — a `stream_position()` error falls through instead of propagating.** §3.1 step 5 implies the offset is always available. A character device that cannot report a position would have become a new hard error for a class that today falls through to the format checks, so the implementation only treats a *successfully read* non-zero offset as decisive (`is_ok_and`) and otherwise defers to the byte comparison. This is strictly less aggressive than the plan and preserves existing behaviour for exotic devices.
+
+*Cost, per Reviewer A:* on any handle whose `stream_position()` **errors**, the byte comparison becomes the sole condition — and the byte comparison is exactly what A2 was retired for, so A2's repeating-prefix residual returns on that branch. Nothing real reaches it: `lseek` fails with `ESPIPE` for pipes, FIFOs and sockets, and all three are rejected by the type check before `reopen_restarts` is called, leaving only regular files and character devices, for which `stream_position()` succeeds.
+
+**D3 — the pre-existing `detect_empty_file_errors` test was strengthened**, not just added to. It asserted only `is_err()`, which would have passed if the empty file had started being reported as non-restartable. It now asserts the empty message is present *and* the restartability message is absent (V4).
+
+### One thing the plan did not anticipate
+
+With layer 1 in place, the binary **never opens** a FIFO given on the command line. A test harness that starts a writer (`cat x > fifo &`) therefore leaves that writer blocked in `open` forever, because no reader ever arrives. §5.3 rule 6 already said to kill the writer child rather than wait on it — but for the EPIPE reason, not this one. The first smoke-test script hit exactly this and hung on its own `wait`, not on the binary. The integration tests avoid it entirely by using writer-less FIFOs, which is also the harder case: it is the one that used to hang forever. Layer 2's unit test still needs a live writer, because `detect_input_format` must get past `File::open` to reach the `fstat`.
+
+### Verification
+
+| Check | Result |
+|---|---|
+| V1 — three #379 reproductions | All three now emit `cannot be re-read from the start`. Per-row negative controls in the integration test: the plain-pipe row asserts absence of `doesn't seem to be in FastQ format`, the gz row absence of `Failed to decompress first block` |
+| V2 — regular files unaffected | **6 output files and 6 trimming reports byte-identical** to a `HEAD` worktree build across SE-gz, SE-plain, PE `--cores 1`, PE `--cores 4`. Both comparisons carry a sentinel negative control that fired correctly |
+| V4 — empty file | `Input file 'X' is empty`, restartability message absent |
+| V5 — no test hangs | Full suite 375 unit + 92 integration, 0 failed. New tests complete in 0.01 s (unit) and 0.92 s (integration) |
+| V5 — **mutation check** | With `is_non_restartable_type` forced to `false`, `detect_rejects_a_fifo_with_the_pipe_message` **fails in 10.01 s** with `blocked; it must fail, not hang`. This is the check the plan cared most about: a dead guard fails loudly instead of wedging for 6 hours |
+| V6 — writer-exited FIFO | Rejected promptly. Also the writer-*less* FIFO, which v2 recorded as an unfixable residual |
+| V7 — every guard, both directions | Layer 1 (`stat` on a writer-less FIFO vs a regular file), layer 2 type check, `reopen_restarts` positive + negative, `/dev/urandom`, and two macOS `/dev/fd` cases |
+| V9 — no accidental platform conditionality | Verified on Darwin only; the `#[cfg(target_os = "macos")]` rows are the two `/dev/fd` cases. CI provides the Linux leg |
+| V10 — every input surface | `cli.input` and `cli.passthrough` both covered by integration tests; see D1 for the third |
+| `cargo fmt --all -- --check` | Clean (two of my own hunks reformatted; `git status` confirms fmt did not stray) |
+| `cargo clippy --all-targets --release -D warnings` | Clean |
+| V3 — Perl 0.6.11 byte-identity | **Not run locally** — needs the CI `validation` / `validation-ubam` jobs. V2's result is strong evidence it holds (no writer path touched), but this is the invariant that must not move, so it needs the CI run before merge |
+
+### Test added beyond the plan
+
+`detect_rejects_dev_fd_when_the_leading_bytes_repeat` — a file whose bytes 4..8 repeat bytes 0..4. The byte comparison alone calls it restartable, so only the start-offset condition rejects it. Without this, nothing isolated the offset check: the ≤4-byte case in §5.4 is caught by the length-aware comparison too, so §2.2.2's central design change had no test that would fail if it were reverted. This is the test that retires A2.
+
+### Iteration log
+
+1. Source + tests written; `cargo build --release` clean first time.
+2. Smoke script hung on its own `wait` for blocked FIFO writers (see above). Not a defect in the binary — all six cases had already produced the right message. Rewritten to use writer-less FIFOs.
+3. `--quiet` used in the V2 harness is not a Trim Galore flag; all eight baseline runs failed silently because the loop redirected stderr. Caught by the sentinel negative control, which reported `CONTROL FAILED`. Re-run without it: 8/8 exit 0.
+4. zsh `nomatch` aborted the md5 loop on `*.fq` with no matches; `NULL_GLOB`.
+5. Report comparison reported three files as `DIFFERS` — `diff: /dev/fd/11: Operation not permitted`, the sandbox blocking process substitution. Re-run with temp files: all six identical. A tooling failure that reads as a real difference.
+
+### Follow-ups
+
+- **#374 merge order.** §7.1 recommends merging Benjamin's PR first; this work was implemented against `dev` @ `40f77ec` and will need the `main.rs` line references re-checked after that lands. Nothing in this change touches the lines #374 edits.
+- **The tty residual** (§11) is in the CHANGELOG entry as a known case rather than fixed.
+
+---
+
+## 13. Fix round — dual code review + coverage audit
+
+`CODE_REVIEW_A.md`, `CODE_REVIEW_B.md` (independent, no shared state) and `COVERAGE.md`. Coverage verdict was **COMPLETE** (62 items, 0 MISSING, 0 PARTIAL). Both reviewers filed the same High finding and the same three Mediums. All findings taken.
+
+### H1 (High) — `--passthrough <uBAM>` regressed. Both reviewers, independently.
+
+Measured before/after on purpose-built binaries:
+
+| | pre-change | after the layer-0 swap | after this fix |
+|---|---|---|---|
+| message | `stream did not contain valid UTF-8` | same, wrapped in `processing pair 1 of 1` | `--passthrough is not supported with uBAM input…` |
+| on disk | output dir, no files | **three empty files** | **no output dir at all** |
+
+Root cause: §3.2's justification was false and §2.4 contained the refutation. Fixed beside `main.rs:253` — Reviewer A's placement, chosen over B's because it precedes `ensure_output_dir` (`main.rs:315`) and makes `main.rs:770`'s BAM arm genuinely unreachable. Defended by `passthrough_ubam_is_rejected_before_output`, which asserts the message, the *absence* of `valid UTF-8`, and that no output file exists.
+
+### Mediums, all three from both reviewers
+
+- **M1** — `bounded()`'s `Err(_)` conflated `Timeout` with `Disconnected`, so a *panicking* body was reported as `blocked; it must fail, not hang`. Reviewer A reproduced it firing in 203 µs with the wrong headline. That is the mirror image of the failure the harness exists to identify, in a change about not misdescribing failures. Now split, with a distinct message per variant.
+- **M2** — layer 1's `map_err(|_| …)` reported `EACCES`/`EMFILE`/`ELOOP` as `Input file not found`. Not a regression (identical to the `exists()` it replaced) but the same wrong-blame §10 Q3 rules out one layer down, at the one site in the diff that had the errno in hand. `NotFound` keeps its wording; everything else propagates with `Cannot stat input file`.
+- **M3** — `reopen_restarts`' `.min()` clamp answered `false` forever for `first.len() > PEEK_LEN` and `true` vacuously for `0`. Unreachable from the sole caller, but the `.min()` made the function look as though it handled a longer slice. Contract documented and `debug_assert`ed.
+
+### Also taken
+
+| Source | Change |
+|---|---|
+| A | `--demux` barcode file now guarded — see the revised **D1** |
+| A | `timeout-minutes` 30 → **45**. A measured `lto = true` + `codegen-units = 1` across ten release test binaries at 175 CPU-seconds locally; scaled to a 2-vCPU runner with a cold cache that is a 15–22 minute job, so 30 was a 1.4–2× margin, not the 10× it looked like |
+| A | `spawn_fifo_writer` now `expect`s its open. A silent failure there left the reader blocking, and the panic blamed the guard. Composes with M1: the failure now reads "panicked", not "blocked" |
+| A | Corrected the test-module comment: each test bounds *the call under test*, not its setup — and no setup step can block |
+| B | `NotRestartable::Socket` added with its own noun. The doc said "pipe, FIFO or socket" while the message said only "pipe or FIFO" — §3.3's own standard, applied to us |
+| B | CHANGELOG: "before anything is written" → "before any output **file** is written". `ensure_output_dir` (`main.rs:315`) precedes the layer-2 sites, so the Reopen class does leave an empty directory |
+| B | `run_bounded` drains stderr **before** the timeout `panic!`, so the failure that matters most carries the binary's own output |
+| B | `passthrough_dev_stdin_is_rejected` (macOS) — B's delete-one-thing check found layer 0 was the only edit with no test that fails when reverted, and it was the edit H1 shows to be harmful |
+
+### D4 — a third multi-read surface, deliberately unguarded
+
+Both reviewers found it independently: an adapter FASTA given as `-a file:x.fa` / `-a2 file:…` is read by `adapter::parse_adapter_spec_inner` once in `Cli::validate` (the `-a2` #369 pre-check) and again per pair in `setup_trimming`. That is a genuine two-open path on a user-supplied file, outside every layer. **Not guarded:** out of scope for #379, and a streamed adapter FASTA is not a real invocation.
+
+**V10's wording is narrowed accordingly.** It claimed "every input-bearing CLI surface"; it covers `cli.input`, `cli.passthrough` and (now) the `--demux` barcode file, and it does *not* cover `-a file:`. Both reviewers also noted the enumeration is by test rather than by mechanism, so a future path-valued flag added unguarded still fails nothing — recorded rather than solved.
+
+### Verification after the fix round
+
+| Check | Result |
+|---|---|
+| Full suite | 375 unit + **95** integration (8 in the #379 file), 0 failed |
+| `cargo fmt --all -- --check`, `clippy --all-targets --release -D warnings` | Clean |
+| H1 | Rejected up front with the right message and **no output directory** |
+| Byte-identity | Re-checked against the retained `HEAD` baseline after the `main.rs`/`cli.rs` edits: SE-gz and PE `--cores 4` outputs identical, sentinel control firing (1 914 872 vs 1 914 882 bytes) |
+| V3 | **Still CI-gated.** Perl 0.6.11 byte-identity needs the `validation` / `validation-ubam` jobs |
+
+### Harness note for the next session
+
+Two more false negatives, both caught by controls rather than by inspection: zsh does **not** word-split unquoted variables, so `set -- $pair` gave one word and a byte-identity loop compared zero files while reporting success; and a negative control comparing two *unrelated* outputs reported "equal" because both md5 inputs were empty. Compare a sentinel-modified copy of a real file, never two different files.

--- a/plans/08032026_reject-non-restartable-input/PLAN.md
+++ b/plans/08032026_reject-non-restartable-input/PLAN.md
@@ -398,6 +398,26 @@ v2 asserted the two changes do not interact. That was true of v2's shape and is 
 
 **Merge order: #374 first.** It is complete, green (468 tests) and an external contributor's; this plan should absorb the churn rather than impose it. Then rebase, correct the `main.rs` references, and re-verify §2.4's three sites. Note that layer 1 lives in `cli.rs`, which #374 does not touch at all — so the part of this change that closes the most cases cannot conflict with it either way.
 
+### 7.2 Post-#374 (2026-08-05)
+
+#374 merged to `dev` as `e470331`. This branch rebased onto it **cleanly, no conflicts** — as predicted, his hunks (`main.rs:14`/`:28`/`:42`) and this change's (`:228`/`:755`) never met.
+
+Every `main.rs` line number elsewhere in this plan predates the rebase. His change removed the duplicate `open_sync_reader`/`open_threaded_reader` from `main.rs`, so the two §2.3 inventory entries at `main.rs:51`/`:68` **no longer exist** — `format.rs`'s factories are now the only ones. Current numbers for the load-bearing sites:
+
+| Site | Was | Now |
+|---|---|---|
+| `sanity_check_any` → `detect_input_format` | `:30` | `:31` |
+| all-inputs detect map | `:187` | `:162` |
+| `--passthrough` + uBAM (`any_bam`) | `:253` | `:228` |
+| the H1 passthrough format check | — | `:237` |
+| passthrough sanity check | `:768` | `:755` |
+| passthrough readers | `:1344`/`:1383` | `:1331`/`:1370` |
+| `main.rs` duplicate factories | `:51`/`:68` | **deleted** |
+
+**§2.1's open count rises again.** `sniff_gzip` (`fastq.rs:48`) opens the path for three magic bytes, and `FastqReader::open` / `open_threaded` / `sanity_check` each call it (`fastq.rs:280`/`:306`/`:525`), so every bare entry point now performs two opens. The guarded factories in `format.rs` call the `_with` variants and are unaffected. This does not weaken anything here — all three layers reject a stream before those paths are reached — but it is one more instance of the count rising without anyone intending it, which is the argument for ALT-4 (memoise detection per path) eventually.
+
+**Composition verified**, not assumed: 482 tests pass (470 + his 12), fmt and clippy clean, #374's `.bgz`-named-gzip case still trims to completion, and a FIFO is still rejected promptly with no output directory.
+
 ---
 
 ## 8. Assumptions

--- a/plans/08032026_reject-non-restartable-input/PLAN_REVIEW_A.md
+++ b/plans/08032026_reject-non-restartable-input/PLAN_REVIEW_A.md
@@ -1,0 +1,527 @@
+# PLAN_REVIEW_A — Reject non-restartable input with an accurate diagnostic
+
+**Reviewer:** A (independent, fresh context)
+**Target:** `plans/08032026_reject-non-restartable-input/PLAN.md` revision **v2**
+**Supporting evidence reviewed:** `MEASUREMENTS_reopen_probe.md`
+**Date:** 2026-08-04 · Darwin 26.5.1 (arm64) · rustc 1.95.0
+
+**Verdict: the design is sound and the v2 fix is the right one. Two Critical items must
+be resolved before implementation — neither invalidates the two-layer guard.** One is a
+whole input path that bypasses the guard (`--passthrough`), contradicting a claim §2.3
+marks "Verified". The other is that the FIFO test specification cannot construct one of
+the two states it requires, and the wedge it produces lands in test *setup*, which §5
+step 7's bound does not cover — with no CI backstop, that is a 6-hour job timeout on
+four job-steps.
+
+---
+
+## 0. What I verified independently
+
+Every line reference and quoted string in the plan checks out except where noted below.
+I reproduced the plan's measurements rather than accepting them, and added the cases §3.2
+omits.
+
+| Plan claim | Result |
+|---|---|
+| `format.rs:208` open, `:211` read, `:215-217` `n==0`, `:219` `@`, `:226-230` comment, `:231` second open | ✅ all exact |
+| `fastq.rs:474` `FastqReader::open` in `sanity_check`, `:478` `seems to be completely empty` | ✅ exact (V4's string is right this time) |
+| `fastq.rs:485` `doesn't seem to be in FastQ format (first line doesn't start with '@')` | ✅ exact — the only occurrence in `src/` |
+| `format.rs:216` `Input file '{}' is empty` | ✅ exact |
+| §2.3 `detect_input_format` inventory (17 sites) | ✅ complete — my grep found no site the plan missed |
+| `adapter.rs:115`/`:268` via `open_sync_reader`; `MAX_SCAN_READS = 1_000_000` (`adapter.rs:84`) | ✅ |
+| A1: nothing in `tests/`, `.github/`, `justfile` uses `/dev/stdin`, `mkfifo`, or `<(…)` | ✅ re-verified with positive control (the `<(` hits are Rust tuple syntax) |
+| A3 / MEASUREMENTS row E: second open on a writer-exited FIFO blocks | ✅ **reproduced** — blocked >3 s on this box |
+| CI matrix `[ubuntu-latest, macos-latest]` (`ci.yml:28`) | ✅ |
+| §5 step 6 "dev-dependencies are `tempfile` only" | ❌ they are `serde_json`, `tempfile`, `bstr`; and `libc 0.2.184` is **already in `Cargo.lock`** (see O1) |
+| §2.3 "`specialty.rs:531`" as a production call site | ❌ it is inside `#[cfg(test)] mod tests` (a `read_fastq` helper) |
+| §2.3 / §7 "every input path passes through `detect_input_format`" | ❌ **`--passthrough` does not** (see C1) |
+
+**I ran the plan's §3 guard verbatim** (open → fstat → read → `n==0` → reopen-and-compare)
+against every case in §3.2 plus the ones it omits. Darwin:
+
+```
+reg.fq            FALLS-THROUGH peek=[64,114,49,10]   type=[reg]
+tiny.fq (1 byte)  FALLS-THROUGH peek=[64]             type=[reg]      ← §3.2 row confirmed
+/dev/stdin <pipe  step2 FIFO-MESSAGE                  type=[fifo]     ← caught by pre-filter
+/dev/stdin <file  step5 REOPEN-MESSAGE                type=[reg]      ← byte probe is load-bearing
+<(cat reg.fq)     step2 FIFO-MESSAGE  (/dev/fd/63)    type=[fifo]
+symlink→fifo      step2 FIFO-MESSAGE                  type=[fifo]     ← follows the link, fstats the target
+symlink→reg       FALLS-THROUGH                                       ← positive control
+/dev/null         step4 EMPTY-MESSAGE                 type=[chardev]  ← as §2.2.1 claims
+/dev/zero         FALLS-THROUGH peek=[0,0,0,0]        type=[chardev]  ← as §2.2.1 claims
+/dev/urandom      step5 REOPEN-MESSAGE                type=[chardev]  ← not in the plan's list
+adir/ (directory) step3 READ-FAILED "Is a directory"  type=[dir]      ← unchanged from today
+/dev/tty          step1 OPEN-FAILED ENXIO             type=[chardev]
+```
+
+So: the two-layer guard behaves exactly as §3 specifies on Darwin, including the
+awkward row B, and it does not disturb the sub-4-byte, `/dev/null`, `/dev/zero`,
+directory or symlink cases. **The core design is correct.** My findings are about
+coverage, tests, and validation — not about the mechanism.
+
+Probe sources are in `$TMPDIR` (`rev_a_probe3.rs`, `rev_a_probe5.rs`, `rev_a_probe6.rs`,
+`rev_a_probe7.rs`); each bounds every wait with `mpsc::recv_timeout(3s)` internally, per
+the reviewer brief.
+
+---
+
+## 1. Logic review
+
+### C1 — `--passthrough` is an input path that never reaches `detect_input_format`
+
+§2.3 states, and marks **Verified**:
+
+> `format::detect_input_format` is the function every input path passes through […] so
+> the guard fires first in every flow.
+
+and §7 repeats it: *"inside `detect_input_format`, which every input path already calls
+before any reader is constructed"*.
+
+That is false for `--passthrough`. The passthrough file lives in `cli.passthrough`, not
+`cli.input`, so it is not in the `main.rs:187` all-inputs map. Its full lifecycle is:
+
+| Step | Site | What it does |
+|---|---|---|
+| 1 | `cli.rs:884` | `if !pt.exists()` — a `stat`; a FIFO passes |
+| 2 | `main.rs:768` | `FastqReader::sanity_check(pt_path)` — **open #1**, one record, drop |
+| 3 | `main.rs:1344` (parallel) / `main.rs:1383` (serial) | `FastqReader::open{_threaded}(p)` — **open #2** |
+
+Two opens, no `detect_input_format`, no guard. Consequences after this change ships:
+
+- **`--passthrough <writer-exited FIFO>` hangs with no message** at step 3 — and by then
+  `ensure_output_dir` has run and the R1/R2 writers exist, so it hangs *with partial
+  output on disk*. This is the exact failure mode §1 says the plan removes.
+- **`--passthrough <live-writer FIFO or /dev/fd/N>`** desyncs: step 2 consumes a record,
+  step 3 resumes mid-stream, and the three-way header sync check (`parallel.rs:640`)
+  fires with a message about a truncated or desynced passthrough — blaming the user's
+  data for a limitation of ours, one flag over.
+
+The plan's own words for this class: *"a diagnostic that blames the user's data for a
+limitation of ours"*.
+
+This is not a reason to move the guard, but the claim must be corrected and the path
+covered. Cheapest in-place fix: route the passthrough through the same entry point —
+replace `main.rs:768`'s `FastqReader::sanity_check(pt_path)` with `sanity_check_any(pt_path)`
+(it already dispatches through `detect_input_format` at `main.rs:30`; passthrough + uBAM is
+rejected at `main.rs:253`, so the BAM arm is unreachable and harmless). Better still, see
+**ALT-1**, which covers this *and* the §11 Medium residual in one place.
+
+**Evidence that would settle it:** already gathered — `grep -n "passthrough" src/main.rs`
+shows `:768`, `:1344`, `:1383` and no `detect_input_format` between them.
+
+### C2 — the FIFO test specification cannot build one of its two states, and its bound does not cover the wedge
+
+§5 step 5 requires:
+
+> a FIFO is rejected with the FIFO message, **in both writer states** — writer exited, and
+> writer still open. With the type check these are deterministic; without it the first one
+> hangs
+
+and §5 step 7 rule 3 is the backstop:
+
+> **Bound every FIFO test in-process** — run **the call** on a thread and `mpsc::recv_timeout`
+
+I implemented all three readings of "writer exited" and measured them. Results:
+
+```
+Shape A  writer held open in-process for the whole call  -> FIFO-MESSAGE in 144 µs   deterministic
+Shape B  child.wait() for the writer BEFORE opening      -> *** BLOCKED >3s ***      in SETUP
+Shape C  spawn writer, then call immediately (rule 1)    -> FIFO-MESSAGE in 28 ms    deterministic
+Shape D  v1's second open, writer gone                   -> *** BLOCKED >3s ***      (row E reproduced)
+```
+
+Three separate problems:
+
+1. **"Writer exited" is unreachable as a pre-condition.** A writer's `open(O_WRONLY)` on a
+   FIFO blocks until a reader opens, and the only reader is `detect_input_format`'s own
+   `File::open`. So the writer cannot have exited before the call under test begins —
+   Shape B blocks in `child.wait()`. What MEASUREMENTS row E actually observed is
+   "writer exited between the *first* and the *second* open", which v2 deletes by
+   construction: with the fstat pre-filter there is no second open, so Shapes B and C
+   traverse identical code and the "two states" collapse into one test.
+
+2. **The wedge is in setup, and rule 3 bounds only "the call".** An implementer who reads
+   "writer exited" literally writes `child.wait()` (or an unbounded `OpenOptions::write`)
+   in setup, outside the `recv_timeout`. Shape B is that code, and it blocks. Rule 3 as
+   worded does not catch it. The rule must be *bound the whole test body*, not the call.
+
+3. **There is no CI backstop at all**, so an escaped wedge is maximally expensive. I
+   checked: no `.config/nextest.toml` exists (so nextest's `slow-timeout` is warn-only,
+   `terminate-after` unset), and `grep -rn "timeout-minutes" .github/workflows/` returns
+   **nothing**. The `rust-tests` job runs `cargo nextest run` *and* `cargo test --release`
+   on both matrix legs (`ci.yml:66`, `:74`), so one wedged FIFO test burns the GitHub
+   default **360-minute** job timeout on **four** job-steps. §9's "a hanging test looks
+   like a slow job in CI" understates this by two orders of magnitude.
+
+A fourth rule is also missing, and I hit it: **the writer must tolerate `EPIPE`.** In
+Shape A the guard bails and drops the reader before the writer's `write_all` lands, so my
+writer thread panicked with `BrokenPipe`. Joining that thread fails the test; not joining
+it hides a real setup failure. Symmetrically, a `sh -c 'cat … > fifo'` writer is killed by
+SIGPIPE, so `assert!(child.wait()?.success())` is payload-size-dependent — flaky. (Rule 2's
+"keep the payload well under 64 KiB" turns out to still be necessary, but for *this*
+reason, not the stale second-open reason it gives.)
+
+And a fifth, because `mkfifo` is shelled out to: **if `mkfifo` fails, `cat x > f` silently
+creates a regular file**, `detect_input_format` returns `FastqPlain`, and the test fails
+with "expected the FIFO message" — a diagnosis pointing at the guard when the fault is in
+the harness. Assert the FIFO exists and *is* a FIFO in setup.
+
+---
+
+## 2. Assumptions
+
+**A1 (every currently-working input is restartable) — holds.** Re-verified independently
+with a positive control. Note the reason it holds is stronger than the plan says: on
+Linux, row B (`/dev/stdin` from a regular file) genuinely restarts, so
+`trim_galore /dev/stdin < reads.fq` works on `ubuntu-latest` today and continues to,
+because the byte probe returns `true` there. On Darwin it fails today and fails after.
+No regression either way. ✅
+
+**A2 (≤4 bytes is enough) — holds, but is missing a sibling.** The plan reasons about
+*content* (a stream repeating its first 4 bytes) and never about *length*. See I1.
+
+**A3 (`File::open` on a writerless FIFO blocks) — verified, twice over.** I reproduced
+row E (Shape D) and also confirmed the writerless case directly: `File::open` blocked
+>3 s while `Path::exists()` and `fs::metadata()` both returned promptly. ✅
+
+**A6 (`fstat` names a FIFO on both platforms) — overstated.** The POSIX `S_IFIFO`
+guarantee the plan invokes covers *named* FIFOs, which is rows E/F. Rows C and D are a
+different mechanism, and the plan itself says so in §2.2.1 (Darwin `dup`s `/dev/fd/N`;
+Linux resolves through `/proc/self/fd/N`). So "`is_fifo()` fires for `/dev/stdin` from a
+pipe **on Linux**" is an inference, not a measurement, and the whole measurement table is
+Darwin-only. See I5 — the inference is almost certainly right, and it is cheap to make CI
+prove it rather than assume it.
+
+**A7 (Unix-only) — correct and adequately flagged.** Worth noting the crate ships a
+`src/lib.rs`, so a bare `use std::os::unix::fs::FileTypeExt;` is the first hard *compile*
+break for a Windows consumer. Three lines of `#[cfg(unix)]` now is cheaper than finding
+out later (O5).
+
+**Missing — A8: both `read` calls return the same number of bytes.** The probe's
+correctness depends on it and nothing states it. See I1.
+
+**Missing — A9: no input path bypasses `detect_input_format`.** §2.3 asserts this as
+verified; it is false (C1). It deserves to be an explicit, testable assumption rather
+than a parenthetical, because it is the single load-bearing claim behind the placement
+decision.
+
+---
+
+## 3. Efficiency
+
+§6 is accurate and I have nothing to add to the numbers: one `fstat` on an already-open
+handle, plus one extra `open` and a ≤4-byte `read` per `detect_input_format` call on the
+regular-file path; no allocation; a FIFO costs the `fstat` only. Against ~5 opens and a
+full-file read per input this is unmeasurable, and the declined gzip-branch optimisation
+is correctly declined — splitting the check across two sites and making it
+branch-conditional is not worth one `open`.
+
+One observation the plan could make in passing: `detect_input_format` is called
+*redundantly* on the same path (`main.rs:178`→`:30`, then `:187`, then `:1328`, then twice
+more via the reader factories), so the guard also runs redundantly. That is a small
+efficiency wart the plan correctly leaves alone, and incidentally a benefit — the guard
+gets several chances to fire. It does mean the same message can be emitted from several
+call frames; since the text is identical, no test is affected.
+
+---
+
+## 4. Validation sufficiency (§9)
+
+Could the change ship broken with all nine rows green? **Yes, in four ways.**
+
+### I4 — V1's negative assertion is vacuous on two of its three rows
+
+V1 asserts, for all three #379 reproductions: *"**no** occurrence of `doesn't seem to be
+in FastQ format`"*. But that string is only what two of the three produce today:
+
+- `<(cat plain.fastq)` → `detect_input_format` returns `FastqPlain` at `format.rs:220`
+  without a second open, then `fastq.rs:485` fires. ✅ the assertion has teeth.
+- `cat reads.fq.gz | … /dev/stdin` → the gzip branch re-opens at `format.rs:231` and
+  `MultiGzDecoder` chokes on the offset-4 prefix → **`Failed to decompress first block of
+  '…' for format detection`** (`format.rs:236`). The V1 negative assertion passes
+  vacuously — it would pass on unpatched `dev` too.
+- `mkfifo f; cat small.fq > f &` → today this **hangs**; there is no stderr to assert on.
+
+So V1 as written cannot distinguish "fixed" from "failed differently". Fix: per-row
+negative controls — assert absence of `doesn't seem to be in FastQ format` on the plain
+row, absence of `Failed to decompress first block` on the gz row, and for the FIFO row
+assert *promptness* (which V6 does, informally). §1's summary sentence should likewise
+name the gz message; right now it generalises one row's diagnostic to all three.
+
+### I3 — V7's byte-probe negative direction is not constructible
+
+V7 requires: *"Byte probe: `reopen_restarts` on a regular file → `true`; on `/dev/stdin`
+from a pipe → `false`"*. The second half cannot be a unit test:
+
+- `/dev/stdin` from a pipe is a FIFO, so in `detect_input_format` the type check bails
+  first and `reopen_restarts` is never called on it;
+- calling `reopen_restarts("/dev/stdin", …)` directly from a test means depending on
+  whatever `cargo test` / `cargo nextest` hands the test process as fd 0 — inherited under
+  one runner, `/dev/null` under another, and nextest's per-test process isolation differs
+  again. Non-deterministic and platform-divergent, i.e. exactly what §5 step 8 rightly
+  refuses to do for row B.
+
+This matters because §9 itself names V7 as one of the three rows that "would quietly not
+hold". A probe only ever observed returning `true` is not a probe — and on
+`ubuntu-latest` the byte probe will in practice *never* return `false`, since row B
+restarts there and every pipe is caught by the type check. Linux CI would exercise the
+`false` branch **zero times**.
+
+Deterministic, portable replacement that keeps the teeth: call the helper with a
+deliberately wrong `first`.
+
+```rust
+// negative control: the comparison itself must be able to say "no"
+assert_eq!(reopen_restarts(&regular_fq, b"XXXX")?, false);
+assert_eq!(reopen_restarts(&regular_fq, b"@rea")?, true);   // positive, same file
+```
+
+Pair it with a Darwin-only `#[cfg(target_os = "macos")]` row-B case if you want the real
+shared-offset mechanism covered — but the mismatched-`first` test is the one that must run
+on both legs.
+
+### I5 — the Linux leg is asserted, not measured
+
+§5 step 8 commits the integration test to asserting `cannot be re-read from the start` for
+`/dev/stdin` from a pipe on **both** legs, and V9 asserts both legs green. All six
+measurement rows are Darwin. I could not run a Linux probe here (the sandbox denies the
+Docker socket), so I reasoned it instead:
+
+- `/proc/self/fd/N` for an anonymous pipe re-opens the pipefs inode; `fstat` gives
+  `S_IFIFO`, so `is_fifo()` fires and the guard produces the FIFO message. Consistent with
+  Darwin's `dup` route reaching the same verdict by a different mechanism.
+- The re-open does **not** block even with the writer closed: the kernel's `fifo_open`
+  blocking wait for a partner is gated on `!is_pipe`, and `is_pipe` is true for a pipefs
+  inode. Named FIFOs (`is_pipe == false`) do block — matching row E on both platforms.
+
+I believe the plan is right. But "I believe" is the wrong footing for a CI assertion that
+gates a merge, and the fix costs nothing: **have the test assert the mechanism instead of
+trusting it.** In the integration test, before invoking the binary, assert
+`fs::metadata("/proc/self/fd/0" or "/dev/stdin")?.file_type().is_fifo()` — or simply have
+the unit test assert `is_fifo()` on a *named* FIFO (POSIX-guaranteed, both legs) and let
+the integration test assert only the shared substring, which §5 step 8 already sensibly
+does. Then the first CI run *is* the Linux measurement, and a platform surprise reports
+itself as a specific failed assertion rather than as an unexplained message mismatch.
+
+### Also missing from §9
+
+- **No row for `--passthrough`** (C1) — the gap is invisible to all nine rows.
+- **No negative control on the FIFO test harness** (C2, point 5): nothing proves the
+  fixture is a FIFO rather than a regular file `>`-created by a failed `mkfifo`.
+- **No row asserting the guard's cost is not paid on the hot path.** A4 is asserted from
+  the call-site inventory, which is fine — but if anyone later moves the check into
+  `FastqReader::open`, nothing fails. Optional: assert `detect_input_format` is not
+  reachable from `next_record` by inspection only; not worth a test.
+
+V2, V3, V4, V6 and V8 are well-specified. **V2's "prove the comparison can fail by
+diffing against a sentinel-appended copy" and V4's corrected string are both exactly
+right** — that discipline is what caught v1's error, and it is applied here.
+
+---
+
+## 5. Alternatives
+
+### ALT-1 (recommended, additive): a non-blocking **path** stat in `Cli::validate`
+
+The measurement file already contains the evidence for this and the plan does not use it:
+`MEASUREMENTS_reopen_probe.md` §2's second column is `fs::metadata(path)`, and it names
+FIFO/pipe for rows C, D and E — identically to the fstat-on-handle column.
+
+I confirmed the decisive property the plan never tests: **a path stat does not block on a
+FIFO with no writer.**
+
+```
+FIFO, no writer ever:   Path::exists = true
+                        fs::metadata = Ok((fifo=true, file=false, chardev=false, sock=false))
+                        File::open   = *** BLOCKED >3s ***
+regular file (control): fs::metadata = Ok((fifo=false, file=true, …));  File::open returned
+```
+
+`cli.rs:933` already stats every input (`if !path.exists()`), unconditionally, for every
+mode, at `main.rs:166` — before any `File::open`. Replacing that `exists()` with a
+`fs::metadata()` match costs **zero extra syscalls** and buys three things:
+
+1. **It kills §11's Medium residual.** `trim_galore fifo` with no writer ever currently
+   blocks at the first open with no message, and §11 calls this "unfixable without opening
+   every input `O_NONBLOCK`". That is not so — `stat(2)` never opens, so the FIFO is named
+   and rejected before anything can block. No `libc`, no `unsafe`, no change to the open
+   path for any input.
+2. **It covers `--passthrough`** (C1) if applied at `cli.rs:884` too, and the `--demux`
+   barcode file at `cli.rs:926` for free.
+3. It fires earliest, so nothing is created before the message.
+
+§2.3's stated objection — *"A guard in CLI validation would miss `clump_only` and
+`specialty`, which call `detect_input_format` directly"* — does not hold for the binary:
+`main()` calls `cli.validate()` at `main.rs:166`, before every dispatch branch. It holds
+only for a third-party library consumer calling `clump_only::clump_only_single` without a
+`Cli`, which is a real but narrow case.
+
+So the right answer is **both layers, not either**: keep the handle-level `is_fifo()` in
+`detect_input_format` (defence in depth, covers library callers, TOCTOU-proof as A6
+notes) *and* add the path-level check in `Cli::validate`. The TOCTOU concern A6 raises
+against a path stat is benign for a *rejection* guard in a layered design: if the path
+changed type between validate and open, the handle-level check is the backstop, and vice
+versa. Two cheap checks that fail closed.
+
+Cost: ~10 lines and one more test. Payoff: one Critical finding and one Medium residual
+risk, both closed.
+
+### ALT-2 (considered, don't take): whitelist regular + char devices instead of blacklisting FIFOs
+
+`if !(ft.is_file() || ft.is_char_device()) { bail }` would also give sockets and
+directories an accurate message instead of today's `ENXIO` / `Is a directory (os error 21)`.
+I verified both of those outcomes are unchanged by the plan. But a whitelist is a
+behaviour change for input classes nobody has complained about (block devices), and it
+converts "unknown file type" from *fall through and let the format check decide* into a
+hard error. The plan's blacklist is the conservative choice and the right one for a
+diagnostic-only fix. Worth one line in §10 as a considered-and-declined alternative,
+since a reviewer will ask.
+
+### ALT-3 (declined, but the cost was mis-stated): `O_NONBLOCK`
+
+§11 rejects this as needing `libc` and changing the open path for all inputs. The second
+half is a good objection. The first half is not: `libc 0.2.184` is **already in
+`Cargo.lock`** (transitively, via `rustix`/`tempfile`). ALT-1 achieves the same outcome
+with neither cost, so `O_NONBLOCK` stays declined — on the better reason.
+
+### ALT-4 (out of scope, worth a sentence): memoise detection per path
+
+Caching `detect_input_format`'s result would remove the redundant opens §2.1 documents
+*and* make the probe genuinely free. It collides with #374 and is a bigger change than
+this plan wants. Noting it because it is the change that would make §6's declined
+optimisation moot.
+
+---
+
+## 6. Action items
+
+### Critical
+
+**C1. Correct §2.3/§7 and cover `--passthrough`.**
+The claim that every input path passes through `detect_input_format` is false; `--passthrough`
+is opened twice (`main.rs:768`, then `main.rs:1344`/`:1383`) with no guard, so
+`--passthrough <fifo>` still hangs with no message *after* output files exist. Either
+change `main.rs:768` to `sanity_check_any(pt_path)`, or take ALT-1 (which covers it at
+`cli.rs:884` and closes the §11 residual too). Add a §9 row. Downgrade "Verified by
+call-site grep" to what the grep actually verified — `cli.input`, not every input.
+
+**C2. Rewrite §5 steps 5 and 7 for the FIFO tests, and add a CI backstop.**
+- Drop "in both writer states". It is unreachable as a pre-condition (measured: Shape B
+  blocks in `child.wait()`), and v2's pre-filter makes the two states traverse identical
+  code. Specify **one** deterministic test, and say how: hold the write end open on an
+  in-process thread for the duration of the call (Shape A, 144 µs), or spawn the writer
+  and call immediately (Shape C, 28 ms). Add one sentence recording *why* "writer exited"
+  is not a testable state, so the next reader does not re-add it.
+- Reword rule 3 from "bound **the call**" to **bound the whole test body, setup
+  included** — the measured wedge is in setup, outside the current bound.
+- Add rule 4: **the writer must tolerate `EPIPE`.** The guard drops the reader before the
+  writer finishes, so an in-process writer must not `unwrap()` its `write_all`, and a
+  spawned `cat` must not have `.success()` asserted unconditionally. (Rule 2's payload
+  advice survives, but for this reason — update its stale rationale.)
+- Add rule 5: **assert the fixture is a FIFO** — check `mkfifo`'s exit status and
+  `assert!(fs::metadata(&f)?.file_type().is_fifo())`. If `mkfifo` fails, `cat x > f`
+  creates a regular file and the test fails pointing at the guard.
+- Add to §5 (new step) and §9: **`timeout-minutes` on the `rust-tests` job** and a
+  `.config/nextest.toml` with `slow-timeout = { period = "30s", terminate-after = 2 }`.
+  Neither exists today; the job runs `cargo nextest run` and `cargo test --release` on
+  both legs, so an escaped wedge costs the GitHub default 360 minutes × 4 job-steps. This
+  is the structural backstop that survives an implementer forgetting rules 3–5, and it is
+  the one thing here that turns the highest-consequence failure mode into a fast, legible
+  failure.
+
+### Important
+
+**I1. Defend against a short `read` on either open, or state the assumption.**
+§4/§5 step 2 say "read up to `first.len()` bytes […] return whether the slices are
+equal". If open #1 returns 4 bytes and open #2 returns 3 (NFS, FUSE), the comparison is
+`false` and a perfectly good regular file is **newly rejected** with "cannot be re-read
+from the start" — the plan's own wrong-blame failure, introduced by the fix. Low
+probability, but the fix is a 3-line fill loop on both reads, and the same loop hardens
+the *existing* `n >= 3` gzip test at `format.rs:226`, which today misclassifies a gzip
+file on a short first read. Add it, or add an explicit A8 saying you accept the risk.
+
+**I2. Give `reopen_restarts`'s `Err` path a context line.**
+§5 step 2 says "Propagate open/read failure as `Err`" with no `with_context`. v2 changed
+Q3 to `Err` precisely to avoid mis-blaming `EMFILE`/`EACCES` — but a bare
+`Too many open files (os error 24)` with no path is only half the improvement. Add
+`.with_context(|| format!("Failed to re-open input file '{}' for the restartability check", path.display()))`,
+matching the style of `format.rs:209`/`:213`.
+
+**I3. Replace V7's byte-probe negative direction.** `/dev/stdin` from a pipe is not
+constructible in a unit test and never reaches the probe anyway. Use
+`reopen_restarts(&regular, b"XXXX") == Ok(false)` as the portable negative control, plus
+the existing positive on the same file. Optionally add a `#[cfg(target_os = "macos")]`
+row-B case for the real shared-offset mechanism. Without this, the `false` branch is
+exercised zero times on `ubuntu-latest`.
+
+**I4. Give V1 per-row negative controls.** The single assertion "no occurrence of
+`doesn't seem to be in FastQ format`" is vacuous on the gz row (which fails with
+`Failed to decompress first block of '…' for format detection`, `format.rs:236`) and on
+the FIFO row (which produces no stderr today because it hangs). Assert the row-specific
+wrong message is absent. Same correction to §1's opening sentence, which generalises the
+plain row's diagnostic to all three.
+
+**I5. Stop asserting the Linux mechanism and have CI prove it.** A6's POSIX `S_IFIFO`
+guarantee covers named FIFOs only; rows C/D on Linux go through `/proc/self/fd/N`, a
+different mechanism, and no row of the measurement table is Linux. My kernel-level reading
+says the plan is right (pipefs re-open yields `S_IFIFO` and does not block even with the
+writer closed, because `fifo_open`'s partner-wait is gated on `!is_pipe`) — but make the
+integration test assert `is_fifo()` on the descriptor it is about to hand over, so the
+first CI run *is* the measurement and a surprise names itself.
+
+### Optional
+
+**O1. Fix the dev-dependency facts in §5 step 6.** They are `serde_json`, `tempfile`,
+`bstr` — not "tempfile only" — and `libc 0.2.184` is **already in `Cargo.lock`**. So
+`libc::mkfifo` adds a line to `[dev-dependencies]` and *zero* new compiled crates, which
+makes the stated trade-off ("adding `libc` […] is the heavier option", "no new
+supply-chain surface") point the wrong way. `Command::new("mkfifo")` is still defensible
+— it needs no `unsafe` — but the honest comparison is "`$PATH` dependency and a failure
+mode that masquerades as a guard bug (C2 rule 5)" versus "one dev-dep line on a crate
+already in the graph, and an immediate errno". Either choice is fine; state it correctly.
+
+**O2. `specialty.rs:531` is a `#[cfg(test)]` helper**, not a production call site. Drop
+it from §2.3's inventory — the remaining entries are all genuine and I verified each.
+
+**O3. Add `/dev/urandom` to §2.2.1's char-device list.** The plan names `/dev/null`
+(→ empty) and `/dev/zero` (→ not-FASTQ), both confirmed. `/dev/urandom` reaches the
+**new** re-open message, which is defensible but is a third outcome the list implies does
+not exist.
+
+**O4. Record ALT-2 (whitelist) in §10** as considered-and-declined. A reviewer will ask
+why sockets and directories keep their raw `errno` messages when the plan is about
+accurate diagnostics; one line pre-empts it. (The socket claim itself is right in
+substance — `open()` on a socket fails — though `ENXIO` is the Linux errno; Darwin
+differs. The branch is unreachable either way.)
+
+**O5. Consider `#[cfg(unix)]` now rather than flagging it.** A7 is honest, but the crate
+ships a `src/lib.rs`, and a bare `use std::os::unix::fs::FileTypeExt;` is the first hard
+compile break for any non-Unix target. Three lines (`#[cfg(unix)]` on the check plus a
+`#[cfg(not(unix))]` no-op) keeps the door open at no cost to the Unix path.
+
+---
+
+## 7. What v2 got right, and did v2 introduce anything new
+
+The v2 fix is correct and I could not break it. The fstat pre-filter is the right shape,
+in the right order, and it does exactly what §2.2.1 claims — I reproduced the whole §3
+flow and every row lands where the plan says, including row B needing the byte probe and
+row E never reaching it. Q3's change from `Ok(false)` to `Err` is a genuine improvement
+and correctly reasoned. V4's corrected string is right. The scope discipline (A over B/C,
+disjoint from #374, with a note for whoever attempts B) is exemplary.
+
+**Did v2 introduce anything new?** Two things, both small and both listed above:
+
+- **I1** is new to v2 in *consequence*, not in mechanism: v1 also compared bytes, but v2
+  made that comparison the sole gate for non-FIFO input, so a short read now turns a
+  working regular file into a hard rejection. Nothing in the plan mentions read length.
+- **The stale rationale for rule 2.** v2 removed the second open that rule 2 existed to
+  survive, but kept the rule with its old justification. It is still needed (EPIPE /
+  writer exit status), so the rule is right and its reason is wrong — the kind of drift
+  that gets a rule deleted by the next reader.
+
+Neither is a design defect. C1 and C2 are the two items I would hold implementation on:
+C1 because the plan's central placement argument is provably incomplete and an implementer
+will not re-check a claim marked "Verified", and C2 because an unbounded wedge in test
+setup with no CI timeout is, as the plan itself says, the failure that looks like a slow
+job — for six hours, four times over.

--- a/plans/08032026_reject-non-restartable-input/PLAN_REVIEW_B.md
+++ b/plans/08032026_reject-non-restartable-input/PLAN_REVIEW_B.md
@@ -1,0 +1,299 @@
+# PLAN_REVIEW_B — Reject non-restartable input with an accurate diagnostic
+
+**Reviewer:** B (independent, fresh context)
+**Target:** `plans/08032026_reject-non-restartable-input/PLAN.md` revision **v2**
+**Supporting evidence reviewed:** `MEASUREMENTS_reopen_probe.md`
+**Source read:** `src/format.rs`, `src/main.rs`, `src/fastq.rs`, `src/clump_only.rs`, `src/specialty.rs`, `src/demux.rs`, `src/cli.rs`, `Cargo.toml`, `.github/workflows/ci.yml`, `tests/`
+**Own measurements:** taken on this machine, kernel Darwin 25.5.0 / macOS 26.5.1, arm64, rustc from `~/.cargo/bin`. Probe sources and outputs quoted inline. Nothing that opens a FIFO was run.
+
+**Verdict:** the design is right and the v2 fix is the correct fix. One completeness claim in §2.3 is false and leaves the bug reachable on one flag; the FIFO test rule set contradicts one of its own test cases; and one §9 row is not implementable as written. All three are fixable in the plan without changing the approach.
+
+---
+
+## 1. Logic review
+
+### 1.1 The two-layer guard: is it sound?
+
+Yes, and the ordering argument in §2.2/§3 is correct. I re-derived it independently:
+
+- The invariant the code depends on is *re-opening the path yields the same bytes from the start* (`format.rs:208` + `format.rs:231`, plus `fastq.rs:474` and `adapter.rs:115`/`:268` each opening afresh). §2.1's inventory of that is accurate — I confirmed all four rows against source.
+- A type check alone cannot work, because row B (`/dev/stdin` from a regular file on Darwin) fstats as regular.
+- A byte comparison alone cannot work, because the second `open` on a writer-less FIFO blocks. This is the v2 discovery and it is a genuine design defect in v1, not a test-hygiene issue. §11's account of that is honest.
+- Therefore fstat-then-bytes, with the fstat before the `read`. Correct, and §3's step ordering pins it.
+
+I also confirmed the two subtler claims that hold the design up:
+
+- **fstat on the handle, not a path stat** (A6) — right, and it also disposes of symlinks: `File::metadata` follows to the target's type. Measured: `symlink → /dev/null` reports `chr=true`, so a symlink to a FIFO reports FIFO. No TOCTOU window on the type check.
+- **The `n == 0` empty check must precede the probe** (A5) — verified against source: `format.rs:215-217` is the `Input file '{}' is empty` bail, and §3 puts the probe after it.
+
+### 1.2 The hole: `--passthrough` never reaches `detect_input_format`
+
+§2.3 states:
+
+> The direct `FastqReader::open` calls in `specialty.rs:531`, `clump_only.rs:290`/`:430`/`:432`, `demux.rs:170` and `main.rs:1373`/`:1374`/`:1383` are all downstream of a `detect_input_format` on the same path, so the guard fires first in every flow. **Verified** by call-site grep.
+
+`main.rs:1383` is not R1 or R2. It is the `--passthrough` file:
+
+```rust
+// src/main.rs:1382-1385
+let mut reader_passthrough = match passthrough_input {
+    Some(p) => Some(FastqReader::open(p)?),
+    None => None,
+};
+```
+
+and its `--cores > 1` / `--clumpify` twin at `src/main.rs:1343-1346` (`FastqReader::open_threaded(p)`) is not in the inventory at all. Nothing detects that path:
+
+- `src/main.rs:187` maps `detect_input_format` over **`cli.input`** only; `cli.passthrough` is a separate `Option<PathBuf>` (`cli.rs:282`).
+- `src/main.rs:768` sanity-checks it with `FastqReader::sanity_check(pt_path)?` — **not** `sanity_check_any`, which is the wrapper that calls `detect_input_format` (`main.rs:29-30`).
+- The internal-invariant loop at `src/main.rs:1328` iterates `[input_r1, input_r2]` only.
+- `cli.rs:884` checks only `pt.exists()`, which a FIFO satisfies.
+
+So `trim_galore --paired --passthrough <(zcat I1.fq.gz) R1 R2` is unchanged by this plan: it reaches `FastqReader::sanity_check` → `FastqReader::open` (`fastq.rs:474`) and produces the old `doesn't seem to be in FastQ format` message; a writer-exited FIFO hangs there, and hangs again at 1383/1344. That is the exact bug #379 reports, left reachable on one flag, in a plan whose stated placement rationale is "the one place every input passes through".
+
+Corroborating observation, out of scope but it shows the gap is structural rather than a one-off: the `--passthrough` + uBAM rejection at `main.rs:253` keys off `any_bam`, which is computed from `cli.input`, so the passthrough file's own container format is never inspected anywhere.
+
+Fix is one line — `sanity_check_any(pt_path)?` at `main.rs:768`, or an explicit `detect_input_format(pt_path)?` beside it — plus a §9 row. See C1.
+
+### 1.3 The rest of the §2.3 inventory
+
+Two more entries are wrong, harmlessly, but they are two of five items in a list stamped "Verified":
+
+- `specialty.rs:531` is inside `#[cfg(test)] mod tests` (module opens at `specialty.rs:508`) — a `read_fastq` test helper, not a production path.
+- `demux.rs:170` opens `trimmed_file`, which is Trim Galore's **own trimming output** (name derived at `demux.rs:129`), not a user input. It is safe because it is a regular file we just wrote, not because a `detect_input_format` preceded it.
+
+The three `clump_only.rs` entries do check out: `:290` is preceded by `:265`, and `:430`/`:432` by `:402`, on the same paths. I also checked every `detect_input_format` call site in `clump_only.rs` (`:265`, `:402`, `:747`, `:910`, `:949`, `:950`) — all are on user inputs, none on a self-created intermediate, so the guard cannot fire on a temp file Trim Galore made itself.
+
+### 1.4 Comparison semantics: the probe can silently pass
+
+§4 says "return whether the slices are equal"; §3.2 says "Probe compares `peek[..n]` against the same length from the second open". Neither pins what happens when the second read is **shorter**. Read as a common-prefix compare — a natural reading of "the same length" — the probe accepts the case it exists to reject. Measured, single `read` of `n1` bytes on the second handle, `/dev/fd/N` over a regular file (the row-B shape at small sizes):
+
+| file size | n1 | n2 | prefix compare | length-aware compare |
+|---|---|---|---|---|
+| 4 B | 4 | 0 | **true — wrongly accepted** | false |
+| 1 B | 1 | 0 | **true — wrongly accepted** | false |
+| 5 B | 4 | 1 | false | false |
+| 8 B | 4 | 4 | false | false |
+
+The required predicate is `n2 == first.len() && buf[..n2] == first`. Blast radius is small — an input of ≤4 bytes fails downstream anyway — but this is the only place the guard can pass unnoticed, and nothing in §5 step 5 exercises `n2 < n1`. §3.2's row "a 1-byte file is restartable and falls through to the existing format errors" is right for a *regular* 1-byte file (measured: n1=1, n2=1, equal) and wrong for the same file reached through `/dev/fd/N`.
+
+### 1.5 Short reads make A1 false in the corner
+
+A single `read` also means a genuine short read on a restartable file is reported as non-restartable. `Read::read` is permitted to return fewer bytes than asked, and `File::read` surfaces `EINTR` as `ErrorKind::Interrupted` rather than retrying — which, under §10 Q3's v2 decision, becomes a hard `Err`. Rare (4 bytes, local FS), realer on NFS/FUSE. Looping the read until `first.len()` or EOF costs three lines and makes A1 ("no input that previously succeeded can newly fail") exactly true instead of nearly true.
+
+### 1.6 Message accuracy
+
+§3.1's FIFO opening is:
+
+```
+Input 'X' is a named pipe (FIFO), so it cannot be re-read from the start.
+```
+
+Two of the three #379 reproductions — `<(zcat reads.fq.gz)` and `cat x | trim_galore /dev/stdin` — are **anonymous** pipes. Both fstat as `S_IFIFO` (MEASUREMENTS §2 rows C and D), so this message fires for them and asserts something untrue about the user's input. A plan whose opening premise is that the current message "blames the user's data for a limitation of ours" should not ship a wrong noun, and nothing catches it: V1 asserts only the shared tail `cannot be re-read from the start`, which both messages contain by design (§3.1). "is a pipe or FIFO, not a regular file" covers all three shapes.
+
+### 1.7 Termination, in both directions
+
+I looked for inputs that terminate in neither direction and found one the plan does not list:
+
+- **FIFO, no writer ever** — blocks at the first `open`. Listed (§3.2, §11 Medium). Correct and correctly scoped out.
+- **Character device that blocks on `read`** — `trim_galore /dev/stdin` at an interactive terminal fstats as a character device, so the pre-filter does not fire, and the **first** `read` at `format.rs:211` blocks with no message. This is a plausible thing for a user who has just read #379 to try, and `/dev/stdin` is one of the forms §3.1's own remedy text names. Same class as the FIFO-with-no-writer residual, and §3.2's character-device row currently claims char devices are handled "both correct". Distinguishing a tty needs `isatty`, i.e. `libc`, so listing it as a residual is the right answer — but it should be listed.
+- Everything else terminates: directories fail at the `read` with `EISDIR` (unchanged), block devices fail at `open` with `EACCES` for a normal user, `/dev/zero` and `/dev/urandom` return promptly.
+
+### 1.8 Character devices: §3.2's row is incomplete
+
+Measured on this machine:
+
+| input | fstat | n1 | byte probe | resulting error |
+|---|---|---|---|---|
+| `/dev/null` | char | 0 | not reached | existing `is empty` ✓ |
+| `/dev/zero` | char | 4 | **true** | existing not-recognised ✓ |
+| `/dev/urandom` | char | 4 | **false** | **new** `cannot be re-read from the start` |
+| symlink → `/dev/null` | char (followed) | 0 | not reached | existing `is empty` ✓ |
+
+§3.2 says character devices produce "existing empty / not-FASTQ errors, both correct" and names only `/dev/null` and `/dev/zero`. A streaming character device gets the new message, whose tail names "pipes, FIFOs, process substitution … and /dev/stdin" — none of which it is. Harmless, but the row claims a completeness it does not have. The silver lining is in §3.4 below: `/dev/urandom` is the portable negative control the plan needs.
+
+---
+
+## 2. Assumptions
+
+| # | Verdict | Note |
+|---|---|---|
+| A1 | **Qualified** | Holds for `cli.input`. The promise it underwrites — "the guard fires first in every flow" — is false for `cli.passthrough` (§1.2). Also only approximately true until the short-read loop lands (§1.5). Its grep half checks out: no `/dev/stdin` or `mkfifo` in `tests/`, `.github/`, `justfile`. The `<(` half of that grep matches Rust generics (`Vec<(…)>`) throughout `tests/`, so re-run it with a tighter pattern before restating it as verified. |
+| A2 | **Superseded** | The pathological repeating-prefix case A2 discusses is not the realistic hole; §1.4's short-second-read case is, and A2 does not mention it. Both vanish under the Alt-1 offset check. |
+| A3 | **Verified** | MEASUREMENTS §1 row E, plus POSIX. Correctly promoted from unverified assumption to the reason the type check exists. |
+| A4 | **Verified independently** | 18 production `detect_input_format` call sites, all per-file. Nothing per-record. |
+| A5 | **Verified against source** | `format.rs:216` is the `is empty` bail and precedes everything. V4's string is now correct; `fastq.rs:478` is indeed the other one (`seems to be completely empty`), and `fastq.rs:485` is `doesn't seem to be in FastQ format` — so V1's negative assertion targets a string that really exists. |
+| A6 | **Verified on Darwin, asserted on Linux** | Acceptable: the ubuntu integration test is self-verifying. The important half — fstat on the held handle, not a path stat — is right, and my symlink measurement confirms `File::metadata` resolves to the target type. |
+| A7 | **Verified** | `grep -rn "cfg(unix)\|cfg(windows)\|cfg(target_os" src/ tests/ build.rs` returns nothing. Unix-only is consistent with the tree as it stands. |
+
+### Unstated assumptions worth surfacing
+
+1. **That a `read` returns everything asked for.** §1.5. It is also the shape the existing code at `format.rs:211` already has, so the plan inherits it rather than introducing it — but the new code is where it produces a *new wrong message*.
+2. **That `is_socket()` is unreachable.** §2.2.1 asserts `File::open` on a socket path fails with `ENXIO`, cited to MEASUREMENTS §2 — whose table has rows A–E and no socket row, even though `probe2.rs` prints `sock=`. I tried to measure it; the sandbox blocks `bind(2)`, so I could not settle it either. See I6: including the check costs one `||` and removes the dependency on an unmeasured claim.
+3. **That the character-device set is `{/dev/null, /dev/zero}`.** §1.8.
+4. **That a unit test can observe its own `/dev/stdin`.** §3.4 / C3.
+5. **That "reap it, do not `wait` on it while holding the reader"** (§5 step 7 rule 2) is actionable. Reaping *is* waiting; the sentence needs to say what to do instead (kill, then wait).
+
+---
+
+## 3. Validation sufficiency (§9)
+
+The nine rows are well chosen and §9's closing paragraph correctly identifies V5/V6/V7 as the fragile ones. Three ways the change could still ship broken with everything green:
+
+### 3.1 A hang is not bounded by anything mechanical
+
+`.github/workflows/ci.yml` has **no `timeout-minutes` on any job** — I grepped all workflows, zero hits. GitHub's default is 360 minutes, on both matrix legs. The debug leg is `cargo nextest run` (ci.yml:66-67), and nextest's default `slow-timeout` only *warns*; it does not terminate. So V5 ("Complete in seconds") is a human observation, and the only thing standing between a wedged test and a 6-hour job is every future test author remembering §5 step 7 rule 3.
+
+This matters more than it looks, because of the chain: **if the fstat pre-filter is accidentally dead** — placed after the `read`, or the predicate inverted — the writer-exited FIFO test does not fail, it *hangs*, because the byte probe's second open blocks (MEASUREMENTS §1 row E). The plan's central v2 design decision therefore fails, if it fails, in the one mode the plan itself calls hardest to notice. Two one-line backstops that do not depend on discipline:
+
+```yaml
+# .github/workflows/ci.yml, rust-tests job
+timeout-minutes: 30
+```
+
+```toml
+# .config/nextest.toml  (no such file today)
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 4 }
+```
+
+### 3.2 Rule 3 does not work for the integration test
+
+The repo's idiom is `Command::new(binary()).output()` on the test's main thread, with no bound — `tests/integration_no_args_help.rs:21-24` and every case in `tests/integration_clump_only*.rs`. `Command::output()` reads both pipes to EOF and cannot be interrupted; a child blocked in `open` on a writer-less FIFO holds those pipes open, so `output()` never returns. §5 step 8 says only "Same three rules from step 7 apply", and rule 3's recipe (`recv_timeout` on a thread) leaves the child alive after the timeout — the test fails, and a wedged `trim_galore` is stranded on the runner. The missing step is: `spawn()` rather than `output()`, keep the `Child`, and on timeout `kill()` then `wait()`.
+
+The same applies to the FIFO **writer** child: give it `Stdio::null()` and kill it in cleanup. Under nextest a leaked child holding output handles trips `leak-timeout` (default 100 ms) and the test is reported LEAK; under the `cargo test --release` leg it can stall output collection.
+
+### 3.3 §5 step 7's rule set contradicts §5 step 5
+
+Rule 2: "Keep the payload well under 64 KiB so the writer completes into the pipe buffer and **exits** rather than lingering."
+Step 5: "a FIFO is rejected with the FIFO message, **in both writer states** — writer exited, and **writer still open**."
+
+Under rule 2, whether the writer is still open when we fstat is a scheduler race — which is precisely the property MEASUREMENTS §1 identifies as making E vs F "a scheduler coin-flip". So as specified, the writer-still-open case is nondeterministic, and it is nondeterministic in the direction that produces the *other* test's conditions rather than failing loudly.
+
+The deterministic construction, and it needs no child process: hold the write end **in the test process on a spawned thread** —
+
+```rust
+let w = { let p = fifo.clone(); thread::spawn(move || {
+    let f = std::fs::OpenOptions::new().write(true).open(&p).unwrap();
+    std::thread::park();            // hold the writer open
+    drop(f);
+}) };
+```
+
+— because the write-only `open` rendezvous with our reader's `open`, so both complete. It must not be on the main thread: a write-only `open` on a FIFO blocks until a reader appears, so doing it before `detect_input_format` on the same thread self-deadlocks. That trap is not in the rule set, and it is the obvious way to write the test.
+
+### 3.4 V7's fourth cell is not implementable as a unit test
+
+> Byte probe: `reopen_restarts` on a regular file → `true`; on `/dev/stdin` from a pipe → `false`
+
+A unit test cannot control its own process's fd 0. Under `cargo test --release` run from a developer's terminal, `File::open("/dev/stdin")` + `read` **blocks waiting for typed input**; under nextest fd 0 is whatever the harness supplies. So this row is either a hang or a coin-flip depending on how the suite was invoked.
+
+Two portable substitutes, both measured here:
+
+1. `reopen_restarts(&regular_file, b"ZZZZ")` → `Ok(false)`. Pure comparison logic, no I/O tricks, no platform dependence.
+2. `/dev/urandom` → `Ok(false)` on both platforms; present on both runners; cannot block; and it is the §1.8 case the edge-case table forgot.
+
+Do **not** use `/dev/fd/{fd}` of a file you opened (the shape I used to reproduce row B): it is a `dup` on Darwin but a fresh open on Linux, so it yields `false` on macOS and `true` on ubuntu. The byte probe's negative direction has no portable *real-world* reproduction, which is worth saying in §9 rather than leaving V7 to be discovered at implementation time.
+
+### 3.5 One more missing row
+
+§9 tests the guard on inputs, not the property that broke in §1.2 — *that every input-bearing CLI surface reaches the guard*. Add a row that enumerates them (`cli.input`, `cli.passthrough`) rather than exercising one of them, so the next flag that takes a path is caught by the test rather than by a reviewer.
+
+Rows that are sound as written: V2's sentinel-appended negative control is exactly the right instinct; V3 is the right invariant to name even though the guard adds no transformation; V4's string is now correct against `format.rs:216`; V8 is adequate. I found no docs debt to add to §5 — `grep` over `docs/`, `README.md` and `--help` finds no `/dev/stdin`, no `mkfifo`, and no `… | trim_galore`, so the CHANGELOG entry really is the whole documentation surface.
+
+---
+
+## 4. Efficiency
+
+§6 is sound and the declined optimisation is declined for the right reason. Two small corrections:
+
+- On the **gzip** branch a `detect_input_format` call now performs **three** opens (`:208`, the probe, `:231`), not two. Immaterial against a full-file read, but the declined-optimisation paragraph reads as if the count were two.
+- The offset variant in Alt-1 is strictly cheaper still: no second `read` at all.
+
+No allocation, no per-record cost, `fstat` on an already-open handle is free. A4 holds.
+
+---
+
+## 5. Alternatives
+
+### Alt-1 — discriminate on the second handle's **file offset**, not on bytes (recommended)
+
+After the second `open`, `Seek::stream_position()` (std, no `libc`, no `read`) is `0` for a genuine fresh open and non-zero when the open shared an offset — which is exactly what rows B, D and F are. Measured on this machine:
+
+| input | second open `stream_position()` | offset verdict | byte verdict |
+|---|---|---|---|
+| regular 4 B / 6 B / 40 B | `Ok(0)` | restartable | restartable |
+| `/dev/fd/N` over 4 B | `Ok(4)` | **not restartable** | **accepted by a prefix compare** (§1.4) |
+| `/dev/fd/N` over 6 B | `Ok(4)` | not restartable | not restartable |
+| `/dev/fd/N` over 40 B | `Ok(4)` | not restartable | not restartable |
+| `/dev/zero`, `/dev/null` | `Ok(0)` | restartable | restartable |
+| `/dev/urandom` | `Ok(0)` | restartable | not restartable |
+
+Why it is better: it is **exact rather than heuristic**, so it retires A2 entirely (no pathological repeating-prefix residual); it is length-insensitive, so §1.4 and §1.5 both disappear; and it needs no read on the second handle. Why it does not replace the type check: the second `open` on a FIFO still blocks, and `seek` on a FIFO returns `ESPIPE`. So the two-layer structure and its ordering survive unchanged — this only swaps the second layer's predicate.
+
+Note this is *not* the seekability probe §2.2 rightly rejects. That one asks "is this fd seekable" of the **first** handle and accepts row B. This asks "did the **second** open start at zero", which is the property that actually differs.
+
+Cheapest form if you would rather not re-argue the design: keep the byte compare and add the offset as an extra reject condition — *not restartable if `pos != 0` **or** the bytes differ*. One line, closes §1.4's hole exactly, and preserves the `/dev/urandom`-class behaviour you already have.
+
+### Alt-2 — type check only, drop the byte probe (correctly rejected)
+
+Row B fstats as regular, so it would be accepted and then fail with the original misleading message. §2.2 already rebuts this. Keep the rebuttal in the plan: it is the first thing a reviewer of the diff will propose, and the rebuttal is not obvious.
+
+### Alt-3 — compare `(st_dev, st_ino)` across the two handles (does not work)
+
+On Darwin `open("/dev/fd/N")` is a `dup`, so the second handle reports the same device and inode as the first. The offset is the only thing that differs — i.e. Alt-1. Worth one line in §10 so nobody re-invents it.
+
+---
+
+## 6. Action items
+
+### Critical
+
+**C1. Close the `--passthrough` bypass, and re-do the §2.3 inventory.**
+`src/main.rs:768` uses `FastqReader::sanity_check`, not `sanity_check_any`, so `cli.passthrough` never reaches `detect_input_format`; its readers are built at `src/main.rs:1344` and `src/main.rs:1383`. §2.3's "the guard fires first in every flow. **Verified** by call-site grep" is false, and 1344 is not even listed. Route the passthrough path through the guard (`sanity_check_any(pt_path)?`, or an explicit `detect_input_format(pt_path)?` beside it), and add the §3.5 validation row. While re-doing the inventory, mark each entry as production / test-only / self-produced-file — `specialty.rs:531` is test code and `demux.rs:170` reads our own output (§1.3).
+
+**C2. Fix the FIFO test rule set: rule 2 contradicts the writer-still-open case, and the deterministic construction is not stated.**
+Specify the in-process writer thread (§3.3), and state explicitly that the write-only `open` must not happen on the test's main thread. Add the fourth rule the set is missing: after a timeout, `kill()` + `wait()` the child; `Stdio::null()` for the writer's stdio. Replace "reap it, do not `wait` on it while holding the reader" with the action to take.
+
+**C3. Replace V7's `/dev/stdin`-from-a-pipe cell with something a unit test can actually do.**
+It is unobservable from inside the harness and blocks on a terminal (§3.4). Use `reopen_restarts(&regular_file, b"ZZZZ") == Ok(false)` plus `/dev/urandom`. Record in §9 that `/dev/fd/N` is *not* a portable substitute (dup on Darwin, fresh open on Linux) and that the byte probe's negative direction has no portable real-world reproduction.
+
+### Important
+
+**I1. Pin the comparison as length-aware.** §4 and §3.2 leave it ambiguous, and the natural prefix reading silently accepts every `/dev/fd/N` input of ≤4 bytes (§1.4, measured). Spec it as `n2 == first.len() && buf[..n2] == first`.
+
+**I2. Loop the second read** until `first.len()` bytes or EOF, retrying `Interrupted`, so a short read on a restartable file is not reported as non-restartable (§1.5). This is what makes A1 exactly true.
+
+**I3. Add mechanical bounds to CI**: `timeout-minutes` on `rust-tests` and a nextest `terminate-after`. Today nothing bounds a hang, and a dead type check manifests as a hang rather than a failure (§3.1).
+
+**I4. Give §5 step 8 its own recipe.** `Command::output()` on a blocked child never returns; "same three rules" does not cover a subprocess (§3.2).
+
+**I5. Reword the FIFO message.** "named pipe (FIFO)" is false for two of the three #379 reproductions, and no assertion catches it because V1 targets the shared tail (§1.6). "is a pipe or FIFO, not a regular file".
+
+**I6. Include `is_socket()` in the type check.** One `||`. It removes the plan's reliance on an unmeasured claim (§2.2.1 cites MEASUREMENTS §2, which has no socket row), and it converts a possible raw-errno path — Linux `open` of a socket through `/proc/self/fd/N` returns `ENXIO`, which §10 Q3 turns into a bare OS error — into the intended diagnostic.
+
+**I7. Fix §3.2's character-device row and add the blocking-char-device residual.** `/dev/urandom` gets the *new* message, not an existing one (§1.8, measured), and `trim_galore /dev/stdin` at a terminal still blocks in the first `read` with no message (§1.7) — a residual of the same class as FIFO-with-no-writer, involving an input form §3.1's own remedy text names.
+
+### Optional
+
+**O1.** §5 step 6: dev-dependencies are `serde_json`, `tempfile`, **`bstr`** (`Cargo.toml:50-56`), not "tempfile only". The argument (no `libc`, no `nix`) is unaffected. `mkfifo` confirmed at `/usr/bin/mkfifo` on Darwin.
+
+**O2.** §5 step 4: the comment is `format.rs:227-230`; `:226` is the `if`.
+
+**O3.** State "one `fresh_tmpdir` slug per FIFO test" explicitly. It is load-bearing rather than hygienic here: the debug leg is process-per-test under nextest, and `fresh_tmpdir` opens with `remove_dir_all`, so a shared slug lets one process unlink another's FIFO while a writer is blocked on it, stranding the writer. ci.yml:52-56 records a completed audit that all 19 existing `temp_dir().join(...)` sites use unique slugs — worth not being the first exception.
+
+**O4.** §6: say three opens on the gzip branch (§4).
+
+**O5.** Add Alt-3 to §10 so the dev/ino idea is pre-rebutted.
+
+**O6.** `MEASUREMENTS_reopen_probe.md` header says "Darwin 26.5.1"; 26.5.1 is the macOS product version and the kernel is Darwin 25.5.0. Trivial, but a measurement doc should name its platform unambiguously so a future reader can tell which runner it does or does not speak for. The larger point stands and the plan already concedes it: every row in that file is Darwin, and the plan's Linux claims (A6, row B "may genuinely restart") are reasoned from POSIX rather than measured. That is acceptable here only because the ubuntu integration test verifies the one that matters.
+
+---
+
+## 7. What v2 got right, and what v2 introduced
+
+**Right:** the fstat pre-filter is the correct fix for the v1 hang, it needs no dependency, it costs nothing, and §2.2.1's explanation of why it *guards* rather than *replaces* the byte probe (row B fstats regular) is exactly the argument that makes the two-layer design necessary rather than belt-and-braces. §11's account of why v1's dismissal of the type check was aimed at the wrong target is honest and correct. The Q3 change from `Ok(false)` to `Err` is right for the reason given — reporting `EMFILE` as "your input is a pipe" would be the same wrong-blame one layer down — and it is now safe precisely because the type check handles the cases v1 needed `Ok(false)` for.
+
+**Introduced by v2:** nothing in the design. Two in the specification. The Q3 change to `Err` widened the surface on which an unexpected `io::Error` becomes a bare OS message, which is what makes I6 worth doing (`ENXIO` on a socket now lands there). And v2's §5 step 7, written to make FIFO tests deterministic, added rule 2 without reconciling it against step 5's writer-still-open case — so the rule introduced to remove a race specifies one (§3.3).
+
+Everything the plan asserts about its own line numbers and error strings checks out this time: `format.rs:208/211/215-217/219/227-230/231/256/273`, `fastq.rs:474/478/485`, `adapter.rs:115/268` with `MAX_SCAN_READS = 1_000_000`, `main.rs:30/51/68/178/187/1328/1900/2050/2051`, and the quoted `format.rs` comment. V4's empty-file string is correct.

--- a/plans/08032026_reject-non-restartable-input/PROGRESS.md
+++ b/plans/08032026_reject-non-restartable-input/PROGRESS.md
@@ -1,0 +1,57 @@
+# Progress: Reject non-restartable input with an accurate diagnostic
+
+**Last updated:** 2026-08-05
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | `PLAN.md`, revised twice — v1 → v2 → v3 |
+| Plan Review | ✅ Complete | Manual review, then dual agents: `PLAN_REVIEW_A.md`, `PLAN_REVIEW_B.md` |
+| Impl Plan | ✅ n/a | The design plan carries its own implementation outline (§5) |
+| Implementation | ✅ Complete | §12 implementation notes; 470 tests pass, fmt + clippy clean |
+| Code Review | ✅ Complete | Dual agents: `CODE_REVIEW_A.md`, `CODE_REVIEW_B.md`. All findings taken — §13 |
+| Coverage | ✅ Complete | `COVERAGE.md` — **COMPLETE**, 62 items, 0 missing, 0 partial |
+
+**Open before merge:** V3 — byte-identity against Perl Trim Galore 0.6.11 needs the CI `validation` / `validation-ubam` jobs. Cannot be run locally.
+
+## Issue
+
+[#379](https://github.com/FelixKrueger/TrimGalore/issues/379) — `<(zcat reads.fq.gz)`, `/dev/stdin` and FIFOs could not be read. Scope: option **A** of three — reject accurately, do **not** add pipe support (§10 costs B and C).
+
+## What shipped
+
+Three layers, each covering what the others cannot:
+
+1. **`Cli::validate`** — a path `stat` (replacing `exists()`, so zero extra syscalls) names a pipe, FIFO or socket before anything opens it. This is the only layer that can diagnose a **writer-less FIFO**, because `fs::metadata` returns where `File::open` blocks forever.
+2. **`detect_input_format`** — an `fstat` on the handle it already holds, before the first `read`.
+3. **The second-open check** — not restartable if `stream_position() != 0` **or** a length-aware leading-byte comparison fails.
+
+Plus `--passthrough` routed through the guard, a uBAM `--passthrough` rejected up front, and the `--demux` barcode file guarded against the blocking-open case.
+
+## The findings that shaped it
+
+Each was a claim verified against a narrower set than it named — the recurring failure of this plan.
+
+| Stage | Finding |
+|---|---|
+| Before v1 | A **seekability probe** — what #379 proposes — accepts `/dev/stdin` redirected from a regular file, which is seekable and still does not restart (`/dev/fd/N` is `dup` on Darwin). Killed by measurement |
+| Manual review of v1 | The byte comparison **alone hangs**: its own second open blocks on a FIFO whose writer has exited, the commonest FIFO shape. A design defect, recorded in v1 only as a test risk. Fixed by the fstat pre-filter |
+| Dual plan review of v2 | Both reviewers independently found the guard **missed `--passthrough` entirely**, and that v2 stamped "Verified" on a claim checked against `cli.input` only |
+| Dual code review of v3 | Both reviewers independently found the layer-0 change **regressed `--passthrough <uBAM>`** from a pre-output error to a deep failure with three empty files on disk. §3.2's justification was false and §2.4 already said why |
+
+## Why the tests are shaped the way they are
+
+`File::open` on a writer-less FIFO blocks, so a careless test hangs CI rather than failing it — which reads as a slow job, not a red X. Mitigations, all in §5.2 and §5.3:
+
+- every FIFO test bounds the call under test in-process (`recv_timeout`), because `timeout(1)` exists on neither Darwin nor `macos-latest`;
+- the integration tests use `spawn` + `kill`, never `Command::output()`, which cannot be interrupted;
+- `timeout-minutes: 45` on the job and a nextest `terminate-after` — the structural backstop that survives an implementer skipping every rule.
+
+Proven, not assumed: forcing the type check to `false` makes the FIFO test **fail in 10 s** with `blocked; it must fail, not hang`.
+
+## History
+
+- 2026-08-03: Plan → ✅. Scope A confirmed after three options were costed
+- 2026-08-04: v2 after manual review (fstat pre-filter); dual plan review; v3 (`--passthrough`, offset predicate, CI backstop); implementation; dual code review + coverage audit; fix round — all findings taken
+- 2026-08-05: Committed on `fix/reject-non-restartable-input`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -479,6 +479,27 @@ where
         .collect()
 }
 
+/// Existence + restartability check for a path the run will re-read (#379).
+///
+/// `stat` rather than `exists()` so a pipe or FIFO is named here, before
+/// anything opens it — `File::open` on a FIFO with no writer blocks forever,
+/// which is a hang with no message rather than a diagnostic.
+fn check_restartable_input(path: &std::path::Path, not_found: &str) -> anyhow::Result<()> {
+    let meta = std::fs::metadata(path).map_err(|e| {
+        // Only NotFound is "not found"; reporting EACCES or EMFILE that way is
+        // the wrong-blame this guard exists to remove.
+        if e.kind() == std::io::ErrorKind::NotFound {
+            anyhow::anyhow!("{not_found}: {}", path.display())
+        } else {
+            anyhow::Error::new(e).context(format!("Cannot stat input file: {}", path.display()))
+        }
+    })?;
+    if let Some(kind) = crate::format::non_restartable_kind(&meta) {
+        anyhow::bail!("{}", crate::format::not_restartable_message(path, kind));
+    }
+    Ok(())
+}
+
 impl Cli {
     /// Shared validation for any paired-end mode (`--paired`, `--clock`,
     /// `--implicon`) that takes input files in pairwise (R1, R2, R1, R2, …)
@@ -880,10 +901,9 @@ impl Cli {
             if self.demux.is_some() {
                 anyhow::bail!("--passthrough is not compatible with --demux");
             }
-            // 1.viii — file must exist
-            if !pt.exists() {
-                anyhow::bail!("--passthrough file not found: {}", pt.display());
-            }
+            // 1.viii — file must exist, and must be re-readable (#379): the
+            // passthrough stream is opened once to sanity-check and again to read.
+            check_restartable_input(pt, "--passthrough file not found")?;
             // 1.ix — case-folded collision with R1/R2 (issue #216-style APFS/NTFS guard).
             // self.input.len() == 2 here per 1.ii. The plan's main.rs::run pre-flight
             // catches case-only output collisions; this catches case-only INPUT aliases
@@ -923,16 +943,14 @@ impl Cli {
             if self.paired {
                 anyhow::bail!("Demultiplexing is only allowed for single-end files");
             }
-            if !demux_file.exists() {
-                anyhow::bail!("Barcode file not found: {}", demux_file.display());
-            }
+            // Read once, so restartability does not apply — but a writer-less FIFO
+            // here blocks after the whole trim run has completed (#379 review).
+            check_restartable_input(demux_file, "Barcode file not found")?;
         }
 
-        // Check input files exist
+        // Check input files exist and can be re-read from the start (#379)
         for path in &self.input {
-            if !path.exists() {
-                anyhow::bail!("Input file not found: {}", path.display());
-            }
+            check_restartable_input(path, "Input file not found")?;
         }
 
         // #369 — say when -a2 cannot be used, otherwise validate it up front so a

--- a/src/format.rs
+++ b/src/format.rs
@@ -13,12 +13,18 @@
 //! BGZF-framed FASTQ — as BAM, because the framing is identical. The only
 //! safe discriminator is the decompressed payload. Both plan reviewers
 //! caught this (A-C2 + B-Crit-2).
+//!
+//! Input that cannot be re-read from the start is rejected before either stage
+//! (#379): every pass over an input re-opens the path.
 
 use anyhow::{Context, Result, bail};
 use flate2::read::MultiGzDecoder;
 use std::fs::File;
-use std::io::Read;
+use std::io::{Read, Seek};
 use std::path::Path;
+
+/// Bytes peeked to classify the container format.
+const PEEK_LEN: usize = 4;
 
 /// Classification of an input file's container format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -200,6 +206,124 @@ pub fn reject_bam_format_mismatch_in_pair(
     Ok(())
 }
 
+/// Why an input cannot be re-read from the start (issue #379).
+pub(crate) enum NotRestartable {
+    /// A pipe or FIFO, named by its file type.
+    Pipe,
+    /// A socket, named by its file type.
+    Socket,
+    /// A second open did not return to the start of the data.
+    Reopen,
+}
+
+/// The user-facing rejection. Shared by the path check in `Cli::validate` and
+/// the handle check here so the wording cannot drift; both forms contain
+/// "cannot be re-read from the start".
+pub(crate) fn not_restartable_message(path: &Path, why: NotRestartable) -> String {
+    let opening = match why {
+        NotRestartable::Pipe => format!(
+            "Input '{}' is a pipe or FIFO, not a regular file, so it cannot be \
+             re-read from the start.",
+            path.display()
+        ),
+        NotRestartable::Socket => format!(
+            "Input '{}' is a socket, not a regular file, so it cannot be \
+             re-read from the start.",
+            path.display()
+        ),
+        NotRestartable::Reopen => format!(
+            "Input '{}' cannot be re-read from the start: opening it a second \
+             time did not return to the beginning of the data.",
+            path.display()
+        ),
+    };
+    format!(
+        "{opening}\n\n\
+         Trim Galore reads each input more than once — format detection, the initial\n\
+         sanity check, and adapter auto-detection each open it independently — so it\n\
+         requires a regular file.\n\n\
+         Common causes are pipes, FIFOs, process substitution such as\n\
+         `<(zcat reads.fq.gz)`, and /dev/stdin. Write the stream to a file first:\n\n\
+         \x20   zcat reads.fq.gz > reads.fq && trim_galore [options] reads.fq"
+    )
+}
+
+/// Why `meta`'s file type cannot be re-read from the start, if it cannot.
+///
+/// Takes `Metadata` so one predicate serves both a path `stat` (which never
+/// blocks, unlike opening a writer-less FIFO) and a handle `fstat`.
+#[cfg(unix)]
+pub(crate) fn non_restartable_kind(meta: &std::fs::Metadata) -> Option<NotRestartable> {
+    use std::os::unix::fs::FileTypeExt;
+    let ft = meta.file_type();
+    if ft.is_fifo() {
+        Some(NotRestartable::Pipe)
+    } else if ft.is_socket() {
+        Some(NotRestartable::Socket)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn non_restartable_kind(_meta: &std::fs::Metadata) -> Option<NotRestartable> {
+    None
+}
+
+/// Read until `buf` is full or EOF, retrying `Interrupted`.
+///
+/// A single short `read` would make the restartability comparison wrong in both
+/// directions: it can reject a good regular file, and an empty second read
+/// compares equal as a prefix.
+fn read_filled(reader: &mut impl Read, buf: &mut [u8]) -> std::io::Result<usize> {
+    let mut n = 0;
+    while n < buf.len() {
+        match reader.read(&mut buf[n..]) {
+            Ok(0) => break,
+            Ok(k) => n += k,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(n)
+}
+
+/// True iff opening `path` a second time returns to the beginning of the data.
+///
+/// Trim Galore opens each input several times (format detection, sanity check,
+/// adapter auto-detection, the trim pass), so a path whose re-open does not
+/// restart cannot be processed. `/dev/fd/N` shares the file offset on some
+/// platforms even though it is seekable, which is why this interrogates the
+/// second handle rather than probing the first for seekability.
+///
+/// Callers must reject FIFOs first: a second open on a FIFO with no live writer
+/// blocks indefinitely. `first` must be the 1..=`PEEK_LEN` bytes the first
+/// handle actually returned — outside that range the answer is meaningless.
+fn reopen_restarts(path: &Path, first: &[u8]) -> Result<bool> {
+    debug_assert!(
+        (1..=PEEK_LEN).contains(&first.len()),
+        "reopen_restarts: `first` must be 1..={PEEK_LEN} bytes, got {}",
+        first.len()
+    );
+    let ctx = || {
+        format!(
+            "Failed to re-open input file '{}' for the restartability check",
+            path.display()
+        )
+    };
+    let mut file = File::open(path).with_context(ctx)?;
+
+    // An inherited offset is the exact signal; anything else defers to the bytes.
+    if file.stream_position().is_ok_and(|pos| pos != 0) {
+        return Ok(false);
+    }
+
+    let mut again = [0u8; PEEK_LEN];
+    let want = first.len().min(PEEK_LEN);
+    let n = read_filled(&mut file, &mut again[..want]).with_context(ctx)?;
+    Ok(n == first.len() && &again[..n] == first)
+}
+
 /// Peek the first bytes of `path` and classify by content (NOT by filename).
 ///
 /// See module-level docs for the algorithm and the rationale for the
@@ -207,13 +331,26 @@ pub fn reject_bam_format_mismatch_in_pair(
 pub fn detect_input_format(path: &Path) -> Result<InputFormat> {
     let mut file = File::open(path)
         .with_context(|| format!("Failed to open input file: {}", path.display()))?;
-    let mut peek = [0u8; 4];
-    let n = file
-        .read(&mut peek)
+
+    // Before the first `read`: a FIFO with a live writer but no data yet blocks
+    // there, and a second open with no writer blocks forever.
+    let meta = file
+        .metadata()
+        .with_context(|| format!("Failed to stat input file: {}", path.display()))?;
+    if let Some(kind) = non_restartable_kind(&meta) {
+        bail!("{}", not_restartable_message(path, kind));
+    }
+
+    let mut peek = [0u8; PEEK_LEN];
+    let n = read_filled(&mut file, &mut peek)
         .with_context(|| format!("Failed to read from {}", path.display()))?;
 
     if n == 0 {
         bail!("Input file '{}' is empty", path.display());
+    }
+
+    if !reopen_restarts(path, &peek[..n])? {
+        bail!("{}", not_restartable_message(path, NotRestartable::Reopen));
     }
 
     if peek[0] == b'@' {
@@ -224,10 +361,8 @@ pub fn detect_input_format(path: &Path) -> Result<InputFormat> {
     // compression method; flate is what every modern gzip implementation
     // uses, and the BGZF spec also fixes it at 08.
     if n >= 3 && peek[0] == 0x1F && peek[1] == 0x8B && peek[2] == 0x08 {
-        // Re-open from byte 0 (cheaper than seeking and sidesteps any
-        // interaction between `MultiGzDecoder` and the already-consumed
-        // prefix; the alternative `PeekReader` wrapper in PLAN §5 step 2.3
-        // is a documented future optimization, not required for correctness).
+        // Re-open rather than seek: sidesteps a `MultiGzDecoder` interaction
+        // with the consumed prefix, and non-restartable input is rejected above.
         let file = File::open(path)?;
         let mut decoder = MultiGzDecoder::new(file);
         let mut payload = [0u8; 4];
@@ -411,8 +546,185 @@ mod tests {
         let dir = fresh_tmpdir("tg_format_empty");
         let p = dir.join("empty.fq");
         std::fs::write(&p, b"").unwrap();
-        let r = detect_input_format(&p);
-        assert!(r.is_err());
+        let msg = detect_input_format(&p)
+            .expect_err("an empty file must error")
+            .to_string();
+        // The empty check must keep winning over the #379 restartability check.
+        assert!(msg.contains("is empty"), "unexpected message: {msg}");
+        assert!(
+            !msg.contains("cannot be re-read"),
+            "empty regular file must not be reported as non-restartable: {msg}"
+        );
+    }
+
+    // ── #379: input that cannot be re-read from the start ────────────────
+    //
+    // `File::open` on a FIFO with no writer blocks, so every test below either
+    // holds the write end open or only ever `stat`s the path, and each bounds the
+    // call under test. No setup step can block: `mkfifo(1)` exits immediately and
+    // the writer's blocking open runs on its own thread.
+
+    /// Run `body` on a thread; fail rather than hang if it blocks.
+    fn bounded<T: Send + 'static>(what: &str, body: impl FnOnce() -> T + Send + 'static) -> T {
+        use std::sync::mpsc::RecvTimeoutError;
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(body());
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+            Ok(v) => v,
+            Err(RecvTimeoutError::Timeout) => panic!("{what} blocked; it must fail, not hang"),
+            // Distinct from a hang: reporting a panicking body as "blocked" would
+            // misdescribe the one failure this harness exists to identify.
+            Err(RecvTimeoutError::Disconnected) => {
+                panic!("{what} panicked; see the panic message above")
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn make_fifo(path: &std::path::Path) {
+        let st = std::process::Command::new("mkfifo")
+            .arg(path)
+            .status()
+            .expect("mkfifo must run");
+        // Without this, a failed mkfifo leaves a regular file and the test
+        // fails pointing at the guard rather than at the harness.
+        assert!(st.success(), "mkfifo {} failed", path.display());
+        use std::os::unix::fs::FileTypeExt;
+        assert!(
+            std::fs::metadata(path).unwrap().file_type().is_fifo(),
+            "fixture must be a FIFO, not a regular file"
+        );
+    }
+
+    /// Hold the write end open so a reader's `open` can complete.
+    ///
+    /// Must be a separate thread: a write-only `open` blocks until a reader
+    /// appears, so opening it on this thread would self-deadlock.
+    #[cfg(unix)]
+    fn spawn_fifo_writer(path: &std::path::Path) -> std::thread::JoinHandle<()> {
+        let p = path.to_path_buf();
+        std::thread::spawn(move || {
+            // Panic rather than return: a silent failure here leaves the reader
+            // blocking, which would be reported against the guard.
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&p)
+                .expect("FIFO writer must open");
+            // EPIPE expected: the guard drops the reader before this lands.
+            let _ = f.write_all(b"@read1\nACGT\n+\nIIII\n");
+        })
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detect_rejects_a_fifo_with_the_pipe_message() {
+        let dir = fresh_tmpdir("tg_format_fifo_detect");
+        let p = dir.join("stream.fq");
+        make_fifo(&p);
+        let _writer = spawn_fifo_writer(&p);
+        let target = p.clone();
+        let msg = bounded("detect_input_format on a FIFO", move || {
+            detect_input_format(&target)
+                .expect_err("a FIFO must be rejected")
+                .to_string()
+        });
+        assert!(
+            msg.contains("cannot be re-read from the start") && msg.contains("is a pipe or FIFO"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    /// Layer 1: a path `stat` names a FIFO *without opening it*, which is what
+    /// lets `Cli::validate` reject a writer-less FIFO instead of blocking.
+    #[cfg(unix)]
+    #[test]
+    fn path_stat_names_a_fifo_without_opening_it() {
+        let dir = fresh_tmpdir("tg_format_fifo_stat");
+        let p = dir.join("stream.fq");
+        make_fifo(&p);
+        let target = p.clone();
+        // No writer, ever: `File::open` here would block forever.
+        let meta = bounded("fs::metadata on a writer-less FIFO", move || {
+            std::fs::metadata(&target).expect("stat must not block")
+        });
+        assert!(matches!(
+            non_restartable_kind(&meta),
+            Some(NotRestartable::Pipe)
+        ));
+
+        let reg = dir.join("a.fq");
+        std::fs::write(&reg, b"@read1\nACGT\n+\nIIII\n").unwrap();
+        assert!(non_restartable_kind(&std::fs::metadata(&reg).unwrap()).is_none());
+    }
+
+    #[test]
+    fn reopen_restarts_answers_both_directions() -> Result<()> {
+        let dir = fresh_tmpdir("tg_format_reopen");
+        let p = dir.join("a.fq");
+        std::fs::write(&p, b"@read1\nACGT\n+\nIIII\n")?;
+        assert!(reopen_restarts(&p, b"@rea")?);
+        // Negative control: the comparison must be able to say no. There is no
+        // portable real-world input that reaches it and returns false.
+        assert!(!reopen_restarts(&p, b"XXXX")?);
+        Ok(())
+    }
+
+    /// A genuinely non-restartable source that cannot block.
+    #[cfg(unix)]
+    #[test]
+    fn reopen_restarts_false_for_a_streaming_char_device() -> Result<()> {
+        let p = std::path::Path::new("/dev/urandom");
+        let mut first = [0u8; PEEK_LEN];
+        let n = read_filled(&mut File::open(p)?, &mut first)?;
+        assert_eq!(n, PEEK_LEN);
+        assert!(!reopen_restarts(p, &first)?);
+        Ok(())
+    }
+
+    /// The case a byte comparison alone accepted: `/dev/fd/N` is a `dup` on
+    /// Darwin, so the second open resumes at the first one's offset and a
+    /// 4-byte file yields an empty second read that compares equal as a prefix.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn detect_rejects_dev_fd_over_a_four_byte_file() -> Result<()> {
+        use std::os::unix::io::AsRawFd;
+        let dir = fresh_tmpdir("tg_format_devfd");
+        let p = dir.join("tiny.fq");
+        std::fs::write(&p, b"@abc")?;
+        let held = File::open(&p)?;
+        let devfd = std::path::PathBuf::from(format!("/dev/fd/{}", held.as_raw_fd()));
+        let msg = detect_input_format(&devfd)
+            .expect_err("/dev/fd over a shared offset must be rejected")
+            .to_string();
+        assert!(
+            msg.contains("cannot be re-read from the start"),
+            "unexpected message: {msg}"
+        );
+        Ok(())
+    }
+
+    /// Isolates the start-offset condition. Bytes 4..8 repeat bytes 0..4, so the
+    /// byte comparison alone calls this restartable and only the offset rejects
+    /// it — the residual the plan carried as A2 until v3.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn detect_rejects_dev_fd_when_the_leading_bytes_repeat() -> Result<()> {
+        use std::os::unix::io::AsRawFd;
+        let dir = fresh_tmpdir("tg_format_devfd_repeat");
+        let p = dir.join("repeat.fq");
+        std::fs::write(&p, b"@a@a@a@a")?;
+        let held = File::open(&p)?;
+        let devfd = std::path::PathBuf::from(format!("/dev/fd/{}", held.as_raw_fd()));
+        let msg = detect_input_format(&devfd)
+            .expect_err("a repeating prefix must not defeat the check")
+            .to_string();
+        assert!(
+            msg.contains("cannot be re-read from the start"),
+            "unexpected message: {msg}"
+        );
+        Ok(())
     }
 
     // ── reject_bam_format_mismatch_in_pair (#363) ──────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,6 +231,16 @@ fn main() -> Result<()> {
              Either convert the uBAM to FASTQ via `samtools fastq` first, or drop --passthrough."
         );
     }
+    // `any_bam` is computed from `cli.input`; the passthrough file is a separate
+    // surface, so it needs its own format check — before any output is created.
+    if let Some(ref pt) = cli.passthrough
+        && matches!(detect_input_format(pt)?, InputFormat::UnalignedBam)
+    {
+        anyhow::bail!(
+            "--passthrough is not supported with uBAM input in this release. \
+             Either convert the uBAM to FASTQ via `samtools fastq` first, or drop --passthrough."
+        );
+    }
     if cli.paired && cli.input.len() == 1 && !matches!(input_formats[0], InputFormat::UnalignedBam)
     {
         anyhow::bail!(
@@ -737,10 +747,12 @@ fn main() -> Result<()> {
             sanity_check_any(&chunk[1])?;
             // --passthrough: sanity-check the third file once (Cli::validate
             // already enforces single-pair-only when passthrough is set).
+            // `sanity_check_any`, not `FastqReader::sanity_check`, so the
+            // passthrough path reaches the #379 restartability guard.
             if pair_idx == 0
                 && let Some(ref pt_path) = cli.passthrough
             {
-                FastqReader::sanity_check(pt_path)?;
+                sanity_check_any(pt_path)?;
             }
 
             let (_label, adapters_r1, adapters_r2, config) = setup_trimming(&cli, &chunk[0])?;

--- a/tests/integration_non_restartable_input.rs
+++ b/tests/integration_non_restartable_input.rs
@@ -1,0 +1,324 @@
+//! Binary-driven integration tests for issue #379 — input that cannot be
+//! re-read from the start.
+//!
+//! Trim Galore opens each input several times (format detection, sanity check,
+//! adapter auto-detection, the trim pass), so a stream cannot be processed.
+//! Before the fix these inputs either blamed the user's data for the format
+//! (`doesn't seem to be in FastQ format`), blamed the compression (`Failed to
+//! decompress first block`), or — for a FIFO — hung with no message at all.
+//!
+//! Every child here is bounded and killed rather than waited on:
+//! `Command::output()` reads both pipes to EOF, so a child blocked in `open()`
+//! would never return and the test would look like a slow job, not a failure.
+
+#![cfg(unix)]
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+const REJECTION: &str = "cannot be re-read from the start";
+
+fn binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_trim_galore"))
+}
+
+/// One directory per test: a shared slug would let one nextest process unlink
+/// another's FIFO.
+fn fresh_dir(slug: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(slug);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write_fastq(path: &Path) {
+    let mut body = String::new();
+    for i in 0..8 {
+        body.push_str(&format!(
+            "@read{i}\nACGTACGTACGTACGTACGT\n+\nIIIIIIIIIIIIIIIIIIII\n"
+        ));
+    }
+    std::fs::write(path, body).unwrap();
+}
+
+fn make_fifo(path: &Path) {
+    let st = Command::new("mkfifo")
+        .arg(path)
+        .status()
+        .expect("mkfifo must run");
+    assert!(st.success(), "mkfifo {} failed", path.display());
+    use std::os::unix::fs::FileTypeExt;
+    assert!(
+        std::fs::metadata(path).unwrap().file_type().is_fifo(),
+        "fixture must be a FIFO; a regular file would test nothing"
+    );
+}
+
+/// Run `cmd` with a hard time bound. Returns `(succeeded, stderr)`.
+fn run_bounded(mut cmd: Command, what: &str) -> (bool, String) {
+    let mut child = cmd
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|e| panic!("failed to spawn {what}: {e}"));
+
+    // Drain stderr concurrently so a child writing more than the pipe buffer
+    // cannot deadlock against our wait loop.
+    let mut pipe = child.stderr.take().expect("stderr is piped");
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut s = String::new();
+        let _ = pipe.read_to_string(&mut s);
+        let _ = tx.send(s);
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let status = loop {
+        match child.try_wait().expect("try_wait failed") {
+            Some(st) => break st,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                // Drain before panicking: on the failure that matters most, the
+                // binary's own output is the only useful diagnostic.
+                let stderr = rx.recv_timeout(Duration::from_secs(5)).unwrap_or_default();
+                panic!("{what} never exited; it must fail, not hang. stderr was: {stderr}");
+            }
+            None => std::thread::sleep(Duration::from_millis(25)),
+        }
+    };
+    let stderr = rx.recv_timeout(Duration::from_secs(5)).unwrap_or_default();
+    (status.success(), stderr)
+}
+
+/// A FIFO with no writer at all. `File::open` on this blocks forever, so before
+/// the fix this hung; the path `stat` in `Cli::validate` is what makes it fail.
+#[test]
+fn fifo_input_is_rejected_and_creates_no_output() {
+    let dir = fresh_dir("tg_379_fifo_in");
+    let fifo = dir.join("stream.fq");
+    make_fifo(&fifo);
+    let out = dir.join("out");
+
+    let mut cmd = Command::new(binary());
+    cmd.arg("-o").arg(&out).arg(&fifo);
+    let (ok, stderr) = run_bounded(cmd, "trim_galore on a FIFO");
+
+    assert!(!ok, "a FIFO must be rejected; stderr was: {stderr}");
+    assert!(stderr.contains(REJECTION), "unexpected message: {stderr}");
+    assert!(
+        stderr.contains("is a pipe or FIFO"),
+        "unexpected message: {stderr}"
+    );
+    assert!(
+        !out.exists(),
+        "rejection must happen before any output directory is created"
+    );
+}
+
+/// Plain FASTQ down a pipe. The old failure blamed the data's format.
+#[test]
+fn dev_stdin_from_a_plain_pipe_is_rejected() {
+    let dir = fresh_dir("tg_379_stdin_plain");
+    let fq = dir.join("reads.fastq");
+    write_fastq(&fq);
+    let out = dir.join("out");
+
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(format!(
+        "cat '{}' | '{}' -o '{}' /dev/stdin",
+        fq.display(),
+        binary().display(),
+        out.display()
+    ));
+    let (ok, stderr) = run_bounded(cmd, "trim_galore on /dev/stdin from a pipe");
+
+    assert!(!ok, "a pipe must be rejected; stderr was: {stderr}");
+    assert!(stderr.contains(REJECTION), "unexpected message: {stderr}");
+    // Negative control for this row specifically.
+    assert!(
+        !stderr.contains("doesn't seem to be in FastQ format"),
+        "must not blame the data's format: {stderr}"
+    );
+}
+
+/// Gzipped FASTQ down a pipe. This row's old failure was a *different* wrong
+/// message — the gzip branch re-opens and `MultiGzDecoder` chokes on the
+/// consumed prefix — so it needs its own negative control.
+#[test]
+fn dev_stdin_from_a_gzipped_pipe_is_rejected() {
+    let dir = fresh_dir("tg_379_stdin_gz");
+    let fq = dir.join("reads.fastq");
+    write_fastq(&fq);
+    let out = dir.join("out");
+
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(format!(
+        "gzip -c '{}' | '{}' -o '{}' /dev/stdin",
+        fq.display(),
+        binary().display(),
+        out.display()
+    ));
+    let (ok, stderr) = run_bounded(cmd, "trim_galore on a gzipped pipe");
+
+    assert!(!ok, "a gzipped pipe must be rejected; stderr was: {stderr}");
+    assert!(stderr.contains(REJECTION), "unexpected message: {stderr}");
+    assert!(
+        !stderr.contains("Failed to decompress first block"),
+        "must not blame the compression: {stderr}"
+    );
+}
+
+/// `--passthrough` is a separate CLI surface from `cli.input`, and it reached
+/// none of the format-detection guards. Both plan reviewers found this
+/// independently; before the fix a FIFO here hung *after* the R1/R2 writers had
+/// been created, leaving partial output on disk.
+#[test]
+fn passthrough_fifo_is_rejected_and_creates_no_output() {
+    let dir = fresh_dir("tg_379_passthrough");
+    let r1 = dir.join("r1.fastq");
+    let r2 = dir.join("r2.fastq");
+    write_fastq(&r1);
+    write_fastq(&r2);
+    let fifo = dir.join("index.fq");
+    make_fifo(&fifo);
+    let out = dir.join("out");
+
+    let mut cmd = Command::new(binary());
+    cmd.arg("--paired")
+        .arg("-o")
+        .arg(&out)
+        .arg("--passthrough")
+        .arg(&fifo)
+        .arg(&r1)
+        .arg(&r2);
+    let (ok, stderr) = run_bounded(cmd, "trim_galore --passthrough on a FIFO");
+
+    assert!(
+        !ok,
+        "a FIFO passthrough must be rejected; stderr was: {stderr}"
+    );
+    assert!(stderr.contains(REJECTION), "unexpected message: {stderr}");
+    assert!(
+        !out.exists(),
+        "rejection must precede output creation, or a hang leaves partial output"
+    );
+}
+
+/// A uBAM passthrough must be rejected before any output exists. The existing
+/// uBAM rejection computes `any_bam` from `cli.input` only, so routing the
+/// passthrough file through `sanity_check_any` made it *pass* — the BAM arm
+/// accepts it — and the run then died in the FASTQ reader with three empty
+/// output files on disk.
+#[test]
+fn passthrough_ubam_is_rejected_before_output() {
+    let dir = fresh_dir("tg_379_passthrough_ubam");
+    let r1 = dir.join("r1.fastq");
+    let r2 = dir.join("r2.fastq");
+    write_fastq(&r1);
+    write_fastq(&r2);
+    let out = dir.join("out");
+
+    let mut cmd = Command::new(binary());
+    cmd.arg("--paired")
+        .arg("-o")
+        .arg(&out)
+        .arg("--passthrough")
+        .arg("test_files/ubam_test.bam")
+        .arg(&r1)
+        .arg(&r2);
+    let (ok, stderr) = run_bounded(cmd, "trim_galore --passthrough on a uBAM");
+
+    assert!(!ok, "a uBAM passthrough must be rejected; stderr: {stderr}");
+    assert!(
+        stderr.contains("not supported with uBAM input"),
+        "unexpected message: {stderr}"
+    );
+    assert!(
+        !stderr.contains("valid UTF-8"),
+        "must not fail deep in the FASTQ reader: {stderr}"
+    );
+    assert!(
+        !out.join("r1_val_1.fq").exists(),
+        "must reject before writing output"
+    );
+}
+
+/// The class layer 1 cannot see: `/dev/fd/N` over a regular file `stat`s as a
+/// regular file, so only the second-open check rejects it. macOS-only because
+/// Linux resolves `/dev/stdin` through `/proc` and genuinely restarts there.
+#[cfg(target_os = "macos")]
+#[test]
+fn passthrough_dev_stdin_is_rejected() {
+    let dir = fresh_dir("tg_379_passthrough_devfd");
+    let r1 = dir.join("r1.fastq");
+    let r2 = dir.join("r2.fastq");
+    let idx = dir.join("idx.fastq");
+    write_fastq(&r1);
+    write_fastq(&r2);
+    write_fastq(&idx);
+    let out = dir.join("out");
+
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(format!(
+        "'{}' --paired -o '{}' --passthrough /dev/stdin '{}' '{}' < '{}'",
+        binary().display(),
+        out.display(),
+        r1.display(),
+        r2.display(),
+        idx.display()
+    ));
+    let (ok, stderr) = run_bounded(cmd, "trim_galore --passthrough /dev/stdin");
+
+    assert!(!ok, "stderr was: {stderr}");
+    assert!(stderr.contains(REJECTION), "unexpected message: {stderr}");
+}
+
+/// The barcode file is read once, so restartability does not apply — but a
+/// writer-less FIFO blocked in `File::open` after trimming and reporting had
+/// already finished.
+#[test]
+fn demux_fifo_barcode_file_is_rejected() {
+    let dir = fresh_dir("tg_379_demux");
+    let fq = dir.join("reads.fastq");
+    write_fastq(&fq);
+    let fifo = dir.join("barcodes.txt");
+    make_fifo(&fifo);
+    let out = dir.join("out");
+
+    let mut cmd = Command::new(binary());
+    cmd.arg("-o").arg(&out).arg("--demux").arg(&fifo).arg(&fq);
+    let (ok, stderr) = run_bounded(cmd, "trim_galore --demux on a FIFO");
+
+    assert!(
+        !ok,
+        "a FIFO barcode file must be rejected; stderr: {stderr}"
+    );
+    assert!(stderr.contains(REJECTION), "unexpected message: {stderr}");
+    assert!(
+        !out.exists(),
+        "rejection must precede trimming, not follow it"
+    );
+}
+
+/// Positive control: the guard must not reject an ordinary regular file. Without
+/// this, every assertion above would pass on a build that rejected everything.
+#[test]
+fn regular_file_still_runs() {
+    let dir = fresh_dir("tg_379_control");
+    let fq = dir.join("reads.fastq");
+    write_fastq(&fq);
+    let out = dir.join("out");
+
+    let mut cmd = Command::new(binary());
+    cmd.arg("-o").arg(&out).arg("--dont_gzip").arg(&fq);
+    let (ok, stderr) = run_bounded(cmd, "trim_galore on a regular file");
+
+    assert!(ok, "a regular file must still trim; stderr was: {stderr}");
+    assert!(
+        !stderr.contains(REJECTION),
+        "regular file wrongly rejected: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes #379.

Trim Galore opens each input at least five times, so it cannot read a stream. Streams failed as though the user's data were at fault — `<(cat reads.fastq)` reported `doesn't seem to be in FastQ format`, a gzipped pipe reported `Failed to decompress first block`, and a named FIFO hung indefinitely with no message. All three now fail immediately, naming the constraint and giving the remedy. This is a diagnostic change, not a capability change: piped input did not work before and still does not.

Three layers, because no single check is sufficient:

- **`Cli::validate`** stats each path (replacing `exists()`, so no extra syscalls). Only this layer can diagnose a **writer-less FIFO**, because `fs::metadata` returns where `File::open` blocks forever.
- **`detect_input_format`** `fstat`s the handle it already holds, before the first `read`.
- **A second open** must start at offset 0 and return the same leading bytes.

`--passthrough` reached none of the format guards, so a stream there hung *after* the R1/R2 output files existed. It now passes through the guard, and a uBAM passthrough is rejected up front instead of failing mid-run with `stream did not contain valid UTF-8`.

Two smaller behaviour changes: a pipe or FIFO `--demux` barcode file is now rejected (read once, so restartability does not apply — but a writer-less FIFO blocked with no message *after* trimming and reporting had finished), and an empty FIFO reports as a pipe rather than as an empty file.

**Merge order:** ideally after #374, which touches the same two files. No overlapping hunks, so this is line shifts rather than conflicts — but #374 is an external contributor's and is green, so this branch should absorb the rebase.

<details>
<summary>Design rationale, verification, and what the reviews changed (AI-assisted)</summary>

Full record in `plans/08032026_reject-non-restartable-input/` — design, measurements with probe sources, two independent plan reviews, two independent code reviews, and a coverage audit.

**Both obvious guards were measured wrong.** A seekability probe — what the issue proposes — accepts `/dev/stdin` redirected from a regular file: that fd *is* seekable and still does not restart, because opening `/dev/fd/N` is `dup` on Darwin and shares the offset. A file-type check cannot replace the second-open test either, since that same input `stat`s as a regular file. And the byte comparison cannot stand alone: its own second open blocks forever on a FIFO whose writer has exited, which is the commonest FIFO shape (`mkfifo f; cat reads.fq > f &`).

Interrogating the **second** handle's start offset, rather than probing the first for seekability, makes the check exact rather than heuristic, and retires the residual where a stream repeating its first four bytes would defeat a byte comparison.

**Test discipline.** A test that opens a writer-less FIFO blocks rather than fails, which reads as a slow job rather than a red X. So every FIFO test bounds itself in-process (`timeout(1)` exists on neither Darwin nor `macos-latest`), the integration tests `spawn`-and-`kill` rather than use `Command::output()` (which cannot be interrupted), and the job now carries `timeout-minutes` plus a nextest `terminate-after`. Proven rather than assumed: forcing the type check to return `false` makes the FIFO test **fail in 10 s** with `blocked; it must fail, not hang`.

**Verification.** 470 tests pass; `fmt` and `clippy --all-targets --release -D warnings` clean. Output byte-identity confirmed against a build of the parent commit for SE-gz, SE-plain, and PE at `--cores 1` and `--cores 4`, each with a sentinel negative control. Byte-identity against Perl Trim Galore 0.6.11 could not be checked locally — **this PR's `Validate vs Perl TrimGalore` job is that check.**

**What review changed, three times.** Each revision was forced by the same class of error: a claim verified against a narrower set than it named.

| Stage | Finding |
|---|---|
| Before v1 | Seekability is a proxy for restartability, not the property itself. Measurement refuted it |
| Manual review of v1 | The byte comparison alone **hangs** on the commonest FIFO shape — a design defect recorded only as a test risk |
| Dual plan review of v2 | `--passthrough` was unguarded; the placement claim was stamped "Verified" against `cli.input` alone |
| Dual code review of v3 | The fix for that **regressed** `--passthrough <uBAM>` from a pre-output error to a deep failure leaving three empty files, on a justification the plan itself refuted two sections earlier |

Both reviewers at both stages independently found the same top finding.

**Known and deliberately not covered:** `trim_galore /dev/stdin` at an interactive terminal still waits for input (that is a terminal, not a pipe; telling them apart needs `isatty`), and an adapter FASTA given as `-a file:x.fa` is also read twice but is left unguarded as out of scope. Both recorded in the plan.

</details>
