### PR TITLE
fix(io): strip .bgz/.bgzf so output and report share a stem (#381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,27 @@
   BAM discrimination is unaffected: `detect_input_format` still owns the
   `BAM\1` payload check, and a `.bam` renamed `.fq.gz` is still read as BAM.
 
-  Two known limitations, both left to separate changes:
+  One known limitation remains, left to a separate change: output compression
+  still mirrors the input *filename*, so a `.bgz` input produces plain `.fq`
+  output. Moving that decision would change behaviour for every run, including
+  the misnamed-`.gz` file whose input handling changed above.
 
-  - Output compression still mirrors the input *filename*, so a `.bgz` input
-    produces plain `.fq` output. Moving that decision would change behaviour
-    for every run, including the misnamed-`.gz` file whose input handling
-    changed above.
-  - `.bgz` is not in the extension-stripping list, so a `sample.fq.bgz` input
-    produces `sample.fq_trimmed.fq` alongside
-    `sample.fq.bgz_trimming_report.txt`. MultiQC takes the sample name from
-    the report filename, so the two disagree.
+- **`.bgz` / `.bgzf` input no longer leaves an inner `.fastq` in the output
+  filename** ([#381](https://github.com/FelixKrueger/TrimGalore/issues/381)).
+  `sample.fastq.bgz` produced `sample.fastq_trimmed.fq` alongside
+  `sample.fastq.bgz_trimming_report.txt`; the two disagreed about the sample
+  name, and MultiQC takes that name from the report filename, so a trimmed
+  file and its report could land under different samples. The output is now
+  `sample_trimmed.fq`, matching what the same bytes under a `.fastq.gz` name
+  have always produced.
+
+  `io::strip_fastq_extensions` now removes a gzip-family suffix (`.gz`,
+  `.bgz`, `.bgzf`) and then the FASTQ extension, instead of matching an
+  enumerated list of combined suffixes. Names with no inner `.fastq`/`.fq`
+  (`sample.bgz`), `.bam` inputs and unrelated extensions keep the stems they
+  had. Output *filenames* only: no fixture in `test_files/` or in the
+  `validation` matrix is named `.bgz`, so the Perl-0.6.11 byte-identity
+  comparison is untouched.
 
 #### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,20 @@
   `io::strip_fastq_extensions` now removes a gzip-family suffix (`.gz`,
   `.bgz`, `.bgzf`) and then the FASTQ extension, instead of matching an
   enumerated list of combined suffixes. Names with no inner `.fastq`/`.fq`
-  (`sample.bgz`), `.bam` inputs and unrelated extensions keep the stems they
-  had. Output *filenames* only: no fixture in `test_files/` or in the
+  are unaffected where they carry a single extension (`sample.bgz` →
+  `sample`). A multi-component name now loses one component more than before
+  (`sample.txt.bgz` → `sample`, previously `sample.txt`), matching what
+  `.gz` has always done. `.bam` inputs and unrelated extensions keep the
+  stems they had.
+
+  The specialty modes name their outputs from the same stem, so they shift
+  too. `--implicon` on `sample_R1.fastq.bgz` now writes
+  `sample_8bp_UMI_R1.fastq` where it wrote `sample_R1.fastq_8bp_UMI_R1.fastq`:
+  its R1/R2 de-duplication only fires on a stem ending in `_R1`, which the
+  old stem never did, so the doubled read tag disappears as well.
+  `--hardtrim5`, `--hardtrim3` and `--clock` shift in the same direction.
+
+  Output *filenames* only: no fixture in `test_files/` or in the
   `validation` matrix is named `.bgz`, so the Perl-0.6.11 byte-identity
   comparison is untouched.
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -435,15 +435,8 @@ pub fn json_report_name(input: &Path, output_dir: Option<&Path>) -> PathBuf {
 /// suffix: `.gz`, or the `.bgz` / `.bgzf` names `bgzip` output is often
 /// given. The two suffix groups are stripped in sequence rather than
 /// enumerated as a combined list, so adding one compression name does not
-/// multiply the cases.
-///
-/// The `.bgz` forms matter because since
-/// [#374](https://github.com/FelixKrueger/TrimGalore/pull/374) such a file is
-/// *read* correctly (gzip-ness comes from the file's first three bytes, not
-/// its name). Before this stripped them too, `sample.fq.bgz` produced
-/// `sample.fq_trimmed.fq` alongside `sample.fq.bgz_trimming_report.txt`, the
-/// output and the report disagreeing about the sample name, which is what
-/// MultiQC groups on
+/// multiply the cases. The `.bgz` forms are here because such a file is read
+/// correctly since #374, and its output name has to follow
 /// ([#381](https://github.com/FelixKrueger/TrimGalore/issues/381)).
 ///
 /// Anything else (a `.bam` input, an unrelated extension) falls through to
@@ -525,6 +518,13 @@ mod tests {
         // below does not lose it.
         assert_eq!(strip_fastq_extensions(Path::new("sample.bgz")), "sample");
         assert_eq!(strip_fastq_extensions(Path::new("sample.bgzf")), "sample");
+        // Multi-component name with no inner .fastq/.fq: the fallback now runs
+        // on the already-stripped name, so one more component goes than before
+        // (this was `sample.txt`). That is what `.txt.gz` has always done.
+        assert_eq!(
+            strip_fastq_extensions(Path::new("sample.txt.bgz")),
+            "sample"
+        );
     }
 
     /// The non-FASTQ names that reach this function must keep their existing

--- a/src/io.rs
+++ b/src/io.rs
@@ -431,7 +431,23 @@ pub fn json_report_name(input: &Path, output_dir: Option<&Path>) -> PathBuf {
 
 /// Strip FASTQ extensions from a filename, returning just the base stem.
 ///
-/// Handles: .fastq.gz, .fastq, .fq.gz, .fq
+/// Handles `.fastq` / `.fq`, each optionally followed by a gzip-family
+/// suffix: `.gz`, or the `.bgz` / `.bgzf` names `bgzip` output is often
+/// given. The two suffix groups are stripped in sequence rather than
+/// enumerated as a combined list, so adding one compression name does not
+/// multiply the cases.
+///
+/// The `.bgz` forms matter because since
+/// [#374](https://github.com/FelixKrueger/TrimGalore/pull/374) such a file is
+/// *read* correctly (gzip-ness comes from the file's first three bytes, not
+/// its name). Before this stripped them too, `sample.fq.bgz` produced
+/// `sample.fq_trimmed.fq` alongside `sample.fq.bgz_trimming_report.txt`, the
+/// output and the report disagreeing about the sample name, which is what
+/// MultiQC groups on
+/// ([#381](https://github.com/FelixKrueger/TrimGalore/issues/381)).
+///
+/// Anything else (a `.bam` input, an unrelated extension) falls through to
+/// `Path::file_stem`, which drops the final component only.
 pub fn strip_fastq_extensions(path: &Path) -> String {
     let name = path
         .file_name()
@@ -439,21 +455,21 @@ pub fn strip_fastq_extensions(path: &Path) -> String {
         .to_string_lossy()
         .to_string();
 
-    // Strip extensions in order of specificity
-    for ext in &[".fastq.gz", ".fq.gz", ".fastq", ".fq"] {
-        if name.ends_with(ext) {
-            return name[..name.len() - ext.len()].to_string();
+    // Strip one gzip-family suffix, if present. These are disjoint: `.bgz`
+    // does not end in `.gz`, so the order within the list does not matter.
+    let stem = [".gz", ".bgz", ".bgzf"]
+        .iter()
+        .find_map(|ext| name.strip_suffix(ext))
+        .unwrap_or(&name);
+
+    // Then the FASTQ extension itself, longest first.
+    for ext in [".fastq", ".fq"] {
+        if let Some(base) = stem.strip_suffix(ext) {
+            return base.to_string();
         }
     }
 
-    // Fallback: strip .gz then whatever extension remains
-    let name = if name.ends_with(".gz") {
-        &name[..name.len() - 3]
-    } else {
-        &name
-    };
-
-    Path::new(name)
+    Path::new(stem)
         .file_stem()
         .unwrap_or_default()
         .to_string_lossy()
@@ -477,6 +493,49 @@ mod tests {
             strip_fastq_extensions(Path::new("sample_R1.fq.gz")),
             "sample_R1"
         );
+    }
+
+    /// REGRESSION ([#381](https://github.com/FelixKrueger/TrimGalore/issues/381)).
+    /// `bgzip` output is commonly named `.bgz`/`.bgzf`, and since #374 such a
+    /// file is read correctly. The stem has to follow, or `sample.fq.bgz`
+    /// produces `sample.fq_trimmed.fq` next to
+    /// `sample.fq.bgz_trimming_report.txt` and the two disagree about the
+    /// sample name (which is what MultiQC groups on).
+    #[test]
+    fn test_strip_fastq_extensions_bgz() {
+        assert_eq!(
+            strip_fastq_extensions(Path::new("sample.fastq.bgz")),
+            "sample"
+        );
+        assert_eq!(strip_fastq_extensions(Path::new("sample.fq.bgz")), "sample");
+        assert_eq!(
+            strip_fastq_extensions(Path::new("sample.fastq.bgzf")),
+            "sample"
+        );
+        assert_eq!(
+            strip_fastq_extensions(Path::new("sample.fq.bgzf")),
+            "sample"
+        );
+        assert_eq!(
+            strip_fastq_extensions(Path::new("sample_R1.fq.bgz")),
+            "sample_R1"
+        );
+        // Bare compression suffix, no inner .fastq/.fq. The old fallback
+        // already handled this one via `file_stem`; pinned so the rewrite
+        // below does not lose it.
+        assert_eq!(strip_fastq_extensions(Path::new("sample.bgz")), "sample");
+        assert_eq!(strip_fastq_extensions(Path::new("sample.bgzf")), "sample");
+    }
+
+    /// The non-FASTQ names that reach this function must keep their existing
+    /// stems: `.bam` inputs (uBAM), bare `.gz`, and unrelated extensions all
+    /// fall through to `file_stem`.
+    #[test]
+    fn test_strip_fastq_extensions_leaves_other_names_alone() {
+        assert_eq!(strip_fastq_extensions(Path::new("sample.bam")), "sample");
+        assert_eq!(strip_fastq_extensions(Path::new("sample.gz")), "sample");
+        assert_eq!(strip_fastq_extensions(Path::new("sample.txt.gz")), "sample");
+        assert_eq!(strip_fastq_extensions(Path::new("sample")), "sample");
     }
 
     #[test]

--- a/src/specialty.rs
+++ b/src/specialty.rs
@@ -795,4 +795,36 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
         Ok(())
     }
+
+    // --- Output naming on `.bgz` input (#381) ---
+
+    /// REGRESSION ([#381](https://github.com/FelixKrueger/TrimGalore/issues/381)).
+    /// Every specialty mode names its output from the same stripped stem, so
+    /// teaching the stripper about `.bgz` moves these filenames too.
+    ///
+    /// For `--implicon` it fixes a second fault rather than only tidying the
+    /// name: the R1/R2 de-duplication above fires on a stem ending in `_R1`,
+    /// which `sample_R1.fastq.bgz` never produced (its stem was
+    /// `sample_R1.fastq`), so the read tag appeared twice. Pinned here because
+    /// nothing else in the suite runs a specialty mode on a `.bgz` name.
+    #[test]
+    fn bgz_stem_reaches_specialty_output_names() {
+        assert_eq!(
+            implicon_output_name(Path::new("sample_R1.fastq.bgz"), 8, "R1", None, false),
+            PathBuf::from("sample_8bp_UMI_R1.fastq"),
+            "implicon R1: the doubled read tag must be gone"
+        );
+        assert_eq!(
+            implicon_output_name(Path::new("sample_R2.fq.bgzf"), 8, "R2", None, false),
+            PathBuf::from("sample_8bp_UMI_R2.fastq")
+        );
+        assert_eq!(
+            hardtrim_output_name(Path::new("sample.fastq.bgz"), 50, "5prime", None, false),
+            PathBuf::from("sample.50bp_5prime.fq")
+        );
+        assert_eq!(
+            clock_output_name(Path::new("sample_R1.fq.bgz"), "R1", None, false),
+            PathBuf::from("sample_R1.clock_UMI.R1.fq")
+        );
+    }
 }

--- a/tests/integration_gzip_non_gz_extension.rs
+++ b/tests/integration_gzip_non_gz_extension.rs
@@ -76,12 +76,10 @@ fn sample_reads(tag: &str) -> String {
 /// asymmetry is deliberate and documented; these tests care that the reads are
 /// correct, not how they are framed.
 ///
-/// Note the stems the callers pass: a `.bgz` input is not recognised by
-/// `io::strip_fastq_extensions`, so `pair_R1.fq.bgz` yields
-/// `pair_R1.fq_val_1.fq`, with the inner `.fq` still in the name. That is a
-/// known cosmetic wart (the report file disagrees with the output file, which
-/// matters to MultiQC) and is filed for a separate change; these tests encode
-/// current behaviour rather than the behaviour we would prefer.
+/// The stems the callers pass are the tidy ones: since #381
+/// `io::strip_fastq_extensions` recognises the `.bgz` forms, so
+/// `pair_R1.fq.bgz` yields `pair_R1_val_1.fq` with no inner `.fq` left in the
+/// name. `bgz_output_and_report_agree_on_the_stem` below pins that directly.
 fn read_output(dir: &Path, stem: &str) -> String {
     let text = read_output_raw(dir, stem);
     assert!(
@@ -127,7 +125,7 @@ fn single_end_bgz_input_is_decompressed() {
         "single-end .bgz must succeed. stderr:\n{}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let trimmed = read_output(&dir, "sample.fq_trimmed");
+    let trimmed = read_output(&dir, "sample_trimmed");
     assert!(
         trimmed.contains("@se_0"),
         "trimmed output must contain the reads, got:\n{trimmed}"
@@ -166,8 +164,8 @@ fn paired_bgz_input_serial_is_decompressed() {
         "paired .bgz at --cores 1 must succeed. stderr:\n{}",
         String::from_utf8_lossy(&out.stderr)
     );
-    assert!(read_output(&dir, "pair_R1.fq_val_1").contains("@pe1_0"));
-    assert!(read_output(&dir, "pair_R2.fq_val_2").contains("@pe2_0"));
+    assert!(read_output(&dir, "pair_R1_val_1").contains("@pe1_0"));
+    assert!(read_output(&dir, "pair_R2_val_2").contains("@pe2_0"));
 }
 
 /// Paired-end at `--cores 2`, which takes the worker-pool path and a different
@@ -199,8 +197,8 @@ fn paired_bgz_input_parallel_is_decompressed() {
         "paired .bgz at --cores 2 must succeed. stderr:\n{}",
         String::from_utf8_lossy(&out.stderr)
     );
-    assert!(read_output(&dir, "pair_R1.fq_val_1").contains("@pp1_0"));
-    assert!(read_output(&dir, "pair_R2.fq_val_2").contains("@pp2_0"));
+    assert!(read_output(&dir, "pair_R1_val_1").contains("@pp1_0"));
+    assert!(read_output(&dir, "pair_R2_val_2").contains("@pp2_0"));
 }
 
 /// Serial and parallel must agree on the reads, not merely both succeed.
@@ -232,7 +230,7 @@ fn paired_bgz_serial_and_parallel_agree() {
             .output()
             .expect("binary must run");
         assert!(out.status.success(), "--cores {cores} must succeed");
-        outputs.push(read_output(&sub, "pair_R1.fq_val_1"));
+        outputs.push(read_output(&sub, "pair_R1_val_1"));
     }
 
     assert_eq!(
@@ -288,4 +286,66 @@ fn plain_fastq_misnamed_gz_is_read_as_plain() {
     );
     // `sample.fastq.gz` IS in the strip list, so this one keeps the tidy stem.
     assert!(read_output(&dir, "sample_trimmed").contains("@mn_0"));
+}
+
+/// The reproduction from
+/// [#381](https://github.com/FelixKrueger/TrimGalore/issues/381): trimmed
+/// output and trimming report must agree on the sample name.
+///
+/// The report filename is the input filename plus a suffix, while the output
+/// filename is the *stripped* stem, so the two only line up when the stripper
+/// knows the input's extension. It did not know `.bgz`, so `sample.fastq.bgz`
+/// gave `sample.fastq_trimmed.fq` next to
+/// `sample.fastq.bgz_trimming_report.txt`. MultiQC takes the sample name from
+/// the report filename, so the pair can land under different samples.
+///
+/// The same bytes are run twice, once under each name, and the assertion is
+/// the same for both: this is a contrast test, not a hard-coded expectation.
+#[test]
+fn bgz_output_and_report_agree_on_the_stem() {
+    for (name, stem) in [
+        ("sample.fastq.bgz", "sample"),
+        ("sample.fq.bgz", "sample"),
+        ("sample.fastq.gz", "sample"), // the control: always worked
+    ] {
+        let dir = fresh_tmpdir(&format!("tg_bgz_stem_{stem}_{}", name.replace('.', "_")));
+        let input = dir.join(name);
+        write_gz(&input, &sample_reads("st"));
+
+        let out = Command::new(binary())
+            .args([
+                "--dont_gzip",
+                "-o",
+                dir.to_str().unwrap(),
+                input.to_str().unwrap(),
+            ])
+            .output()
+            .expect("binary must run");
+        assert!(
+            out.status.success(),
+            "{name} must trim. stderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        let trimmed = dir.join(format!("{stem}_trimmed.fq"));
+        assert!(
+            trimmed.exists(),
+            "{name}: expected output {}, found {:?}",
+            trimmed.display(),
+            std::fs::read_dir(&dir)
+                .unwrap()
+                .map(|e| e.unwrap().file_name())
+                .collect::<Vec<_>>()
+        );
+        for report in [
+            dir.join(format!("{name}_trimming_report.txt")),
+            dir.join(format!("{name}_trimming_report.json")),
+        ] {
+            assert!(
+                report.exists(),
+                "{name}: expected report {}",
+                report.display()
+            );
+        }
+    }
 }


### PR DESCRIPTION
Closes #381.

## The problem

Since #374 a gzipped input named `.fq.bgz` is read correctly, but its trimmed output and its trimming report stopped agreeing on the sample name:

```
$ trim_galore -o out_bgz --dont_gzip sample.fastq.bgz
$ ls out_bgz/
sample.fastq_trimmed.fq
sample.fastq.bgz_trimming_report.json
sample.fastq.bgz_trimming_report.txt
```

The same bytes under a `.fastq.gz` name give `sample_trimmed.fq` next to `sample.fastq.gz_trimming_report.txt`, both resolving to the sample `sample`. MultiQC takes the sample name from the report filename, so on the `.bgz` input the trimmed file and its report can land under different samples.

`io::strip_fastq_extensions` walked an ordered list holding only the `.gz` forms, so `sample.fastq.bgz` matched none of them and reached the `Path::file_stem` fallback, which strips the final component only and leaves `sample.fastq`. The report name is built from the full input filename, which is why it was unaffected and why the two diverged.

## The fix

Strip a gzip-family suffix (`.gz`, `.bgz`, `.bgzf`) and then the FASTQ extension, rather than enumerating the combined suffixes:

```rust
let stem = [".gz", ".bgz", ".bgzf"]
    .iter()
    .find_map(|ext| name.strip_suffix(ext))
    .unwrap_or(&name);

for ext in [".fastq", ".fq"] {
    if let Some(base) = stem.strip_suffix(ext) {
        return base.to_string();
    }
}
```

The two groups are disjoint (`.bgz` does not end in `.gz`), and splitting them means a new compression name costs one list entry instead of doubling the cases.

On the two open questions in the issue:

* **`.bgzf`** is included. It is the other name bgzip output is given in the wild, and on this shape it is one array element.
* **A bare `.bgz`/`.bgzf`** with no inner `.fastq`/`.fq` already worked, via the `file_stem` fallback, and is now pinned by a test so the rewrite cannot lose it.

## Scope and risk

Output *filenames* only. Nothing in `test_files/` and nothing in the `validation` matrix is named `.bgz`, so the Perl-0.6.11 byte-identity comparison does not move. `.bam` inputs, bare `.gz`, and unrelated extensions keep the stems they had, pinned by a second unit test.

The related limitation the CHANGELOG records separately, that output compression still mirrors the input filename so a `.bgz` input produces plain `.fq` output, is **not** touched here. It changes behaviour on every run and deserves its own discussion.

## Tests

Written first, and each watched to fail for the right reason before the fix went in:

* `io::tests::test_strip_fastq_extensions_bgz` covers `.fastq.bgz`, `.fq.bgz`, `.fastq.bgzf`, `.fq.bgzf`, `sample_R1.fq.bgz` and the bare forms. Fails on `dev` with `left: "sample.fastq", right: "sample"`.
* `io::tests::test_strip_fastq_extensions_leaves_other_names_alone` pins `.bam`, bare `.gz`, `.txt.gz` and a bare stem.
* `bgz_output_and_report_agree_on_the_stem` runs the issue's reproduction through the binary under three names, `.fastq.bgz`, `.fq.bgz`, and a `.fastq.gz` control, asserting the same output/report relationship for each. Against unfixed code it reports the issue's exact symptom: `expected output .../sample_trimmed.fq, found ["sample.fastq_trimmed.fq", "sample.fastq.bgz", "sample.fastq.bgz_trimming_report.json", "sample.fastq.bgz_trimming_report.txt"]`.

The existing `.bgz` integration tests in that file move to the tidy stems (`pair_R1_val_1` rather than `pair_R1.fq_val_1`); their module docs recorded the old names as a known wart and now point at the new test instead.

Local: `cargo test` all green (383 lib + integration suites), `cargo fmt --all -- --check` clean, `cargo clippy --all-targets --release -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)