### PR TITLE
fix(io): guard every output path against collisions and inputs (#383)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,6 +639,61 @@ jobs:
           # Fail-fast sanity: NOTHING should be written — covers reports too.
           test -z "$(ls -A /tmp/rust_case/out 2>/dev/null)"
 
+      - name: Validate single-end collision pre-flight (issue #383)
+        run: |
+          # SE trim was the only trim path without the #216 pre-flight: two inputs
+          # sharing a stem produced ONE output at exit 0, first input's reads gone.
+          rm -rf /tmp/rust_se_coll; mkdir -p /tmp/rust_se_coll/out
+          cp test_files/illumina_10K.fastq.gz /tmp/rust_se_coll/sample.fastq.gz
+          cp test_files/illumina_10K.fastq.gz /tmp/rust_se_coll/sample.fq.gz
+          set +e
+          ./target/release/trim_galore -o /tmp/rust_se_coll/out \
+            /tmp/rust_se_coll/sample.fastq.gz /tmp/rust_se_coll/sample.fq.gz 2>&1 | tee /tmp/se_coll.log
+          rc=${PIPESTATUS[0]}
+          set -e
+          test $rc -ne 0
+          grep -q "Output path collision" /tmp/se_coll.log
+          test -z "$(ls -A /tmp/rust_se_coll/out 2>/dev/null)"
+
+      - name: Validate --hardtrim5 collision pre-flight and its own remediation (issue #383)
+        run: |
+          # Hardtrim names output into the CWD, so identical basenames collide even
+          # from different directories and -o does not rescue it. The generic advice
+          # ("different source directories or --output_dir") is wrong here, so the
+          # message must carry the mode-specific hint instead.
+          rm -rf /tmp/rust_ht_coll; mkdir -p /tmp/rust_ht_coll/sub1 /tmp/rust_ht_coll/sub2 /tmp/rust_ht_coll/out
+          cp test_files/illumina_10K.fastq.gz /tmp/rust_ht_coll/sub1/same.fastq.gz
+          cp test_files/illumina_10K.fastq.gz /tmp/rust_ht_coll/sub2/same.fastq.gz
+          set +e
+          ./target/release/trim_galore --hardtrim5 30 -o /tmp/rust_ht_coll/out \
+            /tmp/rust_ht_coll/sub1/same.fastq.gz /tmp/rust_ht_coll/sub2/same.fastq.gz 2>&1 | tee /tmp/ht_coll.log
+          rc=${PIPESTATUS[0]}
+          set -e
+          test $rc -ne 0
+          grep -q "Output path collision" /tmp/ht_coll.log
+          grep -q "one invocation per input" /tmp/ht_coll.log
+          test -z "$(ls -A /tmp/rust_ht_coll/out 2>/dev/null)"
+
+      - name: Validate an output may not overwrite an input (issue #383)
+        run: |
+          # An output path can alias an INPUT of the same run: the run then destroys
+          # that input's reads and writes a second file holding the wrong sample.
+          # Reachable by re-running over a directory that holds a previous output.
+          rm -rf /tmp/rust_alias; mkdir -p /tmp/rust_alias
+          cp test_files/illumina_10K.fastq.gz /tmp/rust_alias/sample.fastq.gz
+          cp test_files/illumina_10K.fastq.gz /tmp/rust_alias/sample_trimmed.fq.gz
+          BEFORE=$(md5sum /tmp/rust_alias/sample_trimmed.fq.gz | awk '{print $1}')
+          set +e
+          ./target/release/trim_galore \
+            /tmp/rust_alias/sample.fastq.gz /tmp/rust_alias/sample_trimmed.fq.gz 2>&1 | tee /tmp/alias.log
+          rc=${PIPESTATUS[0]}
+          set -e
+          test $rc -ne 0
+          grep -q "which is also one of its inputs" /tmp/alias.log
+          # The named input must be byte-identical afterwards, and no new file written.
+          test "$(md5sum /tmp/rust_alias/sample_trimmed.fq.gz | awk '{print $1}')" = "$BEFORE"
+          test "$(ls -A /tmp/rust_alias | wc -l)" -eq 2
+
       - name: Validate multi-pair with --cores 1 (sequential path)
         run: |
           rm -rf /tmp/rust_multi_seq; mkdir -p /tmp/rust_multi_seq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,86 @@
   `validation` matrix is named `.bgz`, so the Perl-0.6.11 byte-identity
   comparison is untouched.
 
+- **Single-end trimming no longer discards one input's reads when two inputs
+  share an output name** ([#383](https://github.com/FelixKrueger/TrimGalore/issues/383)).
+  `trim_galore sample.fastq.gz sample.fq.gz` produced a single
+  `sample_trimmed.fq.gz` and exited 0, having written the second input over the
+  first. Two trimming reports were left behind, each stating that all its reads
+  had been written, so the arithmetic on disk was wrong and nothing checked it.
+
+  The output-collision pre-flight added for
+  [#216](https://github.com/FelixKrueger/TrimGalore/issues/216) already refused
+  this on `--paired`, `--clock`, `--implicon` and `--clump_only`. It was missing
+  from four dispatch paths, all sharing one shape — a loop over the input list
+  with no check in front of it: single-end trim (FASTQ and uBAM output) and
+  `--hardtrim5`/`--hardtrim3` (FASTQ and uBAM output). All four now check, and
+  every path routes through one shared implementation.
+
+  `--hardtrim5`/`--hardtrim3` were the wider case, because they name output into
+  the *current working directory* rather than beside the input: identical input
+  basenames collided there even when the inputs came from different directories,
+  so `--hardtrim5 30 */*.fastq.gz` over a per-sample layout kept only the last
+  sample. Because `--output_dir` cannot resolve that collision, these two modes
+  add their own remediation to the error rather than the generic advice.
+
+  Two further defects in the check itself are fixed at the same time:
+
+  - **The key was a raw path string**, so `./sample.fastq.gz` and
+    `sample.fastq.gz` — or a list mixing absolute and relative paths, as
+    `find`/`xargs` and pipeline staging produce — named one file under two keys
+    and passed. The key is now lexically normalised — absolutised, then `..`
+    folded against the component stack — so `./x`, `<cwd>/x` and `a/../x` all
+    resolve to one key without touching the filesystem. A path reached through a
+    **symlink** still aliases undetected; that is the one remaining case, and it
+    costs the same silent read loss this entry describes.
+  - **The check compared outputs only against other outputs**, never against the
+    run's own inputs — and, once that was fixed, only *primary* outputs were
+    compared. A trimming report, or a `--demux` per-barcode file, could still
+    overwrite a named input while every primary output stayed distinct. Reports
+    and `--demux` outputs are now in the checked set, and `--demux`'s barcode
+    file is treated as an input that may not be written over. An output path can
+    *be* an input:
+    `trim_galore sample.fastq.gz sample_trimmed.fq.gz` (reachable by re-running
+    over a directory holding an earlier run's output) destroyed the second
+    input's reads and wrote a `sample_trimmed_trimmed.fq.gz` containing the
+    first sample's — a wrong-sample file, which is harder to notice than a
+    missing one. This affected `--paired` as well, and is now refused on every
+    path with a message of its own.
+
+  A rejected run still writes nothing, and the diagnostic keeps naming the paths
+  as the user spelled them.
+
 #### Changes
+
+- **A file given twice on one command line is now rejected**
+  ([#383](https://github.com/FelixKrueger/TrimGalore/issues/383)).
+  `trim_galore sample.fastq.gz sample.fastq.gz` previously trimmed the file
+  twice and wrote the same output twice, exiting 0. It is now refused during
+  argument validation, matching the duplicate-pair rejection `--paired` has
+  always had. `--clock` and `--implicon` keep their own more specific
+  "Read 1 and Read 2 appear to be the same file" message.
+
+- **Two collision messages advised `--output-dir`, which is not a valid flag**
+  (only `--output_dir` and `-o` are). Both now name `--output_dir`.
+
+- **`--hardtrim5/3`, `--clock` and `--implicon` name output into the current
+  working directory**, so on a collision the usual advice — use different source
+  directories, or `--output_dir` — is false for them: neither changes the
+  outcome. These four modes now get their own remediation instead, replacing the
+  generic sentence rather than contradicting it a clause later.
+
+- **One definition of "the same file".** `--paired`'s R1≠R2 check, its
+  duplicate-pair check, the duplicate-input check and the `--passthrough` alias
+  check all compared paths more weakly than the collision pre-flight did, so
+  `trim_galore --paired ./a_R1.fq a_R1.fq` exited 0 and wrote two byte-identical
+  files labelled as a validated R1/R2 pair. All four now use the same key as the
+  pre-flight.
+
+- **Case-folded paths are treated as colliding**, which is what makes the
+  APFS/NTFS guard work. On an opt-in case-sensitive volume two genuinely distinct
+  inputs differing only in case are therefore refused. That trade — a loud error
+  over a silent overwrite — is unchanged since v2.0; it is recorded here because
+  it had never been stated.
 
 - **`--clump_only` now supports uBAM in/out** — extending the mode with
   unaligned BAM support via `--output-format ubam` (input auto-detected

--- a/plans/08062026_se-output-collision-preflight/CODE_REVIEW_A.md
+++ b/plans/08062026_se-output-collision-preflight/CODE_REVIEW_A.md
@@ -1,0 +1,370 @@
+# Code Review A — output-collision pre-flight (#383)
+
+**Reviewer:** A (independent; a Reviewer B may have run concurrently — no shared state)
+**Branch:** `fix/383-output-collision-preflight` off `dev` @ `72624c7`, uncommitted
+**Scratch:** `…/scratchpad/creview-a3/` (`p1.sh`–`p6.sh`) and `…/scratchpad/creview-a/`
+
+## No fixes applied
+
+**Nothing was modified** — not source, tests, CI, or the plan. The change is uncommitted in a
+shared working tree with a second reviewer possibly active, and a concurrent edit would corrupt
+the diff both reviewers read. Every item below is a recommendation, including the one-liners.
+The only file this review wrote is this report.
+
+### Provenance note
+
+An earlier Reviewer-A pass wrote a report to this path before it was interrupted. This file
+merges it with a second independent pass. Items it raised are kept **only where I reproduced
+them myself in this pass** — marked *(reproduced)*. C1 in particular turned out worse than the
+earlier pass recorded: it exits **0**, not non-zero. Items neither pass could confirm were
+dropped.
+
+---
+
+## Summary
+
+The change does what it sets out to do. Eleven dispatch paths now route through
+`io::preflight_output_collisions`; I verified assumption A9 site by site (candidate expression vs.
+what the writer actually uses) and found **no mismatch and no fifth hole**. The four hand-rolled
+conversions dropped nothing — an 18-case acceptance battery and a 10-case rejection battery both
+behave. Defect 1 (`./x` vs `x`) and defect 2 (output aliases an input) are genuinely fixed and
+genuinely tested, and there is an unclaimed win: a single-input self-overwrite
+(`--basename s s_trimmed.fq`) is now refused where the writer previously truncated its own input.
+
+Four things I would not merge without addressing:
+
+- **C1** — defect 2 is closed for *primary* outputs only. A `--demux` **secondary** output still
+  overwrites a file named as an input, destroying its reads **at exit 0**. §11 Out-of-scope 2
+  explicitly puts this in scope ("there the user has named the file as an input, so writing it is
+  unambiguously wrong"). Reproduced.
+- **H1** — the lexical key still lets #383 reproduce verbatim through a `..` component. Disclosed
+  as A8, so this is a scope call, not a surprise — but the CHANGELOG states the residual exists
+  without stating that it costs the same silent read loss.
+- **H2** — `--clock`/`--implicon` name output into the CWD *exactly* like hardtrim, so the generic
+  remediation is provably wrong there too, and only hardtrim got the hint built for that purpose.
+- **H3** — the hardtrim hint is factually wrong whenever `-o` is given, and contradicts the clause
+  it is appended to. The CHANGELOG says it replaces the generic advice; the code appends.
+
+Counts: **1 Critical, 3 High, 4 Medium, 7 Low.**
+
+---
+
+## Verified correct
+
+Recorded so the next reader does not redo it.
+
+**A9 — candidate expression vs. writer, all eleven sites.** Argument for argument, including
+`basename` and `gzip`:
+
+| Site | Candidate | Writer |
+|---|---|---|
+| SE trim FASTQ | `main.rs:796` | `main.rs:1103` (character-identical) |
+| SE trim uBAM | `main.rs:1867` | `main.rs:1893` (character-identical) |
+| `--paired` FASTQ | `:701` / `:710` / `:725` | `run_paired` `:1293` / `:1313` / `:1305` |
+| `--paired` uBAM | `:1818` | `:2028` |
+| `--clock` / `--implicon` | closures `:426` / `:440` | same closure reaches the writer arm |
+| `--hardtrim5/3` × 2 formats | `planned_hardtrim_outputs` | `specialty.rs:45`/`:88`/`:139`/`:191`, enum-enforced |
+| `--clump_only` SE FASTQ / SE uBAM / PE A / PE B | `:511` / `:631` / `:578` / `:542` | `clump_only.rs:278` etc. |
+
+**No fifth hole.** Every writing loop over `cli.input` — `:365`, `:396`, `:514`, `:591`, `:634`,
+`:744`, `:800`, `:1828`, `:1870`, `:2433` — has a `preflight_output_collisions` immediately in
+front of it. `main.rs:679` (`run_paired_ubam_single_file`) is the one unguarded path; it is safe
+because `:1610-1620` builds names from `input.file_stem()` and ignores `--basename`, so
+`<stem>_val_{1,2}` can never equal the single BAM input (see L2).
+
+**A2 holds for output-vs-output.** `report_name` (`io.rs:447`), `json_report_name` and demux
+(`demux.rs:129-147`) all resolve their directory by the same `output_dir`-else-`input.parent()`
+rule and key on `input.file_name()`, so secondary-collide ⇒ primary-collide by construction:
+equal dir + equal file name forces equal stem. It does **not** hold for output-vs-input — that is
+C1.
+
+**No false rejections.** 18-case acceptance battery (`p2.sh`): `--paired` × {2 pairs,
+`--retain_unpaired`, `--passthrough`, `--basename`}, `--clock` × {1 pair, 2 pairs},
+`--clump_only` × {SE, PE, SE uBAM}, SE trim × {FASTQ, uBAM}, paired-uBAM out, hardtrim5/3,
+`-o .`, and re-trimming a previous output — all exit 0.
+
+**Conversions kept their rejections and gained the alias check.** 10-case rejection battery
+(`p3.sh`, `p4.sh`): every duplicate-output case still refuses; new alias refusals fire on SE trim,
+`--paired`, `--clump_only` SE and `--clock`; the output directory is empty after each.
+
+**`guarded_inputs()` is the right set.** `cli.input` + `--passthrough`. `passthrough_output_name`
+appends `_passthrough`, so it cannot alias its own input, and the candidate at `:725` uses the
+same `basename`/`gzip` as the writer at `:1305`.
+
+**`collision_key`'s `Err` fallback cannot weaken the guard.** `std::path::absolute` fails only on
+an empty path (clap rejects empty positionals first) or `getcwd` failure, which degrades *every*
+key uniformly to the pre-change raw string — so it cannot create a mixed keyspace.
+
+**Ordering (alias before duplicate) is right.** Where both hold, the alias message is the
+actionable one and its advice is the correct one.
+
+**D1's predicate is complete.** I looked for a fourth paired-shaped mode that does not set
+`paired` and found none: `--clump_only --paired` sets it, hardtrim is genuinely per-file.
+Duplicates `validate_paired_input` misses (`--clock a b a c` — neither within-pair nor a duplicate
+pair) are still caught downstream by `run_specialty_paired`'s pre-flight.
+
+**Unclaimed win** *(reproduced)*: `trim_galore --basename s s_trimmed.fq` is now refused with
+nothing written. Previously `run_single_file` opened the reader (`:1123`) then truncated the same
+file with `FastqWriter::create` (`:1124`). Worth a CHANGELOG sentence — it is sharper than the
+failure #383 reports.
+
+---
+
+## Critical
+
+### C1 — a `--demux` secondary output still overwrites a named input, destroying reads at exit 0
+
+`main.rs:792-799` builds SE candidates from `single_end_output_name` only. Demux outputs
+(`demux.rs:152`, `<primary-stem>_<sample>.fq`) are never compared against the input list.
+
+Reproduced (`p6.sh`, claim 2) — 40 reads destroyed, **exit 0, no warning**:
+
+```bash
+printf 'sampleA\tATCG\n' > bc.txt
+# m.fastq: 40 reads tagged SRC, each carrying the 3' barcode ATCG
+# m_trimmed_sampleA.fq: 40 pre-existing reads tagged PRECIOUS
+trim_galore --demux bc.txt m.fastq m_trimmed_sampleA.fq
+# rc=0
+# PRECIOUS reads in m_trimmed_sampleA.fq: 40 → 0
+# SRC      reads in m_trimmed_sampleA.fq:  0 → 40
+```
+
+Input 1's demultiplexing pass writes `m_trimmed_sampleA.fq`, which **is input 2**; input 2 is then
+trimmed from the file that was just overwritten, so `m_trimmed_sampleA_trimmed.fq` also holds the
+wrong sample. That is #383's exact signature — silent loss plus a wrong-sample file — on the very
+dispatch path this change was written to protect.
+
+A2 does not cover this. A2 reasons about output-vs-**output** distinctness (defect 1's domain);
+defect 2 is output-vs-**input**, and primary distinctness says nothing about whether a *secondary*
+equals an input (`m_trimmed.fq` ≠ `m_trimmed_sampleA.fq`). Nor is it §11 Out-of-scope 2, whose own
+wording carves it in: the user named the file as an input. And unlike A2's `--fastqc_args -o`
+exception, the cost here is reads, not a regenerable QC artifact.
+
+Reachable by a plain re-run glob: demux outputs carry the input extension, and `m.fastq` sorts
+before `m_trimmed_sampleA.fq` under both C and en_US collation (`.` = 0x2E < `_` = 0x5F), so
+`trim_galore --demux bc.txt *.f*q` over a directory holding a previous demux run lands in the
+destructive order.
+
+Cheapest containment: `--demux` is single-end-only and the barcode names are known before any
+write, so add the prospective demux names to the candidate list at `main.rs:792` when
+`cli.demux.is_some()`. If that is deferred, the CHANGELOG must stop saying defect 2 "is now
+refused on every path", and A2 must state that output-vs-input is checked for primaries only.
+
+---
+
+## High
+
+### H1 — `..` defeats the key; #383 reproduces verbatim *(reproduced)*
+
+```bash
+# cwd = work/, data/ is a sibling
+trim_galore ../data/s.fastq /abs/…/data/s.fq
+# Output: ../data/s_trimmed.fq   and   /abs/…/data/s_trimmed.fq
+# rc=0; ALPHA reads surviving: 0, BETA: 40; both misleading reports present
+```
+
+This is A8 / §11 Out-of-scope 3 and the CHANGELOG does disclose it. My objection is to the scope
+decision, not the honesty: the plan closes `./x`-vs-`x` and abs-vs-rel *because* mixed argument
+lists are "the common shape" (§2.2(e)), and `../data/x` mixed with an absolute path is that same
+shape — it is what a workflow manager's relative-to-workdir input looks like.
+
+Two fixes, both consistent with A1's "loud error beats silent loss" trade:
+
+- *Minimal, still lexical:* after `absolute()`, fold `Component::ParentDir` against the accumulated
+  component stack. Can only increase rejections; the only false positive is a symlinked
+  intermediate directory — the same class `norm_path`'s case-fold already accepts.
+- *Thorough:* `fs::canonicalize` the path's **parent** and join the file name. Closes symlink
+  aliasing too, one syscall per path, and retires A8 rather than documenting it.
+
+If A8 stays, the CHANGELOG bullet should say what the residual *costs* (silent read loss identical
+to #383), not merely that it exists.
+
+### H2 — `--clock`/`--implicon` need the hint as much as hardtrim does *(reproduced)*
+
+`clock_output_name` (`specialty.rs:488-491`) and `implicon_output_name` (`:521-524`) end
+`None => PathBuf::from(filename)` / `Some(dir) => dir.join(filename)` with a **stem-only**
+filename — identical to both hardtrim namers, as §2.3 itself records. So the collision class is
+identically wide and `--output_dir` identically fails to rescue it, yet `run_specialty_paired`
+passes `hint: None` (`main.rs:2431`):
+
+```bash
+trim_galore --clock -o out dirA/same_R1.fastq.gz dirA/same_R2.fastq.gz \
+                           dirB/same_R1.fastq.gz dirB/same_R2.fastq.gz
+# Error: … out/same_R1.clock_UMI.R1.fq.gz and out/same_R1.clock_UMI.R1.fq.gz would be written
+# to the same file. Check that inputs produce distinct output paths (e.g., different source
+# directories or `--output_dir`).      ← the user already did both of these
+```
+
+Multi-pair clock is a supported, CI-tested shape, so `--clock */*_R{1,2}.fq.gz` over a per-sample
+layout now hard-fails with advice that provably does not work — the outcome §3.4 exists to
+prevent. Fix: generalise the hint to a CWD-output hint (the sentence is already mode-neutral apart
+from the words "Hard-trimmed") and thread it through `run_specialty_paired`, which must keep
+`None` for `--clump_only --paired` (an `input.parent()` namer).
+
+### H3 — the hardtrim hint is wrong with `-o`, and contradicts the clause it is appended to
+
+`main.rs:55-59`, appended at `io.rs:81`. Rendered message with `-o` — the shape the new test *and*
+the new CI step both use:
+
+> … `out/same.20bp_5prime.fq` and `out/same.20bp_5prime.fq` would be written to the same file.
+> Check that inputs produce distinct output paths (e.g., **different source directories or
+> `--output_dir`**). Hard-trimmed output is written to the **current working directory**, so
+> inputs sharing a basename collide **whatever `--output_dir` is set to** — run one invocation per
+> input, or give the inputs distinct basenames.
+
+Two defects in one sentence. The paths it just printed are inside `out/`, so "written to the
+current working directory" is visibly false — `hardtrim_output_name` (`specialty.rs:449-452`)
+honours `-o`; what it ignores is the **input's parent**. And the generic clause it is appended to
+recommends exactly the two remedies §3.4 established do not work, so the user reads "use different
+source directories or `--output_dir`" immediately followed by "that will not help".
+
+`CHANGELOG.md` says these modes "add their own remediation to the error **rather than** the generic
+advice". The code concatenates. Smallest fix that matches the CHANGELOG: build the advice sentence
+as `hint.unwrap_or(GENERIC_ADVICE)` instead of appending. Repro: `p1.sh`, or
+`trim_galore --hardtrim5 20 -o out dirA/same.fastq dirB/same.fastq`.
+
+Neither the test nor the CI step can catch this: both assert only that `one invocation per input`
+is present, never that the rest of the sentence is true.
+
+---
+
+## Medium
+
+### M1 — the A2 table test does not test A2's direction, and drops most of V5
+
+`io.rs`, `primary_output_key_is_coarser_than_secondary_keys`. A2 needs *primary distinct ⇒
+secondary distinct*. The test instead picks three variants whose **primaries are equal** and
+asserts their **secondaries are distinct** — a witness that the *converse* fails, which is
+reassuring but is not evidence for A2. All three variants also live in one directory and have
+pairwise-distinct `file_name()`, which every secondary namer embeds verbatim, so the `assert_ne!`
+loop is close to a tautology for any implementation of that shape; the real failure mode it should
+detect — a secondary namer that ignores the directory — is invisible to it.
+
+It also departs from V5 with no §13 entry: V5 asked for pairs whose **primaries differ**, covering
+the demux base name and the default-configuration `<stem>_fastqc.zip`, across `--basename` /
+`--dont_gzip` / `-o` on and off. The implemented table covers none of those. The property does
+hold today (see "Verified correct"), so this is rigour, not a live bug — but V5 existed precisely
+because v1's equivalent could only ever pass. Keep the first half (all three primaries equal —
+that pins `.bgz` stem stripping); replace the `assert_ne!` loop with same-basename inputs in
+**different** directories, asserting secondaries differ without `-o` and collide with it.
+
+### M2 — the duplicate message names neither input, and the alias message names only one
+
+When the two colliding paths are textually identical — the common case on every mode — the message
+repeats itself and identifies nothing:
+
+```
+out/same.20bp_5prime.fq and out/same.20bp_5prime.fq would be written to the same file
+out/same_R1_val_1.fq and out/same_R1_val_1.fq would be written to the same file
+```
+
+The user is told to make the inputs produce distinct paths, but not which two inputs to look at.
+The alias branch (`io.rs:66-73`) has the mirror problem: it prints the aliased path but not the
+input that would clobber it, where the duplicate branch names both participants. On a 40-file
+command line neither is actionable. Pass `(candidate, source_input)` pairs so both messages can
+name inputs; or minimally special-case `existing == p` to "two inputs produce the same output
+path: X". Pre-existing wording inherited from all four hand-rolled copies — but it is now the one
+shared message, so this is the moment.
+
+### M3 — `Cli::validate`'s duplicate-input check is byte-equality, so two spellings get the wrong message
+
+`cli.rs:631` compares `other == path`:
+
+```bash
+trim_galore dup.fq dup.fq     # → "Input file dup.fq was given more than once …"   (intended)
+trim_galore ./dup.fq dup.fq   # → "Output path collision (case-insensitive, for APFS/NTFS …"
+```
+
+§4.4's whole rationale is that a duplicated input should get a precise message "rather than the
+case-insensitive output-collision pre-flight's APFS/NTFS message", and A6 explicitly worries about
+"an inconsistency worse than either clean choice". Both shapes are rejected, so this is diagnostic
+quality only. Keying that loop with the same normalisation (`collision_key` as `pub(crate)`) makes
+the two consistent.
+
+### M4 — `--hardtrim3`'s hint is untested, one argument from the gap the plan designed around
+
+`tests/integration_output_collision.rs:360-379` asserts the prefix and `DUP_MSG` but not
+`one invocation per input`; only the `--hardtrim5` test (`:354`) and the `--hardtrim5` CI step check
+the hint. §4.2 introduced `HardtrimEnd` precisely because a copy-paste slip in the `--hardtrim3`
+block "would produce a pre-flight that hashes paths the run never writes, while every rejection
+test still passed" — the enum closes that for the end discriminator and nothing closes it for the
+adjacent `hint` argument. I confirmed `main.rs:391` does pass it, so this is coverage, not a
+defect. One line closes it.
+
+---
+
+## Low
+
+**L1 — "(arguments N and M)" indexes positionals, not argv.** `cli.rs:632-639`;
+`trim_galore -q 20 a.fq a.fq` reports "arguments 1 and 2" for argv items 4 and 5. Suggest "input
+files 1 and 2".
+
+**L2 — the helper's doc-comment overstates and miscounts.** `io.rs:51-54` says "all four output
+formats"; there are two (`Fastq`, `UBam`) — it presumably means the four `--clump_only` arms. And
+"every `main.rs` dispatch path that writes more than one file" is untrue: `run_paired_ubam_single_file`
+writes 2 (4 with `--retain_unpaired`) and does not call it. It is safe, but §4.1's stated purpose
+is to make a fifth omission visible *from the helper*, which only works if the list is exact. Name
+that path as deliberately exempt and why.
+
+**L3 — `HARDTRIM_HINT` carries its own leading space** (`main.rs:56`) and the helper appends it raw
+via `hint.unwrap_or("")`. Correct today (verified in the rendered message), but a future caller
+that forgets the space glues two sentences together. Prefer the helper owning the separator.
+
+**L4 — stale line references in code this change touched.** `main.rs:2422` says "the `--paired`
+pre-flight at lines 82–125" (now `:699-734`); `ci.yml` still points at `src/main.rs:101–111` for the
+`--retain_unpaired` branch (now `:709-719`). Both predate the change.
+
+**L5 — `input_keys: HashMap<String, &PathBuf>` collapses two inputs sharing a key** to whichever
+was listed last (`.collect()` keeps the last value), so the alias message can name a spelling the
+user did not type. Detection is unaffected — the surviving entry has the same key. `HashSet` for
+membership plus `entry().or_insert()` if the `&PathBuf` is wanted makes it deterministic.
+
+**L6 — D5's YAML `#` truncation is worth fixing while the steps are new.** The three new step names
+lose everything from ` #383` onward, so the Actions UI shows "… pre-flight (issue". Consistency
+with the existing `(issue #216)` step is defensible, but quoting three new names is a one-line
+change and the consistency argument then applies in the other direction.
+
+**L7 — one fixture passes for a reason its comment does not give.**
+`se_trim_rejects_gz_and_bgz_sharing_a_stem` (`:196`) writes plain text into `wide.fastq.gz` /
+`.bgz`; the comment says "Content is irrelevant: the pre-flight runs before any read", true only
+because `detect_input_format` peeks the first byte and classifies `@…` as plain FASTQ while `gzip`
+is derived from the *filename*. It does exercise the intended path today, and
+`assert_rejected_cleanly` requires the collision prefix so it cannot pass for an unrelated
+failure — but a clause naming the filename-vs-content split would stop the next reader trusting
+the wrong reason.
+
+---
+
+## Vacuous-pass audit (§13 D3's failure class)
+
+| Test | Can it fail? | Note |
+|---|---|---|
+| `preflight_rejects_dot_slash_alias`, `…absolute_versus_relative_alias` | yes | fail without `absolute()` |
+| `preflight_rejects_output_that_aliases_an_input` | yes | also asserts *absence* of the duplicate wording |
+| `preflight_accepts_dotdot_alias_known_limitation` | yes | inverts if the key gains `canonicalize` |
+| `primary_output_key_is_coarser_than_secondary_keys` | yes, but not on A2 | **M1** |
+| `se_trim_rejects_dot_slash_alias`, `…absolute…` | yes | D3's fix (drop `-o`) is right; `assert_dir_holds_only` pins it |
+| `se_trim_rejects_same_basename_across_dirs_with_output_dir` | yes | the `output_dir`-vs-`None` slip detector; its acceptance twin at `:241` is what makes it non-trivial |
+| `hardtrim3_rejects_same_basename_across_dirs` | partly | hint unasserted — **M4** |
+| hardtrim5/3 acceptance tests | yes | filename assertions catch a wrong `HardtrimEnd` |
+| `paired_rejects_output_that_aliases_an_input` | yes | all four planned outputs are distinct, so only the input-key set can reject |
+| `duplicate_input_gets_a_precise_message` | yes | asserts absence of `APFS/NTFS` |
+| CI steps 1 and 3 | yes | `rc != 0` + message + residue; step 3 also md5-pins the input |
+| CI step 2 | presence yes, accuracy no | **H3** |
+
+`tempdir()`'s `canonicalize` (D4) is load-bearing and correctly commented: without it the
+absolute-vs-relative case compares `/tmp/…` against the child's `/private/tmp/…` `getcwd` and
+passes vacuously. I confirmed the symlink is real on this machine, so D4 is a genuine catch.
+
+Acceptance coverage note: the new file has no acceptance case for `--clump_only` or
+`run_specialty_paired`. Both are covered elsewhere (`tests/integration_clump_only*.rs`, and the
+multi-pair `--clock`/`--implicon` CI steps), so this is a completeness note — worth a sentence in
+the module doc-comment so a reader does not conclude those two conversions are untested.
+
+## Efficiency
+
+Nothing to report. One `getcwd` per path via `std::path::absolute`, one `String` per key, one
+`PathBuf` clone per candidate, `with_capacity` on the planned map — unmeasurable at command-line
+n. `guarded_inputs()` clones the input vector per call, but exactly one site executes per run. The
+guard now runs before adapter auto-detection's ≤1 M-record scan, so colliding invocations fail in
+microseconds instead of after a full detection pass — a real improvement on the four new paths.

--- a/plans/08062026_se-output-collision-preflight/CODE_REVIEW_A_supplementary.md
+++ b/plans/08062026_se-output-collision-preflight/CODE_REVIEW_A_supplementary.md
@@ -1,0 +1,278 @@
+# Code Review — output-collision pre-flight (#383) — supplementary
+
+> **On the filename.** This review was first written to `CODE_REVIEW_A.md`, which turned out to
+> still be owned by another reviewer agent that later wrote its own review there. That file is a
+> different agent's **independent** review, not an earlier version of this one — the two are not
+> versions of each other and should be read as two separate opinions. This copy is unchanged in
+> substance from what I originally wrote; only the filename differs.
+
+**Target:** uncommitted working tree on `fix/383-output-collision-preflight` off `dev` @ `72624c7`
+**Files:** `src/io.rs`, `src/main.rs`, `src/cli.rs`, `src/specialty.rs`, `src/demux.rs`,
+`.github/workflows/ci.yml`, `CHANGELOG.md`, `tests/integration_output_collision.rs`
+**Date:** 2026-08-07
+
+## Caveats on the weight of this review
+
+1. **Not blind.** I audited this same change against its plan earlier in this session, so I
+   have prior exposure to the plan's reasoning, its assumption list (A1–A10) and its
+   deviation log (D1–D6). A reviewer who had read the design is measurably less likely to
+   question the design. Findings below that agree with the plan should be discounted
+   accordingly; findings that contradict it are the ones worth the most.
+2. **Not dual.** The workflow asks for two independent reviewers in separate context
+   windows. This is one, and it is the same agent that produced the coverage audit. A second
+   independent reviewer is still owed and should be run before this lands. This is also why the
+   filename is "supplementary" rather than "A".
+3. **No fixes applied.** The caller requires the diff to stay stable, which overrides the
+   skill's "fix directly" clause. Everything below is a recommendation.
+
+## Summary
+
+The change is sound where it matters most. The part I expected to find broken — whether each
+of the eleven guards hashes the paths its writer actually writes — is correct at all eleven,
+verified expression by expression (C1). `guarded_inputs()` is correct on the one path where
+`--passthrough` can be set and provably vacuous on the other ten (C2). D6's `demux_base_name`
+extraction is byte-for-byte behaviour-preserving, so the Perl `--demux` byte-identity path is
+safe (C3). Both defect fixes work on invocations the test suite does not construct.
+
+**1 High, 4 Medium, 4 Low.** No Critical.
+
+The High finding and two of the Mediums are one root cause: the diff establishes
+`collision_key` as this crate's definition of "the same file" but leaves three sibling identity
+checks in `cli.rs` on weaker definitions. The sharpest consequence is that
+`trim_galore --paired ./a_R1.fq a_R1.fq` exits 0 and writes two byte-identical files labelled
+as a validated R1/R2 pair (H1) — pre-existing, not a regression, but this is the commit that
+makes it an inconsistency rather than a uniform limitation. Making `collision_key` `pub` and
+using it at those three sites closes H1 and M3 together.
+
+The remaining Mediums are independent: `guarded_inputs()` omits the `--demux` barcode file, and
+a run whose trim output aliases it destroys that file before any check (M2, reproduced); and
+D6 detached `demultiplex`'s doc-comment onto the new helper (M1) — the same orphaning that
+Step 2 of this very plan was fixing elsewhere.
+
+Five probes were run from a scratch directory, never the repo root; three reproduced findings
+and two confirmed correct behaviour. Nothing was fixed, per instruction.
+
+## Findings
+
+### Clean bills of health (the three things I tried hardest to break)
+
+**C1 — All 11 call sites guard the paths their writers actually write.** This was the
+highest-value check available, because a mismatch is invisible to every rejection test: the
+guard would hash paths the run never touches, reject nothing, and the acceptance tests would
+still pass. I paired each candidate expression against its writer's naming expression:
+
+| Guard | candidate expression | writer's expression | verdict |
+|---|---|---|---|
+| `main.rs:360` hardtrim5 | `hardtrim_output_name(input, n, Five, output_dir, gzip)` / `hardtrim_bam_output_name(input, n, Five, output_dir)` | `specialty.rs:45` / `:139` — same args | match |
+| `:391` hardtrim3 | as above with `Three` | `specialty.rs:88` / `:191` | match |
+| `:513` clump_only SE FASTQ | `clumped_output_name(input, output_dir, basename, gzip)` | `clump_only.rs:278`, param `gzip_output` receives `gzip` (4th positional, `clump_only.rs:250-261`) | match |
+| `:548` clump_only PE uBAM, 1 file | `clumped_paired_bam_output_name(&cli.input[0], None, output_dir, basename)` | `clump_only.rs:922` `(input, None, output_dir, basename)` | match |
+| `:585` clump_only PE uBAM, N pairs | `(&chunk[0], Some(&chunk[1]), output_dir, basename)` | `clump_only.rs:969` `(r1_path, Some(r2_path), …)` | match |
+| `:633` clump_only SE uBAM | `clumped_bam_output_name(input, output_dir, basename)` | `clump_only.rs:754` | match |
+| `:734` paired FASTQ | `paired_end_output_names` + `unpaired_output_names` + `passthrough_output_name` | `clump_only.rs:416` / `main.rs:1305` | match |
+| `:799` SE trim FASTQ | `single_end_output_name(input, output_dir, cli.basename.as_deref(), gzip)` | `main.rs:1103` — character-identical | match |
+| `:1825` paired uBAM | `paired_bam_output_name(&chunk[0], &chunk[1], output_dir, cli.basename.as_deref())` | `main.rs:2028` | match |
+| `:1869` SE trim uBAM | `single_end_bam_output_name(input, output_dir, cli.basename.as_deref())` | `main.rs:1893` — character-identical | match |
+| `:2430` `run_specialty_paired` | caller's `output_names` closure | `specialty.rs:254-255` (clock), `:367-368` (implicon), `clump_only.rs:416` | match |
+
+The one argument that could plausibly have desynchronised the hardtrim pair — `cli.rename` —
+does not reach naming at all: it gates a per-read header rewrite inside the record loop
+(`specialty.rs:60`, `:104`, `:164`, `:217`), never the output path. The clock/implicon
+closures capture the same `output_dir`, `gzip` and `umi_len` bindings their worker closures
+do, so they cannot drift.
+
+**C2 — `guarded_inputs()` is harmless where `--passthrough` cannot be set, and correct where
+it can.** `cli.rs:885-921` confines `--passthrough` to `--paired` with exactly one pair, and
+rejects it alongside `--clock`, `--implicon`, `--hardtrim5/3`, `--demux`, `--clump_only`,
+`--clumpify`, `--retain_unpaired` and uBAM output. So on ten of the eleven call sites
+`cli.passthrough` is provably `None`, and on the eleventh the paired FASTQ candidate list
+(`main.rs:724-731`) adds its output. The `--retain_unpaired` exclusion also means the two
+conditional candidate blocks at `:709` and `:724` can never both fire.
+
+**C3 — D6's `demux_base_name` extraction is behaviour-preserving.** `demux.rs:122-135` is the
+original statement sequence verbatim: same source (`file_name().unwrap_or_default()
+.to_string_lossy().to_string()`), same two `ends_with` strips in the same order, same
+non-idempotent single-pass semantics (`x.fq.gz.gz` → `x.fq`, unchanged). `trimmed_name` is
+still live at `demux.rs:232` for the progress line, so nothing was orphaned and clippy stays
+quiet. The `--demux` byte-identity path in the Perl validation matrix is safe. The one problem
+with D6 is structural, not behavioural — see M1.
+
+### Critical
+
+None found. Nothing in the diff loses reads on a path the diff itself introduced, and the
+"nothing written" contract holds on all eleven guarded paths (probe 1 and probe 5 below).
+
+### High
+
+**H1 — `--paired` accepts one file as its own mate and silently emits a fake pair
+(exit 0, no warning).** Not introduced here, but this diff is the change that decides what
+"the same file" means in this crate, and it leaves the R1≠R2 check on the weakest notion.
+`cli.rs:534-541` compares `chunk[0] == chunk[1]` — raw `PathBuf` equality — so any two
+spellings of one path slip through, and the pre-flight cannot catch it afterwards because
+`_val_1` and `_val_2` are genuinely distinct output paths and neither aliases an input.
+Measured:
+
+```
+$ trim_galore --paired ./a_R1.fq a_R1.fq      # 20-read single-end file
+rc=0, no warning
+a_R1_val_1.fq  20 reads  md5=984ac651…
+a_R1_val_2.fq  20 reads  md5=984ac651…      ← byte-identical to val_1
+```
+
+Two byte-identical files presented as a validated R1/R2 pair. An aligner maps that as proper
+pairs where every fragment is a self-pair, and the trimming report looks normal. This is the
+same failure class as #383 — exit 0 with wrong data — and the plan's own words for it are
+"harder to notice than a missing one". The duplicate-*pair* check at `cli.rs:545-557`
+(`r1 == pr1 && r2 == pr2`) has the identical weakness.
+**Recommendation:** make `collision_key` `pub` and key all three `cli.rs` identity checks on
+it. One-line change per site. See M3 — H1 is the sharp end of the same root cause.
+
+### Medium
+
+**M1 — D6 detached `demultiplex`'s doc-comment and hung it on `demux_base_name`.**
+`demux.rs:106-115` is `demultiplex`'s doc-comment (the 5-step algorithm and "Also writes a
+summary file with per-barcode counts"); `demux_base_name` was inserted at `:116` *inside* it,
+so rustdoc now attributes all of it to the new two-line helper, whose own doc-comment reads as
+a continuation of it, and `demultiplex` at `:137` has no doc-comment at all. This is precisely
+the defect §5 Step 2 set out to repair in `main.rs`, where deleting `preflight_collision_bam`
+reunited `resolve_clump_layout` with its orphaned comment. Behaviourally inert; wrong in
+`cargo doc` and misleading to read. **Recommendation:** move the new function above
+`:106`, or below `demultiplex`.
+
+**M2 — `guarded_inputs()` omits `cli.demux`, and the omission destroys the barcode file
+before any check runs.** `main.rs:62-68` builds the guarded set from `cli.input` plus
+`cli.passthrough`. `cli.rs` has exactly four path-typed fields — `input`, `output_dir`,
+`passthrough`, `demux` — so `--demux`'s barcode file is the one input the run reads that the
+pre-flight never sees. The plan reasoned it away by argument (§3.2: output names always carry
+a `_trimmed`/`_val_` segment, so they cannot equal a barcode text file "except by deliberate
+contrivance"). Measured, the contrivance is destructive:
+
+```
+$ trim_galore --dont_gzip --demux sample_trimmed.fq sample.fastq
+barcode file md5 before=8a96bd56… after=984ac651…   ← overwritten with trimmed reads
+rc=1 (demux then fails to parse the file it just destroyed)
+```
+
+`read_barcode_file` is not called until `main.rs:1266`, *after* trimming has written
+`output_path`, so the pre-flight is the only thing that could have prevented this — and the
+run also breaches the "nothing written" contract, leaving two report files behind. I am
+sizing this Medium rather than High because reachability needs a barcode file named exactly
+like a trim output, which no sane workflow produces. But the argument was unnecessary:
+`guarded_inputs()` exists precisely to be the answer, and adding `cli.demux` to it is one
+line that retires the reasoning entirely. `guarded_inputs`'s doc-comment ("Input paths a run
+must not overwrite: the positionals plus `--passthrough`") also overstates its completeness.
+
+**M3 — three different notions of "same file" now coexist, and the weakest ones are the
+user-facing ones.** After this diff the crate compares paths three ways: raw `PathBuf`
+equality (`cli.rs:534`, `:547`, and the new duplicate-input check at `:627`), `norm_path`
+(case-folded only — the `--passthrough`-aliases-R1/R2 guard at `cli.rs:931-933`), and
+`collision_key` (case-folded *and* absolutised — the pre-flight). The diff upgraded the third
+and left the first two, so defect 1's own analysis now applies verbatim to two checks sitting
+one layer above the one that was fixed. The visible cost:
+
+```
+$ trim_galore ./s.fastq s.fastq
+Output path collision (case-insensitive, for APFS/NTFS safety): … would be written to the same file.
+```
+
+That is the generic APFS/NTFS message, not the precise "was given more than once" — and §4.4
+introduced the `Cli::validate` check specifically so this case would get the precise one,
+quoting `cli.rs:504-516`'s doc-comment to that effect. It fires only for byte-identical
+spellings, so the plan's stated goal is half-delivered. No data is lost (the pre-flight still
+rejects), so this is a diagnostic-quality finding on its own; it is Medium only because it
+shares a root cause with H1, where the same weakness does cost correctness.
+**Recommendation:** `pub fn collision_key`, then use it at all three `cli.rs` sites. That
+closes M3 and H1 together and leaves one definition of file identity in the crate.
+
+**M4 — a seven-line comment above the paired call site documents the key that was just
+replaced.** `main.rs:692-698` still reads "Hash key is the full path, case-folded (ASCII
+lowercase) … (issue #216)", followed by the "Pragmatic trade-off" paragraph — sitting directly
+above `preflight_output_collisions`, which no longer hashes the full path as-is. A reader
+debugging a future collision report will take the absolutisation as absent. The same trade-off
+paragraph is also now duplicated verbatim in `norm_path`'s doc-comment (`io.rs:40-42`), which
+is where it belongs. **Recommendation:** delete `:692-698`; the helper documents itself.
+
+### Low
+
+**L1 — `HashMap<String, &PathBuf>` over inputs does drop an entry, but it cannot cause a
+missed rejection.** `inputs.iter().map(…).collect()` keeps the last value for a repeated key,
+so when two inputs alias one file the map holds one of them. The map is used only for
+membership (unaffected — the key is still present) and to name the offending path in the
+message, so the sole consequence is which of the two aliases is printed. Reachable via
+`./x.fq x.fq`, and probe 1 confirms the run is still rejected. Worth one word in the message
+("one of its inputs") rather than a code change — the current wording already avoids claiming
+which argument index it was.
+
+**L2 — `collision_key`'s `Err` fallback is a silent downgrade to the pre-fix key.**
+`std::path::absolute(p).unwrap_or_else(|_| p.to_path_buf())` fails on an empty path or a failed
+`getcwd`. Degrading to the raw string is the right call — strictly better than skipping the
+check — and both triggers are effectively unreachable: an empty positional dies in
+`detect_input_format` before dispatch, and a `getcwd` failure is global, so every key degrades
+together rather than inconsistently. The inline comment at `io.rs:49` explains what the key
+*does*, not that the fallback silently reverts to the behaviour #383 was filed about. Worth
+half a sentence there.
+
+**L3 — one violation reported per run.** The loop bails on the first offending planned path,
+so an invocation with both a duplicate output and an input alias reports only whichever comes
+first in `planned` order (measured: the duplicate). This is §3.3.3 as specified, and
+collecting all violations would complicate the two message shapes; noting it only because a
+user fixing a glob may need two round trips.
+
+**L4 — the `"R1"`/`"R2"` discriminators stayed `&str` while hardtrim's became an enum.**
+`HardtrimEnd` (§4.2) exists because a copy-pasted `"5prime"` in the `--hardtrim3` block would
+make the guard hash paths the run never writes — a hole invisible to every rejection test.
+`clock_output_name` and `implicon_output_name` take the same kind of discriminator as a bare
+`&str`, duplicated between the `output_names` closure (`main.rs:426-427`, `:440-441`) and the
+writer (`specialty.rs:254-255`, `:367-368`). The hazard is real but milder: swapping R1/R2 in
+the closure yields the same hash *set*, and doubling one value causes a false rejection that
+the acceptance tests catch. Left as-is is defensible; it is now the only untyped instance.
+
+### Efficiency
+
+Nothing actionable. `preflight_output_collisions` is O(n+m) with one `String` per path, and
+`HashMap::with_capacity(planned.len())` is already there. `std::path::absolute` costs one
+`getcwd` per relative path, so n+m syscalls at command-line cardinality — immeasurable, and
+paid before adapter auto-detection's ≤1 M-record scan rather than after it, which is a net win
+on the rejecting path. Building `input_keys` unconditionally does hash the input list even when
+`planned` is empty or length 1; guarding that would trade a branch for a few hundred
+nanoseconds and is not worth the line.
+
+## Fixes applied
+
+None, by instruction.
+
+## Recommendations by priority
+
+| # | Priority | Recommendation | Cost | Ship-blocking? |
+|---|---|---|---|---|
+| H1 | High | `pub fn collision_key`, then key `cli.rs:534` (R1≠R2), `cli.rs:547` (duplicate pair) and `cli.rs:627` (new duplicate input) on it instead of `==` | 4 lines + 1 test | **No** — pre-existing, not a regression. But it is the cheapest correctness win adjacent to this diff, and leaving it makes the commit internally inconsistent. Own issue if not taken here. |
+| M2 | Medium | Add `cli.demux` to `guarded_inputs()`; correct its doc-comment | 3 lines | No |
+| M3 | Medium | Covered by H1's change; also move `cli.rs:931-933`'s `--passthrough` alias check from `norm_path` to `collision_key` | 1 line | No |
+| M1 | Medium | Move `demux_base_name` out of `demultiplex`'s doc-comment | move 20 lines | No |
+| M4 | Medium | Delete the stale key description at `main.rs:692-698` | −7 lines | No |
+| L2 | Low | One clause at `io.rs:49` noting the `Err` fallback reverts to the pre-#383 key | 1 line | No |
+| L1, L3, L4 | Low | Noted for the record; no change recommended | — | No |
+
+**Verdict:** nothing here blocks the commit. H1 is the one I would not leave unfiled — it is a
+silent-wrong-output bug in `--paired`, it is one line from being fixed, and the fix belongs with
+this change rather than after it, because this is the commit that decides what "the same file"
+means. M1 and M4 are tidy-ups I would fold in before pushing, since both are artifacts of this
+diff. M2 is a judgement call the author has already made once, consciously; my only argument is
+that the one-line fix is cheaper than the paragraph of reasoning defending its absence.
+
+## Probes run
+
+All from `/private/tmp/…/scratchpad/creview-warm/`, using a 20-read slice of
+`test_files/illumina_10K.fastq.gz`. Script retained at `creview-warm/probe.sh`.
+
+| Probe | Invocation | Result |
+|---|---|---|
+| 1 | `trim_galore ./s.fastq s.fastq` | rc=1, duplicate-output wording (not the precise one) → M3; nothing written |
+| 2 | `trim_galore --paired ./a_R1.fq a_R1.fq` | **rc=0**, two byte-identical `_val_` files, no warning → H1 |
+| 3 | `trim_galore --dont_gzip --demux sample_trimmed.fq sample.fastq` | barcode file **overwritten**, then rc=1 → M2 |
+| 4 | duplicate output *and* input alias in one command line | duplicate wording wins (first in `planned` order) → L3 |
+| 5 | `trim_galore --dont_gzip --hardtrim5 20 x.fastq x.20bp_5prime.fq` | rc=1, alias wording, aliased file **intact** → correct |
+
+One process note: an early probe attempt wrote a fixture into the repo root because agent-thread
+`cd` does not persist between tool calls. It was deleted immediately and `git status` re-verified
+against the 7-modified-file baseline before continuing; the diff under review was never touched.

--- a/plans/08062026_se-output-collision-preflight/CODE_REVIEW_B.md
+++ b/plans/08062026_se-output-collision-preflight/CODE_REVIEW_B.md
@@ -1,0 +1,446 @@
+# Code Review B — #383 output-collision pre-flight
+
+**Reviewer:** B (independent; no coordination with Reviewer A)
+**Target:** uncommitted working tree on `fix/383-output-collision-preflight` off `dev` @ `72624c7`
+**Plan:** `plans/08062026_se-output-collision-preflight/PLAN.md` (v2, incl. §13)
+
+**No fixes were applied — not even one-liners.** The change is uncommitted in a working tree
+shared with a concurrent reviewer, so an edit from me would corrupt the diff we are both reading.
+Everything below is a recommendation.
+
+**Two process notes, both material to reading this report:**
+
+1. **The tree moved during the review.** I started against `6 files changed, +503/−99`
+   (`io.rs +216`, no `demux.rs`). It is now `7 files changed, +595/−111` (`io.rs +289`,
+   `demux.rs +31/−11`), and `PLAN.md` gained a **D6** entry. The added work is
+   `demux::demux_base_name` plus a second A2 unit test
+   (`distinct_primary_outputs_imply_distinct_secondary_outputs`). Every finding below is
+   re-checked against the **current** source; where a finding was overtaken I say so.
+   `target/release/trim_galore` (built 2026-08-06 23:34) is **stale** relative to the current
+   tree — see the note under Finding 1 for why that does not affect the reproductions.
+2. **A different file was already at this path** (64 lines, "In progress", findings B-1/B-2)
+   when I came to write. I have preserved it verbatim at
+   `…/scratchpad/creview-b/CODE_REVIEW_B.preexisting.md` and reproduced its two findings,
+   independently verified, in Appendix A. If another agent is also writing here, that content
+   is not lost.
+
+Verification method: constructing invocations the new tests and CI steps do not cover, and
+running the binary. Scratch scripts `t1.sh`–`t9.sh` in
+`/private/tmp/claude-501/-Users-fkrueger-Github-TrimGalore/d0ee0171-fc72-476b-bdba-c46c90a5bacd/scratchpad/creview-b/`.
+Everything marked *reproduced* was executed.
+
+---
+
+## 1. Summary
+
+The fix is sound on every path I exercised. All eleven call sites pass a candidate list that
+matches what the corresponding writer actually opens (A9 holds — checked call-by-call, not
+assumed), the four converted hand-rolled sites are behaviour-preserving apart from the two
+intended defect fixes, and both new defects are genuinely closed. D1's predicate is right, and
+no fifth paired-shaped mode needs excluding. The two dispatch paths that still have no
+pre-flight cannot alias their own input — verified, not assumed.
+
+One finding is material: **defect 2 is closed for primary outputs only, and `--demux` still
+destroys a named input at exit 0** — reproduced. That also makes a CHANGELOG sentence
+inaccurate, which is why it is High rather than a scoped residual.
+
+The rest is diagnostics quality (one error message states something false), one coverage gap on
+the widest hardtrim case, and a doc-comment re-parenting introduced by the mid-review D6 change.
+
+Counts: **0 Critical, 1 High, 4 Medium, 9 Low.**
+
+---
+
+## 2. Verified correct (so it need not be re-checked downstream)
+
+**A9 — candidate expression vs. writer, all eleven sites.** Each candidate builder is
+character-identical to the namer call inside the writer it guards:
+
+| Site (`main.rs`) | Candidate | Writer's own call |
+|---|---|---|
+| `:360` `--hardtrim5` | `planned_hardtrim_outputs(…, Five, output_dir, gzip)` | `specialty.rs:45` / `:139` (BAM) |
+| `:391` `--hardtrim3` | same, `Three` | `specialty.rs:88` / `:191` |
+| `:513` `--clump_only` SE FASTQ | `clumped_output_name(input, output_dir, basename, gzip)` | `clump_only.rs:278` |
+| `:548` `--clump_only` PE uBAM N=1 | `clumped_paired_bam_output_name(input[0], None, …)` | `clump_only.rs:922` |
+| `:585` `--clump_only` PE uBAM N≥2 | `clumped_paired_bam_output_name(chunk[0], Some(chunk[1]), …)` | `clump_only.rs:969` |
+| `:633` `--clump_only` SE uBAM | `clumped_bam_output_name(input, output_dir, basename)` | `clump_only.rs:754` |
+| `:734` `--paired` trim FASTQ | `paired_end_output_names` + unpaired + passthrough | `main.rs:1293`, `:1311`, `:1305` |
+| `:799` SE trim FASTQ | `single_end_output_name(input, output_dir, basename, gzip)` | `main.rs:1103` |
+| `:1825` `--paired` trim uBAM | `paired_bam_output_name(chunk[0], chunk[1], …)` | `run_ubam_output_paired_two_files` |
+| `:1869` SE trim uBAM | `single_end_bam_output_name(input, output_dir, basename)` | `main.rs:1893` |
+| `:2430` `run_specialty_paired` | caller's `output_names` closure | `specialty.rs:254`/`:367`, `clump_only.rs:416` |
+
+`--rename` does not participate in naming (`specialty.rs:60`, `:104` only mutate read IDs), and
+`gzip` is one variable on both sides, so **A4 holds in both argument orders** — *reproduced*
+(`t8.sh`): `sample.fastq sample.fq.gz` → rejects on `sample_trimmed.fq`;
+`sample.fq.gz sample.fastq` → rejects on `sample_trimmed.fq.gz`.
+
+**The four converted sites, probed individually** (`t2.sh`, `t3.sh`, `t4.sh`, `t6.sh`):
+
+- `--clump_only` SE colliding stems → exit 1, and the message now says `` `--output_dir` ``
+  (`grep -rn -- "--output-dir" src/ docs/` is empty, so §2.5's correction landed).
+- `--clump_only` SE distinct stems → exit 0, both `_clumped.fq` + both clumping reports.
+- `--clock`, two colliding pairs → exit 1 with an empty `-o` dir; one pair → exit 0 with both
+  `_UMI_` outputs.
+- `--paired` uBAM, two pairs colliding into one `-o` → exit 1, nothing written; two distinct
+  pairs → exit 0, both `_val.bam`.
+- `--paired --retain_unpaired` where an **unpaired** candidate aliases an input → exit 1 with the
+  alias wording, prior file byte-intact — so the `--retain_unpaired` extras survived the
+  conversion.
+- `--paired` with mixed `./` spelling across two pairs → exit 1: the paired path gained
+  defect-1 protection as well as defect-2.
+- The alias check is **order-independent** — `trim_galore s_trimmed.fq s.fastq` (alias listed
+  first) rejects identically, with the prior file intact.
+
+**`guarded_inputs()` is the right input set.** `--passthrough` is `--paired`-only
+(`cli.rs:885`) and single-pair-only (`:890`), so on every other guarded path it contributes
+nothing. *Reproduced*: the full `--passthrough` recipe (`BS-seq_10K_R1/R2 + I1`) still exits 0
+with all seven expected outputs, i.e. adding the passthrough file to the *input* set produced no
+false positive. §3.2's argument holds for the `--demux` **barcode file** — but not for demux
+**outputs**, see Finding 1.
+
+**D1's predicate.** `!self.paired && !self.clock && self.implicon.is_none()` is exactly right:
+`--paired`, `--clock`, `--implicon` and `--clump_only --paired` (which sets `paired`) are the
+only paired-shaped modes, and `--hardtrim5/3` never call `validate_paired_input`
+(`cli.rs:617`, `:955`, `:958` are its only call sites) and loop per file, so including them is
+correct. *Reproduced*: `--clock R1 R1` → "Read 1 and Read 2 appear to be the same file";
+`--implicon=8` with a duplicated pair → "is a duplicate of pair 1"; a duplicated positional
+under `--hardtrim5` → "was given more than once".
+
+**The two unguarded dispatch paths cannot alias their input.** `run_paired_ubam_single_file`
+(`main.rs:1610`) and `run_ubam_output_paired_single_file` (`:2183`) both derive the stem from
+`Path::file_stem()` and append `_val`/`_val_1`, and neither reads `cli.basename`, so output ≠
+input for every input name. *Reproduced*: `--paired --output-format ubam x_val.bam` →
+`Output: x_val_val.bam`, exit 0. The one namer that does honour `--basename`
+(`paired_bam_output_name` → `foo_val.bam`) is reachable only on the two-file path, which is
+guarded — and a BAM inside a two-file pair is rejected earlier by
+`reject_bam_format_mismatch_in_pair` anyway.
+
+**Test and CI non-vacuity.** All nine acceptance cases (7 integration + 2 unit) drive a guarded
+dispatch path and assert success, so an unconditionally-rejecting helper fails every one — the
+property the plan wanted does hold. The three new CI steps are each capable of failing: step 1
+would see exit 0 plus three files without the SE guard; step 2 greps hint text only the hardtrim
+sites can produce; step 3 greps the alias wording *and* md5-pins the named input. The
+`validation` job is `ubuntu-latest` only (`ci.yml:315`) and already uses `md5sum` in ~14 places,
+so the new `md5sum` introduces no portability problem. `collision_key`'s `Err` arm is unreachable
+from the CLI: clap rejects an empty positional with exit 2 before `validate()` runs
+(*reproduced*).
+
+---
+
+## 3. Issues
+
+### HIGH
+
+#### H-1 — Defect 2 is closed for primary outputs only; `--demux` still destroys a named input at exit 0
+
+The candidate lists hold primaries plus the `--retain_unpaired` / `--passthrough` extras. Every
+other file a run writes — trimming report, JSON report, clumping report, **demux per-barcode
+outputs**, FastQC artifacts — is absent, so none is compared against the input set. A2 justifies
+that for *output-vs-output* collisions, and that justification is sound (the new
+`distinct_primary_outputs_imply_distinct_secondary_outputs` test now demonstrates it properly).
+A2 says nothing about output-vs-**input**, which is the defect this change adds. So the second
+half of the fix is narrower than §1 ("every prospective output path … checked … against every
+input path") and narrower than the CHANGELOG, which claims the alias case "is now refused on
+every path with a message of its own".
+
+Reproduction (`t6.sh` scenario Q2 — plain `--demux`, no exotic flags):
+
+```bash
+cp test_files/demux_test.fastq.gz test_files/demux_test_samplesheet.txt .
+trim_galore --demux demux_test_samplesheet.txt demux_test.fastq.gz     # exit 0
+#   → demux_test_trimmed_sample1.fq.gz (1234 reads) among the per-barcode outputs
+# a later re-run picks its own earlier output up in the input list:
+trim_galore --demux demux_test_samplesheet.txt \
+            demux_test.fastq.gz demux_test_trimmed_sample1.fq.gz
+```
+
+Observed **with the fix in place: exit 0, no collision message.** Input 2
+(`demux_test_trimmed_sample1.fq.gz`, seeded with 10 marker reads for the test) is overwritten by
+input 1's demux stage — 0 of the 10 marker reads survive — and is then read in its overwritten
+state, so `demux_test_trimmed_sample1_trimmed.fq.gz` holds 1202 reads of the wrong sample. That
+is precisely the failure mode the CHANGELOG describes as fixed ("destroyed the second input's
+reads and wrote a … file containing the first sample's — a wrong-sample file, which is harder to
+notice than a missing one"), with the same reachability story ("re-running over a directory
+holding an earlier run's output").
+
+*On the stale binary:* this was run against the 23:34 build, i.e. before D6. It is unaffected —
+D6 is a pure extraction (`demux_base_name` recomputes `file_name()` from the same `trimmed_file`
+and applies the identical `.gz`-then-`.fq` strips; `demux.rs:145-153`), `main.rs` is byte-identical
+to the revision I reproduced on, and no demux path entered any candidate list. The behaviour under
+the current source is the same.
+
+The same class is reachable through the report namer, which shows the blind spot is structural
+rather than demux-specific (`t7.sh` scenario W): `trim_galore a.fastq a.fastq_trimming_report.txt`,
+where the second file is a valid FASTQ → input 1's report write clobbers input 2 (marker reads
+gone), *then* the run fails on the corrupted input. Contrived, unlike the demux case, but it
+generalises the finding to "every non-primary output".
+
+**Recommendation** — one of:
+
+1. Feed the derived secondaries into the **input-alias comparison only** (they need not join the
+   duplicate-output comparison, which A2 covers). `report_name`, `json_report_name` and
+   `clumping_report_name` are one line per site. Demux is the harder one: its per-barcode names
+   need the barcode file read, which the pre-flight deliberately does not do — so demux
+   realistically needs option 2.
+2. State the residual the way A8 is stated — name it as an assumption in the plan, pin it with a
+   test that documents the limitation, and **soften the CHANGELOG**: "refused on every path" →
+   "refused wherever the trimmed/validated output itself is an input", plus one sentence that
+   `--demux` per-barcode outputs are not yet covered.
+
+Either way the CHANGELOG sentence must change: as written it claims something the code does not do.
+
+---
+
+### MEDIUM
+
+#### M-1 — The hardtrim hint states something false whenever `--output_dir` is set, in the same sentence that prints the `-o` path
+
+`HARDTRIM_HINT` (`main.rs:56-60`) opens with "Hard-trimmed output is written to the current
+working directory". That is true only without `-o`; `hardtrim_output_name` ends
+`Some(dir) => dir.join(filename)` (`specialty.rs:450-453`). *Reproduced* (`t9.sh`):
+
+```
+trim_galore --hardtrim5 20 -o <w>/out dirA/same.fastq dirB/same.fastq
+Error: … <w>/out/same.20bp_5prime.fq and <w>/out/same.20bp_5prime.fq would be written to the
+same file. Check that inputs produce distinct output paths (e.g., different source directories
+or `--output_dir`). Hard-trimmed output is written to the current working directory, so inputs
+sharing a basename collide whatever `--output_dir` is set to — …
+```
+
+The message names `out/…` and then denies that `out/` is where output goes. The operative clause
+("collide whatever `--output_dir` is set to") is correct and worth keeping; the CWD claim is not.
+Both `tests/integration_output_collision.rs:336`/`:361` and the new `ci.yml` hardtrim step use
+exactly this `-o` shape, so the contradiction is currently asserted as correct behaviour rather
+than caught.
+
+**Recommendation:** reword the first clause to be true in both cases — "Hard-trimmed output is
+named from the input's basename only, ignoring the input's directory" — or gate the CWD sentence
+on `output_dir.is_none()`.
+
+#### M-2 — The duplicate-output message names the same path twice and never names the inputs
+
+`preflight_output_collisions` reports `{existing} and {p}`, i.e. the two *planned* paths. For the
+#383 shape those are byte-identical strings, so the diagnostic is tautological and names neither
+input. *Reproduced* on three paths:
+
+```
+# --hardtrim5 20 dirA/same.fastq dirB/same.fastq
+… same.20bp_5prime.fq and same.20bp_5prime.fq would be written to the same file. …
+# -o out sample.fastq sample.fq.gz
+… out/sample_trimmed.fq and out/sample_trimmed.fq would be written to the same file. …
+# --clump_only --cores 2 sample.fastq sample.fq
+… sample_clumped.fq and sample_clumped.fq would be written to the same file. …
+```
+
+The identical-string case is the *common* case for the paths this change adds — it is #383 as
+filed — whereas the inherited wording was written for #216, where the two paths differ by letter
+case. On `--hardtrim5 30 */*.fastq.gz` over a per-sample layout (the pattern §3.4 exists for) the
+user gets one repeated bare filename and has to work backwards to find which two of N inputs
+produced it. The offending basename *is* recoverable, which is why this is Medium, not High.
+
+**Recommendation:** carry the source input alongside each candidate (`&[(PathBuf, &Path)]`, or a
+parallel index vector) and phrase the message around the inputs: "Inputs `dirA/same.fastq` and
+`dirB/same.fastq` would both be written to `same.20bp_5prime.fq`." That also makes M-1's hint read
+as a consequence rather than a rebuttal of the sentence before it.
+
+#### M-3 — Case-folding now refuses genuinely distinct inputs on case-sensitive filesystems, undocumented
+
+`collision_key` case-folds via `norm_path`, so the SE and hardtrim paths — which had **no** check
+before — now reject two inputs whose stems differ only in case. *Reproduced*:
+`trim_galore Sample.fastq sAMPLE.fq` → exit 1, "Output path collision (case-insensitive, for
+APFS/NTFS safety)". On ext4 those are two files with two distinct outputs, and the run used to
+succeed.
+
+A1 records the trade but frames the false-positive surface as "opt-in case-sensitive APFS
+volumes". ext4 is case-sensitive **by default** and Linux (containers, nf-core) is the primary
+deployment target, so the surface is larger than A1 states — and it grew in this commit from
+`--paired` to every path. The CHANGELOG does not mention it, while it does log the much rarer
+duplicate-positional refusal under `#### Changes`.
+
+**Recommendation:** no code change — the trade is right. Add one `#### Changes` bullet: inputs
+whose output paths differ only in letter case are now refused on all paths, deliberately, for
+APFS/NTFS safety, with the remedy. And widen A1's wording beyond APFS.
+
+#### M-4 — No test or CI step covers hardtrim without `--output_dir`, the widest collision class
+
+All four hardtrim rejection tests and the hardtrim CI step pass `-o`, under which the two
+candidates collide simply because both are `<-o>/<same stem>` — the same mechanism as SE trim.
+The behaviour that motivates the mode-specific hint, §2.2 repro (c) and §2.3's CWD asymmetry is
+`--hardtrim5 20 dirA/same.fastq dirB/same.fastq` with **no** `-o`, and nothing exercises it.
+§10 V2.5/V2.6 asked for `current_dir(tempdir)` cases; the implementation added `-o` on top, and
+§13 does not record the deviation.
+
+It does work — *reproduced* (`t1.sh`): exit 1 with the hint and nothing written into the CWD, and
+the matching acceptance case (distinct basenames, no `-o`) exits 0 with correct per-file
+attribution. So this is unpinned coverage rather than a defect: a future change that dropped the
+`output_dir` argument from `planned_hardtrim_outputs` would still pass every hardtrim test today,
+because the bare-filename form collides on the string alone.
+
+**Recommendation:** drop `-o` from one of the two hardtrim FASTQ rejection tests and assert the
+CWD afterwards holds only `dirA`/`dirB`.
+
+---
+
+### LOW
+
+1. **`demultiplex`'s doc-comment was re-parented onto `demux_base_name` by D6.** The new function
+   was inserted *between* `demultiplex`'s doc block and `demultiplex` itself, so `demux.rs:106-133`
+   now reads as one comment — the five-step "For each read: 1. Extract … 5. Write to the matching
+   sample's output file" plus "Also writes a summary file with per-barcode counts", followed by the
+   new stem/A2 paragraphs, all attached to `demux_base_name` (`demux.rs:122`). `demultiplex`
+   (`:134`) is now undocumented and `cargo doc` renders the demultiplexing algorithm as the
+   documentation for a filename helper. Move the new function above the doc block, or below
+   `demultiplex`. (D6's behaviour claim is otherwise sound — see the stale-binary note in H-1.)
+2. **`primary_output_key_is_coarser_than_secondary_keys` still carries a claim it does not
+   establish.** Its doc-comment says the shown property means "checking primaries covers the
+   secondaries"; it actually exhibits a member of `~primary \ ~secondary`, which shows strictness,
+   not containment. The new `distinct_primary_outputs_imply_distinct_secondary_outputs` is the
+   test that carries A2, so the older one is now really a #382 stem-equivalence pin — relabel it
+   and drop the coverage claim, otherwise a future reader will trust the wrong test. (This was
+   Medium before D6 landed; the new test overtakes it.)
+3. **The alias message prints the input's spelling as the path that would be written.**
+   `io.rs:71-78` reports `input.display()`, not the planned path sharing its key. For a case-only
+   or `./` alias those differ textually, so the user is told the run "would write output to
+   `s_trimmed.fq`" when it would open `./s_trimmed.fq` or `S_trimmed.fq`. Naming both costs one
+   `{}`.
+4. **`HashMap<String, &PathBuf>` for `input_keys` keeps only the last of two aliasing inputs.**
+   Harmless — the key *set* is unchanged, so whether the check fires is unaffected; only which
+   input the message names. A one-line comment on the last-wins behaviour would save a future
+   reader the analysis.
+5. **The helper's call-site enumeration is incomplete.** `io.rs:53-56` says "every `main.rs`
+   dispatch path that writes more than one file", but `run_paired_ubam_single_file` writes two
+   FASTQ outputs and does not call it, and `run_ubam_output_paired_single_file` does not either.
+   §4.1's stated purpose is that "a fifth omission [is] visible from here"; as written, an auditor
+   finds two contradictions and no explanation. Name them as deliberately excluded (one input
+   cannot duplicate, and `file_stem` + `_val` cannot alias). Also "all four output formats" should
+   read "both output formats" — there are two.
+6. **`--clock`/`--implicon` being excluded from the duplicate-input scan costs precision for
+   cross-pair repeats.** `--clock A_R1 A_R2 A_R1 B_R2` is neither an R1==R2 nor a duplicate pair,
+   so it falls through to the pre-flight and gets the APFS/NTFS wording (*reproduced*: exit 1,
+   "Output path collision"). Correctly rejected, just not with the precise message §4.4 argues
+   for. Fixable later by ordering the scan after `validate_paired_input` instead of excluding the
+   modes.
+7. **The duplicate-input message's argument numbers are positions in the input list, not argv.**
+   `trim_galore -q 20 a.fq a.fq` reports "arguments 1 and 2" for what the user sees as words 4
+   and 5. Say "input files 1 and 2", or drop the numbers.
+8. **`tempdir()`'s `canonicalize(&d).unwrap_or(d)`** (`tests/integration_output_collision.rs:35`)
+   silently returns to the vacuous-pass state D4 fixed if `canonicalize` ever fails. `.expect()`
+   fails loudly instead — the point of D4 is that this exact silence cost an iteration.
+9. **New CI directories are missing from the failure-artifact upload list.** `ci.yml:938-946`
+   lists `/tmp/rust_case/` (the analogous #216 guard) but not `/tmp/rust_se_coll/`,
+   `/tmp/rust_ht_coll/`, `/tmp/rust_alias/`. `/tmp/*.log` does pick up the three logs, so this is
+   consistency only. Related: `docs/src/content/docs/modes/hardtrim.md:38` ("Both modes accept
+   multiple input files in a single invocation") is now incomplete, since that shape is a hard
+   failure when basenames repeat — §11 Open 4, deliberately deferred; line recorded so the
+   follow-up is one edit.
+
+---
+
+## 4. Fixes applied
+
+**None**, by instruction — see the header. H-1 and M-1 are the two I would act on before merge;
+M-2 is a small signature change; M-3 is a CHANGELOG sentence; M-4 is a test change; the Lows can
+ride along or wait.
+
+---
+
+## 5. Priority table
+
+| # | Finding | Priority | Kind |
+|---|---|---|---|
+| H-1 | Non-primary outputs (esp. `--demux`) can still overwrite an input at exit 0; CHANGELOG overclaims | **High** | correctness + docs |
+| M-1 | `HARDTRIM_HINT` asserts CWD output in the same message that prints the `-o` path | **Medium** | diagnostics |
+| M-2 | Duplicate message names one path twice, never the inputs | **Medium** | diagnostics |
+| M-3 | Case-fold now refuses distinct inputs on case-sensitive filesystems, unlogged | **Medium** | docs |
+| M-4 | Hardtrim without `-o` (the widest class) untested | **Medium** | coverage |
+| L-1…L-9 | See §3 | Low | polish |
+
+---
+
+## Appendix A — content found at this path before I wrote (preserved)
+
+A 64-line in-progress report was at `CODE_REVIEW_B.md` when I came to write; full text kept at
+`…/scratchpad/creview-b/CODE_REVIEW_B.preexisting.md`. Its two findings, both of which I then
+verified independently, are carried above:
+
+- its **B-1** (`HARDTRIM_HINT` false under `-o`) → my **M-1**, reproduced independently in `t9.sh`.
+- its **B-2** (`demultiplex`'s doc-comment re-parented onto `demux_base_name` by D6) → my
+  **L-1**, confirmed from `git diff src/demux.rs`.
+
+Nothing else in that file was lost: it had empty Errors / Efficiency sections and an unfilled
+summary.
+
+---
+
+## Appendix B — second independent B pass (author of the pre-existing file)
+
+I am the reviewer whose in-progress file was replaced above. Rather than overwrite this report I
+have finished my pass and record only (a) where I independently reached the same conclusion, and
+(b) the findings not carried above. **No fixes applied.** My scratch scripts are in
+`…/scratchpad/blind-b/` (`p1.sh`–`p5.sh`), run against a `target/release/trim_galore` copied at
+mtime 12:57 (newer than every source file, and confirmed current by exercising the new SE guard).
+
+### Independently reproduced, same conclusion
+
+- **H-1.** Reached independently and by a different route: my `p3.sh` scenario H
+  (`a.fastq` + `a.fastq_trimming_report.txt` holding valid FASTQ) destroyed the named input via
+  the *report* writer, and `p5.sh` produced the exit-0 `--demux` version —
+  `--demux bc.txt -q 32 src.fastq`, then `--demux bc.txt src.fastq src_trimmed_sample1.fq` →
+  exit 0, `src_trimmed_sample1.fq` md5 changes from `503ad5d9…` (1224 reads) to `6e89e90c…`
+  (1234 reads). Two reviewers converging on this from different fixtures is worth weighting.
+- **M-1** (was my B-1) and **L-1** (was my B-2): confirmed as stated.
+- **A9 across all eleven sites, the four converted sites, `guarded_inputs`, D1's predicate, the
+  two unguarded N=1 paths, no fifth hole:** my call-by-call check and probes agree throughout.
+  Adding to the above: `--paired --hardtrim5 20 a.fastq a.fastq` correctly yields "Read 1 and
+  Read 2 appear to be the same file" (D1's exclusion of `paired` does not lose precision there),
+  and `--paired --retain_unpaired` with an unpaired candidate fed back as a fourth input rejects
+  with the alias wording and leaves the prior file intact.
+
+### Findings not carried above
+
+**B-3 (Medium) — `distinct_primary_outputs_imply_distinct_secondary_outputs` cannot fail, so it
+does not carry A2.** H-1 credits it with demonstrating A2 "properly"; I disagree. Its three
+fixture inputs (`d/alpha.fastq.gz`, `d/beta.fastq.gz`, `e/gamma.fq.gz`, `io.rs:1057-1061`) have
+**pairwise-distinct basenames**, and all three secondary namers under test — `report_name`,
+`json_report_name`, `clumping_report_name` — are injective in the input's filename. So
+`namer(inputs[i]) != namer(inputs[j])` is true by construction for every pair the loop reaches,
+independent of the pre-flight, the primaries, and the `basename`/`gzip`/`output_dir` matrix. The
+two outer loop dimensions add nothing at all: none of the three namers takes `basename` or
+`gzip`. The `demux_base_name` sub-assertion is injective in the primary's stem for the same
+reason.
+
+The shape that *could* fail is the one the fixture omits: two inputs with the **same basename in
+different directories** (`d/same.fastq.gz`, `e/same.fastq.gz`). Without `-o` the primaries differ
+and the reports must differ by directory — a real assertion; with `-o` both collapse and the
+`a == b` guard makes the case `continue`. Adding that pair is a two-line change and turns a test
+that cannot fail into one that can. As it stands this is v1's V6 failure mode in a new costume,
+and it is the one the plan's §10 V5 was rewritten specifically to avoid.
+
+**B-4 (Low) — `assert_rejected_cleanly`'s nothing-written check goes vacuous on a missing
+directory.** `tests/integration_output_collision.rs:105-111` is
+`std::fs::read_dir(dir).map(…).unwrap_or_default()`, so a `read_dir` failure yields an empty
+`leftovers` and the assertion passes. Every current caller `create_dir_all`s the `-o` directory
+first, so it is sound today; but this is the same silent-fallback shape as L-8's
+`canonicalize(&d).unwrap_or(d)`, and D4/D3 are the record of what that costs. `.expect()` here
+too.
+
+**B-5 (Low, efficiency) — the new duplicate-input scan is O(n²) in the input count.**
+`cli.rs:627-628` does `self.input[..i].iter().position(|other| other == path)` per input, i.e.
+`n²/2` `PathBuf` comparisons; the pre-flight it complements is O(n). At a 5 000-file glob that is
+~12 M path compares — still well under a second, and it matches the shape of the existing
+duplicate-pair check, so this is a note rather than a request. If it is ever touched, a
+`HashSet<&PathBuf>` makes it O(n) and the module already carries the imports.
+
+**B-6 (Low) — the `.gz`/`.bgz` regression test writes plain text into gzip-named files.**
+`se_trim_rejects_gz_and_bgz_sharing_a_stem` (`:196`) seeds `wide.fastq.gz` and `wide.fastq.bgz`
+with uncompressed FASTQ. It does still pin #382's widening (pre-#382 stem-stripping left
+`wide.fastq` on the `.bgz` arm, so no collision), but because `is_gzipped` is content-based the
+run resolves to `gzip = false` and both candidates end `.fq`, not `.fq.gz` — so the case never
+exercises the gzip-suffixed spelling it is named for. Using real gzip/bgzip bytes would cost one
+`flate2` write in the fixture helper.
+
+### My counts
+
+0 Critical, 1 High (H-1, converged), 3 Medium (M-1 converged, plus B-3; I did not independently
+assess M-2/M-3/M-4, which look right to me on reading), 3 Low unique to this appendix.

--- a/plans/08062026_se-output-collision-preflight/CODE_REVIEW_D13.md
+++ b/plans/08062026_se-output-collision-preflight/CODE_REVIEW_D13.md
@@ -1,0 +1,173 @@
+# Code review — D13 (`d2a1c3a`), the `path_identity_key` / `collision_key` split
+
+Scope: commit `d2a1c3a` only, on `fix/383-output-collision-preflight`. Files `src/io.rs`,
+`src/cli.rs`. All behaviour below was executed against `target/release/trim_galore` (current
+with the change). Scratch: `/private/tmp/claude-501/…/scratchpad/d13/`. No repo file other
+than this report was touched.
+
+## What the commit does
+
+`io::collision_key` is factored into a private `lexical_normalise(&Path) -> PathBuf`
+(absolutise, drop `.`, fold `..`) plus two public string keys over it:
+
+- `path_identity_key` — case **preserved** → the three `Cli::validate` input-identity checks
+  (`src/cli.rs:537`, `:549-550`, `:635`/`:638`).
+- `collision_key` — `norm_path()`-folded → `io::preflight_output_collisions` (`src/io.rs:97`,
+  `:102`) and the `--passthrough`-aliases-R1/R2 check (`src/cli.rs:939-941`).
+
+## Verification setup
+
+The machine's `/` is case-insensitive APFS. To test the Linux direction properly I built a
+genuinely case-sensitive volume inside scratch and ran both sides:
+
+```
+hdiutil create -size 60m -fs "Case-sensitive APFS" -volname CSTEST cs.dmg
+hdiutil attach cs.dmg -mountpoint "$PWD/csmnt" -nobrowse     # needed sandbox bypass
+```
+Confirmed case-sensitive (`Aa` and `aA` coexist as two files); the APFS side confirmed
+case-insensitive (`r1.fq` and `R1.fq` share inode 194103634).
+
+| # | FS | invocation | result |
+|---|----|-----------|--------|
+| B | APFS | `--paired ./a_R1.fq a_R1.fq` | refused, "appear to be the same file" ✓ |
+| C | APFS | `a_R1.fq A_R1.fq` (SE) | refused, output-collision/APFS message ✓ |
+| D | APFS | `--paired Sample_R1 Sample_R2 SAMPLE_R1 SAMPLE_R2` | output-collision/APFS message ✓ |
+| E | APFS | `--paired S_R1 S_R2 S_R1 S_R2` | "duplicate of pair 1" ✓ (fires before pre-flight) |
+| G | **case-sens** | the #216 guard, four genuinely distinct files | output-collision/APFS message ✓ |
+| H | **case-sens** | `--paired r1.fq R1.fq`, two real files | runs; 2 outputs + 4 distinct reports ✓ |
+| A | APFS | `--paired r1.fq R1.fq` (one physical file) | **runs** — see Q1 |
+| I | **case-sens** | `--paired r1.fq r2.fq --passthrough R1.fq` | **refused** — see Q2 |
+
+G is the load-bearing one: on a real case-sensitive filesystem the commit produces exactly the
+message the CI guard asserts, and E shows the `Cli::validate` duplicate-pair check does pre-empt
+the pre-flight when it fires — so the D8 failure mode is understood and closed.
+
+Aside: the commit message's "not reproducible on macOS" is half right. The four-distinct-files
+*premise* needs a case-sensitive FS, but which message fires is pure path math — case D above
+reproduces the diagnostic swap on APFS. A local test was therefore available; see finding 3.
+
+## Q1 — is case-sensitive input identity right in both directions?
+
+**Yes, ship it.** Direction that matters is verified (G, H): on a case-sensitive filesystem two
+files differing only in case are two files, they pair correctly, and the #216 guard reaches the
+output pre-flight. Case-folding input identity rejects valid input, which is a worse failure
+than the residual below.
+
+The APFS false-negative is real and I reproduced it (A). `--paired r1.fq R1.fq` on APFS names
+one physical file twice: `path_identity_key` sees two paths, and the outputs (`r1_val_1.fq` /
+`R1_val_2.fq`) fold to different keys because the `_1`/`_2` suffix differs, so nothing catches
+it. The run self-pairs the file and exits 0. Two consequences:
+
+1. Nonsense-but-harmless output: R1 and R2 are the same reads.
+2. **One trimming report is silently overwritten.** The run announces
+   `r1.fq_trimming_report.txt` and `R1.fq_trimming_report.txt`; only one file exists afterwards
+   and it contains `Input filename: R1.fq`. The R1 report is gone — the #383 harm class.
+
+Two things keep this from being a blocker. First, it is **not a regression**: `dev` compared
+inputs with raw `PathBuf ==`, also case-sensitive, so `dev` behaves identically. The parent
+commit `080c1d0` covered this case only as a side effect of the overreach that broke CI.
+Second, the sharp SE case *is* caught (C) — `a.fq A.fq` collides on the trimmed-output key with
+the APFS message, and SE is where #383's data loss lived.
+
+The reachable-harm set is also narrower than it looks: multi-pair case-only variants *are*
+caught, because a `_val_1` path folds and collides (D). Only R1==R2-within-one-pair escapes,
+precisely because `_1`/`_2` differ.
+
+**Recommended follow-up (not this commit's fault):** the paired pre-flight's candidate list is
+`vec![o1, o2]` plus unpaired/passthrough (`src/main.rs:740`) — it omits the report paths, while
+the SE path includes them via `planned_secondary_outputs` (`src/main.rs:90-93`). Adding the two
+report paths per pair converts the Q1 false-negative into a loud pre-flight error on APFS at
+zero cost on Linux (H shows those four report names stay distinct on a case-sensitive FS, so no
+false positive is possible). The principled fix for the whole class — filesystem identity via
+`dev`+`ino` instead of string keys, which would also retire the symlink residual A8 — is bigger
+than this PR should carry.
+
+## Q2 — is every call site on the right key?
+
+`grep` over `src/` finds no remaining raw path-equality comparison and no other consumer of
+either key. Audit:
+
+| site | question it asks | key | verdict |
+|---|---|---|---|
+| `cli.rs:537` R1≠R2 in pair | same file? | identity | correct |
+| `cli.rs:549-550` duplicate pair | same file? | identity | correct |
+| `cli.rs:635`/`:638` duplicate SE input | same file? | identity | correct |
+| `io.rs:97` pre-flight input map | would an output land on an input? | collision | correct |
+| `io.rs:102` pre-flight planned | same output file? | collision | correct |
+| `cli.rs:939-941` `--passthrough` alias | **same file?** | collision | **finding 2** |
+
+`guarded_inputs` (`src/main.rs:64`) feeds the pre-flight's input side and correctly inherits
+the folded key — "would an output land on this input" should fold on APFS.
+
+The `--passthrough` check is the one mismatch. Its own comment (`src/cli.rs:935-937`) says it
+catches "case-only INPUT aliases" — an identity question wearing a collision key. Test I shows
+the consequence: on a case-sensitive volume, with `R1.fq` genuinely distinct from `r1.fq`, the
+run is refused with a message asserting `R1.fq` "aliases an input file", false on that
+filesystem. That is verbatim the failure mode the commit fixes for the other three checks. It
+is pre-existing and deliberate, it fails loudly, and the input shape is exotic, so I would not
+block — but the commit's own rationale argues against it.
+
+## The `..`-folding loop
+
+Executed a verbatim copy of `lexical_normalise` over edge cases (`scratchpad/d13/norm.rs`):
+
+```
+"/.." -> "/"    "/../.." -> "/"    "/../x" -> "/x"    "//a" -> "/a"    "/a/" -> "/a"
+"/a/b/../.." -> "/"    "/a/b/../../.." -> "/"    "/a/b/../c/./d/../e" -> "/a/c/e"
+```
+
+POSIX `/..` == `/` is right, and `..` cannot walk above root or leak a stray `..` into the key.
+Two dead-code notes, both harmless: the `_ => stack.push(c)` unfoldable-`..` arm is unreachable
+on POSIX, because `std::path::absolute` only fails on the empty path (verified:
+`absolute("")` → `InvalidInput`, `absolute("..")` → `Ok`) and an empty path has no components;
+and the `Component::CurDir => {}` arm is redundant, since `absolute()` plus `Components`'
+own skipping of interior `.` already removes it. Windows `Prefix` handling looks right for
+drive-rooted paths, and verbatim (`\\?\`) paths — where folding `..` would change meaning
+because Windows treats it literally — are moot: the CI matrix is `ubuntu-latest` and
+`macos-latest` only.
+
+## Can the two new tests fail?
+
+Mutation-checked in the standalone copy rather than by editing the repo.
+
+- `identity_key_is_case_sensitive_but_collision_key_is_not` — **yes, load-bearing.** Re-folding
+  case in `path_identity_key` (i.e. re-doing D8) flips the `assert_ne` to false. Both halves
+  bite.
+- `both_keys_normalise_spelling` — **yes, but narrowly.** Removing the `ParentDir` fold makes
+  the `a/../x.fq` case fail. It does **not** catch removal of the `absolute()` call
+  (`./x.fq` and `a/../x.fq` still normalise to `x.fq` without it), so the absolutisation that
+  the original H1 finding was actually about is unpinned. Comparing `x.fq` against
+  `current_dir().join("x.fq")` would close that.
+
+## Findings
+
+1. **APFS false-negative, low-medium, pre-existing, not blocking.** `--paired r1.fq R1.fq` on a
+   case-insensitive FS self-pairs one file and silently overwrites one trimming report
+   (reproduced). Same on `dev`. Cheapest fix: add the per-pair report paths to the paired
+   pre-flight candidate list at `src/main.rs:740`.
+2. **`--passthrough` alias check is an identity question on a collision key, low.**
+   `src/cli.rs:939-941` false-positives on a case-sensitive filesystem (reproduced, test I).
+   Pre-existing and loud. Either fold it into `path_identity_key` and accept the APFS gap
+   symmetrically, or note in the comment why passthrough is treated differently from the other
+   three identity checks.
+3. **The regression that caused this commit has no unit-level guard, low, cheap to fix.** The
+   two new tests pin the *keys*; what broke was the *wiring* in `cli.rs`. A test in the
+   existing `Cli::parse_from(…).validate()` style — no files on disk needed, so it runs
+   identically on macOS and Linux — would have failed on D8:
+
+   ```rust
+   let cli = Cli::parse_from(["trim_galore", "--paired",
+       "Sample_R1.fastq.gz", "Sample_R2.fastq.gz", "SAMPLE_R1.fastq.gz", "SAMPLE_R2.fastq.gz"]);
+   assert!(cli.validate().is_ok(), "case-only variants are distinct inputs");
+   ```
+   No existing test uses those four names against `validate()`; only the CI validation job
+   covers it.
+4. **Nits:** `both_keys_normalise_spelling` does not pin absolutisation (above); and
+   `norm_path`'s doc block (`src/io.rs:33-42`) is still the only place describing the key
+   family yet never mentions `path_identity_key` or the identity/collision distinction — one
+   line would make the split discoverable from the function a reader hits first.
+
+None of the five changes behaviour that this commit got wrong in the direction it set out to
+fix, and none is a regression against `dev`.
+
+MERGE

--- a/plans/08062026_se-output-collision-preflight/COVERAGE.md
+++ b/plans/08062026_se-output-collision-preflight/COVERAGE.md
@@ -1,0 +1,336 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs. implementation plan — the plan's own §5 is the ledger source; no separate `IMPL.md`, by design)
+**Plan(s):** `plans/08062026_se-output-collision-preflight/PLAN.md` (revision v2, §13 notes D1–D6 + post-audit closures)
+**Date:** 2026-08-07
+**Verdict:** COMPLETE
+
+> **Provenance.** This is a third, independent audit, written without reading `COVERAGE_round1.md`,
+> `SNAPSHOT_coverage_reaudit.md`, or any `CODE_REVIEW_*.md`. It replaces the previous `COVERAGE.md`,
+> which is preserved byte-identically as `SNAPSHOT_coverage_reaudit.md`
+> (both md5 `0e709a371a890fa482660441a9f7272c`) — nothing was lost.
+>
+> `PLAN.md` was edited while this audit was in progress: it grew from 703 to 726 lines, gaining **D6**
+> and the "Post-audit gap closures" section. The ledger below is verified against the **726-line**
+> version. This audit's one deviation finding is documented there, which is why the verdict is
+> COMPLETE rather than INCOMPLETE.
+
+## Summary
+
+- Total items: 65
+- DONE: 64
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED: 1 — item 47 (V5), documented at §13 "Post-audit gap closures" ¶2, therefore acceptable
+
+Audited state: `fix/383-output-collision-preflight` off `dev` @ `72624c7`, uncommitted.
+Actual diff: **7 files changed, +595/−111**, plus the new `tests/integration_output_collision.rs`
+(604 lines, 20 tests).
+
+Gates re-run by this audit:
+
+| Gate | Result |
+|---|---|
+| `cargo fmt --all -- --check` | clean |
+| `cargo clippy --all-targets --release -- -D warnings` | clean (exit 0) |
+| `cargo test` (crate root) | **521 passed, 0 failed** (399 lib + 122 integration) |
+| `cargo build --release` | succeeds |
+| `.github/workflows/ci.yml` parses | valid YAML, **41** steps in `validation` |
+
+## Coverage ledger
+
+### §5 — the 13 implementation steps
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `collision_key` + `preflight_output_collisions` in `io.rs`, after `norm_path`; extend `norm_path`'s doc-comment to name the new caller | Step 1 | DONE | `src/io.rs:47-51` (key), `:53-90` (helper). `norm_path` doc-comment names `collision_key` at `io.rs:37-38`, and the stale "`main::run` paired-end" locator is gone. |
+| 2 | Delete `preflight_collision_bam`; re-point its three calls | Step 2 | DONE | Symbol absent from the whole tree. Three calls now at `main.rs:548`, `:585`, `:633`. The incidental fix landed: `resolve_clump_layout`'s doc-comment rejoined its function. |
+| 3 | Convert the four hand-rolled copies, preserving each site's semantics | Step 3 | DONE | `main.rs:513` (clump_only SE FASTQ), `:734` (paired FASTQ — candidates accumulated across **all** chunks into one `Vec` before a single call, so cross-pair collisions are still caught; `--retain_unpaired` and `--passthrough` extras kept), `:1825` (paired uBAM), `:2430` (`run_specialty_paired`). Every site passes `guarded_inputs()`. Both `--output-dir` message sites are gone (§2.5). |
+| 4 | `HardtrimEnd` enum + `pub` on both namers; update the 4 internal call sites and the bgz test | Step 4 | DONE | `specialty.rs:19-31` (enum, `as_str`, derives `Debug, Clone, Copy, PartialEq, Eq`); `pub fn` at `:442` and `:465`; call sites `:45`, `:88`, `:139`, `:191`; test updated at `:838-846`. |
+| 5 | `planned_hardtrim_outputs` matching on `cli.output_format` | Step 5 | DONE | `main.rs:69-88`. `std::path::PathBuf` spelled in full per §4.3/§8. |
+| 6 | Guard `--hardtrim5`, first statement in the block, with `HARDTRIM_HINT` | Step 6 | DONE | `main.rs:358-364`, immediately before the write loop at `:365`. `HARDTRIM_HINT` at `:55-59`, naming the real remedies (one invocation per input, or distinct basenames). |
+| 7 | Guard `--hardtrim3` identically with `HardtrimEnd::Three` | Step 7 | DONE | `main.rs:389-395`, before the write loop at `:396`. |
+| 8 | Guard SE trim FASTQ in the `} else {` arm before the loop | Step 8 | DONE | `main.rs:791-799`. The namer call is character-identical to the writer's, closing A9 by construction. |
+| 9 | Guard SE trim uBAM, same shape with `single_end_bam_output_name` | Step 9 | DONE | `main.rs:1863-1869`. |
+| 10 | Reject duplicate SE inputs in `cli.rs` with its own message | Step 10 | DONE | `cli.rs:625-642`, with D1's corrected predicate `!self.paired && !self.clock && self.implicon.is_none()`. |
+| 11 | Tests: unit in `io.rs` (V1) and `cli.rs` (V4); new `tests/integration_output_collision.rs` (V2, V3) | Step 11 | DONE | 10 new `io.rs` preflight unit tests + 2 A2-table tests; 3 new `cli.rs` tests; 20 integration tests. Conventions match `tests/integration_paired_format_guard.rs`: `env!("CARGO_BIN_EXE_trim_galore")`, `tempdir(tag)` keyed on `process::id()`, `(bool, String)` from `Command::output()`. The `current_dir` hazard is handled more strongly than the plan asked — fixtures are built in-test, so no case references `test_files/` at all. |
+| 12 | CI: three validation steps | Step 12 | DONE | `ci.yml:642-696`, inserted after the existing `/tmp/rust_case/out` guard as §10 V6 specified. |
+| 13 | CHANGELOG: `#### Bug fixes` for #383 + the two defects; `#### Changes` for A6 and the `--output-dir` correction | Step 13 | DONE | `CHANGELOG.md:63-117`. All four required entries present; `#### Changes` reused, not duplicated. |
+
+### §4 — specified signatures
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 14 | `fn collision_key(p: &Path) -> String` = `norm_path(absolute(p).unwrap_or_else(…))` | §4.1 | DONE | Matches the plan exactly, including the `Err` fallback that degrades to the raw-string key rather than skipping the check. |
+| 15 | `pub fn preflight_output_collisions(planned: &[PathBuf], inputs: &[PathBuf], hint: Option<&str>) -> Result<()>` | §4.1 | DONE | Signature exact. Doc-comment enumerates the call sites as §4.1 requires and adds "A new dispatch path needs a call here too." Inputs are held as `HashMap<String, &PathBuf>` rather than the planned `HashSet<String>` — that is what lets the alias message name the offending input, which §3.2 requires. Planned paths use `HashMap::with_capacity` per §6. |
+| 16 | `pub enum HardtrimEnd { Five, Three }`, `.as_str()` → `"5prime"`/`"3prime"`; both namers `pub` | §4.2 | DONE | As specified. `fn` → `pub fn` trips no lint, confirmed by the clean clippy run (§8's prediction holds). |
+| 17 | `fn planned_hardtrim_outputs(cli, keep, end, output_dir, gzip) -> Vec<std::path::PathBuf>` | §4.3 | DONE | Five arguments, under clippy's `too_many_arguments` threshold. |
+| 18 | A6 duplicate-SE-input check in `Cli::validate`, own message in the style of `cli.rs:535` | §4.4 | DONE | "Input file {} was given more than once (arguments {} and {}). List each input once — trimming it twice would write the same output file twice." Placed at `:629`, after the `--basename` check rather than literally beside the duplicate-pair check, but inside `Cli::validate` and before `ensure_output_dir` — both properties the plan required (A7). |
+
+### §10 V1 — unit tests in `src/io.rs` (9 specified, 9 found)
+
+| # | Item | Source | Status | Test |
+|---|------|--------|--------|------|
+| 19 | distinct outputs → `Ok` | V1.1 | DONE | `preflight_accepts_distinct_outputs` |
+| 20 | byte-identical outputs → `Err`, message names both | V1.2 | DONE | `preflight_rejects_identical_outputs` — asserts the duplicate wording **and** that the path is named |
+| 21 | case-only variants → `Err` | V1.3 | DONE | `preflight_rejects_case_only_variants`; the plan's "unreachable from integration — cannot coexist on APFS" rationale is carried into the doc-comment |
+| 22 | `./x_trimmed.fq.gz` vs `x_trimmed.fq.gz` → `Err` | V1.4 | DONE | `preflight_rejects_dot_slash_alias` |
+| 23 | `<cwd>/x_trimmed.fq.gz` vs `x_trimmed.fq.gz` → `Err` | V1.5 | DONE | `preflight_rejects_absolute_versus_relative_alias` |
+| 24 | planned == an input → `Err` with the **alias** wording, not the duplicate wording | V1.6 | DONE | `preflight_rejects_output_that_aliases_an_input` — asserts the alias wording present *and* the duplicate wording absent, exactly as specified |
+| 25 | `a/../x_trimmed.fq.gz` vs `x_trimmed.fq.gz` → `Ok`, pinning A8 | V1.7 | DONE | `preflight_accepts_dotdot_alias_known_limitation`, with a comment instructing that A8 be retired deliberately if it ever starts failing |
+| 26 | `hint: Some(…)` appears in the duplicate message; `None` does not add it | V1.8 | DONE | `preflight_appends_hint_only_when_given` — both directions asserted |
+| 27 | empty `planned` → `Ok` | V1.9 | DONE | `preflight_accepts_empty_and_single` (also covers the single-input no-op) |
+
+Beyond plan: `preflight_rejects_input_alias_across_spellings` — the alias check is keyed the same way, so a `./` spelling still catches it.
+
+### §10 V2 — integration rejections (11 specified, 11 found)
+
+All assert non-zero exit, the `Output path collision (case-insensitive, for APFS/NTFS safety)` prefix,
+the case-appropriate wording, **and** that nothing was written — via `assert_rejected_cleanly`
+(output directory empty) or `assert_dir_holds_only` (exact directory contents, for the no-`-o` cases
+that D3 introduced). This is the "stronger than the primary is absent" contract §10 V2 asked for.
+
+| # | Item | Source | Status | Test |
+|---|------|--------|--------|------|
+| 28 | SE trim FASTQ, `sample.fastq.gz` + `sample.fq.gz` | V2.1 | DONE | `se_trim_rejects_shared_stem` |
+| 29 | SE trim FASTQ, `./sample.fastq.gz` + `sample.fq.gz` (defect 1) | V2.2 | DONE | `se_trim_rejects_dot_slash_alias` — runs without `-o` per D3, so the output inherits the input's spelling and the test cannot pass for the wrong reason |
+| 30 | SE trim FASTQ, `dirA/same` + `dirB/same` with `-o <third>` | V2.3 | DONE | `se_trim_rejects_same_basename_across_dirs_with_output_dir` — the plan's highest-value single case, pinning `output_dir` (not `None`) in Step 8 |
+| 31 | SE trim uBAM, colliding stems | V2.4 | DONE | `se_trim_ubam_rejects_shared_stem` |
+| 32 | `--hardtrim5 20` FASTQ, same basename in two dirs, `current_dir` | V2.5 | DONE | `hardtrim5_rejects_same_basename_across_dirs` |
+| 33 | `--hardtrim3 20` FASTQ, same shape | V2.6 | DONE | `hardtrim3_rejects_same_basename_across_dirs` |
+| 34 | `--hardtrim5 20 --output-format ubam` | V2.7 | DONE | `hardtrim5_ubam_rejects_shared_stem` |
+| 35 | `--hardtrim3 20 --output-format ubam` | V2.8 | DONE | `hardtrim3_ubam_rejects_shared_stem` |
+| 36 | SE trim, output aliases an input — alias message (defect 2) | V2.9 | DONE | `se_trim_rejects_output_that_aliases_an_input` |
+| 37 | `--paired`, output aliases an input (the §2.2(f) four-file invocation) | V2.10 | DONE | `paired_rejects_output_that_aliases_an_input` — also asserts the pre-existing `a_R1_val_1.fq` still holds its 40 `OLD1` reads: byte-level proof the converted paired site gained the protection |
+| 38 | `.gz` + `.bgz` sharing a stem (#382 regression pin) | V2.11 | DONE | `se_trim_rejects_gz_and_bgz_sharing_a_stem` |
+
+Beyond plan: `se_trim_rejects_absolute_versus_relative_alias` — the second of D3's two defect-1 integration tests.
+
+### §10 V3 — integration acceptances (7 specified, 7 found)
+
+Every case asserts content or filename, never mere existence.
+
+| # | Item | Source | Status | Test |
+|---|------|--------|--------|------|
+| 39 | SE trim, `dirA/same` + `dirB/same`, **no** `-o` → exit 0, two outputs, content-attributed | V3.1 | DONE | `se_trim_accepts_same_basename_across_dirs` — asserts all four directions (dirA holds 40 `DIRA_` and 0 `DIRB_`; dirB the converse). Zero crosstalk, and the case that would have passed on existence alone while #383 was live |
+| 40 | SE trim, single input → exit 0, one output | V3.2 | DONE | `se_trim_accepts_single_input` — asserts 40 reads present |
+| 41 | `--hardtrim5 20 -o <tmp>`, two distinct stems → both `*.20bp_5prime.fq` | V3.3 | DONE | `hardtrim5_accepts_distinct_stems_and_names_output` |
+| 42 | `--hardtrim3 20 -o <tmp>`, two distinct stems → both `*.20bp_3prime.fq` | V3.4 | DONE | `hardtrim3_accepts_distinct_stems_and_names_output` — the first output-producing coverage `--hardtrim3` has ever had, as §10 V3.4 noted |
+| 43 | `--hardtrim3 20 --output-format ubam`, two distinct stems → both `*.20bp_3prime.bam` | V3.5 | DONE | `hardtrim3_ubam_accepts_distinct_stems_and_names_output` |
+| 44 | SE trim uBAM, two distinct stems → both `<stem>_trimmed.bam` | V3.6 | DONE | `se_trim_ubam_accepts_distinct_stems` — catches an over-rejecting candidate list |
+| 45 | `--paired`, two distinct pairs → four `_val_` outputs | V3.7 | DONE | `paired_accepts_two_distinct_pairs` |
+
+The filename assertions on the hardtrim acceptances are what actually close A9 for the enum: a
+candidate list built with the wrong end discriminator would pass every V2 rejection test and fail these.
+
+### §10 V4–V7
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 46 | Duplicate SE input rejected with the dedicated message, not the APFS/NTFS wording; distinct SE inputs still validate; existing duplicate-pair and R1≠R2 tests still pass | V4 | DONE | `test_validate_single_end_duplicate_input_rejected` (asserts the precise message **and** the absence of "APFS/NTFS"), `test_validate_single_end_distinct_inputs_accepted` (negative control), plus beyond-plan `test_validate_hardtrim_duplicate_input_rejected` and integration-level `duplicate_input_gets_a_precise_message`. The three `--clock`/`--implicon` tests D1 broke are green in the 399-test lib run. |
+| 47 | A2 as a table: `report_name`, `json_report_name`, demux base name, and default-config `<stem>_fastqc.zip` all differ where primaries differ, across `--basename`/`--dont_gzip`/`-o` on and off; comment naming the `--fastqc_args --outdir` exception | V5 | **DEVIATED** (documented) | See Deviations below. |
+| 48 | CI step 1 — SE trim collision: non-zero exit, collision grep, empty output dir | V6.1 | DONE | `ci.yml:642-656`. `set +e` / `rc=${PIPESTATUS[0]}` / `set -e` / `test $rc -ne 0` / `grep -q "Output path collision"` / `test -z "$(ls -A …)"` — the existing guards' idiom exactly, on `illumina_10K.fastq.gz` copied to `sample.fastq.gz` + `sample.fq.gz` as specified. |
+| 49 | CI step 2 — `--hardtrim5 30` collision, same basename in two subdirs, with `-o` (not `cd`) | V6.2 | DONE | `ci.yml:658-675`. All three assertions present, plus a beyond-plan `grep -q "one invocation per input"` that pins the mode-specific hint actually reaching the user. |
+| 50 | CI step 3 — SE output-aliases-input | V6.3 | DONE | `ci.yml:677-696`. Non-zero exit, `grep -q "which is also one of its inputs"`, and a **stronger** no-side-effects check than specified: md5 of the aliased input must match before/after, and `ls -A \| wc -l` must still be 2. |
+| 51 | Gates; rebuild; re-run the §2.2 reproductions; the V3.1 positive control | V7 | DONE | `fmt` clean, `clippy -D warnings` clean, `cargo test` 521/521, `cargo build --release` succeeds — all four re-run by this audit. **Scope note:** the six §2.2 shell reproductions were *not* re-run by this audit (the command was denied by the permission gate). They are covered equivalently by V2.1/V2.2/V2.11/V2.5/V2.7/V2.9/V2.10 and the V3.1 positive control, all of which I ran and confirmed passing; §13's "all eight reproductions exit non-zero" remains the implementer's claim, corroborated but not independently reproduced here. |
+
+### §3.5 — edge-case table (15 rows, all traced)
+
+| # | Case | Expected | Status | Trace |
+|---|------|----------|--------|-------|
+| 52 | One input, no alias | no-op | DONE | `preflight_accepts_empty_and_single`, `se_trim_accepts_single_input` |
+| 53 | `sample.fastq.gz` + `sample.fq.gz` | reject | DONE | `se_trim_rejects_shared_stem`, CI step 1 |
+| 54 | `sample.fastq.gz` + `sample.fastq.bgz` | reject | DONE | `se_trim_rejects_gz_and_bgz_sharing_a_stem` |
+| 55 | `./x.fastq.gz` + `x.fq.gz` | reject (new in v2) | DONE | `preflight_rejects_dot_slash_alias` + `se_trim_rejects_dot_slash_alias` |
+| 56 | `/abs/x.fastq.gz` + `x.fq.gz`, cwd `/abs` | reject (new in v2) | DONE | `preflight_rejects_absolute_versus_relative_alias` + `se_trim_rejects_absolute_versus_relative_alias` |
+| 57 | `a/../x.fastq.gz` + `x.fq.gz` | accept — known residual | DONE | `preflight_accepts_dotdot_alias_known_limitation`, pinning A8 |
+| 58 | Output path equals an input path | reject, own message | DONE | `preflight_rejects_output_that_aliases_an_input`, `se_trim_rejects_output_that_aliases_an_input`, `paired_rejects_output_that_aliases_an_input`, CI step 3 |
+| 59 | Same file listed twice | reject in `Cli::validate`, own message, before `ensure_output_dir` | DONE | `cli.rs:629-642`; `test_validate_single_end_duplicate_input_rejected`, and `duplicate_input_gets_a_precise_message`, which also asserts `dup_trimmed.fq` does not exist — i.e. pins the "before `ensure_output_dir`" half |
+| 60 | Case-only path variants | reject | DONE | `preflight_rejects_case_only_variants` (unit only — two case variants cannot coexist on APFS, which is the plan's stated reason the helper lives in the library) |
+| 61 | Same basename, different dirs, no `-o` — SE trim | accept | DONE | `se_trim_accepts_same_basename_across_dirs` |
+| 62 | Same basename, different dirs, no `-o` — hardtrim | reject | DONE | `hardtrim5_rejects_same_basename_across_dirs`, `hardtrim3_rejects_same_basename_across_dirs` |
+| 63 | Same basename, different dirs, **with** `-o` | reject; V2.3 pins this | DONE | `se_trim_rejects_same_basename_across_dirs_with_output_dir` |
+| 64 | `--basename` with >1 SE input | unchanged, already rejected | DONE | `cli.rs:620-624` verified present and untouched. No dedicated SE unit test exists and the plan required none ("unchanged"); the behaviour is also relied on by the V5 test's `--basename` carve-out comment. |
+| 65 | Zero inputs / `--hardtrim5 N --hardtrim3 M` | unreachable / unchanged | DONE | Zero inputs: clap `required`, assumption A5 — no test warranted. Dual hardtrim: unchanged, the `hardtrim5` branch still returns early at `main.rs:387`; explicitly deferred as §11 Open 3 and confirmed in §13 "Left undone, deliberately". |
+
+## Deviations (detail)
+
+### Item 47 (V5): the `<stem>_fastqc.zip` row of the A2 table — DEVIATED, documented
+
+**Expected.** §10 V5 specifies a table asserting that where two inputs' primary output paths differ,
+`report_name`, `json_report_name`, the demux base name, **and the default-configuration
+`<stem>_fastqc.zip`** all differ too — across `--basename` / `--dont_gzip` / `-o`, each on and off —
+with a comment naming the `--fastqc_args --outdir` exception so a future reader does not delete a row.
+
+**Found.** `distinct_primary_outputs_imply_distinct_secondary_outputs` (`src/io.rs`) asserts
+`report_name`, `json_report_name`, `clumping_report_name` (beyond plan) and
+`crate::demux::demux_base_name`. The flag matrix is complete: `basename in [None, Some("fixed")]` ×
+`gzip in [true, false]` × `output_dir in [None, Some]`. The `--fastqc_args "-o DIR"` exception comment
+is present as required. The demux assertion goes through the same function `demultiplex` now calls —
+which is what D6's `demux.rs` extraction exists for, so the test cannot pass against a stale copy of
+the formula. A second beyond-plan test, `primary_output_key_is_coarser_than_secondary_keys`,
+establishes the direction that makes the argument non-circular (three spellings collapsing to one
+primary while keeping three distinct report names), repairing the flaw the plan itself identified in
+v1's V6.
+
+The `<stem>_fastqc.zip` assertion is **absent**, with a nine-line rationale in the test's doc-comment:
+the bundled crate derives the artifact name from the primary path handed to it, so there is no second
+key of ours to compare, and writing the formula out would only test the formula.
+
+**Why this is acceptable.** §13 "Post-audit gap closures" ¶2 records the substitution explicitly,
+including "FastQC's zip name is documented as not-separately-assertable rather than faked." That
+satisfies the plan's own convention that deviations be registered in §13, so this is
+DEVIATED-with-reason, not a gap. No action required.
+
+*(Audit history: this item was the sole finding that would have made the verdict INCOMPLETE. It was
+already closed in §13 before this report was finalised — the §13 text post-dates the 703-line PLAN.md
+this audit started from.)*
+
+## Test verification
+
+### Suites (`cargo test`, crate root)
+
+| Suite | Tests | Status |
+|---|---|---|
+| `src/lib.rs` unit | 399 | PASS |
+| `tests/integration_output_collision.rs` (new) | 20 | PASS |
+| `tests/integration_adapter2.rs` | 15 | PASS |
+| `tests/integration_clump_only.rs` | 12 | PASS |
+| `tests/integration_clump_only_ubam.rs` | 15 | PASS |
+| `tests/integration_gzip_non_gz_extension.rs` | 7 | PASS |
+| `tests/integration_no_args_help.rs` | 1 | PASS |
+| `tests/integration_non_restartable_input.rs` | 8 | PASS |
+| `tests/integration_paired_format_guard.rs` | 11 | PASS |
+| `tests/integration_passthrough.rs` | 2 | PASS |
+| `tests/integration_ubam.rs` | 8 | PASS |
+| `tests/integration_ubam_out.rs` | 23 | PASS |
+| **Total** | **521** | **0 failed** |
+
+### Named tests behind the plan's V-items
+
+| Test name | File | Covers | Status |
+|-----------|------|--------|--------|
+| `preflight_accepts_distinct_outputs` | `src/io.rs` | V1.1 | PASS |
+| `preflight_rejects_identical_outputs` | `src/io.rs` | V1.2 | PASS |
+| `preflight_rejects_case_only_variants` | `src/io.rs` | V1.3 | PASS |
+| `preflight_rejects_dot_slash_alias` | `src/io.rs` | V1.4 | PASS |
+| `preflight_rejects_absolute_versus_relative_alias` | `src/io.rs` | V1.5 | PASS |
+| `preflight_rejects_output_that_aliases_an_input` | `src/io.rs` | V1.6 | PASS |
+| `preflight_accepts_dotdot_alias_known_limitation` | `src/io.rs` | V1.7 (A8) | PASS |
+| `preflight_appends_hint_only_when_given` | `src/io.rs` | V1.8 | PASS |
+| `preflight_accepts_empty_and_single` | `src/io.rs` | V1.9 | PASS |
+| `preflight_rejects_input_alias_across_spellings` | `src/io.rs` | beyond plan | PASS |
+| `distinct_primary_outputs_imply_distinct_secondary_outputs` | `src/io.rs` | V5 | PASS |
+| `primary_output_key_is_coarser_than_secondary_keys` | `src/io.rs` | beyond plan | PASS |
+| `se_trim_rejects_shared_stem` | `tests/integration_output_collision.rs` | V2.1 | PASS |
+| `se_trim_rejects_dot_slash_alias` | same | V2.2 | PASS |
+| `se_trim_rejects_absolute_versus_relative_alias` | same | beyond plan (D3) | PASS |
+| `se_trim_rejects_same_basename_across_dirs_with_output_dir` | same | V2.3 | PASS |
+| `se_trim_ubam_rejects_shared_stem` | same | V2.4 | PASS |
+| `hardtrim5_rejects_same_basename_across_dirs` | same | V2.5 | PASS |
+| `hardtrim3_rejects_same_basename_across_dirs` | same | V2.6 | PASS |
+| `hardtrim5_ubam_rejects_shared_stem` | same | V2.7 | PASS |
+| `hardtrim3_ubam_rejects_shared_stem` | same | V2.8 | PASS |
+| `se_trim_rejects_output_that_aliases_an_input` | same | V2.9 | PASS |
+| `paired_rejects_output_that_aliases_an_input` | same | V2.10 | PASS |
+| `se_trim_rejects_gz_and_bgz_sharing_a_stem` | same | V2.11 | PASS |
+| `se_trim_accepts_same_basename_across_dirs` | same | V3.1 | PASS |
+| `se_trim_accepts_single_input` | same | V3.2 | PASS |
+| `hardtrim5_accepts_distinct_stems_and_names_output` | same | V3.3 | PASS |
+| `hardtrim3_accepts_distinct_stems_and_names_output` | same | V3.4 | PASS |
+| `hardtrim3_ubam_accepts_distinct_stems_and_names_output` | same | V3.5 | PASS |
+| `se_trim_ubam_accepts_distinct_stems` | same | V3.6 | PASS |
+| `paired_accepts_two_distinct_pairs` | same | V3.7 | PASS |
+| `duplicate_input_gets_a_precise_message` | same | V4 (integration) | PASS |
+| `test_validate_single_end_duplicate_input_rejected` | `src/cli.rs` | V4 | PASS |
+| `test_validate_hardtrim_duplicate_input_rejected` | `src/cli.rs` | beyond plan | PASS |
+| `test_validate_single_end_distinct_inputs_accepted` | `src/cli.rs` | V4 negative control | PASS |
+| `test_validate_clock_r1_equal_r2_within_pair_rejected` | `src/cli.rs` | D1 regression | PASS |
+| `test_validate_clock_duplicate_pair_rejected` | `src/cli.rs` | D1 regression | PASS |
+| `test_validate_implicon_duplicate_pair_rejected` | `src/cli.rs` | D1 regression | PASS |
+| `bgz_stem_reaches_specialty_output_names` | `src/specialty.rs` | Step 4 (updated for the enum) | PASS |
+
+### Call-site count (§1, §5, §4.1's "eleven call sites")
+
+`grep -c 'naming::preflight_output_collisions' src/main.rs` → **11**.
+
+| Line | Dispatch path | Class |
+|---|---|---|
+| 360 | `--hardtrim5` | new |
+| 391 | `--hardtrim3` | new |
+| 513 | `--clump_only` SE FASTQ | converted |
+| 548 | `--clump_only` PE uBAM, 1-file interleaved | re-pointed |
+| 585 | `--clump_only` PE uBAM, multi-pair | re-pointed |
+| 633 | `--clump_only` SE uBAM | re-pointed |
+| 734 | `--paired` trim FASTQ | converted |
+| 799 | SE trim FASTQ | new |
+| 1825 | `--paired` trim uBAM | converted |
+| 1869 | SE trim uBAM | new |
+| 2430 | `run_specialty_paired` — serves `--clock`, `--implicon`, **and** `--clump_only --paired` FASTQ (routed at `main.rs:483`) | converted |
+
+**4 new + 4 converted + 3 re-pointed = 11**, exactly as §1 claims. All 16 `cli.input` /
+`cli.input.chunks(2)` loop sites in `main.rs` were enumerated; the 10 that write output are each
+preceded by a guard, and the rest are candidate-building loops feeding those guards.
+`preflight_collision_bam` appears nowhere in `src/`.
+
+Guard-before-reader ordering (§3.3 contract item 1) verified on all four trim paths: SE FASTQ guard
+`:799` precedes `setup_trimming` at `:805`; paired FASTQ `:734` precedes `:765`; SE uBAM `:1869`
+precedes `:1875`; paired uBAM `:1825` precedes `:1838`. So no guarded path opens a reader — and
+therefore runs adapter auto-detection — before the collision check.
+
+## Observations (not ledger items)
+
+Recorded for the orchestrator; none is a plan-coverage gap.
+
+1. **§13's headline statistics are stale.** Line 634 says "**520 tests pass** (398 lib + 122
+   integration)" — actual **521** (399 lib + 122). Line 638 says "6 files changed, +503/−99" —
+   actual **7 files, +595/−111** (D6's `src/demux.rs` is the seventh, and is documented as a
+   deviation but not folded into the headline count). Line 720 says "40 steps in `validation`" —
+   actual **41**. Worth a one-line refresh before commit; no bearing on correctness.
+
+2. **`demux.rs`'s doc-comment was re-parented by D6.** `demux_base_name` was inserted between
+   `demultiplex`'s doc-comment and `demultiplex` itself, so the "1. … 5. Write to the matching
+   sample's output file (or NoCode)" list and "Also writes a summary file with per-barcode counts."
+   now document `demux_base_name`. Cosmetic; already noted in `PROGRESS.md`.
+
+3. **The helper's doc-comment is marginally broader than the code.** It says the helper is "Called by
+   every `main.rs` dispatch path that writes more than one file." The `--paired` +
+   single-interleaved-BAM-input path with FASTQ output (`main.rs:677-689`) writes two `_val_` files
+   and has no call. §2.1 classified that row as "n/a — one output" and both plan reviewers signed off
+   on "no fifth hole exists", so it is outside this ledger — and no collision is constructible there,
+   because a single input yields two names differing by a fixed `_val_1`/`_val_2` suffix, neither of
+   which can equal the input. One clause of the doc-comment would make it exact.
+
+4. **D5 confirmed as described.** Parsing `ci.yml` shows the three new step names truncating at
+   `(issue`, as does the pre-existing `(issue #216)` step — consistent, as D5 says.
+
+5. **Out of scope for coverage, flagged for routing.** `PROGRESS.md` records a unanimous code-review
+   High — that `--demux` can still overwrite a named input at exit 0, contradicting §3.2's argument
+   that the barcode file is excluded "by argument". This audit neither reproduced nor evaluated it;
+   it is a defect in the *plan's* reasoning rather than a shortfall of the code against the plan, so
+   it does not affect the verdict. It does mean §3.2 and the corresponding CHANGELOG sentence may
+   need revising, which is a plan/CHANGELOG action rather than a coverage one.
+
+## Verdict
+
+**COMPLETE.**
+
+Everything the plan specified is implemented and passing: all 13 of §5's steps; all four §4 signature
+groups as written; 9/9 V1 cases, 11/11 V2 cases, 7/7 V3 cases; V4; all three V6 CI steps with the
+assertions they were specified to make; V7's gates; and all 15 rows of §3.5's edge-case table traced
+to a test, an assumption, or an explicit out-of-scope entry. The eleven call sites are verified by
+count and by checking every `cli.input` loop for a preceding guard, with the guard proven to precede
+the reader on all four trim paths.
+
+The one deviation — V5's `<stem>_fastqc.zip` row, replaced by a `clumping_report_name` assertion and
+a documented not-separately-assertable note — is registered in §13's "Post-audit gap closures", which
+is the plan's own register for deviations. Nothing is unresolved.
+
+The implementation exceeds the plan in several places worth keeping: the CI hardtrim step asserts the
+mode-specific hint text reaches the user; CI step 3 asserts md5 byte-identity of the aliased input
+rather than just its presence; six tests exist beyond those specified; and the integration fixtures
+are built in-test, which is a stronger fix for the `current_dir` hazard than the absolutised paths
+Step 11 called for.
+
+Two follow-ups, neither blocking: refresh §13's stale statistics (Observation 1), and route the
+`--demux` review finding (Observation 5) as a plan/CHANGELOG amendment rather than a coverage item.

--- a/plans/08062026_se-output-collision-preflight/COVERAGE_round1.md
+++ b/plans/08062026_se-output-collision-preflight/COVERAGE_round1.md
@@ -1,0 +1,238 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs. plan — §5 is the implementation plan; no `IMPL.md` by design)
+**Plan(s):** `plans/08062026_se-output-collision-preflight/PLAN.md` (v2)
+**Date:** 2026-08-07
+**Verdict:** INCOMPLETE — 2 items unresolved
+
+## Summary
+
+- Total items: 22
+- DONE: 19
+- PARTIAL: 2
+- MISSING: 0
+- DEVIATED: 1 (documented in §13 as D1)
+
+Scope per instruction: §5 steps 1–13, §10 V1–V6 with named sub-cases counted, and the
+eleven call sites cross-checked against every loop over `cli.input`. §3.5 and §4 were
+spot-confirmed only, and are marked as such.
+
+## Coverage ledger
+
+### Part 1 — §5 implementation outline (steps 1–13)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `collision_key` + `preflight_output_collisions` in `io.rs` | Step 1 | PARTIAL | Both fns present (`io.rs:48-92`), signature matches §4.1 exactly. Sub-clause "Extend `norm_path`'s doc-comment to name the new caller" **not done** — `io.rs:33-43` still lists only `Cli::validate` and the paired pre-flight. |
+| 2 | Delete `preflight_collision_bam`, re-point its 3 calls | Step 2 | DONE | Fn gone; calls now at `main.rs:548`, `:585`, `:633`. Incidental doc-comment reunion with `resolve_clump_layout` confirmed. |
+| 3 | Convert the four hand-rolled copies | Step 3 | DONE | `main.rs:513` (clump_only SE FASTQ), `:734` (paired FASTQ, candidates accumulated across all chunks into one `Vec` before one call), `:1825` (paired uBAM), `:2430` (`run_specialty_paired`, both names per pair across all pairs). All pass `guarded_inputs()`. Both `--output-dir` message sites gone (§2.5 fix landed). |
+| 4 | `HardtrimEnd` enum + `pub` on both hardtrim namers | Step 4 | DONE | See Part 3 note. |
+| 5 | `planned_hardtrim_outputs` in `main.rs` | Step 5 | DONE | `main.rs:71-89`, matches on `cli.output_format`, `std::path::PathBuf` spelled in full per §4.3. |
+| 6 | Guard `--hardtrim5` | Step 6 | DONE | `main.rs:358-364`, first statement in the block, `HardtrimEnd::Five`, `Some(HARDTRIM_HINT)`. `HARDTRIM_HINT` const at `:56-60`. |
+| 7 | Guard `--hardtrim3` | Step 7 | DONE | `main.rs:389-395`, identical with `HardtrimEnd::Three`. |
+| 8 | Guard SE trim FASTQ | Step 8 | DONE | `main.rs:791-799`, in the `} else {` arm before the loop, `single_end_output_name`. |
+| 9 | Guard SE trim uBAM | Step 9 | DONE | `main.rs:1863-1869`, `single_end_bam_output_name`. |
+| 10 | `cli.rs`: reject duplicate SE inputs | Step 10 | DEVIATED (documented) | Predicate widened to `!self.paired && !self.clock && self.implicon.is_none()` — recorded as D1 in §13. |
+| 11 | Tests: V1 unit in `io.rs`, V4 unit in `cli.rs`, new `tests/integration_output_collision.rs` (V2, V3) | Step 11 | DONE | 20 new tests in the integration file; detail in Part 2 items 14–17. The "`current_dir` cases must pass absolutised fixture paths" caveat is honoured — the file writes its own fixtures via `write_fastq` into the tempdir instead of referencing `test_files/`, and `tempdir()` is canonicalised (D4). |
+| 12 | CI: three validation steps | Step 12 | DONE | Detail in Part 2 item 19. |
+| 13 | CHANGELOG entries | Step 13 | DONE | `#### Bug fixes` (`CHANGELOG.md:63-107`) covers #383 plus both defects and the hardtrim CWD widening; `#### Changes` (`:106+`) covers the A6 duplicate-input refusal and the `--output-dir` → `--output_dir` message correction. Both required sections and both required `#### Changes` entries present. |
+
+### Part 2 — §10 validation
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 14 | V1 unit, 9 sub-cases in `io.rs` | §10 V1 | DONE | **9/9 named cases present**, all in `src/io.rs` mod tests: V1.1 `preflight_accepts_distinct_outputs`; V1.2 `preflight_rejects_identical_outputs`; V1.3 `preflight_rejects_case_only_variants`; V1.4 `preflight_rejects_dot_slash_alias`; V1.5 `preflight_rejects_absolute_versus_relative_alias`; V1.6 `preflight_rejects_output_that_aliases_an_input` (asserts alias wording **and** absence of duplicate wording); V1.7 `preflight_accepts_dotdot_alias_known_limitation`; V1.8 `preflight_appends_hint_only_when_given`; V1.9 `preflight_accepts_empty_and_single`. +1 bonus `preflight_rejects_input_alias_across_spellings`. |
+| 15 | V2 integration rejections, 11 sub-cases | §10 V2 | DONE | **11/11 present** in `tests/integration_output_collision.rs`: 1 `se_trim_rejects_shared_stem`; 2 `se_trim_rejects_dot_slash_alias`; 3 `se_trim_rejects_same_basename_across_dirs_with_output_dir`; 4 `se_trim_ubam_rejects_shared_stem`; 5 `hardtrim5_rejects_same_basename_across_dirs`; 6 `hardtrim3_rejects_same_basename_across_dirs`; 7 `hardtrim5_ubam_rejects_shared_stem`; 8 `hardtrim3_ubam_rejects_shared_stem`; 9 `se_trim_rejects_output_that_aliases_an_input`; 10 `paired_rejects_output_that_aliases_an_input`; 11 `se_trim_rejects_gz_and_bgz_sharing_a_stem`. +1 bonus `se_trim_rejects_absolute_versus_relative_alias`. Empty-output-dir assertion is real: `assert_rejected_cleanly` (`:95-116`) checks exit≠0, the `Output path collision (case-insensitive, for APFS/NTFS safety)` prefix, the case-specific wording, and an empty dir; the two no-`-o` defect-1 cases use `assert_dir_holds_only` per D3. |
+| 16 | V3 integration acceptances, 7 sub-cases | §10 V3 | DONE | **7/7 present**, and every one asserts content or filename, never bare existence: 1 `se_trim_accepts_same_basename_across_dirs` (40 own reads / 0 crosstalk each way); 2 `se_trim_accepts_single_input` (read count); 3 `hardtrim5_accepts_distinct_stems_and_names_output` (`*.20bp_5prime.fq`); 4 `hardtrim3_accepts_distinct_stems_and_names_output` (`*.20bp_3prime.fq`); 5 `hardtrim3_ubam_accepts_distinct_stems_and_names_output` (`*.20bp_3prime.bam`); 6 `se_trim_ubam_accepts_distinct_stems` (`<stem>_trimmed.bam`); 7 `paired_accepts_two_distinct_pairs` (four `_val_` filenames). |
+| 17 | V4 unit, duplicate SE input in `cli.rs` | §10 V4 | DONE | `test_validate_single_end_duplicate_input_rejected` (dedicated message **and** `!contains("APFS/NTFS")`), `test_validate_single_end_distinct_inputs_accepted` (negative control), plus `test_validate_hardtrim_duplicate_input_rejected`. Existing duplicate-pair / R1≠R2 tests all still pass. Integration analogue: `duplicate_input_gets_a_precise_message`. |
+| 18 | V5 unit, A2 as a table | §10 V5 | PARTIAL | See Gap 2. `primary_output_key_is_coarser_than_secondary_keys` exists and can fail, but covers only `report_name`, `json_report_name`, `clumping_report_name`, `single_end_bam_output_name` — the plan also named the **demux base name** and the **default-config `<stem>_fastqc.zip`**, and required the matrix "across `--basename` / `--dont_gzip` / `-o` on and off". Premise is also inverted relative to §10 V5. The `--fastqc_args -o` exception comment **is** present. |
+| 19 | V6 CI, three validation steps | §10 V6 | DONE | `.github/workflows/ci.yml`, all three after the existing `rust_case` guard: `Validate single-end collision pre-flight`, `Validate --hardtrim5 collision pre-flight and its own remediation` (also greps the hint string `one invocation per input`), `Validate an output may not overwrite an input`. Idiom matches (`set +e` / `rc=${PIPESTATUS[0]}` / `set -e` / `test $rc -ne 0` / `grep -q "Output path collision"` / `ls -A` residue). Step 3 substitutes a stronger check — md5 of the aliased input unchanged + exactly 2 files — for the bare `ls -A`. |
+
+### Part 3 — the eleven call sites, and spot-confirmations
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 20 | Eleven `preflight_output_collisions` call sites; no loop over `cli.input` missed | §1, §4.1, §5 | DONE | See the enumeration below. `grep -c naming::preflight_output_collisions src/main.rs` = **11**, matching §1's 3 re-pointed + 4 converted + 4 new. Every writing loop over `cli.input` has a guard immediately in front of it; the two unguarded `cli.input.len() == 1` interleaved-BAM branches produce a single output (§2.1 marks them n/a). No fifth hole. |
+| 21 | §3.5 edge-case table | §3.5 | DONE (spot-confirmed) | Spot-confirmed, not deep-audited, per instruction. 12 of the 15 rows are directly pinned by a V1/V2/V3/V4 case above; the three unpinned rows are the pre-existing/unreachable ones (`--basename` with >1 SE input, zero inputs, `--hardtrim5 N --hardtrim3 M`), all marked "unchanged" in the plan. |
+| 22 | §4 signatures | §4 | DONE (spot-confirmed) | `preflight_output_collisions(&[PathBuf], &[PathBuf], Option<&str>) -> Result<()>` and `collision_key` match §4.1 verbatim; `HardtrimEnd` + `pub` namers match §4.2; `planned_hardtrim_outputs` matches §4.3 including the fully-spelled `std::path::PathBuf`; the `cli.rs` check sits beside the duplicate-pair check per §4.4. `cargo fmt --check` clean; 520 tests pass. |
+
+**Call-site enumeration** (`src/main.rs`, current working tree):
+
+| Guard | Dispatch path | Writing loop it protects |
+|---|---|---|
+| `:360` | `--hardtrim5` (both formats) | `:365` | 
+| `:391` | `--hardtrim3` (both formats) | `:396` |
+| `:513` | `--clump_only` SE FASTQ | `:514` |
+| `:548` | `--clump_only` PE uBAM, 1-file interleaved | single output |
+| `:585` | `--clump_only` PE uBAM, multi-pair | `:591` |
+| `:633` | `--clump_only` SE uBAM | `:634` |
+| `:734` | `--paired` trim FASTQ (candidates accumulated across all chunks) | `:744` |
+| `:799` | SE trim FASTQ (**new**) | `:800` |
+| `:1825` | `--paired` trim uBAM | `:1828` |
+| `:1869` | SE trim uBAM (**new**) | `:1870` |
+| `:2430` | `run_specialty_paired` — `--clock`, `--implicon`, `--clump_only --paired` FASTQ | `:2433` |
+
+Unguarded-by-design: `:677`/`:1796` (`--paired` single interleaved BAM → one output) and `:475-481` (`--clump_only --paired` with one FASTQ input → hard `bail!`).
+
+## Gaps (detail)
+
+### Gap 1 — item 1: `norm_path`'s doc-comment was not extended (Step 1)
+
+**Expected:** §5 Step 1 — "add `collision_key` and `preflight_output_collisions` …
+**Extend `norm_path`'s doc-comment to name the new caller.**"
+**Found:** both functions added exactly as specified (`src/io.rs:48-92`). `norm_path`'s
+doc-comment (`src/io.rs:33-43`) is byte-unchanged and still enumerates only two callers:
+`Cli::validate()`'s `--passthrough` check and "`main::run` paired-end output-collision
+pre-flight … (issue #216)". It does not mention `collision_key`, `preflight_output_collisions`,
+or #383 — and the paired pre-flight it names no longer lives in `main::run`, so the
+existing text is now stale as well as incomplete.
+**Gap:** one doc-comment edit. Documentation-only — no behavioural effect, nothing a test
+could catch. Not recorded in §13.
+
+### Gap 2 — item 18: V5's A2 table is narrower than specified, and tests the converse
+
+**Expected:** §10 V5 — "For path pairs whose primaries **differ**, assert that
+`report_name`, `json_report_name`, **the demux base name**, and the *default-configuration*
+**`<stem>_fastqc.zip`** all differ too, **across `--basename` / `--dont_gzip` / `-o` on and
+off**."
+**Found:** `primary_output_key_is_coarser_than_secondary_keys` in `src/io.rs` mod tests. It
+takes three variants whose primaries are **equal** (`d/sample.{fastq.gz,fq.gz,fastq.bgz}`),
+asserts the primaries collapse to one, then asserts `report_name`, `json_report_name` and
+`clumping_report_name` stay pairwise distinct, and that the uBAM primary also collapses. The
+`--fastqc_args -o` exception is named in a comment, as required.
+**Gap:** three things. (a) Two of the four named namers are absent — the demux base name
+(`demux.rs:142-147`, which A2 explicitly claims to have verified) and the default-config
+`<stem>_fastqc.zip`; `clumping_report_name` was substituted for them, which the plan did not
+ask for. (b) The `--basename` / `--dont_gzip` / `-o` on-and-off matrix is absent — every
+call passes `None, None, true` or `None`. (c) The premise runs the other way: the test
+establishes "primaries equal → secondaries distinct", whereas A2's claim, and V5's stated
+form, is "primaries distinct → secondaries distinct". The implemented assertion is failable
+(so it is not v1's V6 defect returning), but it does not exercise the implication A2 rests
+on. Not recorded in §13.
+
+Neither gap affects the fix's behaviour: the 11 guards, both defect fixes, the 27 named
+V1–V4 sub-cases and all three CI steps are in place and green.
+
+## Test verification
+
+`cargo test` from the crate root: **520 passed, 0 failed, 0 ignored** across 14 binaries —
+exactly the count §13 claims. `cargo fmt --all -- --check` clean.
+
+| Plan case | Test name | File | Status |
+|---|---|---|---|
+| V1.1 | `preflight_accepts_distinct_outputs` | `src/io.rs` | PASS |
+| V1.2 | `preflight_rejects_identical_outputs` | `src/io.rs` | PASS |
+| V1.3 | `preflight_rejects_case_only_variants` | `src/io.rs` | PASS |
+| V1.4 | `preflight_rejects_dot_slash_alias` | `src/io.rs` | PASS |
+| V1.5 | `preflight_rejects_absolute_versus_relative_alias` | `src/io.rs` | PASS |
+| V1.6 | `preflight_rejects_output_that_aliases_an_input` | `src/io.rs` | PASS |
+| V1.7 | `preflight_accepts_dotdot_alias_known_limitation` | `src/io.rs` | PASS |
+| V1.8 | `preflight_appends_hint_only_when_given` | `src/io.rs` | PASS |
+| V1.9 | `preflight_accepts_empty_and_single` | `src/io.rs` | PASS |
+| V1 bonus | `preflight_rejects_input_alias_across_spellings` | `src/io.rs` | PASS |
+| V2.1 | `se_trim_rejects_shared_stem` | `tests/integration_output_collision.rs` | PASS |
+| V2.2 | `se_trim_rejects_dot_slash_alias` | same | PASS |
+| V2.3 | `se_trim_rejects_same_basename_across_dirs_with_output_dir` | same | PASS |
+| V2.4 | `se_trim_ubam_rejects_shared_stem` | same | PASS |
+| V2.5 | `hardtrim5_rejects_same_basename_across_dirs` | same | PASS |
+| V2.6 | `hardtrim3_rejects_same_basename_across_dirs` | same | PASS |
+| V2.7 | `hardtrim5_ubam_rejects_shared_stem` | same | PASS |
+| V2.8 | `hardtrim3_ubam_rejects_shared_stem` | same | PASS |
+| V2.9 | `se_trim_rejects_output_that_aliases_an_input` | same | PASS |
+| V2.10 | `paired_rejects_output_that_aliases_an_input` | same | PASS |
+| V2.11 | `se_trim_rejects_gz_and_bgz_sharing_a_stem` | same | PASS |
+| V2 bonus | `se_trim_rejects_absolute_versus_relative_alias` | same | PASS |
+| V3.1 | `se_trim_accepts_same_basename_across_dirs` | same | PASS |
+| V3.2 | `se_trim_accepts_single_input` | same | PASS |
+| V3.3 | `hardtrim5_accepts_distinct_stems_and_names_output` | same | PASS |
+| V3.4 | `hardtrim3_accepts_distinct_stems_and_names_output` | same | PASS |
+| V3.5 | `hardtrim3_ubam_accepts_distinct_stems_and_names_output` | same | PASS |
+| V3.6 | `se_trim_ubam_accepts_distinct_stems` | same | PASS |
+| V3.7 | `paired_accepts_two_distinct_pairs` | same | PASS |
+| V4 | `test_validate_single_end_duplicate_input_rejected` | `src/cli.rs` | PASS |
+| V4 | `test_validate_single_end_distinct_inputs_accepted` | `src/cli.rs` | PASS |
+| V4 bonus | `test_validate_hardtrim_duplicate_input_rejected` | `src/cli.rs` | PASS |
+| V4 (integration) | `duplicate_input_gets_a_precise_message` | `tests/integration_output_collision.rs` | PASS |
+| V5 | `primary_output_key_is_coarser_than_secondary_keys` | `src/io.rs` | PASS, but PARTIAL coverage — see Gap 2 |
+| V6.1 | `Validate single-end collision pre-flight` | `.github/workflows/ci.yml` | PRESENT (not run here) |
+| V6.2 | `Validate --hardtrim5 collision pre-flight and its own remediation` | same | PRESENT (not run here) |
+| V6.3 | `Validate an output may not overwrite an input` | same | PRESENT (not run here) |
+
+## Verdict
+
+**Verdict:** INCOMPLETE — 2 items unresolved
+
+Both unresolved items are shortfalls against the plan text that are undocumented in §13; neither
+changes the behaviour of the fix.
+
+1. **Item 1 / Gap 1** — Step 1's sub-clause "Extend `norm_path`'s doc-comment to name the new
+   caller" was not done. `src/io.rs:33-43` is unchanged and now both incomplete (no mention of
+   `collision_key` / `preflight_output_collisions` / #383) and stale (it locates the paired
+   pre-flight in `main::run`, which no longer holds it). One comment edit.
+2. **Item 18 / Gap 2** — §10 V5's A2 table is narrower than specified and tests the converse
+   implication. Missing: the demux base name, the default-config `<stem>_fastqc.zip`, and the
+   `--basename` / `--dont_gzip` / `-o` on-and-off matrix. `clumping_report_name` was substituted
+   for the two absent namers. The existing assertion is failable, so v1's V6 defect has not
+   returned, but A2's actual claim ("primaries distinct → secondaries distinct") is not exercised.
+
+Everything else is in place: all 11 `preflight_output_collisions` call sites (3 re-pointed,
+4 converted, 4 new), no unguarded writing loop over `cli.input`, both defect fixes, the
+`HardtrimEnd` enum, `planned_hardtrim_outputs`, the `Cli::validate` duplicate-input check (with
+D1's documented predicate widening), all 27 named V1–V4 sub-cases, all three V6 CI steps, and the
+CHANGELOG entries in both required sections. 520 tests pass; `cargo fmt --check` clean.
+
+Also noted, and correctly scoped out by the plan itself: §11 Open 3 (`--hardtrim5` + `--hardtrim3`
+silently ignoring the 3′ trim) and Open 4 (the `modes/hardtrim.md` CWD-output sentence) remain
+unaddressed, as §13 "Left undone, deliberately" states.
+
+---
+
+## Addendum — resolution of both gaps
+
+**Everything above this line is the auditing agent's own work, and its verdict was correct when
+rendered. This section was written by the orchestrating session and is not an independent
+finding.** Both unresolved items were closed after the audit ran; the verdict line above is
+therefore a snapshot, not the current state.
+
+**Gap 1 closed.** `src/io.rs:33-43` now names `collision_key` as the absolutising key that every
+`main.rs` pre-flight hashes, and drops the stale "`main::run` paired-end" locator the audit
+flagged. Written as plain backticks rather than a rustdoc intra-doc link: `norm_path` is `pub`
+and `collision_key` is private, so the link form emits `public documentation links to private
+item` (confirmed with `cargo doc`; no CI gate runs it, but the repo already carries one such
+warning and there was no reason to add a second).
+
+**Gap 2 closed, addressing all three sub-points (a), (b) and (c).**
+
+- **(c) the inverted premise.** New `distinct_primary_outputs_imply_distinct_secondary_outputs`
+  asserts A2 in its stated direction — primaries distinct ⇒ every secondary distinct. The
+  original coarser-than test is kept as its complement, since coarseness is *why* checking
+  primaries covers reports rather than merely coinciding with them.
+- **(b) the matrix.** That test runs the full 2 × 2 × 2 over `--basename` / `--dont_gzip` / `-o`,
+  skipping the `--basename` combinations where primaries legitimately collapse (the pre-flight
+  rejects those, and `cli.rs:620` rejects them earlier still for multi-input SE).
+- **(a) the missing namers.** The demux base name is now genuinely covered. Its derivation was
+  inline in `demultiplex`, so asserting it would have meant copying the formula into the test —
+  a test that cannot detect drift in the code it claims to check. Extracted as
+  `demux::demux_base_name`, called from both; recorded as deviation **D6** in `PLAN.md` §13, and
+  verified behaviour-preserving by re-running `--demux` end-to-end (output stems and the
+  full-filename summary line unchanged). The default-config `<stem>_fastqc.zip` is deliberately
+  *not* asserted, and the test says why: the bundled crate derives it from the primary path we
+  hand it, so there is no second key of ours to compare, and writing the formula out would only
+  test the formula. Its one real exception, `--fastqc_args "-o DIR"`, remains the known residual
+  in §9 A2 and §11.
+
+Writing the matrix surfaced a subtlety the plan had not stated, and the new test caught it on
+first run. Under `--basename` with no `-o`, `d/fixed_trimmed.fq.gz` and `e/fixed_trimmed.fq.gz`
+are distinct primaries whose demux *stems* are identical, because `demux_base_name` drops the
+directory. The demux *paths* still differ, because `demultiplex` resolves its directory to `-o`
+else the primary's parent. So the stem alone is not the key, and the assertion is now conditioned
+on the two primaries sharing a parent — exactly when a stem collision would be a path collision.
+
+**Post-fix gates:** 521 tests pass (was 520), `cargo fmt --all -- --check` clean,
+`cargo clippy --all-targets --release -- -D warnings` clean, `cargo doc` adds no new warning.
+Negative control on the new test: breaking `report_name` makes it fail, reverting makes it pass.
+
+**Outstanding action:** re-run `plan-manager` in a healthy session. Six consecutive subagent
+failures meant this audit's own gaps section, test table and verdict came within one attempt of
+being written by the session that wrote the code — which would not have been an independent
+check. The ledger above is complete enough to make a re-audit short.

--- a/plans/08062026_se-output-collision-preflight/COVERAGE_round2.md
+++ b/plans/08062026_se-output-collision-preflight/COVERAGE_round2.md
@@ -1,0 +1,202 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs. implementation plan — §5's 13 steps are the implementation plan; no separate `IMPL.md` exists by design)
+**Plan(s):** `plans/08062026_se-output-collision-preflight/PLAN.md` (v2)
+**Date:** 2026-08-07
+**Verdict:** COMPLETE
+
+Audited state: branch `fix/383-output-collision-preflight` off `dev` @ `72624c7`, change uncommitted
+(7 modified files + new untracked `tests/integration_output_collision.rs`).
+
+`cargo test` from the crate root: **521 passed, 0 failed** (399 lib + 122 integration across 12
+integration binaries; `tests/integration_output_collision.rs` contributes 20).
+
+## Summary
+
+- Total items: 25
+- DONE: 25
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED: 0 (D1–D6 are all documented in §13 and all verified against the code)
+
+Breakdown: 13 §5 steps · 7 §10 validation groups (V1 9/9, V2 11/11, V3 7/7, V4, V5, V6 3/3, V7) ·
+2 call-site items · 2 items for §3.5 and §4 · 1 item for §13's deviations.
+
+## Coverage ledger
+
+### §5 Implementation outline — steps 1–13
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `collision_key` + `preflight_output_collisions` in `io.rs`; extend `norm_path` doc-comment | Step 1 | DONE | `io.rs:48` (private) and `:57` (pub), placed directly after `norm_path` as specified. `norm_path`'s doc-comment now names `collision_key` (`:37-38`); the stale "`main::run` paired-end" locator is gone. Input keys held in a `HashMap<String,&PathBuf>` rather than §4.1's `HashSet<String>` — forced by §3.2's requirement that the alias message name the input; superset, not a shortfall. |
+| 2 | Delete `preflight_collision_bam`; re-point 3 calls; doc-comment rejoins `resolve_clump_layout` | Step 2 | DONE | Function gone (no grep hit anywhere). Baseline `72624c7` had calls at `:533`/`:566`/`:614`; all three now call the shared helper (`:548`, `:585`, `:633`). The clumpify-budget doc-comment is attached to `resolve_clump_layout` at `main.rs:91-95`. |
+| 3 | Convert the 4 hand-rolled copies to the shared helper | Step 3 | DONE | All four baseline `Output path collision` string literals (base `:490`, `:718`, `:1812`, `:2420`) are deleted. Converted: `:513` clump_only SE FASTQ (one candidate/input); `:734` paired FASTQ (accumulates across **all** `chunks(2)` into one `Vec` before a single call, keeps `--retain_unpaired` `:709-719` and `--passthrough` `:724-731` candidates); `:1825` paired uBAM (one candidate/pair); `:2430` `run_specialty_paired` (both names per pair, all pairs, one call). Every site passes `guarded_inputs(...)`. §2.5 side effect confirmed: `grep -rn "output-dir" src/ ci.yml` (excluding `output_dir`) returns nothing. |
+| 4 | `HardtrimEnd` enum + `pub` on both hardtrim namers; update 4 internal sites + 1 test | Step 4 | DONE | `specialty.rs:19` enum, `:25-29` `as_str()` → `"5prime"`/`"3prime"`. Both namers `pub fn` (`:442`, `:465`). Four internal sites updated: `:45`, `:88`, `:139`, `:191`. `bgz_stem_reaches_specialty_output_names` updated (`:844`, plan anchor `:822` shifted). |
+| 5 | `planned_hardtrim_outputs` in `main.rs` | Step 5 | DONE | `main.rs:71-89`; matches §4.3 signature exactly, `match cli.output_format` dispatches FASTQ vs uBAM namer. |
+| 6 | Guard `--hardtrim5` with `HardtrimEnd::Five` + `HARDTRIM_HINT` | Step 6 | DONE | `main.rs:359-364`, first statement in the `if let Some(n) = cli.hardtrim5` block, before the `for input in &cli.input` loop at `:365`. `HARDTRIM_HINT` at `:56-59` names both real remedies ("one invocation per input", "distinct basenames"). |
+| 7 | Guard `--hardtrim3` with `HardtrimEnd::Three` | Step 7 | DONE | `main.rs:390-395`, identical shape, `HardtrimEnd::Three`. |
+| 8 | Guard SE trim FASTQ | Step 8 | DONE | `main.rs:791-799`, in the `} else {` SE arm before the loop at `:800`. A9 verified: the candidate expression at `:796` is argument-identical to the writer's at `:1103`. Uses `guarded_inputs(&cli)` in place of the plan's `&cli.input` (D2). |
+| 9 | Guard SE trim uBAM | Step 9 | DONE | `main.rs:1863-1869`. A9 verified: candidate `:1867` argument-identical to writer `:1893`. |
+| 10 | `cli.rs` rejects duplicate SE inputs with its own message | Step 10 | DONE | `cli.rs:625-642`, inside `Cli::validate()` (hence before `ensure_output_dir` at `main.rs:314`). Message "Input file … was given more than once (arguments N and M)." plus the why-clause — matches §11 Open 1's proposed shape. Predicate `!self.paired && !self.clock && self.implicon.is_none()` per D1. |
+| 11 | Tests: unit (io.rs, cli.rs) + `tests/integration_output_collision.rs` | Step 11 | DONE | 12 unit tests in `io.rs:936-1164`, 3 in `cli.rs:1201-1233`, 20 in the new integration file. Follows `integration_paired_format_guard.rs` conventions (`CARGO_BIN_EXE_trim_galore`, `tempdir(tag)` keyed on `process::id()`, `(bool, String)` from `Command::output()`). Step 11's absolutised-fixture-path clause is satisfied by a stronger route: every fixture is written in-test (file header `:16-18`), so no `current_dir` case ever references a crate-root-relative path. |
+| 12 | CI: three validation steps | Step 12 | DONE | `ci.yml:642`, `:658`, `:677` — inserted directly after the `#216` guard block ending at `:640`. Idiom matches the existing guards exactly (`set +e` / `rc=${PIPESTATUS[0]}` / `set -e` / `test $rc -ne 0` / `grep -q "Output path collision"` / `test -z "$(ls -A …)"`). |
+| 13 | CHANGELOG: bug fixes + changes | Step 13 | DONE | `#### Bug fixes`: #383 plus both v2 defects (raw-string key, output-vs-output-only), each with its reachability. `#### Changes`: the A6 duplicate-input refusal (flagged as a behaviour change, noting the `--clock`/`--implicon` carve-out) and the `--output-dir` → `--output_dir` message correction. |
+
+### §10 Validation
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| V1 | 9 unit sub-cases in `src/io.rs` | §10 V1 | DONE | **9/9 present**, plus 1 bonus. 1→`preflight_accepts_distinct_outputs`; 2→`preflight_rejects_identical_outputs` (asserts the path is named); 3→`preflight_rejects_case_only_variants`; 4→`preflight_rejects_dot_slash_alias`; 5→`preflight_rejects_absolute_versus_relative_alias` (builds the key off `current_dir()`); 6→`preflight_rejects_output_that_aliases_an_input` (asserts alias wording **and** the absence of duplicate wording); 7→`preflight_accepts_dotdot_alias_known_limitation`; 8→`preflight_appends_hint_only_when_given` (both directions); 9→`preflight_accepts_empty_and_single`. Bonus: `preflight_rejects_input_alias_across_spellings`. |
+| V2 | 11 integration rejection sub-cases | §10 V2 | DONE | **11/11 present**, plus 2 bonus, in `tests/integration_output_collision.rs`. 1→`se_trim_rejects_shared_stem`; 2→`se_trim_rejects_dot_slash_alias`; 3→`se_trim_rejects_same_basename_across_dirs_with_output_dir`; 4→`se_trim_ubam_rejects_shared_stem`; 5→`hardtrim5_rejects_same_basename_across_dirs` (also greps the hint); 6→`hardtrim3_rejects_same_basename_across_dirs`; 7→`hardtrim5_ubam_rejects_shared_stem`; 8→`hardtrim3_ubam_rejects_shared_stem`; 9→`se_trim_rejects_output_that_aliases_an_input`; 10→`paired_rejects_output_that_aliases_an_input`; 11→`se_trim_rejects_gz_and_bgz_sharing_a_stem`. Bonus: `se_trim_rejects_absolute_versus_relative_alias`, `duplicate_input_gets_a_precise_message`. The empty-output-directory assertion is centralised in `assert_rejected_cleanly` (`:95-116`) and used by 9 of the 11; the two no-`-o` cases assert exact directory contents instead, which is the stronger form where output lands beside the inputs. Shape note: V2.5/V2.6 add `-o` on top of `current_dir(tempdir)` — the plan named only `current_dir` — for the same reason V6.2 states explicitly (the residue check needs a dedicated directory, and `-o` does not rescue a hardtrim collision). Consequence recorded under §3.5 row 11 below. |
+| V3 | 7 integration acceptance sub-cases | §10 V3 | DONE | **7/7 present**, every one asserting content or filename. 1→`se_trim_accepts_same_basename_across_dirs` (four assertions: each output holds 40 of its own reads and 0 of the other's); 2→`se_trim_accepts_single_input` (read count); 3→`hardtrim5_accepts_distinct_stems_and_names_output` (`x.20bp_5prime.fq` + `y.20bp_5prime.fq` by name); 4→`hardtrim3_accepts_distinct_stems_and_names_output` (`3prime` by name); 5→`hardtrim3_ubam_accepts_distinct_stems_and_names_output` (`*.20bp_3prime.bam`); 6→`se_trim_ubam_accepts_distinct_stems`; 7→`paired_accepts_two_distinct_pairs`. The `3prime`/`5prime` filename assertions are what make the §4.2 enum's purpose testable. |
+| V4 | `src/cli.rs` duplicate-SE-input unit tests | §10 V4 | DONE | `cli.rs:1201-1233`: `test_validate_single_end_duplicate_input_rejected` (asserts the dedicated wording **and** `!contains("APFS/NTFS")`), `test_validate_hardtrim_duplicate_input_rejected` (specialty-mode coverage), `test_validate_single_end_distinct_inputs_accepted` (negative control). The pre-existing duplicate-pair and R1≠R2 tests still pass — they are what caught D1, and all 399 lib tests are green. |
+| V5 | A2-as-a-table unit test | §10 V5 | DONE | `distinct_primary_outputs_imply_distinct_secondary_outputs` (`io.rs:1071-1123`) asserts the plan's stated direction (distinct primaries ⇒ distinct secondaries) over the full 2×2×2 `--basename`/`--dont_gzip`/`-o` matrix across 3 inputs, for `report_name`, `json_report_name`, `clumping_report_name`, and the demux stem via `demux::demux_base_name` (D6). The `--basename`-collapses-everything case is skipped with a comment pointing at the two guards that reject it. FastQC's zip name is documented as not separately assertable (`:1065-1070`) with the `--fastqc_args "-o DIR"` exception named, so the row cannot be "fixed" away. `primary_output_key_is_coarser_than_secondary_keys` retained as the complement, and covers the uBAM primary too. |
+| V6 | 3 CI validation steps | §10 V6 | DONE | `ci.yml:642` (SE collision, `illumina_10K.fastq.gz` copied to `sample.fastq.gz` + `sample.fq.gz`), `:658` (`--hardtrim5 30`, two subdirectories, with `-o`, and it greps the mode-specific hint as well as the collision prefix), `:677` (output-aliases-input, which additionally asserts the named input is md5-byte-identical afterwards and that the directory still holds exactly 2 files). All three verified to run and pass locally against the release binary as reproductions (a)/(c)/(f1) below. |
+| V7 | Gates + manual reproduction re-runs | §10 V7 | DONE | Verified independently this audit, not taken on report. `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --release -- -D warnings` exit 0, no warnings; `cargo test` from the crate root **521 passed / 0 failed**. `target/release/trim_galore` rebuilt, then all **eight** §2.2 invocations re-run from a scratch directory: each exits 1 with the correct message and writes nothing. The V3.1 positive control accepts with zero crosstalk. Full transcript in the table below. |
+
+### The 11 call sites
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| C | 3 re-pointed + 4 converted + 4 new = 11; no `cli.input` loop left unguarded | §1 / §5 | DONE | Exactly **11** `naming::preflight_output_collisions` calls in `src/main.rs`: `:360`, `:391`, `:513`, `:548`, `:585`, `:633`, `:734`, `:799`, `:1825`, `:1869`, `:2430`. Cross-checked against `72624c7`, which had 3 `preflight_collision_bam` calls (`:533`/`:566`/`:614`) + 4 hand-rolled `Output path collision` literals (`:490`/`:718`/`:1812`/`:2420`) = 7 guarded sites. 7 + 4 new = 11, and the arithmetic 3 re-pointed + 4 converted + 4 new holds exactly. |
+| C2 | No fifth hole — every `cli.input` traversal accounted for | §2.1 | DONE | `grep -nE "for .* in .*cli\.input\|cli\.input\.iter\(\)\|cli\.input\.chunks\("` on `src/main.rs` returns 15 loops. **5** are candidate-accumulation loops feeding a guard (`:577`→`:585`, `:630`→`:633`, `:700`→`:734`, `:1817`→`:1825`, `:2425`→`:2430`). The other **10** are output-producing, and each has an immediately preceding guard: `:365`←`:360`, `:396`←`:391`, `:514`←`:513`, `:591`←`:585`, `:634`←`:633`, `:744`←`:734`, `:800`←`:799`, `:1828`←`:1825`, `:1870`←`:1869`, `:2433`←`:2430`. This matches §2.1's "ten `cli.input` loops" independently. The 11th call (`:548`) guards the loop-free single-interleaved-uBAM `--clump_only` branch. The four remaining `cli.input.len() == 1` branches (`:475`, `:536`, `:677`, `:1796`) each produce outputs from a single input, so no duplicate and no self-alias is constructible — §2.1 marks them n/a and that holds. `--clump_only` PE FASTQ is not a separate hole: it delegates to `run_specialty_paired` (`:483`), guarded at `:2430`. |
+
+### §3.5 edge cases and §4 signatures
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| E | 15-row edge-case table traces to test / assumption / out-of-scope | §3.5 | DONE | All 15 rows trace. 1 one input→`preflight_accepts_empty_and_single` + `se_trim_accepts_single_input`. 2 `.fastq.gz`+`.fq.gz`→`se_trim_rejects_shared_stem`, V6.1, repro (a). 3 `.bgz`→`se_trim_rejects_gz_and_bgz_sharing_a_stem`, repro (b). 4 `./x`→2 tests + repro (e2). 5 `/abs/x`→2 tests + repro (e1). 6 `a/../x` accepted→`preflight_accepts_dotdot_alias_known_limitation` + repro, A8 held. 7 output==input→3 tests, V6.3, repros (f1)(f2). 8 same file twice→2 unit + 1 integration + repro, A6. 9 case-only→unit only, correctly, since two case variants cannot coexist on APFS. 10 same basename/diff dirs/no `-o`/SE accepted→`se_trim_accepts_same_basename_across_dirs` (content-attributing) + V3.1 repro. 11 same basename/diff dirs/no `-o`/hardtrim rejected→**not pinned by `cargo test`** (both hardtrim FASTQ rejection tests add `-o`); pinned only by V7 repro (c), which I ran and which rejects with the hint. Low risk, since the writer and the candidate builder share one namer (A9 + the §4.2 enum), so the two arms cannot disagree — but it is the mode's documented `--hardtrim5 N */*.fastq.gz` pattern, and the automated pin is weaker than the plan's wording implies. 12 with `-o`→`se_trim_rejects_same_basename_across_dirs_with_output_dir` (V2.3), the highest-value case, present. 13 `--basename` >1 SE input→`cli.rs:620` untouched, lib tests green. 14 zero inputs→clap `required` (A5). 15 `--hardtrim5`+`--hardtrim3`→unchanged, §11 Open 3, explicitly left undone in §13. |
+| S | 4 signature groups match the code | §4.1–§4.4 | DONE | §4.1 both signatures match character-for-character, including `hint: Option<&str>` and the private `collision_key`; the doc-comment enumerates the call sites and adds "A new dispatch path needs a call here too" as §4.1 intended. §4.2 `HardtrimEnd { Five, Three }` with `as_str()` → `"5prime"`/`"3prime"`, both namers `pub fn` taking `end: HardtrimEnd`. §4.3 `planned_hardtrim_outputs` matches, `std::path::PathBuf` spelled in full as §8 requires (`main.rs:5` still imports `Path` only). §4.4 present in `Cli::validate()` with its own message; placed at `:625` (after the `--basename` check) rather than literally adjacent to the duplicate-pair check at `:534-558`, but all four properties §4.4 argued for hold — precise message, runs before `ensure_output_dir` (`main.rs:314`), one place for all non-paired modes, unit-testable. §4.4's "covers every mode in one place" is narrowed by D1's `--clock`/`--implicon` carve-out, which is documented. |
+
+### §13 deviations D1–D6
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| D | Each of D1–D6 is real, matches the code, and is the only deviation | §13 | DONE | **D1** predicate is `!self.paired && !self.clock && self.implicon.is_none()` (`cli.rs:629`) — verified, and the three `--clock`/`--implicon` tests it protects are green. **D2** `guarded_inputs()` at `main.rs:62`; `grep -c "guarded_inputs("` = 12 = 1 definition + 11 call sites, and all 11 pre-flight calls pass it, so §3.2's input set (positionals + `--passthrough`) reaches every guarded path. **D3** both defect-1 integration tests now run **without** `-o` (`:144`, `:162`, each with a comment saying why) and close with `assert_dir_holds_only(&dir, &["sample.fastq", "sample.fq"])`. **D4** `tempdir()` ends in `std::fs::canonicalize` (`:35`) with the `/tmp` → `/private/tmp` rationale spelled out. **D5** confirmed and confirmed *consistent*: the pre-existing `#216` step at `ci.yml:617` has the identical unquoted-`#` quirk, so all four collision steps truncate the same way. **D6** `demux::demux_base_name` at `demux.rs:122`, called from both `demultiplex` (`:153`) and the V5 test; the separate `trimmed_name` binding that feeds the Perl-byte-identity-relevant "Processed sequences from file" message survives at `:148-152`. |
+
+## Gaps (detail)
+
+No coverage gaps. Every §5 step, every §10 validation sub-case, all 11 call sites, all 15 §3.5
+edge-case rows and all four §4 signature groups are implemented as specified, and every
+deviation is recorded in §13.
+
+Two observations that are **not** coverage gaps, recorded so they are not lost:
+
+### Observation 1 — `demultiplex` lost its doc-comment to D6's extraction (documentation only)
+
+**What:** `demux.rs:106-115` is `demultiplex`'s original doc-comment (the 5-step algorithm plus
+"Also writes a summary file with per-barcode counts"). D6 inserted `demux_base_name`'s own
+doc-comment immediately after it (`:116-121`), so the whole block now documents
+`demux_base_name`, and `pub fn demultiplex` at `:137` has no doc-comment at all.
+
+**Why it is not a coverage gap:** the plan never specifies `demux.rs`; D6 is itself a documented
+deviation and its stated claim — "pure refactor, behaviour-preserving" — holds. Nothing
+executable is affected, and `cargo doc` warnings are not gated.
+
+**Why it is still worth one line:** this is precisely the defect class the plan's own Step 2 went
+out of its way to repair ("removing it rejoins the comment to `resolve_clump_layout`"), so
+leaving the mirror image of it in `demux.rs` is inconsistent with the change's own standard.
+Fix is a one-line move. Flagged for the code reviewers, who own that call.
+
+### Observation 2 — §3.5 row 11 is pinned by a manual run, not by `cargo test`
+
+**What:** the row "same basename, different dirs, **no** `-o` — hardtrim → reject" is the
+documented `--hardtrim5 N */*.fastq.gz` pattern and hardtrim's widest collision class. Both
+hardtrim FASTQ rejection tests (`hardtrim5_rejects_same_basename_across_dirs`,
+`hardtrim3_rejects_same_basename_across_dirs`) add `-o`, so `cargo test` exercises only the
+`output_dir`-join arm of `hardtrim_output_name`, never the bare-filename/CWD arm.
+
+**Why it is not a coverage gap:** V2.5/V2.6 as written require `current_dir(tempdir)`, which the
+tests do set; `-o` was added for the reason V6.2 states in the plan itself (the "nothing written"
+residue check needs a dedicated directory). The uncovered arm cannot silently regress, because
+the candidate builder and the writer share one namer through `HardtrimEnd` (A9 + §4.2), so a
+namer change moves both together. And I re-ran the no-`-o` case directly this audit — repro (c)
+below — where it rejects with the mode-specific hint and writes nothing to the CWD.
+
+## Test verification
+
+`cargo test` from the crate root, single run, no filters: **521 passed, 0 failed, 0 ignored**
+(399 lib + 122 integration). New tests: 12 unit in `src/io.rs`, 3 unit in `src/cli.rs`,
+20 integration in `tests/integration_output_collision.rs`.
+
+| Test | File | Status |
+|---|---|---|
+| `preflight_accepts_distinct_outputs` (V1.1) | `src/io.rs` | PASS |
+| `preflight_rejects_identical_outputs` (V1.2) | `src/io.rs` | PASS |
+| `preflight_rejects_case_only_variants` (V1.3) | `src/io.rs` | PASS |
+| `preflight_rejects_dot_slash_alias` (V1.4) | `src/io.rs` | PASS |
+| `preflight_rejects_absolute_versus_relative_alias` (V1.5) | `src/io.rs` | PASS |
+| `preflight_rejects_output_that_aliases_an_input` (V1.6) | `src/io.rs` | PASS |
+| `preflight_accepts_dotdot_alias_known_limitation` (V1.7, pins A8) | `src/io.rs` | PASS |
+| `preflight_appends_hint_only_when_given` (V1.8) | `src/io.rs` | PASS |
+| `preflight_accepts_empty_and_single` (V1.9) | `src/io.rs` | PASS |
+| `preflight_rejects_input_alias_across_spellings` (bonus) | `src/io.rs` | PASS |
+| `distinct_primary_outputs_imply_distinct_secondary_outputs` (V5) | `src/io.rs` | PASS |
+| `primary_output_key_is_coarser_than_secondary_keys` (V5 complement) | `src/io.rs` | PASS |
+| `test_validate_single_end_duplicate_input_rejected` (V4) | `src/cli.rs` | PASS |
+| `test_validate_hardtrim_duplicate_input_rejected` (V4) | `src/cli.rs` | PASS |
+| `test_validate_single_end_distinct_inputs_accepted` (V4 control) | `src/cli.rs` | PASS |
+| `se_trim_rejects_shared_stem` (V2.1) | `tests/integration_output_collision.rs` | PASS |
+| `se_trim_rejects_dot_slash_alias` (V2.2) | `tests/integration_output_collision.rs` | PASS |
+| `se_trim_rejects_same_basename_across_dirs_with_output_dir` (V2.3) | `tests/integration_output_collision.rs` | PASS |
+| `se_trim_ubam_rejects_shared_stem` (V2.4) | `tests/integration_output_collision.rs` | PASS |
+| `hardtrim5_rejects_same_basename_across_dirs` (V2.5, +hint grep) | `tests/integration_output_collision.rs` | PASS |
+| `hardtrim3_rejects_same_basename_across_dirs` (V2.6) | `tests/integration_output_collision.rs` | PASS |
+| `hardtrim5_ubam_rejects_shared_stem` (V2.7) | `tests/integration_output_collision.rs` | PASS |
+| `hardtrim3_ubam_rejects_shared_stem` (V2.8) | `tests/integration_output_collision.rs` | PASS |
+| `se_trim_rejects_output_that_aliases_an_input` (V2.9) | `tests/integration_output_collision.rs` | PASS |
+| `paired_rejects_output_that_aliases_an_input` (V2.10) | `tests/integration_output_collision.rs` | PASS |
+| `se_trim_rejects_gz_and_bgz_sharing_a_stem` (V2.11) | `tests/integration_output_collision.rs` | PASS |
+| `se_trim_rejects_absolute_versus_relative_alias` (bonus) | `tests/integration_output_collision.rs` | PASS |
+| `duplicate_input_gets_a_precise_message` (bonus, A6) | `tests/integration_output_collision.rs` | PASS |
+| `se_trim_accepts_same_basename_across_dirs` (V3.1) | `tests/integration_output_collision.rs` | PASS |
+| `se_trim_accepts_single_input` (V3.2) | `tests/integration_output_collision.rs` | PASS |
+| `hardtrim5_accepts_distinct_stems_and_names_output` (V3.3) | `tests/integration_output_collision.rs` | PASS |
+| `hardtrim3_accepts_distinct_stems_and_names_output` (V3.4) | `tests/integration_output_collision.rs` | PASS |
+| `hardtrim3_ubam_accepts_distinct_stems_and_names_output` (V3.5) | `tests/integration_output_collision.rs` | PASS |
+| `se_trim_ubam_accepts_distinct_stems` (V3.6) | `tests/integration_output_collision.rs` | PASS |
+| `paired_accepts_two_distinct_pairs` (V3.7) | `tests/integration_output_collision.rs` | PASS |
+
+### V7 gates and reproductions, re-run this audit
+
+| Check | Result |
+|---|---|
+| `cargo fmt --all -- --check` | clean |
+| `cargo clippy --all-targets --release -- -D warnings` | exit 0, no warnings |
+| `cargo test` (crate root) | 521 passed, 0 failed |
+| `cargo build --release` then §2.2 (a) shared stem | exit 1, "Output path collision", only the 2 inputs left |
+| §2.2 (b) `.gz` + `.bgz` | exit 1, "Output path collision" |
+| §2.2 (c) hardtrim5 same basename, 2 dirs, **no `-o`** | exit 1, "one invocation per input", nothing in CWD |
+| §2.2 (d) hardtrim5 uBAM arm | exit 1, "Output path collision", nothing written |
+| §2.2 (e1) absolute vs relative | exit 1, "Output path collision", only the 2 inputs left |
+| §2.2 (e2) `./` prefix | exit 1, "Output path collision", only the 2 inputs left |
+| §2.2 (f1) SE output aliases an input | exit 1, "which is also one of its inputs", the named input's 40 PRIOR reads intact |
+| §2.2 (f2) `--paired` output aliases an input | exit 1, "which is also one of its inputs", `a_R1_val_1.fq`'s 40 reads intact |
+| §10 V3.1 positive control (no `-o`) | exit 0; `dirA` 40 DIRA / 0 DIRB, `dirB` 40 DIRB / 0 DIRA |
+| A6 same file twice | exit 1, "was given more than once", 0 occurrences of "APFS/NTFS" |
+| A8 residual `a/../x` + `y` | exit 0 — accepted, as A8 states |
+
+Transcript and driver script:
+`/private/tmp/claude-501/-Users-fkrueger-Github-TrimGalore/d0ee0171-fc72-476b-bdba-c46c90a5bacd/scratchpad/reaudit/v7.sh`
+
+## Verdict
+
+**Verdict:** COMPLETE
+
+All 25 audited items are DONE: §5 steps 1–13, §10 V1–V7 (with 9/9, 11/11 and 7/7 named sub-cases
+present and individually located, not merely "a test file exists"), all 11 call sites with the
+3-re-pointed / 4-converted / 4-new arithmetic reconciled against `72624c7`, the "no fifth hole"
+claim re-derived independently from the 15 `cli.input` traversals, all 15 §3.5 edge-case rows,
+all four §4 signature groups, and D1–D6 each verified against the code.
+
+The two items the earlier audit raised are closed. `norm_path`'s doc-comment names
+`collision_key` and the stale `main::run` locator is gone (`io.rs:33-45`). V5 is now
+`distinct_primary_outputs_imply_distinct_secondary_outputs`, which asserts A2 in the direction
+the plan states across the full `--basename`/`--dont_gzip`/`-o` matrix and reaches the demux stem
+through D6's extracted function rather than a copy of its formula.
+
+Nothing is blocked and nothing needs implementing to satisfy the plan. Two non-blocking
+observations are recorded above for the code reviewers: `demultiplex`'s doc-comment is now
+attached to `demux_base_name` (documentation only, one-line fix), and §3.5 row 11 — hardtrim
+colliding with no `-o` — is pinned by a manual reproduction rather than by `cargo test`.
+

--- a/plans/08062026_se-output-collision-preflight/COVERAGE_round3.md
+++ b/plans/08062026_se-output-collision-preflight/COVERAGE_round3.md
@@ -1,0 +1,270 @@
+# Plan Coverage Report — second independent re-audit
+
+**Mode:** B (code vs. implementation plan — the plan's own §5 is the implementation ledger; no separate `IMPL.md`, by design)
+**Plan(s):** `plans/08062026_se-output-collision-preflight/PLAN.md` (v2, §13 through "Post-audit gap closures")
+**Date:** 2026-08-07
+**Verdict:** COMPLETE
+
+**Provenance.** This is a *third* coverage pass, run concurrently with and independently of the
+re-audit in `COVERAGE.md` (neither read the other while auditing; I read `COVERAGE.md` only after
+finishing, to reconcile). `COVERAGE_round1.md` is the first pass. **`COVERAGE.md` remains the
+canonical report** — `PROGRESS.md` cites it, it is correct, and this pass concurs with it. This
+file exists to record an independent cross-check at finer granularity (67 items vs 25) and one
+classification disagreement that I resolved in `COVERAGE.md`'s favour after checking §10 V7.
+
+Audited state: branch `fix/383-output-collision-preflight` off `dev` @ `72624c7`, uncommitted —
+**7 modified files** (`ci.yml`, `CHANGELOG.md`, `src/cli.rs`, `src/demux.rs`, `src/io.rs`,
+`src/main.rs`, `src/specialty.rs`) plus untracked `tests/integration_output_collision.rs`;
+`git diff --stat` +595/−111.
+
+> **The tree moved mid-audit.** This pass began against the tree as the brief described it
+> (6 modified files, +503/−99, 520 tests) and the `src/io.rs` + new `src/demux.rs` changes landed
+> at 12:54–12:55, closing two of the three gaps this pass had found independently — the same two
+> `COVERAGE_round1.md` raised. Every finding below is re-verified against the **current** tree
+> with a release binary rebuilt at 13:18 (51 s compile — confirmed a real build, not a stale
+> artifact).
+
+## Summary
+
+- Total items: 67
+- DONE: 63
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED: 4 — D1 and D6 documented in §13 and acceptable; the V2.5/V2.6 test-shape change
+  undocumented but behaviourally covered by V7 (see Reconciliation)
+
+Gates re-run independently, from scratch, on the current tree:
+
+| Gate | Result |
+|---|---|
+| `cargo test` (crate root) | **521 passed, 0 failed** — 399 lib + 122 integration across 12 binaries |
+| `cargo fmt --all -- --check` | clean |
+| `cargo clippy --all-targets --release -- -D warnings` | clean |
+| §2.2 reproductions (a)–(f), 8 invocations | all exit 1 with the correct message, nothing written |
+| §10 V3.1 positive control | exit 0; `dirA` 40 own/0 foreign, `dirB` 40/0 — zero crosstalk |
+| Three new `ci.yml` steps, executed locally | all pass every assertion |
+| `ci.yml` YAML parse | valid; `validation` job has **41** steps (§13 still says 40) |
+| Over-rejection probes: `--demux`, `--clock` ×2 pairs | both exit 0 — the widened input set does not over-reject |
+| `--clock` R1==R2 | keeps its own precise message (D1 verified behaviourally) |
+| Cross-pair duplicate `--paired a1 a2 b1 a2` | exit 1 via the pre-flight |
+
+These figures were produced without reference to `COVERAGE.md` and match its independently
+obtained figures exactly, including the 41-vs-40 CI step discrepancy.
+
+## Coverage ledger
+
+### §5 — Implementation outline (13 steps)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `io.rs`: `collision_key` + `preflight_output_collisions` after `norm_path`; extend `norm_path`'s doc-comment | Step 1 | DONE | `collision_key` `io.rs:48`, `preflight_output_collisions` `:57`. **Doc-comment sub-clause closed in the 12:55 change**: `:37-38` now names `collision_key`; the stale "`main::run` paired-end" locator is gone |
+| 2 | Delete `preflight_collision_bam`; re-point 3 calls; doc-comment rejoins `resolve_clump_layout` | Step 2 | DONE | Absent from `src/`; calls at `:548`, `:585`, `:633`; clumpify-budget doc-comment reattached |
+| 3 | Convert the 4 hand-rolled copies, preserving semantics | Step 3 | DONE | `:513` clump_only SE FASTQ; `:734` paired FASTQ (candidates accumulated across **all** `chunks(2)` into one `Vec`, so cross-pair collisions still fire — verified live; `--retain_unpaired` and `--passthrough` extras preserved); `:1825` paired uBAM; `:2430` `run_specialty_paired`. All pass `guarded_inputs(…)`. No `--output-dir` left in any source message (§2.5) |
+| 4 | `HardtrimEnd` + `pub` on both namers; 4 internal sites + the bgz test | Step 4 | DONE | Enum `specialty.rs:19`; namers `pub` at `:442`, `:465`; sites `:45`, `:88`, `:139`, `:191`; `bgz_stem_reaches_specialty_output_names` updated |
+| 5 | `planned_hardtrim_outputs` | Step 5 | DONE | `main.rs:71-89`, `match cli.output_format` |
+| 6 | Guard `--hardtrim5`, first statement in the block | Step 6 | DONE | `main.rs:359-364`, ahead of the writer loop; passes `HARDTRIM_HINT` (`:56-59`) naming both real remedies |
+| 7 | Guard `--hardtrim3` with `HardtrimEnd::Three` | Step 7 | DONE | `main.rs:390-395` |
+| 8 | Guard SE trim FASTQ before the loop | Step 8 | DONE | `main.rs:791-799`; A9 verified — candidate call argument-identical to the writer's |
+| 9 | Guard SE trim uBAM | Step 9 | DONE | `main.rs:1863-1869`; A9 likewise |
+| 10 | `cli.rs`: reject duplicate SE inputs, own message | Step 10 | **DEVIATED** (documented, D1) | `cli.rs:625-642`. Predicate `!self.paired && !self.clock && self.implicon.is_none()`, not the planned `!self.paired`. Verified necessary: the `--clock`/`--implicon` `validate_paired_input` calls sit *after* this check, and `--clock s.fastq.gz s.fastq.gz` still yields "Read 1 and Read 2 appear to be the same file". Acceptable |
+| 11 | Tests: `io.rs` (V1), `cli.rs` (V4), new integration file; `current_dir` cases absolutised | Step 11 | DONE | 12 + 3 + 20 tests. The absolutised-fixture clause is met by a stronger route: all fixtures written in-test, so no `current_dir` case references a crate-root-relative path |
+| 12 | CI: three validation steps | Step 12 | DONE | Steps 23/24/25 of `validation`; idiom matches the existing guards |
+| 13 | CHANGELOG: bug fixes + changes | Step 13 | DONE | `#### Bug fixes` covers #383 and both defects with reachability; `#### Changes` covers A6 (flagged as a behaviour change, with the clock/implicon carve-out) and the `--output-dir` → `--output_dir` correction |
+
+### §4 — Specified signatures
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 14 | `collision_key` / `preflight_output_collisions` | §4.1 | DONE | Character-identical. Input keys in `HashMap<String, &PathBuf>` rather than §4.1's `HashSet<String>` — **required**, since §3.2 demands the alias message name the aliased input, which a set of keys cannot recover. Doc-comment enumerates call sites plus "a new dispatch path needs a call here too" |
+| 15 | `pub enum HardtrimEnd`; both namers `pub`, taking it | §4.2 | DONE | Exact; `as_str` left private (unspecified by the plan) |
+| 16 | `planned_hardtrim_outputs(...) -> Vec<std::path::PathBuf>` | §4.3 | DONE | Exact, `PathBuf` spelled in full per §4.3/§8 |
+| 17 | A6 in `Cli::validate`, before `ensure_output_dir`, own message | §4.4 | DONE | `validate()` `main.rs:155` vs `ensure_output_dir` `:314`; verified empirically that a rejected duplicate leaves no `-o` directory (A7). Sited at `cli.rs:625` rather than "beside `:534-558`" — cosmetic |
+
+### §1 / §2.4 — Call-site count
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 18 | 11 call sites: 3 re-pointed, 4 converted, 4 new; no path missed | §1, §5 | DONE | Exactly **11**. Re-pointed `:548`/`:585`/`:633`; converted `:513`/`:734`/`:1825`/`:2430`; new `:360`/`:391`/`:799`/`:1869`. Cross-checked against all 16 `cli.input` iterations: `:365`←`:360`, `:396`←`:391`, `:514`←`:513`, `:591`←`:585`, `:634`←`:633`, `:744`←`:734`, `:800`←`:799`, `:1828`←`:1825`, `:1870`←`:1869`, `:2433`←`:2430`, the rest being candidate builders. `--clump_only --paired` FASTQ delegates to `run_specialty_paired` (guarded `:2430`); `--demux` runs inside the SE loop (guarded `:799`). No unguarded writing loop |
+
+### §10 V1 — unit, `src/io.rs` (9 sub-cases)
+
+All 9 present and individually located; all PASS. 1→`preflight_accepts_distinct_outputs`;
+2→`preflight_rejects_identical_outputs`; 3→`preflight_rejects_case_only_variants`;
+4→`preflight_rejects_dot_slash_alias`; 5→`preflight_rejects_absolute_versus_relative_alias`;
+6→`preflight_rejects_output_that_aliases_an_input` (asserts the alias wording **and** the absence
+of the duplicate wording); 7→`preflight_accepts_dotdot_alias_known_limitation` (pins A8, with a
+comment saying to retire A8 deliberately if it ever fails); 8→`preflight_appends_hint_only_when_given`
+(both directions); 9→`preflight_accepts_empty_and_single`. Bonus:
+`preflight_rejects_input_alias_across_spellings`. Items 19–27 — all DONE.
+
+### §10 V2 — integration rejections (11 sub-cases)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 28 | SE trim FASTQ, shared stem | V2.1 | DONE | `se_trim_rejects_shared_stem` |
+| 29 | SE trim FASTQ, `./sample` + `sample` | V2.2 | DONE | `se_trim_rejects_dot_slash_alias`; runs **without** `-o`, asserts exact directory contents (D3) |
+| 30 | `dirA`+`dirB` same basename **with `-o`** | V2.3 | DONE | `se_trim_rejects_same_basename_across_dirs_with_output_dir`. Paired against V3.1's no-`-o` acceptance, so the `output_dir`-vs-`None` slip in Step 8 is pinned from both sides — the plan's stated highest-value case, correctly built |
+| 31 | SE trim uBAM, colliding stems | V2.4 | DONE | `se_trim_ubam_rejects_shared_stem` |
+| 32 | `--hardtrim5 20` FASTQ, same basename two dirs, `current_dir(tempdir)` | V2.5 | **DEVIATED** (undocumented) | `hardtrim5_rejects_same_basename_across_dirs` sets `current_dir` but **also** passes `-o`, so it exercises the `-o` arm rather than the CWD arm. Asserts the hint. Behaviour covered by V7 repro (c) — see Reconciliation |
+| 33 | `--hardtrim3 20` FASTQ, same shape | V2.6 | **DEVIATED** (undocumented) | `hardtrim3_rejects_same_basename_across_dirs`, same shape change |
+| 34 | `--hardtrim5 20 --output-format ubam` | V2.7 | DONE | `hardtrim5_ubam_rejects_shared_stem` |
+| 35 | `--hardtrim3 20 --output-format ubam` | V2.8 | DONE | `hardtrim3_ubam_rejects_shared_stem` |
+| 36 | SE trim, output aliases an input | V2.9 | DONE | `se_trim_rejects_output_that_aliases_an_input`; asserts alias wording, the negative, **and** that the named input keeps its own 40 reads and none of the source's |
+| 37 | `--paired`, output aliases an input | V2.10 | DONE | `paired_rejects_output_that_aliases_an_input`; proves the converted paired site gained defect-2 protection |
+| 38 | `.gz` + `.bgz` sharing a stem | V2.11 | DONE | `se_trim_rejects_gz_and_bgz_sharing_a_stem` |
+
+Bonus: `se_trim_rejects_absolute_versus_relative_alias` (the mixed absolute/relative list §2.2(e)
+names) and `duplicate_input_gets_a_precise_message`.
+
+### §10 V3 — integration acceptances (7 sub-cases)
+
+Items 39–45, all DONE, all asserting content or filename:
+V3.1→`se_trim_accepts_same_basename_across_dirs` (four assertions: each output holds 40 of its own
+and 0 of the other's); V3.2→`se_trim_accepts_single_input`;
+V3.3→`hardtrim5_accepts_distinct_stems_and_names_output`;
+V3.4→`hardtrim3_accepts_distinct_stems_and_names_output` (first output-producing coverage
+`--hardtrim3` has ever had); V3.5→`hardtrim3_ubam_accepts_distinct_stems_and_names_output`;
+V3.6→`se_trim_ubam_accepts_distinct_stems`; V3.7→`paired_accepts_two_distinct_pairs`.
+V3.3/V3.4 assert `.fq` rather than the plan's `.fq.gz` because the in-test fixtures are plain
+FASTQ (`gzip=false`); the `5prime`/`3prime` discriminator — the point of the test under A9 and
+§4.2 — is asserted.
+
+### §10 V4–V7
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 46 | Duplicate SE input rejected with the dedicated message; distinct inputs validate; existing tests pass | V4 | DONE | `test_validate_single_end_duplicate_input_rejected` (positive **and** `!contains("APFS/NTFS")`), `test_validate_single_end_distinct_inputs_accepted`, bonus `test_validate_hardtrim_duplicate_input_rejected`. All pre-existing paired/clock/implicon validation tests green |
+| 47 | A2 as a table that can fail, across the flag matrix, incl. demux stem and FastQC zip | V5 | DONE | **Closed in the 12:54–12:55 change.** `distinct_primary_outputs_imply_distinct_secondary_outputs` asserts the plan's stated direction (primaries differ ⇒ secondaries differ) over all 8 `--basename`/`--dont_gzip`/`-o` combinations for `report_name`, `json_report_name`, `clumping_report_name` and the demux stem via the newly extracted `demux::demux_base_name` (D6). FastQC's zip is **documented as not separately assertable** — the bundled crate derives it from the primary path handed to it, so there is no second key of ours to compare — with A2's `--fastqc_args -o` exception named so the row cannot be deleted as dead weight. The former inverse-premise test is retained as an explicit complement |
+| 48 | CI: SE trim collision | V6.1 | DONE | Executed locally: rc=1, grep OK, `out/` empty |
+| 49 | CI: `--hardtrim5 30` collision with `-o` | V6.2 | DONE | Also greps `one invocation per input`. Executed locally: rc=1, both greps OK, `out/` empty |
+| 50 | CI: output-aliases-input | V6.3 | DONE | Greps the alias-specific wording plus an md5 byte-identity check on the named input and a file-count check — stronger than V6's stated idiom. Executed locally: rc=1, grep OK, md5 unchanged, count=2 |
+| 51 | Gates, rebuild, all §2.2 reproductions, V3.1 positive control | V7 | DONE | Re-verified independently on a freshly rebuilt binary; all 8 reproductions reject, positive control clean. **Repro (c) is the no-`-o` hardtrim case** and it rejects with the hint, writing nothing to the CWD |
+
+### §3.5 — Edge-case table (15 rows)
+
+Items 52–66. All 15 rows trace. Abbreviated, with the two that need comment given in full:
+
+1→V1.9 + V3.2 · 2→V2.1, V6.1, repro (a) · 3→V2.11, repro (b) · 4→V1.4, V2.2, repro (e-dot) ·
+5→V1.5, bonus test, repro (e-abs) · 6→V1.7 (A8 residual, pinned) · 7→V1.6, V2.9, V2.10, V6.3,
+repros (f-se)/(f-pe) · 9→V1.3 (unit only, correctly — two case variants cannot coexist on APFS) ·
+10→V3.1 + the V7 positive control · 12→V2.3 · 13→`cli.rs:620-624` untouched, precedence unchanged ·
+14→clap `required` (A5) · 15→§11 Open 3, explicitly left undone in §13.
+
+- **Row 8 (same file listed twice) — DONE.** V4 + `duplicate_input_gets_a_precise_message`. Under
+  `--paired`/`--clock`/`--implicon` the precise message comes from `validate_paired_input` instead
+  (D1); a cross-pair duplicate (`--paired a1 a2 b1 a2`) falls through to the pre-flight's collision
+  message. All three shapes verified rejecting, so the row's claim holds on every path even though
+  the message differs by mode.
+- **Row 11 (same basename, different dirs, no `-o` — hardtrim → reject) — DONE.** Traces to
+  **V7 repro (c)**, which the plan mandates re-running and which I ran: rc=1, hint present, CWD
+  left holding only `dirA dirB`. Not pinned by `cargo test` — every hardtrim test adds `-o` — so
+  the pin is a manual gate rather than CI. See Reconciliation.
+
+### Beyond-plan change
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 67 | `src/demux.rs`: extract `pub fn demux_base_name(&Path) -> String` | not in plan | **DEVIATED** (documented, D6) | Pure extraction so V5 can assert the demux stem against the real derivation rather than a copy of the formula; called from both `demultiplex` (`demux.rs:153`) and the V5 test, so the test cannot drift from the code. Verified behaviour-preserving: `--demux` on `test_files/demux_test.fastq.gz` still emits `demux_test_trimmed_sample{1..6}.fq.gz`, `_NoCode.fq.gz` and `_demultiplexing_summary.txt`. §13's D6 also records that the `trimmed_name` binding feeding the `Processed sequences from file >…<` line was restored after the first attempt dropped it — material, since `--demux` is in the Perl byte-identity matrix. Acceptable |
+
+## Gaps (detail)
+
+**No unresolved coverage gaps.** Every §5 step, every §10 sub-case, all 11 call sites, all 15 §3.5
+rows and all four §4 signature groups are implemented as specified; every deviation is either
+documented in §13 (D1, D6) or behaviourally covered by another plan item (V2.5/V2.6 → V7).
+
+### Reconciliation — where this pass first disagreed with `COVERAGE.md`, and why it no longer does
+
+This pass initially recorded the hardtrim `-o` shape change as a gap: V2.5 and V2.6 DEVIATED and
+§3.5 row 11 PARTIAL, on the grounds that row 11 had no trace to a test, an assumption, or an
+out-of-scope entry. **That was wrong, and I withdrew it.** §2.2 reproduction (c) *is* the no-`-o`
+hardtrim collision — `trim_galore --hardtrim5 20 dirA/same.fastq.gz dirB/same.fastq.gz`, with the
+plan's own note "(outputs land in CWD)" — and §10 V7 mandates re-running (a)–(f), explicitly
+adding "Run (c) from a scratch directory, not the repo root." Row 11 therefore traces to a
+plan-specified validation item, which I executed and which passes. `COVERAGE.md` reached the
+correct classification.
+
+Two independent passes converged on the same underlying fact from different directions, which is
+worth more than either verdict alone:
+
+- **Agreed fact.** All seven hardtrim tests and the new CI step pass `-o`, so `cargo test` never
+  exercises `hardtrim_output_name`'s bare-filename/CWD arm (`specialty.rs:447`). The widest
+  collision class in the change is pinned only by a manual gate.
+- **Agreed classification.** Not a coverage gap: V2.5/V2.6 as written require `current_dir(tempdir)`,
+  which the tests do set; `-o` was added for the reason the plan itself gives at V6.2 (the
+  "nothing written" residue check needs a dedicated directory); and the candidate builder and the
+  writer share one namer through `HardtrimEnd`, so the untested arm cannot silently drift out of
+  sync (A9 + §4.2).
+- **Agreed residual risk.** Low, and behavioural correctness is verified today.
+
+Independently of the classification, `PROGRESS.md` already carries this as an open code-review
+finding ("Hardtrim without `-o` — the widest collision class — is untested"), so it is captured
+for the decision the reviewers own. Two cheap, non-blocking follow-ups:
+
+1. Add one hardtrim rejection case with **no** `-o` — two same-basename inputs in different
+   directories under `current_dir(tempdir)` — asserting the CWD holds only its two input
+   directories. `assert_dir_holds_only` already exists in the file for exactly this shape; D3
+   introduced it when the SE defect-1 cases had to drop `-o` for the same reason. This moves the
+   pin from a manual gate into CI.
+2. Add one line to §13 recording the V2.5/V2.6 shape change, so the only two undocumented
+   deviations in the change become documented ones.
+
+### Observations (not coverage gaps)
+
+1. **§13's headline numbers are stale.** It records "520 tests pass (398 lib + 122 integration)"
+   and "6 files changed, +503/−99"; the tree is now 521 (399 lib) and 7 files, +595/−111. The
+   negative-control table says "40 steps in `validation`" where a YAML parse gives 41.
+2. **Three comments went stale with Step 1**, all comment-only, none a plan item: `main.rs:271`
+   ("the three output-collision pre-flights" — there are eleven); `main.rs:692-698` (describes the
+   paired key as "the full path, case-folded", omitting the absolutisation that is the whole of
+   defect 1's fix); `tests/integration_clump_only_ubam.rs:625` (cites the deleted
+   `preflight_collision_bam`). `COVERAGE.md` independently flags a fourth, `demux.rs`'s
+   re-parented `demultiplex` doc-comment.
+3. **The hardtrim hint reads oddly under `-o`.** With `-o out` the message prints
+   `out/same.30bp_5prime.fq.gz` while the hint says output "is written to the current working
+   directory". Each half is defensible; the sentence contradicts the paths shown above it.
+   `COVERAGE.md` and two of three code reviewers reached the same place — the hint should replace
+   the generic advice rather than append to it.
+4. **The duplicate-output message names the same path twice** ("X and X would be written to the
+   same file") when the two planned paths are byte-identical. Pre-existing #216 wording, unchanged
+   here.
+5. **The `HashSet` → `HashMap` change at §4.1 is required, not incidental** (§3.2 needs the message
+   to name the input). Worth a §13 line so nobody "restores" the plan's data structure.
+6. **§3.5 has 15 rows, not the 14 the audit brief cited.** All 15 audited.
+7. **D5 confirmed.** All three new CI step names truncate at `(issue` in the parsed YAML, matching
+   the pre-existing `(issue #216)` step. Cosmetic.
+
+## Test verification (Mode B)
+
+`cargo test`, crate root, single run, no filters: **521 passed, 0 failed, 0 ignored** (399 lib +
+122 integration). New: 12 unit in `src/io.rs`, 3 unit in `src/cli.rs`, 20 integration in
+`tests/integration_output_collision.rs`.
+
+Per-test status is identical to the table in `COVERAGE.md` — all 35 named new tests PASS, and I
+verified the V1/V2/V3 sub-case counts independently as 9/9, 11/11 and 7/7 by name rather than by
+file existence. The one row worth restating:
+
+| Test | File | Status |
+|---|---|---|
+| hardtrim rejection with **no** `-o` (§3.5 row 11) | — | not in `cargo test`; covered by V7 repro (c), executed and passing |
+
+Driver scripts for this pass:
+`/private/tmp/claude-501/-Users-fkrueger-Github-TrimGalore/d0ee0171-fc72-476b-bdba-c46c90a5bacd/scratchpad/coverage/{ci_steps,repros,extra}.sh`
+
+## Verdict
+
+**Verdict:** COMPLETE
+
+All 67 audited items resolve: 63 DONE, 0 PARTIAL, 0 MISSING, 4 DEVIATED — D1 and D6 documented in
+§13 and verified against the code, and the V2.5/V2.6 test-shape change behaviourally covered by
+V7 repro (c), which I executed. The implementation matches the plan, the 11 call sites reconcile
+against `72624c7`, no dispatch path is unguarded, and the two gaps raised by
+`COVERAGE_round1.md` — Step 1's doc-comment sub-clause and V5's A2 table — are closed, which I
+confirmed independently rather than taking on report.
+
+This pass concurs with `COVERAGE.md`, including on the one point where it initially differed
+(§3.5 row 11 / V2.5 / V2.6), having found that row 11 traces to §10 V7. Nothing needs implementing
+to satisfy the plan.
+
+Two non-blocking follow-ups, both already visible to the reviewers via `PROGRESS.md`: move the
+hardtrim no-`-o` pin from V7's manual gate into `cargo test`, and refresh §13's counts
+(520→521, 6→7 files, 40→41 CI steps) plus the V2.5/V2.6 shape note.

--- a/plans/08062026_se-output-collision-preflight/PLAN.md
+++ b/plans/08062026_se-output-collision-preflight/PLAN.md
@@ -1,0 +1,776 @@
+# Plan — Output-collision pre-flight: close the four uncovered paths and the two key defects (#383)
+
+**Issue:** [#383](https://github.com/FelixKrueger/TrimGalore/issues/383)
+**Branch:** `dev` @ `72624c7`
+**Revision:** v2 (2026-08-06) — see §12
+
+---
+
+## 1. Goal
+
+Make every prospective output path of a run checked, against every other prospective
+output path **and** against every input path, before any file is opened. Fix #383 and the
+three sibling holes on the same dispatch pattern.
+
+Two defects in v1's design, each found independently by one reviewer and reproduced by the
+orchestrator, are in scope:
+
+- **The key was a raw string.** `./sample.fastq.gz` and `sample.fastq.gz` hash differently
+  while naming one inode, so #383 reproduced verbatim through v1's own guard.
+- **The check was output-vs-output only.** A planned output can be an *input* of the same
+  invocation; the run then destroys that input's reads and emits a second output holding
+  the wrong sample's data. `--paired` has this hole today, with the pre-flight in place.
+
+Scope note: closing the second defect requires the shared helper to see the input list, and
+`--paired` needs it as much as the new paths do. The four existing hand-rolled copies
+therefore **convert to the shared helper in this commit** — what v1 deferred as a cosmetic
+"commit 2" is now load-bearing, and it also corrects two error messages that advise a flag
+that does not parse (§2.5).
+
+---
+
+## 2. Context
+
+### 2.1 The verified hole map
+
+Measured against `target/release/trim_galore` at `72624c7`. Every row was executed; read
+counts come from grepping read-ID prefixes in the surviving output.
+
+| Dispatch path | Pre-flight today | Measured on a colliding invocation |
+|---|---|---|
+| `--paired` trim FASTQ | ✅ `main.rs:672-727` | exit 1, message, nothing written |
+| `--paired` trim uBAM (2-file) | ✅ `main.rs:1800-1820` | — |
+| `--paired` trim uBAM (1-file interleaved) | n/a — one output | — |
+| `--clock` / `--implicon` | ✅ `run_specialty_paired`, `main.rs:2412-2429` | exit 1, message |
+| `--clump_only` SE FASTQ | ✅ `main.rs:481-498` | exit 1, message |
+| `--clump_only` SE uBAM | ✅ `main.rs:609-614` | exit 1, message |
+| `--clump_only` PE (both formats) | ✅ 2 sites | exit 1, message |
+| **SE trim FASTQ** | ❌ `main.rs:781-792` | **exit 0, 40 of 80 reads lost** |
+| **SE trim uBAM** | ❌ `main.rs:1857-1865` | **exit 0**, one `.bam`, two reports |
+| **`--hardtrim5/3` FASTQ** | ❌ `main.rs:344-393` | **exit 0, 40 of 80 reads lost** |
+| **`--hardtrim5/3` uBAM** | ❌ `main.rs:344-393` | **exit 0**, one `.bam` written twice |
+
+Both reviewers independently enumerated all ten `cli.input` loops in `main()` and confirmed
+exactly these four lack a preceding pre-flight. **No fifth hole exists.**
+
+### 2.2 Reproductions (all re-run at v2)
+
+```bash
+# (a) #383 as filed — same stem, different FASTQ extension
+trim_galore sample.fastq.gz sample.fq.gz
+# → exit 0; one sample_trimmed.fq.gz; ALPHA 0 / BETA 40; TWO reports, each "40 (100.0%)"
+
+# (b) the .bgz widening from #382
+trim_galore wide.fastq.gz wide.fastq.bgz          # → exit 0; GZALPHA 0 / BGZBETA 40
+
+# (c) hardtrim, same basename in DIFFERENT directories (outputs land in CWD)
+trim_galore --hardtrim5 20 dirA/same.fastq.gz dirB/same.fastq.gz
+# → exit 0; one ./same.20bp_5prime.fq.gz; DIRA 0 / DIRB 40
+
+# (d) hardtrim uBAM arm
+trim_galore --hardtrim5 20 --output-format ubam s_R1.fastq.gz s_R1.fq.gz
+# → exit 0; "Writing hard-trimmed" twice; one .bam
+
+# (e) DEFECT 1 — v1's guard accepts these; both lose 40 of 80 reads at exit 0
+cd d && trim_galore /abs/d/sample.fastq.gz sample.fq.gz
+#   Output: /abs/d/sample_trimmed.fq.gz  +  Output: sample_trimmed.fq.gz   (one inode)
+cd d && trim_galore ./sample.fastq.gz sample.fq.gz
+#   Output: ./sample_trimmed.fq.gz       +  Output: sample_trimmed.fq.gz   (one inode)
+
+# (f) DEFECT 2 — a planned output IS an input; --paired is affected too
+trim_galore s.fastq.gz s_trimmed.fq.gz
+# → exit 0; s_trimmed.fq.gz overwritten with input 1's reads (prior 40 destroyed);
+#   s_trimmed_trimmed.fq.gz ALSO holds input 1's reads — a file of the wrong sample
+trim_galore --paired a_R1.fq.gz a_R2.fq.gz a_R1_val_1.fq.gz a_R2_val_2.fq.gz
+# → exit 0; a_R1_val_1.fq.gz's 40 prior reads destroyed; a_R1_val_1_val_1.fq.gz created
+```
+
+Reachability, stated precisely so the CHANGELOG can be too:
+
+- (e) needs an argument list that mixes spellings — `find`/`xargs` output, staged pipeline
+  inputs, hand-assembled lists. A *uniform* glob (`*.fastq.gz` or `./*.fastq.gz`) is safe,
+  because the prefix is then consistent. Mixed lists are the common shape.
+- (f) needs a previous run's output in the input list, with the source file ordered
+  **first**. A bare `*.gz` glob is safe under the default shell collation on this machine —
+  both zsh and bash expand to `s_trimmed.fq.gz s.fastq.gz`, the harmless order. The
+  destructive order arises from C-locale sorting (`LC_ALL=C`), an `ls | sort` pipeline, or an
+  explicit list. Reviewer B's report claims a bare glob suffices; that is **not** reproducible
+  here, and the plan does not rely on it.
+
+### 2.3 Two naming asymmetries the plan depends on
+
+**Output directory.** With no `--output_dir`, `io.rs` trim namers end
+`None => input.parent()` (`io.rs:101`, `:121`, `:189`), while all four `specialty.rs` namers
+end `None => PathBuf::from(filename)` (`specialty.rs:435`, `:456`, `:471`, `:504`) — a bare
+filename, hence **CWD**. Measured consequence: SE trim on two same-basename inputs from
+different directories does not collide (2 outputs, correct attribution), but `--hardtrim5`
+on the same two does. Hardtrim's collision class is strictly wider and includes the
+ordinary `--hardtrim5 20 */*.fastq.gz`. Neither naming rule changes here (§11 Out of scope 1).
+
+**Secondary outputs.** See A2 in §9 for the narrowed claim and its one exception.
+
+### 2.4 What already exists
+
+`preflight_collision_bam` (`main.rs:64-80`) is path-generic — `&[PathBuf]`, hashes
+`naming::norm_path`, bails on the first duplicate. Only its name and doc-comment say BAM.
+Beside it sit **four** hand-rolled copies of the same HashMap-and-bail: `main.rs:482-498`
+(`--clump_only` SE FASTQ), `:680-727` (paired FASTQ), `:1800-1820` (paired uBAM),
+`:2412-2429` (`run_specialty_paired`). Three call sites use the helper: `:533`, `:566`, `:614`.
+
+### 2.5 `--output-dir` is not a valid flag
+
+`cli.rs:152` declares `short = 'o', long = "output_dir"` only. Verified:
+`trim_galore --output-dir /tmp …` → `error: unexpected argument '--output-dir' found`.
+Two of the four hand-rolled copies (`:721` paired FASTQ, `:1815` paired uBAM) advise
+`--output-dir` in their error text. Converting them to the shared helper replaces that with
+`--output_dir`, so this commit fixes a user-visible wrong instruction as a side effect.
+
+---
+
+## 3. Behavior
+
+### 3.1 The collision key
+
+```
+key(p) = norm_path(std::path::absolute(p).unwrap_or_else(|_| p.to_path_buf()))
+```
+
+`std::path::absolute` is lexical — no filesystem access, no symlink resolution — and
+stabilised in Rust 1.79, below the crate's 1.88 floor. Verified behaviour:
+
+| input | absolute() |
+|---|---|
+| `sample_trimmed.fq.gz` | `<cwd>/sample_trimmed.fq.gz` |
+| `./sample_trimmed.fq.gz` | `<cwd>/sample_trimmed.fq.gz` — `.` removed |
+| `a//sample_trimmed.fq.gz` | `<cwd>/a/sample_trimmed.fq.gz` — separators collapsed |
+| `a/../sample_trimmed.fq.gz` | `<cwd>/a/../sample_trimmed.fq.gz` — `..` **kept** |
+| `/tmp/x/sample_trimmed.fq.gz` | unchanged |
+
+Absolutising can only ever *increase* rejections: two paths that absolutise equal are the
+same file. `..` and symlinks still alias — a stated residual (A8), not a silent one. The
+`Err` fallback (empty path, or `getcwd` failure) degrades to v1's raw-string key rather
+than skipping the check.
+
+**Messages print the user's original paths**, never the absolutised key, so the existing CI
+greps and every "nothing written" assertion stay valid.
+
+### 3.2 Two distinct rejections
+
+1. **Duplicate output.** Two prospective outputs share a key. Existing wording, canonical
+   `--output_dir`, plus a mode-specific hint where the generic advice is wrong (§3.4).
+2. **Output aliases an input.** A prospective output shares a key with a file this run
+   reads. Its own message — "would be written to the same file" is untrue and its advice
+   inapplicable. Names the input, says it looks like a previous run's output, and offers
+   `--output_dir` (which does help in this case, unlike case 1 on hardtrim).
+
+The input set is `cli.input` plus `--passthrough` when set. The `--demux` barcode file is
+excluded by argument: every output name carries a `_trimmed` / `_val_` / `_unpaired_` /
+`.Nbp_` / `_UMI_` segment plus a FASTQ or BAM extension, so it cannot equal a
+user-supplied barcode text file except by deliberate contrivance.
+
+### 3.3 Pre-flight contract
+
+1. Runs before any reader is opened **on the guarded path** — hence before adapter
+   auto-detection, the trimming banner, and any output file. Not before all I/O:
+   `sanity_check_any(&cli.input[0])` (`main.rs:153`) and `detect_input_format` over every
+   input (`:159`) precede dispatch, so **format and sanity errors take precedence over
+   collision errors**. That ordering is correct and now stated.
+2. Builds the full prospective-output list for **every** input, not per file.
+3. On the first violation: `anyhow::bail!`, exit 1, nothing written.
+4. Single input with no alias, or all-distinct keys: no-op.
+
+### 3.4 Mode-specific remediation on hardtrim
+
+The generic advice — "different source directories or `--output_dir`" — is wrong on
+`--hardtrim5/3`, because the namer ignores the input's parent and `-o` joins a stem-only
+filename. Verified: `--hardtrim5 20 -o out dirA/same.fastq.gz dirB/same.fastq.gz` still
+collides inside `out`. Both suggestions lead back to the same error.
+
+This matters because the mode's multi-file use is documented:
+`docs/src/content/docs/modes/hardtrim.md` and the carried v0.6.x changelog text
+(`docs/…/reference/changelog.md:955`, `:997`) both say it processes "one or more files",
+and neither mentions CWD output. So `--hardtrim5 N */*.fastq.gz` is a documented pattern
+that becomes a hard failure — correctly, since it loses data today, but it must fail with
+usable advice. The two hardtrim call sites pass a hint naming the real remedies: one
+invocation per input, or distinct input basenames.
+
+### 3.5 Edge cases
+
+| Case | After change | Why |
+|---|---|---|
+| One input, no alias | no-op | nothing to compare |
+| `sample.fastq.gz` + `sample.fq.gz` | **reject** | #383 as filed |
+| `sample.fastq.gz` + `sample.fastq.bgz` | **reject** | #382 widening |
+| `./x.fastq.gz` + `x.fq.gz` | **reject** (new in v2) | absolutised key |
+| `/abs/x.fastq.gz` + `x.fq.gz`, cwd `/abs` | **reject** (new in v2) | absolutised key |
+| `a/../x.fastq.gz` + `x.fq.gz` | **accept** — known residual | `absolute` keeps `..` (A8) |
+| Output path equals an input path | **reject** (new in v2) | defect 2; own message |
+| Same file listed twice | **reject** in `Cli::validate` | A6; own message, before `ensure_output_dir` |
+| Case-only path variants | **reject** | `norm_path` case-fold, #216 |
+| Same basename, different dirs, no `-o` — SE trim | **accept** | outputs genuinely distinct |
+| Same basename, different dirs, no `-o` — hardtrim | **reject** | outputs identical in CWD |
+| Same basename, different dirs, **with** `-o` | **reject** | both land in `-o`; V2.3 pins this |
+| `--basename` with >1 SE input | unchanged, already rejected | `cli.rs:620` |
+| Zero inputs | unreachable | clap `required` |
+| `--hardtrim5 N --hardtrim3 M` | unchanged | `hardtrim5` returns at `:367`; §11 Open 3 |
+
+---
+
+## 4. Signatures
+
+### 4.1 `src/io.rs` — the shared helper
+
+```rust
+/// Case-folded, lexically-absolutised collision key (issues #216, #383).
+fn collision_key(p: &Path) -> String {
+    norm_path(&std::path::absolute(p).unwrap_or_else(|_| p.to_path_buf()))
+}
+
+/// Reject duplicate outputs, or an output that would overwrite an input, before
+/// any file is opened. Called by every dispatch path in `main.rs` that writes
+/// more than one file: SE trim (FASTQ + uBAM), `--paired` trim (FASTQ + uBAM),
+/// `--hardtrim5/3`, `--clock`/`--implicon`, and all four `--clump_only` arms.
+pub fn preflight_output_collisions(
+    planned: &[PathBuf],
+    inputs: &[PathBuf],
+    hint: Option<&str>,
+) -> Result<()>
+```
+
+Behaviour: build `HashSet<String>` of input keys; then walk `planned`, checking each against
+the input set first and against a `HashMap<String, PathBuf>` of prior planned paths second.
+Both messages print original paths. `hint`, when `Some`, is appended to the duplicate-output
+message.
+
+The doc-comment lists all call sites deliberately: this plan fixes the fourth instance of
+one omission, and an enumeration at the helper makes a fifth omission visible from here.
+(Alternative considered: an `OutputPlan { planned, inputs, hint }` struct. Rejected as
+ceremony for eleven call sites, nine of which pass `None`.)
+
+### 4.2 `src/specialty.rs` — visibility and a typed discriminator
+
+```rust
+pub enum HardtrimEnd { Five, Three }   // `.as_str()` → "5prime" / "3prime"
+
+pub fn hardtrim_output_name(input: &Path, keep: usize, end: HardtrimEnd, output_dir: Option<&Path>, gzip: bool) -> PathBuf
+pub fn hardtrim_bam_output_name(input: &Path, keep: usize, end: HardtrimEnd, output_dir: Option<&Path>) -> PathBuf
+```
+
+`fn` → `pub fn` follows the precedent of `clock_output_name` / `implicon_output_name`, which
+are already `pub` so `main()` can build collision candidates. The `&str` → enum change exists
+because after this plan the discriminator is written in two places — the candidate builder and
+the writer — and a copy-paste slip passing `"5prime"` in the `--hardtrim3` block would produce
+a pre-flight that hashes paths the run never writes, while every rejection test still passed.
+The enum makes that slip a compile error instead of a test gap.
+
+### 4.3 `src/main.rs`
+
+```rust
+fn planned_hardtrim_outputs(
+    cli: &Cli,
+    keep: usize,
+    end: specialty::HardtrimEnd,
+    output_dir: Option<&Path>,
+    gzip: bool,
+) -> Vec<std::path::PathBuf>
+```
+
+`std::path::PathBuf` spelled in full: `main.rs:5` imports `Path` only, as the existing helper
+does. Same for every `Vec<PathBuf>` in §5.
+
+### 4.4 `src/cli.rs` — A6 moves here
+
+A single-end analogue of the duplicate-pair check, beside `cli.rs:534-558`, with its own
+message in the style of `:535` ("Read 1 and Read 2 appear to be the same file"). Placing it
+in `Cli::validate` gives a precise message, runs before `ensure_output_dir` so no empty `-o`
+directory is left behind, covers every mode in one place, and is unit-testable. `cli.rs:504-516`'s
+own doc-comment already states that duplicate inputs should get a precise error "rather than
+the case-insensitive output-collision pre-flight's APFS/NTFS message" — v1 did the thing that
+comment argues against.
+
+---
+
+## 5. Implementation outline
+
+Anchors are against `72624c7` and shift as steps apply; each carries a searchable token.
+
+**Step 1 — `src/io.rs`: add `collision_key` and `preflight_output_collisions`** (§4.1), after
+`norm_path` (`io.rs:44`). Extend `norm_path`'s doc-comment to name the new caller.
+
+**Step 2 — `src/main.rs`: delete `preflight_collision_bam`** (`:60-80`) and re-point its three
+calls (`:533`, `:566`, `:614`) to `naming::preflight_output_collisions(&planned, &cli.input, None)`.
+Incidental fix that falls out: the doc-comment at `:55-59` describes `resolve_clump_layout`'s
+clumpify-budget fallback but is attached to the deleted function; removing it rejoins the comment
+to `resolve_clump_layout` (`:82`).
+
+**Step 3 — convert the four hand-rolled copies** to the shared helper, preserving each site's
+existing semantics:
+- `:482-498` `--clump_only` SE FASTQ — one candidate per input.
+- `:680-727` paired FASTQ — accumulate candidates across **all** chunks into one `Vec` before
+  the single call, so cross-pair collisions are still caught; keep the `--retain_unpaired` and
+  `--passthrough` extra candidates.
+- `:1800-1820` paired uBAM — one candidate per pair.
+- `:2412-2429` `run_specialty_paired` — collect both names per pair across all pairs, then call once.
+Every site passes `&cli.input` (plus `--passthrough` where applicable) as `inputs`, so all four
+gain defect-2 protection. Note the two `--output-dir` message sites disappear here (§2.5).
+
+**Step 4 — `src/specialty.rs`: `HardtrimEnd` enum + `pub`** on both namers (§4.2); update the
+four internal call sites in `hardtrim5`/`hardtrim3`/`hardtrim5_to_bam`/`hardtrim3_to_bam` and
+the `bgz_stem_reaches_specialty_output_names` test at `:822`.
+
+**Step 5 — `src/main.rs`: add `planned_hardtrim_outputs`** (§4.3), matching on `cli.output_format`.
+
+**Step 6 — guard `--hardtrim5`** at `:344`, first statement in the block:
+
+```rust
+// #383 — collide across all inputs before the first write.
+naming::preflight_output_collisions(
+    &planned_hardtrim_outputs(&cli, n, specialty::HardtrimEnd::Five, output_dir, gzip),
+    &cli.input,
+    Some(HARDTRIM_HINT),
+)?;
+```
+
+with `HARDTRIM_HINT` a `const &str` naming the real remedies (§3.4).
+
+**Step 7 — guard `--hardtrim3`** at `:369`, identically with `HardtrimEnd::Three`.
+
+**Step 8 — guard SE trim FASTQ** at `:781`, in the `} else {` arm, before the loop:
+
+```rust
+// #383 — SE was the only trim path without the #216 pre-flight.
+let planned: Vec<std::path::PathBuf> = cli
+    .input
+    .iter()
+    .map(|input| naming::single_end_output_name(input, output_dir, cli.basename.as_deref(), gzip))
+    .collect();
+naming::preflight_output_collisions(&planned, &cli.input, None)?;
+```
+
+**Step 9 — guard SE trim uBAM** at `:1857`, same shape with `single_end_bam_output_name`.
+
+**Step 10 — `src/cli.rs`: reject duplicate SE inputs** (§4.4) with its own message.
+
+**Step 11 — tests.** Unit in `io.rs` (V1) and `cli.rs` (V4); new
+`tests/integration_output_collision.rs` (V2, V3) following
+`tests/integration_paired_format_guard.rs` conventions — `env!("CARGO_BIN_EXE_trim_galore")`,
+a `tempdir(tag)` keyed on `std::process::id()`, `(bool, String)` from `Command::output()`.
+**Any case that sets `Command::current_dir` must pass absolutised fixture paths** — `test_files/…`
+is relative to the crate root, so otherwise the run fails with "Input file not found" and the
+`!ok` half of the assertion passes for the wrong reason.
+
+**Step 12 — CI**: three validation steps (V6).
+
+**Step 13 — CHANGELOG**: `#### Bug fixes` for #383 and the two defects; `#### Changes` (the
+section already exists at `:63`) for the A6 duplicate-input refusal and the
+`--output-dir` → `--output_dir` message correction.
+
+**Comment discipline:** one line per new comment. Detail belongs in the commit message; the
+surrounding `main.rs` comments are far longer and that divergence is deliberate.
+
+---
+
+## 6. Efficiency
+
+O(n) over a command line's worth of paths: one `HashSet<String>` of input keys, one
+`HashMap<String, PathBuf>` of planned keys, one `String` per key, one `PathBuf` clone per
+planned path. One `getcwd` per `absolute` call — n + m calls, or one if the CWD is fetched
+once and reused; either is unmeasurable at these n.
+
+The check runs before adapter auto-detection's ≤1 M-record scan, so colliding invocations
+fail in microseconds rather than after a full detection pass. `HashMap::with_capacity` is a
+free micro-win nobody will measure.
+
+---
+
+## 7. Integration
+
+**Reads:** `cli.input`, `cli.passthrough`, `cli.output_format`, `cli.basename`, `output_dir`,
+`gzip`. Nothing new from disk except `getcwd`.
+
+**Writes:** nothing. The change only prevents writes.
+
+**Order:** after `Cli::validate()` (which now also rejects duplicate SE inputs), after the
+`--phred64`/BAM-format guards, after `ensure_output_dir`, before every reader open on the
+guarded path.
+
+**Downstream:**
+
+- **Validation matrix — unaffected.** Both reviewers independently read every `trim_galore`
+  invocation in `ci.yml`: no step passes more than one single-end input, and multi-pair steps
+  use distinct `A_`/`B_`/`C_` stems. The two existing collision guards still reject
+  (distinct dirs into a shared `-o`), and their `test -z "$(ls -A …)"` assertions (`:615`,
+  `:640`) still hold. No byte-identity path changes.
+- **`docs/`** — `modes/hardtrim.md` advertises "one or more files" without noting CWD output.
+  A doc sentence is warranted, but it is a docs change, not part of this fix; recorded as
+  §11 Open 4 so it is not lost.
+- **Existing tests** — no test asserts that a colliding SE or hardtrim invocation succeeds.
+  The four converted sites keep their behaviour, so `--paired`/`--clock`/`--implicon`/
+  `--clump_only` tests should pass unchanged; V7's `cargo test` confirms rather than assumes.
+- **nf-core / MultiQC** — a pipeline that today produces one trimmed file and two reports from
+  a colliding SE invocation now exits non-zero. Newly loud, not newly broken.
+
+---
+
+## 8. Signatures compile
+
+Checked, because v1 asserted this and was wrong: `main.rs:5` is `use std::path::Path;` with no
+`PathBuf`, so every `PathBuf` in `main.rs` is spelled `std::path::PathBuf` (§4.3). `io.rs`
+already imports `anyhow::{Context, Result}` and `std::path::{Path, PathBuf}`, so §4.1 needs no
+new `use`. `preflight_output_collisions` being `pub` in the library avoids a `dead_code`
+warning. The five-argument `planned_hardtrim_outputs` is under clippy's `too_many_arguments`
+threshold. There is no crate-level `missing_docs` lint and no `[lints]` table, so `fn` → `pub fn`
+on an undocumented namer will not trip `-D warnings`.
+
+---
+
+## 9. Assumptions
+
+- **A1 (fixed).** `norm_path`'s ASCII case-fold is the right case treatment. Inherited from
+  #216; may false-positive on opt-in case-sensitive APFS volumes, and a loud error is the
+  accepted trade.
+- **A2 (fixed, narrowed in v2).** *For every secondary output whose directory is resolved by the
+  same `output_dir`-else-parent rule as the primary, primary-path distinctness implies
+  secondary-path distinctness.* Verified for `report_name`, `json_report_name`,
+  `single_end_bam_output_name`, and `--demux` (`demux.rs:142-147` resolves
+  `output_dir` else `trimmed_file.parent()`, base name from the trimmed file's own name — so its
+  key is a function of the primary). **Named exception:** `--fastqc_args "-o DIR"` /
+  `--outdir` (`fastqc.rs:91-96`) overwrites `config.output_dir` with a directory the pre-flight
+  never sees, while the artifact filename still derives from the trimmed output. Both reviewers
+  reproduced two distinct primaries yielding one `same_trimmed_fastqc.{zip,html}`. Not widened
+  into the candidate list: it costs a regenerable QC artifact rather than reads, it is
+  pre-existing on every path including `--paired`, and parsing `--fastqc_args` twice would still
+  miss the next `FastQCConfig` field. Recorded as §11 Out of scope 5.
+- **A3 (fixed).** `--hardtrim5` and `--hardtrim3` never both execute: the `hardtrim5` branch
+  returns at `main.rs:367`. Verified empirically. Per-block checks suffice.
+- **A4 (fixed).** `gzip` is decided once from `cli.input[0]` (`main.rs:295`) and threaded to both
+  the candidate namer and the writer, so prospective and actual paths cannot disagree — and
+  argument order cannot produce a false accept (`.gz` first → both `.fq.gz`; `.bgz` first →
+  both `.fq`; either way they collide).
+- **A5 (fixed).** `cli.input` is non-empty (clap `required`), and `cli.rs:620` rejects
+  `--basename` with multiple SE inputs on both output formats.
+- **A6 (decision).** The same file listed twice is **rejected**, in `Cli::validate` (§4.4), not
+  silently de-duplicated. It exits 0 with correct output today, so this is a behaviour change and
+  is logged under `#### Changes`. Rationale: it matches `--paired`; de-duplicating by byte-equal
+  path would accept `x.fq.gz x.fq.gz` while still rejecting `x.fq.gz ./x.fq.gz`, an
+  inconsistency worse than either clean choice; and de-duplicating properly needs
+  `fs::canonicalize`, a syscall per input with different answers across symlinks and bind mounts.
+- **A7 (fixed).** Rejection by the pre-flight leaves an empty `--output_dir` behind, matching the
+  paired contract that `ci.yml:615`/`:640` already assert. A6's rejection precedes
+  `ensure_output_dir`, so it leaves nothing.
+- **A8 (fixed, new in v2).** The key is *lexical*. `a/../x` vs `x`, and any symlink alias, still
+  hash differently and are still accepted. Pinned by a test (V1.7) so the limitation is visible
+  rather than discovered.
+- **A9 (fixed, new in v2).** The candidate expression and the writer's expression must stay in
+  sync. True by construction for SE (Step 8/9 use calls character-identical to `main.rs:1086-1087`
+  and `:1880-1881`) and enforced for hardtrim by the enum (§4.2). This is the assumption whose
+  violation is invisible to every *rejection* test, which is why V3 asserts filenames.
+- **A10 (fixed).** `std::path::absolute` has POSIX semantics on the CI targets (ubuntu, macos).
+  Windows semantics differ (UNC, drive-relative paths); the crate has no Windows CI target and
+  none is claimed.
+
+---
+
+## 10. Validation
+
+Every rejection case is paired with an acceptance case **on the same dispatch path and output
+format**, and acceptance cases assert *content or filename*, never mere existence — v1's
+weakest point, and the exact failure mode SESSION_HANDOFF §5 records four instances of.
+
+**V1 — unit, `src/io.rs`.**
+1. distinct outputs → `Ok`.
+2. byte-identical outputs → `Err`, message names both.
+3. case-only variants → `Err` (unreachable from an integration test: two case-variant paths
+   cannot coexist on APFS — this is why the helper is in the library).
+4. `./x_trimmed.fq.gz` vs `x_trimmed.fq.gz` → `Err` (defect 1).
+5. `<cwd>/x_trimmed.fq.gz` vs `x_trimmed.fq.gz` → `Err` (defect 1).
+6. planned path equal to an input path → `Err`, and the message is the **alias** wording, not
+   the duplicate wording (defect 2).
+7. `a/../x_trimmed.fq.gz` vs `x_trimmed.fq.gz` → `Ok`, pinning A8's residual.
+8. `hint: Some(…)` appears in the duplicate message; `None` does not add it.
+9. empty `planned` → `Ok`.
+
+**V2 — integration, rejections.** Non-zero exit, stderr contains
+`Output path collision (case-insensitive, for APFS/NTFS safety)` (or the alias wording for
+2.9–2.10), **and the output directory is empty** — stronger than "the primary is absent", and it
+pins the absence of the two misleading reports that made #383 hard to spot.
+1. SE trim FASTQ, `sample.fastq.gz` + `sample.fq.gz`.
+2. SE trim FASTQ, `./sample.fastq.gz` + `sample.fq.gz` (defect 1).
+3. **SE trim FASTQ, `dirA/same.fastq.gz` + `dirB/same.fastq.gz` with `-o <third>`.** The
+   highest-value single test in the plan: it is the only case where writing `None` instead of
+   `output_dir` in Step 8 silently under-rejects, and every other SE case collides either way.
+4. SE trim uBAM, colliding stems.
+5. `--hardtrim5 20` FASTQ, same basename in two dirs, `current_dir(tempdir)`.
+6. `--hardtrim3 20` FASTQ, same shape.
+7. `--hardtrim5 20 --output-format ubam`.
+8. `--hardtrim3 20 --output-format ubam`.
+9. SE trim, output aliases an input (`s.fastq.gz` + `s_trimmed.fq.gz`) — alias message (defect 2).
+10. `--paired`, output aliases an input (the §2.2(f) four-file invocation) — proves the
+    converted paired site gained the protection.
+11. `.gz` + `.bgz` sharing a stem (#382 regression pin).
+
+**V3 — integration, acceptance.** All assert content or filename.
+1. SE trim, `dirA/same.fastq.gz` + `dirB/same.fastq.gz`, **no** `-o` → exit 0, two outputs,
+   `dirA`'s containing only `DIRA_` reads and `dirB`'s only `DIRB_`. Existence alone would have
+   passed while #383 was live.
+2. SE trim, single input → exit 0, one output.
+3. `--hardtrim5 20 -o <tmp>`, two distinct stems → exit 0, both `*.20bp_5prime.fq.gz` present.
+4. `--hardtrim3 20 -o <tmp>`, two distinct stems → exit 0, both `*.20bp_3prime.fq.gz` present.
+   `--hardtrim3` has **zero** output-producing coverage in the repository today
+   (`tests/integration_adapter2.rs:377-382` only asserts a `-a2` rejection message), and Step 7
+   is a fresh copy of Step 6 into it.
+5. `--hardtrim3 20 --output-format ubam`, two distinct stems → exit 0, both `*.20bp_3prime.bam`.
+6. SE trim uBAM, two distinct stems → exit 0, both `<stem>_trimmed.bam`. Catches an
+   over-rejecting candidate list, e.g. hashing the input path instead of the output.
+7. `--paired`, two normal pairs with distinct stems → exit 0, four `_val_` outputs. Regression
+   guard on the converted paired site.
+
+**V4 — unit, `src/cli.rs`.** Duplicate SE input rejected with the dedicated message, not the
+APFS/NTFS wording; a distinct-input SE command line still validates; the existing duplicate-pair
+and R1≠R2 tests still pass. v1 had no test at all for its only intentional behaviour change.
+
+**V5 — unit, A2 as a table.** For path pairs whose primaries differ, assert that
+`report_name`, `json_report_name`, the demux base name, and the *default-configuration*
+`<stem>_fastqc.zip` all differ too, across `--basename` / `--dont_gzip` / `-o` on and off.
+A comment names the `--fastqc_args --outdir` exception so a future reader does not "fix" the
+table by deleting a row. This replaces v1's V6, whose premise
+(`report_name(a) == report_name(b)` with `a != b`) forced its own conclusion and could
+therefore only ever pass.
+
+**V6 — CI validation job**, after `ci.yml:640`, mirroring the existing guards' idiom exactly
+(`set +e`, `rc=${PIPESTATUS[0]}`, `set -e`, `test $rc -ne 0`,
+`grep -q "Output path collision"`, `test -z "$(ls -A <out>)"`):
+1. SE trim collision — `illumina_10K.fastq.gz` copied as `sample.fastq.gz` and `sample.fq.gz`.
+2. `--hardtrim5 30` collision — same basename in two subdirectories, with `-o` (not `cd`),
+   since `-o` does not rescue this collision (§3.4) and the `ls -A` residue check needs a
+   directory to inspect.
+3. SE output-aliases-input — a copy named `sample.fastq.gz` plus one named
+   `sample_trimmed.fq.gz`.
+
+**V7 — gates and manual re-runs.** `cargo fmt --all -- --check`;
+`cargo clippy --all-targets --release -- -D warnings`; `cargo test` from the crate root. Then
+rebuild `target/release/trim_galore` (clippy does not refresh it) and re-run all six §2.2
+reproductions — (a)–(f) must each exit non-zero with the right message — **plus** the positive
+control from V3.1, which is the behaviour most at risk from an over-broad key and which no CI
+step covers. Run (c) from a scratch directory, not the repo root.
+
+---
+
+## 11. Questions and ambiguities
+
+**Open 1 — A6's message wording.** Rejection is settled; the exact sentence is not. Proposal:
+mirror `cli.rs:535`'s shape — "Input file '<path>' was given more than once." plus one clause on
+why that is refused.
+
+**Open 2 — hint mechanism.** `hint: Option<&str>` is the least ceremonious way to fix the
+hardtrim advice. Alternative: a small enum of remediation classes, if a reviewer prefers the
+message text to live entirely in `io.rs`.
+
+**Open 3 — pre-existing, not fixed.** `--hardtrim5 N --hardtrim3 M` is accepted by
+`Cli::validate` but the `hardtrim5` branch returns early, so `--hardtrim3` is silently ignored.
+Verified. Its own issue; the fix is a clap `conflicts_with`. Worth filing before this lands,
+since a reviewer of these blocks will ask.
+
+**Open 4 — a docs sentence.** `modes/hardtrim.md` advertises multi-file use without noting that
+output goes to the CWD, which is exactly why the collision class is wide there. Docs-only,
+separate commit, but it should not be lost.
+
+**Out of scope**
+
+1. The CWD-vs-`input.parent()` naming asymmetry (§2.3). The pre-flight is the right response;
+   changing the naming moves output locations for every existing hardtrim user.
+2. Refusing to clobber files already on disk that are *not* named as inputs — a `--force` /
+   no-clobber policy. Distinct from defect 2, which is now in scope: there the user has named
+   the file as an input, so writing it is unambiguously wrong and no policy is needed.
+3. Symlink and `..` aliasing (A8).
+4. Hoisting all collision checks above `ensure_output_dir`; it would change the tested paired
+   contract (A7).
+5. `--fastqc_args "-o DIR"` collisions (A2's named exception).
+6. #384 (uppercase `.FASTQ.GZ`) — it changes what `norm_path` and `strip_fastq_extensions`
+   mean, so it should follow this, not precede it.
+7. A single mode → candidate-list `match` in `main()` instead of per-branch checks. Both
+   reviewers raised it; it is the structural answer to "each new mode grows its own loop and
+   three of eight forget the check", but it duplicates the dispatch logic it sits above. The
+   helper's call-site enumeration (§4.1) is this plan's cheaper mitigation. Recorded as the
+   direction, not adopted.
+8. A writer-level registry of already-opened output paths (B's alternative 2). It would catch
+   all of these plus the FastQC and symlink cases at one choke point, but fires after the first
+   write, so it cannot deliver the "nothing written" contract the CI guards assert.
+   Defence-in-depth later; explicitly not a substitute.
+
+---
+
+## 12. Revision history
+
+**v1 → v2**, after dual independent plan review (`PLAN_REVIEW_A.md`, `PLAN_REVIEW_B.md`); every
+finding below was re-verified by the orchestrator against the binary before adoption.
+
+Adopted from **A**: the absolutised collision key (A's Critical — v1's raw-string key let
+`./x` and `x` through, so #383 reproduced through v1's own guard); the helper doc-comment
+enumerating call sites; the sanity/format-before-collision ordering note.
+
+Adopted from **B**: the output-aliases-input check (B's Critical — and `--paired` has the hole
+today, which is why the four hand-rolled copies convert in this commit rather than later); A6
+moving to `Cli::validate`; the hardtrim-specific remediation hint and the `docs/` check; the
+`PathBuf` import correction (**A asserted the signatures compile; B was right that they do
+not**); the `HardtrimEnd` enum in place of a duplicated `&str`; `--hardtrim3` having no
+output-producing coverage at all.
+
+Adopted from **both**: A2 narrowed with `--fastqc_args -o` as a named exception; V1's V6
+replaced because it could not fail; acceptance cases added for the three unpaired arms;
+V2 upgraded to assert an empty output directory; `current_dir` tests pinned to absolutised
+fixture paths; the copy count corrected from five to four.
+
+**Rejected:** B's claim that a bare `trim_galore *.gz` reaches defect 2. Not reproducible —
+both zsh and bash collate `s_trimmed.fq.gz` before `s.fastq.gz`, which is the harmless order.
+§2.2 states the narrower reachability that was measured.
+
+---
+
+## 13. Implementation notes
+
+Implemented on branch `fix/383-output-collision-preflight` off `dev` @ `72624c7`.
+All 13 steps done. Gates: `cargo fmt --check` clean, `cargo clippy --all-targets --release
+-- -D warnings` clean, **520 tests pass** (398 lib + 122 integration, 20 of them new).
+All eight §2.2 reproductions now exit non-zero; the §10 V3.1 positive control still
+succeeds with zero crosstalk and a prior output left byte-intact.
+
+Diff: 6 files changed, +503/−99, plus the new `tests/integration_output_collision.rs`.
+
+### Deviations from the plan
+
+**D1 — Step 10's predicate was wrong (behavioural, caught by existing tests).**
+The plan specified `if !self.paired` for the duplicate-input check. `--clock` and
+`--implicon` are paired modes that **never set `self.paired`**; they call
+`validate_paired_input` separately at `cli.rs:953-956`, i.e. *after* the new check.
+The guard therefore pre-empted their more specific "Read 1 and Read 2 appear to be
+the same file" message, breaking `test_validate_clock_r1_equal_r2_within_pair_rejected`,
+`test_validate_clock_duplicate_pair_rejected` and
+`test_validate_implicon_duplicate_pair_rejected`. Predicate is now
+`!self.paired && !self.clock && self.implicon.is_none()`. Neither reviewer caught this,
+and neither did the plan — the three existing tests did.
+
+**D2 — `guarded_inputs()` helper added.** Not named in the plan. §3.2 required the input
+set to be `cli.input` plus `--passthrough`; rather than repeat that at eleven call sites,
+one `main.rs` helper builds it. Behaviour as planned.
+
+**D3 — two defect-1 integration tests were passing for the wrong reason.** As first
+written they passed `-o`, under which the output path is built from `output_dir` + stem,
+so the input's `./` or absolute spelling never reaches the output key and the plain
+duplicate check caught them. Found by negative control 1 (below): both passed with the
+absolutisation reverted. They now run without `-o`, so the output inherits the input's
+spelling, and assert the directory afterwards holds exactly its two inputs.
+
+**D4 — `tempdir()` in the new test file is canonicalised.** `std::env::temp_dir()` yields
+`/tmp/…` while the child process's `getcwd` yields `/private/tmp/…` on macOS. The key is
+lexical (A8), so it cannot see through that symlink and the absolute-vs-relative test
+passed vacuously. This is A8 showing up in the harness rather than a defect in the fix,
+and it is now a documented comment on the helper.
+
+**D5 — CI step names truncate at `#383` in YAML** (an unquoted ` #` opens a comment), so
+the Actions UI shows "… (issue". The existing `(issue #216)` step has the identical
+quirk; left consistent rather than fixing only the new ones. Cosmetic, and a candidate
+for a separate one-line sweep.
+
+**D6 — `demux::demux_base_name` extracted (new function, beyond the plan).** Closing the
+coverage audit's Gap 2 required asserting that the demux stem is a function of the primary
+output path. That derivation was inline in `demultiplex`, so the assertion would have been a
+copy of the formula — a test incapable of detecting drift in the code it checks. Extracted as
+`pub fn demux_base_name(&Path) -> String` and called from both `demultiplex` and the test.
+Pure refactor; verified behaviour-preserving by re-running `--demux` on
+`test_files/demux_test.fastq.gz` (stems still `demux_test_trimmed_<sample>.fq.gz`, and the
+`Processed sequences from file >…<` line still carries the full filename, which matters because
+`--demux` is in the Perl byte-identity matrix). The separate `trimmed_name` binding that feeds
+that message was restored after the first extraction attempt dropped it — caught at compile time.
+
+### Post-audit gap closures
+
+The coverage audit (`COVERAGE.md`) returned **INCOMPLETE — 2 items**, both plan shortfalls with
+no behavioural effect, both now closed. See the addendum in `COVERAGE.md` for detail.
+
+1. **Step 1's doc-comment sub-clause** — `norm_path` now names `collision_key`, and the stale
+   "`main::run` paired-end" locator is gone. Written without rustdoc link brackets to avoid a
+   new `private_intra_doc_links` warning.
+2. **§10 V5's A2 table** — replaced with `distinct_primary_outputs_imply_distinct_secondary_outputs`,
+   which asserts the plan's stated direction over the full `--basename`/`--dont_gzip`/`-o`
+   matrix and covers the demux stem via D6; the original coarser-than test is retained as its
+   complement. FastQC's zip name is documented as not-separately-assertable rather than faked.
+
+### Post-code-review round (4 review passes, 3 coverage audits)
+
+Coverage: two independent audits returned **COMPLETE** (25 items and 65 items). Code review:
+0 Critical, 1 unanimous High. Applied, with the `..` decision taken by the user:
+
+- **D7 — `collision_key` folds `..` lexically** (was A8's documented residual). Absolutise, then
+  fold `Component::ParentDir` against the component stack, keeping POSIX `/..` == `/` and
+  preserving an unfoldable leading `..`. Reason for the reversal: A8 was scoped out on the
+  grounds that `..` is rare, but the reachable shape is the *same* mixed absolute/relative
+  argument list §2.2(e) used to justify fixing `./x` — so #383 reproduced verbatim through its
+  own fix. **A8 is now narrowed to symlinks only.**
+- **D8 — one definition of file identity.** `collision_key` is `pub`; `--paired`'s R1≠R2 check,
+  its duplicate-pair check, the duplicate-input check and the `--passthrough` alias check all
+  use it instead of raw `==` / `norm_path`. Closes a silent-wrong-output bug: `--paired
+  ./a_R1.fq a_R1.fq` exited 0 and wrote two byte-identical files labelled a validated pair.
+- **D9 — secondary outputs are checked against inputs.** The unanimous finding: A2 justifies
+  checking primaries for output-vs-**output** collisions and says nothing about
+  output-vs-**input**, so a report or a `--demux` per-barcode file could overwrite a named input
+  while every primary stayed distinct. Reports and demux outputs now join the candidate list;
+  `guarded_inputs()` gains the `--demux` barcode file. New `demux::demux_output_paths` shares
+  `demux_output_dir` / `output_filename` with the writer, and
+  `demux_writes_exactly_the_planned_paths` pins the two together.
+- **D10 — the CWD hint covers all four CWD-naming modes and replaces the generic advice.**
+  `--clock`/`--implicon` name output into the CWD exactly as hardtrim does, so the generic
+  "use different source directories or `--output_dir`" is false for them too. `HARDTRIM_HINT`
+  became `CWD_OUTPUT_HINT`, `run_specialty_paired` takes a `hint` (passed for clock/implicon,
+  `None` for `--clump_only --paired`, whose namer uses `input.parent()`), and the helper now
+  substitutes the hint for the generic clause instead of appending to it.
+- **D11 — the V5 fixture can now fail.** Two reviewers found
+  `distinct_primary_outputs_imply_distinct_secondary_outputs` unfalsifiable: its inputs had
+  pairwise-distinct basenames, and every secondary namer embeds `file_name()`, so the assertion
+  held regardless of whether a namer honoured the directory. Confirmed by making `report_name`
+  directory-blind and watching the test stay green. Added `d/same.fastq.gz` + `e/same.fastq.gz`;
+  the same control now fails. The earlier negative control (constant return) was too crude to
+  expose this.
+- **D12 — mechanical.** `demux_base_name` lifted out of `demultiplex`'s doc-comment (D6 had
+  re-parented it — the same defect Step 2 repaired in `main.rs`); stale key descriptions deleted
+  at the paired and `run_specialty_paired` sites; `assert_rejected_cleanly`'s
+  `unwrap_or_default()` replaced with a panic so a `read_dir` failure cannot pass vacuously;
+  CHANGELOG corrected where it overclaimed defect 2's coverage, plus new entries for the CWD
+  hint, the single identity definition, and A1's previously unstated case-fold trade-off.
+
+Gates after the round: **530 tests** pass, `fmt --check` clean, `clippy -D warnings` clean,
+`cargo doc` adds no warning. All eight original reproductions plus the two new ones (`..`,
+self-mate pair) reject; both acceptance controls still pass with zero crosstalk and the prior
+output byte-intact. All three demux routes verified closed individually.
+
+**Still open, unchanged:** §11 Opens 3 and 4; symlink aliasing (A8, now the sole residual);
+`--fastqc_args -o` (A2's named exception).
+
+### Iteration log
+
+**#1 — duplicate-input predicate.** Three `--clock`/`--implicon` validation tests failed
+after Step 10. Excluded both modes from the new check (D1). All 398 lib tests green.
+
+**#2 — defect-1 test rigour.** Negative control 1 (revert `collision_key` to
+`norm_path` only) showed the unit test failing but both integration tests still passing.
+Removed `-o` from those two cases and switched to an exact-directory-contents assertion;
+they then failed under the control and passed once it was reverted (D3).
+
+**#3 — symlink-induced vacuous pass.** After #2 the absolute-vs-relative test failed with
+the fix in place, because the child's `getcwd` resolved `/tmp` → `/private/tmp` while the
+test's absolute path did not. Canonicalised `tempdir()` (D4). 20/20 green.
+
+### Negative controls run (per SESSION_HANDOFF §5)
+
+| Control | Expectation | Result |
+|---|---|---|
+| `collision_key` → `norm_path` only | defect-1 tests fail | 1 unit + (after D3) 2 integration failed; reverted → all pass |
+| input-key set emptied | defect-2 tests fail | 1 unit + 2 integration failed; reverted → all pass |
+| three CI step bodies run locally on `illumina_10K.fastq.gz` | all three pass | all three PASS |
+| `ci.yml` parsed | valid YAML | 40 steps in `validation` |
+
+### Left undone, deliberately
+
+§11 Opens 3 (`--hardtrim5` + `--hardtrim3` silently ignoring the 3′ trim) and 4 (the
+`modes/hardtrim.md` sentence about CWD output) are unaddressed, as scoped. Both want
+their own issue.

--- a/plans/08062026_se-output-collision-preflight/PLAN.md
+++ b/plans/08062026_se-output-collision-preflight/PLAN.md
@@ -746,6 +746,25 @@ output byte-intact. All three demux routes verified closed individually.
 **Still open, unchanged:** §11 Opens 3 and 4; symlink aliasing (A8, now the sole residual);
 `--fastqc_args -o` (A2's named exception).
 
+**D13 — the identity key is split in two, after CI caught D8 overreaching.** D8 re-keyed
+`Cli::validate`'s input-identity checks on `collision_key`, which case-folds. That broke the
+#216 validation guard: it feeds four genuinely distinct files on a case-sensitive filesystem
+(`Sample_R1` / `SAMPLE_R1`) and asserts the *output* pre-flight refuses them with the APFS/NTFS
+message — but the case-folded input check fired first with "Pair 2 is a duplicate of pair 1",
+which on Linux is false. Case-folding is correct for **output** paths (distinct inputs whose
+outputs alias on APFS/NTFS — the whole point of #216) and wrong for **input identity** (folding
+case claims two real files are one). Split accordingly:
+
+- `path_identity_key` — absolutised, `..`-folded, **case preserved** → the three `cli.rs`
+  input-identity checks.
+- `collision_key` — the same, **plus** case-folding → the output-collision pre-flight, and the
+  `--passthrough` alias check, which was deliberately case-folded for APFS safety all along.
+
+The reviewers' H1 finding was about *spelling* (`./x` vs `x`), not case; D8 extended it further
+than the finding warranted. `--paired ./a_R1.fq a_R1.fq` is still refused. Not reproducible
+locally — APFS is case-insensitive, so the two filenames are one file on this machine, which is
+why the validation matrix rather than any local test caught it.
+
 ### Iteration log
 
 **#1 — duplicate-input predicate.** Three `--clock`/`--implicon` validation tests failed

--- a/plans/08062026_se-output-collision-preflight/PLAN_REVIEW_A.md
+++ b/plans/08062026_se-output-collision-preflight/PLAN_REVIEW_A.md
@@ -1,0 +1,470 @@
+# Plan Review A — Output-collision pre-flight for the four uncovered dispatch paths (#383)
+
+**Plan:** `plans/08062026_se-output-collision-preflight/PLAN.md` (v1, 2026-08-06)
+**Reviewed against:** `dev` @ `72624c7`, binary `target/release/trim_galore` (built 2026-08-06 16:41)
+**Reviewer:** A (independent; no shared state with Reviewer B)
+**Verdict:** Sound plan, correct diagnosis, accurate anchors. One Critical gap: the fix
+does not close #383 for path-aliased spellings of the same directory, which I reproduced
+against the current binary. Five Important items, six Optional.
+
+---
+
+## 1. Verification of the plan's factual claims
+
+I checked every load-bearing claim rather than taking it on trust. Unless noted, the claim
+is **confirmed**.
+
+### 1.1 Anchors
+
+| Plan claim | Verified |
+|---|---|
+| `preflight_collision_bam` at `main.rs:64-80`, path-generic `&[PathBuf]` | ✅ exact |
+| Doc-comment at `:55-59` documents `resolve_clump_layout`, misattached to the pre-flight | ✅ exact |
+| Three call sites `main.rs:533`, `:566`, `:614` | ✅ exact |
+| `--paired` FASTQ pre-flight `main.rs:672-727` | ✅ (`if cli.paired {` at 672, candidate loop ends 727) |
+| `--paired` uBAM pre-flight `main.rs:1799-1821` | ✅ (block 1800-1820) |
+| `run_specialty_paired` pre-flight `main.rs:2410-2430` | ✅ (block 2412-2429) |
+| `--clump_only` SE FASTQ pre-flight `main.rs:481-498` | ✅ exact |
+| `--clump_only` SE uBAM pre-flight `main.rs:609-614` | ✅ exact |
+| Insertion points `:344` (hardtrim5), `:369` (hardtrim3), `:781` (SE `} else {`), `:1857` (`// Single-end loop.`) | ✅ all four exact |
+| `hardtrim5` branch returns at `main.rs:367` | ✅ exact |
+| `gzip` derived from `cli.input[0]` at `main.rs:295`; `ensure_output_dir` at `:300` | ✅ exact |
+| `norm_path` at `io.rs:44-46` | ✅ exact |
+| `specialty.rs:435/:456/:471/:504` are the `None => PathBuf::from(filename)` arms | ✅ all four exact |
+| `hardtrim_output_name` at `:423`, `hardtrim_bam_output_name` at `:446`, both private | ✅ exact |
+| `report_name` / `json_report_name` key on full input filename, `io.rs:401-430` | ✅ exact |
+| `strip_fastq_extensions` at `io.rs:444` | ✅ exact |
+| `--basename` + >1 SE input rejected at `cli.rs:620` | ✅ exact, and outside the UBam block so it covers both formats |
+| `--paired` rejects duplicate pairs / R1==R2, `cli.rs:~535/~549` | ✅ (R1==R2 at 535, duplicate-pair loop 543-556) |
+| CI case-alias guard at `ci.yml:617-640`; `test -z "$(ls -A …)"` at `:615`/`:640` after the `-o` runs at `:604`/`:628` | ✅ (plan's `:604`/`:628` name the invocations, not the assertions — harmless off-by-a-few) |
+| CHANGELOG has `### Unreleased` → `#### Bug fixes` | ✅ (lines 4/6) |
+
+### 1.2 The hole map is exhaustive, not just illustrative
+
+I enumerated every loop over `cli.input` in `main.rs`: lines 345, 370, 484/499, 558/572,
+611/615, 683/737, 784, 1803/1823, 1858, 2415/2432. Exactly four processing loops lack a
+preceding pre-flight — 345, 370, 784, 1858 — which is precisely the plan's set. **No fifth
+hole exists.** This is the strongest part of the plan.
+
+### 1.3 Measured behaviour (all four reproductions re-run)
+
+Tiny 40-read fixtures with `ALPHA_`/`BETA_` read-ID prefixes, in
+`…/scratchpad/review-a/`. Negative control run first: single-input `alpha.fastq.gz` gives
+`ALPHA=40 BETA=0`, so the attribution grep is capable of reporting a non-zero ALPHA count.
+
+| Repro | Result |
+|---|---|
+| (a) `sample.fastq.gz` + `sample.fq.gz` | exit 0, one `sample_trimmed.fq.gz`, `ALPHA=0 BETA=40`, **two** reports |
+| (c) `--hardtrim5 20 dirA/same.fastq.gz dirB/same.fastq.gz` | exit 0, one `./same.20bp_5prime.fq.gz` in CWD, `ALPHA=0 BETA=40` |
+| (d) `--hardtrim5 20 --output-format ubam` colliding stems | exit 0, "Writing hard-trimmed" ×2, one `.bam` |
+| SE trim uBAM colliding stems | exit 0, `Output: sample_trimmed.bam` printed twice, one `.bam` |
+| §2.3 accept case (SE trim, two dirs, no `-o`) | exit 0, two outputs, `dirA`=ALPHA only, `dirB`=BETA only — **correct attribution**, not merely two files |
+| A6 premise (same file twice, today) | exit 0, one output, 40 reads, correct content |
+| Open 4 (`--hardtrim5 20 --hardtrim3 15`) | exit 0, only `x.20bp_5prime.fq.gz` written — hardtrim3 silently ignored |
+
+Every behavioural claim in §2.1/§2.2/§2.3/§8-A3/§10-Open-4 holds.
+
+### 1.4 Downstream claim (validation matrix)
+
+I read every `trim_galore` invocation in `ci.yml` (48 of them). **No step passes more than
+one single-end input**, and the multi-pair steps use `A_`/`B_` distinct stems. The plan's
+"validation matrix unaffected" is correct.
+
+### 1.5 One factual error
+
+§2.4 says "**five** hand-rolled copies … (`main.rs:482`, `:680`, `:1801`, `:2414`, and the
+`--clump_only` SE FASTQ one at `:486`)". `grep -n "Output path collision"` returns five
+sites, but one is the helper itself (`:70`). There are **four** hand-rolled copies —
+`:482`, `:680`, `:1800`, `:2412` — and `:482`/`:486` are the same block counted twice
+(`:482` is `let mut out_paths`, `:486` is the `if let Some(existing)` inside it). This
+misstates the size of the out-of-scope consolidation commit (§10-3). Cosmetic, but the
+count appears twice in the plan.
+
+### 1.6 Signatures compile as written
+
+`main.rs` imports `trim_galore::io as naming`, `trim_galore::specialty`, `std::path::Path`;
+at `:344`/`:369` `output_dir: Option<&Path>` and `gzip: bool` are both in scope, and `cli`
+is owned so `&cli` type-checks. §4.1's body uses `norm_path` unqualified (correct inside
+`io.rs`), fully-qualified `std::collections::HashMap`, and `anyhow::bail!` — `io.rs`
+already imports `anyhow::{Context, Result}` and `std::path::{Path, PathBuf}`, so no new
+`use` lines. `preflight_output_collisions` being `pub` in the library means no
+`dead_code` warning even though only the binary calls it. §4.3's five-arg helper is under
+clippy's `too_many_arguments` threshold. `preflight_collision_bam(&[planned])` at `:533`
+coerces `&[PathBuf; 1]` → `&[PathBuf]` unchanged. Nothing here will fail
+`clippy -D warnings`.
+
+---
+
+## 2. Logic review
+
+### 2.1 CRITICAL — the fix does not close #383 for path-aliased spellings
+
+`norm_path` is a pure string lowercase. The candidate paths handed to it come from
+`single_end_output_name`, which does `input.parent().join(filename)` — so the *directory
+portion of the key is whatever the user typed*. Two spellings of the same directory produce
+two different keys for the same physical file, and the pre-flight accepts.
+
+Reproduced against the current binary (the fix cannot change these outcomes, because the
+candidate list Step 7 builds is exactly the `Output:` line the binary already prints):
+
+```
+$ cd <dir>; trim_galore <abs>/sample.fastq.gz sample.fq.gz     # ALPHA + BETA
+exit=0
+Output:   /private/tmp/.../t2/sample_trimmed.fq.gz
+Output:   sample_trimmed.fq.gz
+ALPHA=0 BETA=40
+$ ls -i <abs>/t2/sample_trimmed.fq.gz sample_trimmed.fq.gz
+193763599 …/t2/sample_trimmed.fq.gz
+193763599 sample_trimmed.fq.gz          ← same inode
+```
+
+```
+$ trim_galore ./sample.fastq.gz sample.fq.gz
+exit=0
+Output:   ./sample_trimmed.fq.gz
+Output:   sample_trimmed.fq.gz
+ALPHA=0 BETA=40                          ← same inode, 193763651
+```
+
+Lowercased, `"/private/…/t2/sample_trimmed.fq.gz"` ≠ `"sample_trimmed.fq.gz"` and
+`"./sample_trimmed.fq.gz"` ≠ `"sample_trimmed.fq.gz"`, so `seen.insert` returns `None`
+twice and the helper returns `Ok(())`. **After the fix, #383 reproduces verbatim — same
+exit 0, same 40 reads lost, same two reports — if either argument carries a `./` prefix or
+an absolute path while the other does not.**
+
+This is not exotic. `find`/`xargs` lists, `ls -d ./*` idioms, Snakemake and Nextflow input
+staging, and hand-assembled file lists all mix absolute and relative spellings within one
+argument vector. A uniform glob (`*.fastq.gz` or `./*.fastq.gz`) is safe because the prefix
+is consistent; a *mixed* list is not.
+
+§1 claims the change makes it "impossible for one invocation to silently overwrite one
+input's output with another's". That claim is false as written, and no assumption in §8
+records the limitation.
+
+**Fix — cheap and strictly safe.** Key on the lexically absolutised path. I verified
+`std::path::absolute` (stable, no filesystem access, well inside the 1.88 floor):
+
+```
+sample_trimmed.fq.gz       -> /…/review-a/sample_trimmed.fq.gz
+./sample_trimmed.fq.gz     -> /…/review-a/sample_trimmed.fq.gz   ← `.` removed
+a//sample_trimmed.fq.gz    -> /…/review-a/a/sample_trimmed.fq.gz  ← separators collapsed
+a/../sample_trimmed.fq.gz  -> /…/review-a/a/../sample_trimmed.fq.gz  ← `..` kept (POSIX-correct)
+```
+
+So absolutising the **key only** (keep the message printing the user's original paths, so
+the CI greps and the two `test -z "$(ls -A …)"` assertions stay valid) closes both aliases
+above at the cost of one `getcwd`. It can only ever *increase* rejections, never decrease
+them, and two paths that absolutise equal are genuinely the same file — so no new false
+positives beyond the case-fold one #216 already accepted. It also strictly improves the
+existing paired / clock / implicon / clump_only guards once the consolidation commit lands.
+`..` and symlinks still alias; that residual should become an explicit assumption rather
+than going unstated (the plan already argues correctly against `fs::canonicalize`, and that
+argument is untouched — `absolute` is lexical).
+
+Note the namers' `parent().join()` already collapses duplicate separators, which is why
+`a//x` vs `a/x` is *not* a hole today. It is specifically `.` and absolute-vs-relative that
+leak.
+
+### 2.2 Assumption A2 is false in one documented flag combination
+
+A2 says the primary output path is a sufficient collision key for "reports, JSON, FastQC,
+demux". I verified the four secondaries individually:
+
+- **reports / JSON** — ✅ A2's reasoning is right, and I checked the implication in both
+  directions. `report_name` is injective in `(parent-string, file_name-string)`, so equal
+  report names force equal input path strings, hence equal stems, hence equal primaries.
+  Conversely distinct primaries in the same directory require distinct stems, which require
+  distinct file names, so distinct reports. The claim holds.
+- **`--demux`** — ✅ safe, and for a reason the plan does not state: `demux::demultiplex`
+  resolves its output directory as `output_dir.unwrap_or(trimmed_file.parent())`
+  (`demux.rs:142-147`) and derives `base_name` from the trimmed file's name
+  (`demux.rs:129-140`). Both keys are functions of the primary path, so the resolution is
+  parallel to the primary's by construction. Worth one sentence in §2.3 — the current
+  argument ("`--demux` is handed `&output_path`") is not sufficient on its own, because
+  being handed the path says nothing about how the directory is resolved.
+- **FastQC, default** — ✅ safe. `fastqc-rust 1.0.1` `runner.rs:224-233` falls back to
+  `group.files.first().parent()`, i.e. the primary's parent. Parallel resolution again.
+- **FastQC with `--fastqc_args "-o DIR"`** — ❌ **counterexample.**
+  `fastqc.rs:91-96` (`apply_fastqc_args`) overwrites `config.output_dir` with an arbitrary
+  directory that the pre-flight never sees. Verified:
+
+```
+$ trim_galore --fastqc_args "-o <qc>" dirA/same.fastq.gz dirB/same.fastq.gz
+exit=0
+Output:   dirA/same_trimmed.fq.gz      ← distinct primaries: pre-flight ACCEPTS
+Output:   dirB/same_trimmed.fq.gz
+$ ls <qc>
+same_trimmed_fastqc.html
+same_trimmed_fastqc.zip               ← ONE pair of artifacts, not two
+$ unzip -p <qc>/same_trimmed_fastqc.zip …/fastqc_data.txt | grep Filename
+Filename	same_trimmed.fq.gz          ← dirA's QC report silently clobbered by dirB's
+```
+
+Consequence is a lost QC artifact, not lost reads, and the hole is pre-existing and
+identical on the `--paired` path (which has had the pre-flight since #216) — so this is not
+a regression the plan introduces. But A2 is stated as an unqualified universal and flagged
+as "load-bearing", so it needs narrowing: either add the `--fastqc_args`-derived output
+directory to the candidate list, or scope A2 to "given FastQC's *default* output-directory
+resolution" and record `--fastqc_args -o` as a known residual. V6 as designed cannot detect
+this (it only compares `report_name` with `single_end_output_name`).
+
+### 2.3 A3, A4, A5, A6, A7
+
+- **A3** ✅ verified two ways: `main.rs:367` returns, and empirically
+  `--hardtrim5 20 --hardtrim3 15` writes only the 5′ output. Per-block checks suffice.
+  Also confirmed `5prime`/`3prime` keeps the two modes' names distinct, so even a
+  hypothetical combined run could not self-collide.
+- **A4** ✅ verified. `gzip` is one run-wide flag (`:295`) threaded into both the candidate
+  namer and the writer, so prospective and actual paths cannot disagree. I checked the
+  awkward orderings: `.fastq.bgz` first → `gzip=false` → both candidates `sample_trimmed.fq`
+  → still collides; `.fastq.gz` first → both `.fq.gz` → still collides. Order-independent.
+- **A5** ✅ `cli.rs:620` is outside the UBam block, so it guards the SE uBAM arm too. Zero
+  inputs is unreachable (`required = true`).
+- **A6** ✅ premise verified: `trim_galore dup.fastq.gz dup.fastq.gz` exits 0 today with a
+  correct 40-read output. So this genuinely is a behaviour change. **I agree with the
+  decision to reject** — it matches `--paired`, avoids canonicalisation, and a duplicated
+  argument is almost always a mistake. But see Important-3: the message the user will get is
+  actively misleading.
+- **A7** ✅ `ensure_output_dir` at `:300` precedes all four new insertion points, so a
+  rejected run leaves an empty `-o` directory, matching the tested paired contract.
+
+### 2.4 Ordering side effects the plan does not mention (benign, but worth a line)
+
+Inserting the check before the SE loop at `:784` moves the collision error *ahead of*
+`sanity_check_any` for inputs 1..n (that call lives inside the loop at `:787`). So
+`trim_galore good.fastq.gz truncated.fq.gz` with colliding stems now reports the collision
+rather than the truncation. That is the correct precedence — fail before any read — but it
+is an observable change in which of two errors surfaces, and someone will eventually notice.
+
+---
+
+## 3. Validation sufficiency
+
+### 3.1 The §9 pairing property does not hold as claimed
+
+§9 opens: "Every rejection test is paired with an acceptance test **on the same dispatch
+path**. Without that pairing a helper that rejected unconditionally would pass the whole
+suite." Auditing the proposed list:
+
+| Dispatch path | Rejection test | Acceptance test |
+|---|---|---|
+| SE trim FASTQ | V2, V4, V5 | V3 (two dirs; single input) ✅ |
+| `--hardtrim5` FASTQ | V2, V5 | V3 (`-o`, distinct stems) ✅ |
+| `--hardtrim3` FASTQ | V2 | **none** ❌ |
+| SE trim uBAM | V2 | **none** ❌ |
+| `--hardtrim5` uBAM | V2 | **none** ❌ |
+
+The strong version of the property (an unconditionally-rejecting *helper* is caught) does
+hold, because two paths do have acceptance partners. The stated version — per dispatch path
+— does not, for three of five. A mistake confined to one arm (e.g. Step 8 accidentally
+handing the pre-flight a constant, or `planned_hardtrim_outputs` mis-`match`ing) would pass
+the whole suite. Two cheap additions close it: one SE-uBAM acceptance case (two distinct
+inputs → exit 0, two `.bam`) and one `--hardtrim3` acceptance case.
+
+Mitigating note the plan could make: several plausible slips are *behaviourally inert* for
+the collision decision, because every candidate namer is stem-keyed. Passing `"5prime"` in
+the hardtrim3 block, or the FASTQ namer on the uBAM arm, yields candidate paths that are
+isomorphic to the real ones — colliding exactly when the real outputs collide. That is why
+the acceptance gap is Important rather than Critical.
+
+### 3.2 IMPORTANT — the one slip nothing tests: `output_dir` omitted from Step 7
+
+`single_end_output_name` is the only candidate namer whose directory resolution depends on
+`output_dir` in a *behaviour-changing* way (`None` → `input.parent()`, i.e. a different
+directory per input). If Step 7's candidate builder were written with `None` instead of
+`output_dir`:
+
+- inputs `dirA/same.fastq.gz` + `dirB/same.fastq.gz` with `-o /shared` → candidates
+  `dirA/same_trimmed.fq.gz` and `dirB/same_trimmed.fq.gz`, distinct → **accepted**, while
+  both writes land on `/shared/same_trimmed.fq.gz`. #383 survives, with `-o` set.
+- Every proposed test still passes: V2, V4 and V5's SE step all use two inputs in the *same*
+  directory, so their candidates collide with or without `output_dir`; V3's acceptance cases
+  are unaffected.
+
+§3.3 lists "Same basename, different dirs, **with** `-o` → reject" as an edge case but no
+V-item exercises it. **This is the single highest-value test to add** — it is the exact
+shape of #383's sibling in a pipeline that stages inputs per-sample and writes to a shared
+results directory, and it is the only case where a natural implementation slip in the
+plan's own Step 7 goes undetected. (The corresponding hardtrim slip is inert: both hardtrim
+namers key on a bare filename either way.)
+
+### 3.3 IMPORTANT — V6 as specified asserts nothing
+
+V6: "unit test in `io.rs` asserting that for a set of paths where
+`report_name(a) == report_name(b)`, `single_end_output_name(a) == single_end_output_name(b)`
+also holds."
+
+`report_name(a) == report_name(b)` requires equal parent strings and equal file-name
+strings — i.e. `a` and `b` are the same path (or trivially separator-equivalent, e.g.
+`a/x.fq.gz` vs `a//x.fq.gz`). So any hand-built witness set either contains identical inputs,
+making the assertion a tautology, or separator variants, for which both sides collide anyway.
+The test will be green on day one and stay green under a naming change that *breaks* A2,
+because the hypothesis can never be satisfied by an interesting pair. It is exactly the
+class of self-satisfying check the plan's own §9 preamble warns about.
+
+The constructible, meaningful version is the contrapositive with witnesses: assert that for
+`sample.fastq.gz` / `sample.fq.gz` / `sample.fastq.bgz` in one directory, the **report names
+are all distinct** *while* the **primary names are all equal** — i.e. demonstrate directly
+that the primary key is strictly coarser than the report key. That fails loudly if a future
+change makes `strip_fastq_extensions` finer-grained than `file_name`, which is the actual
+risk A2 carries. Consider adding the same shape for `single_end_bam_output_name`.
+
+### 3.4 V1–V5, V7 — otherwise well-shaped
+
+V1's case-fold assertion genuinely is unreachable from an integration test on APFS, which
+justifies Open 2's decision to move the helper into `io.rs`. I agree with that call. V3's
+upgrade from existence to per-file read attribution is the right instinct and I confirmed
+it discriminates (dirA=ALPHA only / dirB=BETA only). V2's `current_dir(tempdir)` pin is
+necessary — I re-confirmed hardtrim writes to CWD. V4 is a worthwhile #382 regression pin.
+V5 mirrors the existing guards' shell idiom correctly.
+
+Small gaps: V2 asserts only that the *output* file is absent; the #383 signature was "one
+data file, **two reports**, both claiming 100%", so V2 should also assert no
+`*_trimming_report.txt`/`.json` exists (the CI step gets this free via `ls -A`, the
+integration tests do not). And V7's repro (c) needs the same scratch-CWD discipline V2
+gets, or `cargo`-adjacent runs will litter the repo root — the plan's own §11 records this
+happening during investigation.
+
+---
+
+## 4. Efficiency
+
+Nothing to object to. O(n) time and memory over a command line's worth of paths; one
+`String` key and one `PathBuf` clone per input; no I/O. Running before the ≤1 M-record
+adapter scan means colliding invocations fail faster than today, which the plan correctly
+notes. `planned_hardtrim_outputs`'s `Vec` is dropped immediately.
+
+Two notes if Critical-1 is adopted: §6's "no syscalls" becomes "one `getcwd`" (or zero, if
+the CWD is fetched once and reused), and `HashMap::with_capacity(paths.len())` is a free
+micro-win nobody will measure.
+
+---
+
+## 5. Alternatives considered
+
+1. **One hoisted pre-flight above dispatch instead of four insertion points.** Rejected —
+   correctly, though the plan does not discuss it. A unified check needs a mode → namer
+   `match` that duplicates the dispatch logic it sits above, so it trades four small
+   omissions for one large one. The plan's per-branch shape is right for a data-loss fix.
+   The residual risk is structural: a fifth dispatch path added later will silently lack the
+   guard again, exactly as these four did. Cheapest mitigation is a comment at the helper
+   naming all call sites (the `norm_path` doc-comment already uses this pattern), which Step 1
+   half-does; extend it to list all guarded paths so an omission is visible from the helper.
+2. **Fold duplicate inputs before hashing instead of rejecting (A6).** I prefer the plan's
+   rejection, but with a dedicated message (Important-3).
+3. **`fs::canonicalize` for the key.** The plan's argument against it is sound (syscall per
+   input, symlink and bind-mount semantics). `std::path::absolute` gets most of the benefit
+   with none of those costs — see Critical-1.
+4. **Refusing to clobber files already on disk** (§10-2) — agreed, separate feature.
+5. **Consolidating the four hand-rolled copies** (§10-3) — agreed, separate commit. Splitting
+   it out of the data-loss fix is the right instinct.
+
+---
+
+## 6. Action items
+
+### Critical
+
+**C1. The pre-flight does not close #383 for path-aliased directory spellings.** Reproduced
+against the current binary: `trim_galore <abs>/sample.fastq.gz sample.fq.gz` (cwd =
+`<abs>`) and `trim_galore ./sample.fastq.gz sample.fq.gz` both exit 0 and lose 40 of 80
+reads, and the candidate keys the plan hashes are exactly the two textually-different
+`Output:` paths the binary prints for the same inode. Because `norm_path` is a pure string
+lowercase, the planned helper accepts both invocations. Either (a) key on
+`std::path::absolute(p)` — verified to strip `./` and prepend the CWD, lexical, no
+filesystem access, message keeps printing the user's original paths so the CI greps stay
+valid — and record `..`/symlink aliasing as the remaining limitation; or (b) if that is
+deferred, strike the "impossible" framing in §1, add it as an explicit assumption, and say
+so in the CHANGELOG, because the issue as filed will still reproduce in one common spelling.
+Add a test: two inputs in the same directory, one absolute and one relative, sharing a stem
+→ must reject.
+
+### Important
+
+**I1. Add the one test that catches an omitted `output_dir` in Step 7.** SE trim,
+`dirA/same.fastq.gz` + `dirB/same.fastq.gz`, **with** `-o <third dir>` → must reject. §3.3
+lists this case but no V-item covers it, and it is the only proposed-code slip that
+silently under-rejects: every existing V2/V4/V5 SE case uses same-directory inputs whose
+candidates collide with or without `output_dir`. See §3.2.
+
+**I2. Narrow A2 — it is false for `--fastqc_args "-o DIR"`.** Verified: two distinct
+primaries are accepted while both FastQC artifact sets are written to the overridden
+directory under one name, silently clobbering the first. `fastqc.rs:91-96` sets
+`config.output_dir` from `--fastqc_args`, and the pre-flight never sees it. Pre-existing and
+identical on the `--paired` path, and the loss is a regenerable QC artifact — so scope A2 to
+FastQC's *default* directory resolution and record the override as a known residual, or add
+the parsed `-o` directory to the candidate list.
+
+**I3. Give the A6 duplicate-input rejection its own message.** With the generic message, the
+user who typed `trim_galore dup.fastq.gz dup.fastq.gz` gets "…: `dup_trimmed.fq.gz` and
+`dup_trimmed.fq.gz` would be written to the same file. Check that inputs produce distinct
+output paths (e.g., different source directories or `--output_dir`)" — two byte-identical
+paths and two remedies that both fail to fix it. Mirror `cli.rs:535`'s dedicated wording
+("Read 1 and Read 2 appear to be the same file"). Detecting exact-duplicate inputs in
+`Cli::validate` is unit-testable, runs before `ensure_output_dir` (so no empty `-o`
+directory is left behind), and keeps the pre-flight message meaning what it says.
+
+**I4. Rewrite V6 — as specified it cannot fail.** `report_name(a) == report_name(b)` implies
+`a` and `b` are the same path string, so the assertion is a tautology on any constructible
+witness set. Invert it: assert that `sample.fastq.gz` / `sample.fq.gz` / `sample.fastq.bgz`
+in one directory produce three **distinct** report names and one **shared** primary name,
+demonstrating the primary key is strictly coarser. See §3.3.
+
+**I5. §9's stated pairing property holds for only two of five rejection paths.** `--hardtrim3`,
+SE trim uBAM and hardtrim uBAM get a rejection test and no acceptance test. Add one
+acceptance case each (or weaken the claim and say which arms are rejection-only, and why the
+stem-keyed namers make the residual risk small — see §3.1).
+
+### Optional
+
+**O1.** §2.4/§10-3 say "five hand-rolled copies"; there are four (`:482`, `:680`, `:1800`,
+`:2412`). `:482` and `:486` are the same block. The count appears twice.
+
+**O2.** V2 should also assert no `*_trimming_report.txt`/`.json` was written. Two reports
+next to one data file *is* the #383 signature; existence-of-output-absent alone misses a
+regression that writes reports before bailing.
+
+**O3.** V7's repro (c) needs the scratch-CWD discipline V2 gets, or a manual re-run writes
+`same.20bp_5prime.fq.gz` into the repo root — §11 records this having happened once already.
+
+**O4.** V2's hardtrim cases use `Command::current_dir(tempdir)`, which breaks the
+`fixture()` helper's relative `test_files/…` path used elsewhere in `tests/`. Copy fixtures
+into the tempdir or pass absolute paths, and say which.
+
+**O5.** §2.3's `--demux` safety argument ("is handed `&output_path`") is incomplete — being
+handed the path says nothing about directory resolution. The actual reason it is safe is
+that `demux.rs:142-147` resolves `output_dir.unwrap_or(trimmed_file.parent())`, so its key
+is a function of the primary. One sentence, and it makes A2 auditable rather than
+plausible.
+
+**O6.** Note in §3.4 that the new SE check moves the collision error ahead of
+`sanity_check_any` for inputs 1..n (`main.rs:787`), so a run with both a collision and a
+truncated second input now reports the collision. Correct precedence, observable change.
+
+**O7.** A6 is a behaviour change; the CHANGELOG's `### Unreleased` has both
+`#### Bug fixes` and `#### Changes` (line 63). Step 12 sends everything to `#### Bug fixes`
+— the duplicate-input refusal probably belongs under `#### Changes`.
+
+**O8.** Open 4 (`--hardtrim5` + `--hardtrim3` → 3′ silently ignored) is confirmed
+reproducible. Since a reviewer will ask, file it as its own issue before this lands; the
+fix is a clap `conflicts_with`.
+
+---
+
+## 7. Summary
+
+The diagnosis is correct and unusually well evidenced — I re-ran every reproduction and
+confirmed the hole map is exhaustive by enumerating all ten `cli.input` loops in `main.rs`.
+The design (reuse the existing generic helper, move it to `io.rs` for unit-testability,
+four minimal per-branch insertions, defer consolidation) is the right shape for a data-loss
+fix, and the anchors are accurate enough to implement from. A6's rejection is the right
+call.
+
+The one thing I would not ship without addressing is **C1**: `norm_path`'s pure-string key
+means a `./` prefix or a mixed absolute/relative argument list walks straight through the
+new guard and reproduces #383 exactly, which I demonstrated on the current binary against
+the very paths the plan hashes. A one-call lexical absolutisation of the key closes it at
+essentially zero cost and strictly improves the four existing guards too. Beyond that, the
+validation section is one test short of catching the most plausible slip in its own Step 7
+(**I1**), one of its two assumption-tests cannot fail (**I4**), and A2 is a universal claim
+with a real counterexample (**I2**).

--- a/plans/08062026_se-output-collision-preflight/PLAN_REVIEW_B.md
+++ b/plans/08062026_se-output-collision-preflight/PLAN_REVIEW_B.md
@@ -1,0 +1,482 @@
+# Plan Review B — Output-collision pre-flight for the four uncovered dispatch paths (#383)
+
+**Plan:** `plans/08062026_se-output-collision-preflight/PLAN.md` (v1, 2026-08-06)
+**Reviewer:** B (independent; no shared state with Reviewer A)
+**Repo state:** `dev` @ `72624c7`; verified against `target/release/trim_galore` as built at that commit
+**Verdict:** the plan is accurate and implementable. One **Critical** gap: after the fix, a two-argument
+single-end command line can still lose 100 % of one input's reads and exit 0. Assumption A2 is **false**
+in one verified corner, and the plan's chosen error message gives remediation advice that is
+**demonstrably wrong** on the `--hardtrim` path it newly guards.
+
+---
+
+## 0. Claim verification
+
+Everything below was checked against source or by running the binary. Reproductions live under
+`/private/tmp/claude-501/-Users-fkrueger-Github-TrimGalore/d0ee0171-fc72-476b-bdba-c46c90a5bacd/scratchpad/review-b/`.
+
+### Confirmed as stated
+
+| Plan claim | Verified |
+|---|---|
+| `preflight_collision_bam` is path-generic, `main.rs:64-80` | ✅ exactly as quoted, body identical to §4.1 |
+| Its three call sites are `main.rs:533`, `:566`, `:614` | ✅ `grep` finds exactly three |
+| Doc-comment at `:55-59` documents `resolve_clump_layout` but is attached to `preflight_collision_bam` | ✅ — `:55-59` is the clump-budget prose, `:60-63` the BAM prose, one `///` run, `resolve_clump_layout` at `:82` |
+| Four unguarded loops: `main.rs:345`, `:370`, `:784`, `:1858` | ✅ I enumerated all ten `cli.input` loops in `main()`; the other six each sit behind a pre-flight (`:484`→`:499`, `:558`→`:572`, `:611`→`:615`, `:683`→`:737`, `:1803`→`:1823`, `:2415`→`:2432`). **The hole map is complete.** |
+| `--clock`/`--implicon` already covered via `run_specialty_paired` | ✅ pre-flight at `:2412-2429` |
+| `--clump_only` SE FASTQ already rejects | ✅ ran it: exit 1 + message |
+| #383 repro (a): `sample.fastq.gz` + `sample.fq.gz` | ✅ exit 0, one `sample_trimmed.fq.gz`, ALPHA=0 / BETA=40, two reports each claiming 100 % written |
+| Repro (c): `--hardtrim5 20` on same basename in two dirs | ✅ exit 0, one `same.20bp_5prime.fq.gz` in CWD, DIRA=0 / DIRB=40 |
+| SE trim uBAM hole | ✅ exit 0, one `sample_trimmed.bam`, two reports |
+| SE trim on same basename in different dirs is **accepted** today and correct | ✅ two outputs, DIRA→dirA only, DIRB→dirB only |
+| A3: `hardtrim5` block `return`s at `main.rs:367` | ✅ and no `Cli::validate` conflict between `--hardtrim5`/`--hardtrim3` (Open 4 real) |
+| A4: `gzip` decided once at `main.rs:295` from `cli.input[0]`, threaded to every writer | ✅ `run_single_file`/`specialty::hardtrim*` all take the one flag |
+| A5: `cli.rs:620` rejects `--basename` + multi SE input | ✅ |
+| A6: same file twice exits 0 with correct output today | ✅ ran it: exit 0, 40 reads |
+| `cli.rs:549` cross-pair duplicate rejection | ✅ (and `:535` R1≠R2) |
+| Namer signatures in §4.2 | ✅ byte-exact, `specialty.rs:423` and `:446` |
+| Step 7/8 candidate expressions match what the writers use | ✅ `run_single_file` (`main.rs:1086-1087`) and `run_ubam_output_single` (`:1880-1881`) build their paths with the identical calls |
+| Specialty namers resolve to CWD (`specialty.rs:435/456/471/504`) | ✅ |
+| `report_name`/`json_report_name` key on the full input filename (`io.rs:401-430`) | ✅ |
+| No CI validation step passes colliding stems | ✅ I read every `trim_galore` invocation in `ci.yml`; all multi-input ones are `--paired` with `A_`/`B_`/`C_` or the two deliberate collision guards |
+| CI guards assert *empty*, not *absent* | ✅ `test -z "$(ls -A …)"` at `:615` and `:640` |
+| `CHANGELOG.md` has `### Unreleased` → `#### Bug fixes` | ✅ at `:4`/`:6` |
+| No crate-level `missing_docs`, no `[lints]` table | ✅ so `fn`→`pub fn` on an undocumented namer will not trip `-D warnings` |
+
+### Wrong or imprecise
+
+1. **"five hand-rolled copies" is four** (§2.4, and Out of scope 3 depends on the count).
+   The list `(main.rs:482, :680, :1801, :2414, and the --clump_only SE FASTQ one at :486)` double-counts:
+   `:482` **is** the `--clump_only` SE FASTQ copy and `:486` is the `insert` line inside that same block.
+   The four distinct sites are `:482-498`, `:680-727`, `:1800-1820`, `:2412-2429`.
+
+2. **Message-drift description is off by one.** Two sites say `--output-dir` (`:721` paired FASTQ,
+   `:1815` paired uBAM), not one; three say `--output_dir` (`:493`, `:2423`, and the shared helper `:73`).
+   More usefully: **`--output-dir` is not a valid flag.** `cli.rs:152` declares `long = "output_dir"` only,
+   and `trim_galore --output-dir …` fails with clap's usage error. So the deferred consolidation commit
+   (Out of scope 3) is *not* behaviour-neutral in the user-visible sense — it fixes a wrong flag name in
+   two error messages. Worth saying so, because it raises that commit's priority. The plan's choice of
+   `--output_dir` as the canonical wording is the correct one.
+
+3. **§3.1 point 1 overstates the ordering.** "Runs before any reader is opened" is not literally true:
+   `sanity_check_any(&cli.input[0])` (`main.rs:153`) opens a reader and `detect_input_format` runs over
+   *every* input at `:159`, both before dispatch. §7's phrasing ("before every reader open on the guarded
+   path") is the accurate one. Consequence worth one line in §3.3: a corrupt or missing input **N** is
+   diagnosed before the collision, so error precedence is format/sanity → collision.
+
+4. **§3.4 anchors.** `:604`/`:628` are the `trim_galore` invocation lines; the `test -z "$(ls -A …)"`
+   assertions the sentence describes are at `:615`/`:640`.
+
+---
+
+## 1. Logic review
+
+### 1.1 Critical — the fix does not close the reported failure class
+
+§1 states the goal as making it impossible for one invocation to silently overwrite one input's output.
+An output-vs-output check does not achieve that, because an output can also collide with an **input of
+the same invocation**. Verified:
+
+```
+e4/s.fastq.gz          (40 reads, ALPHA)
+e4/s_trimmed.fq.gz     (40 reads, BETAPRIOR — a previous run's output sitting in the directory)
+
+$ trim_galore e4/s.fastq.gz e4/s_trimmed.fq.gz
+exit=0
+s_trimmed.fq.gz        : ALPHA=40 BETAPRIOR=0
+s_trimmed_trimmed.fq.gz: ALPHA=40 BETAPRIOR=0     ← wrong sample's reads, exit 0
+```
+
+Input 1's output path *is* input 2. Input 1 is processed first, clobbers input 2 on disk, and input 2 is
+then read back as ALPHA. `BETAPRIOR`'s reads are gone and **both** output files claim success. The
+planned pre-flight accepts this invocation, because `s_trimmed.fq.gz ≠ s_trimmed_trimmed.fq.gz`.
+
+This is not a contrived ordering: `trim_galore *.gz` in a directory that already contains a previous
+run's output reproduces it, and the glob order (`s.fastq.gz` < `s_trimmed.fq.gz`, `.` = 0x2E < `_` = 0x5F)
+puts the clobberer first. Severity is at least #383's: #383 loses one input's reads; this produces a
+*second* output file populated with the wrong sample's reads, which is harder to notice than a missing file.
+
+§10 Out of scope 2 does not cover this, or at least will not be read as covering it: it is written about
+"files already on disk **from an earlier run**" and frames the answer as "a `--force` / no-clobber policy".
+No policy is needed here. The user has explicitly named the file as an input, so writing it is
+unambiguously wrong, and the check is a set intersection over data the pre-flight already has:
+
+```rust
+// alongside the duplicate-output loop, in the same helper or a sibling
+let inputs: HashSet<String> = cli.input.iter().map(|p| naming::norm_path(p)).collect();
+// then, per planned path: if inputs.contains(&norm_path(p)) → bail with a distinct message
+```
+
+Cost is ~6 lines and one `HashSet`, and it needs its **own** message (the "would be written to the same
+file" wording is wrong for this case). It applies to all four newly guarded paths — and to `--paired`,
+which has the same hole today, so the helper should take the input list and the whole family benefits.
+
+**Recommendation:** add it to this plan (it is the same commit, the same helper, the same test file), or
+if scope must stay tight, replace Out of scope 2 with two entries — one for the `--force`/no-clobber
+policy, one naming *this* case explicitly with its own issue number — so that a future reader does not
+conclude #383's class was closed.
+
+### 1.2 The insertion points are correct and the candidate expressions match the writers
+
+I traced each of the four:
+
+- `main.rs:344` / `:369` — `output_dir` and `gzip` are both in scope (bound at `:295-296`), `cli` is owned
+  so `&cli` is fine, and the check precedes `specialty::hardtrim*`, hence every reader and writer on that
+  path. A3 holds, so a per-block check is sufficient.
+- `main.rs:781` — precedes `setup_trimming` (which is where adapter auto-detection reads up to 1 M
+  records) and `run_single_file`. The candidate expression in Step 7 is *character-identical* to
+  `main.rs:1086-1087`, so the checked path cannot diverge from the written path.
+- `main.rs:1857` — same property against `main.rs:1880-1881`.
+
+This last property is the one that matters most and the plan gets it right for SE. It is **not** true of
+the hardtrim insertions, see 1.3.
+
+### 1.3 The `"5prime"` / `"3prime"` literal is now duplicated, and nothing tests the duplicate
+
+After Steps 5–6 the discriminator string exists twice per mode: once in the collision candidate
+(`planned_hardtrim_outputs(&cli, n, "5prime", …)`) and once in the writer (`specialty::hardtrim5` →
+`hardtrim_output_name(input, keep, "5prime", …)`). A copy-paste slip in Step 6 that passes `"5prime"` for
+`--hardtrim3` produces a pre-flight that hashes paths the run never writes. Every rejection test in §9 V2
+still passes (both candidates carry the same wrong discriminator, so they still collide), and there is no
+hardtrim3 acceptance test to catch it — see §4.2. Two ways out: assert the expected output filename in a
+hardtrim3 acceptance test, or have `planned_hardtrim_outputs` take an enum/`cli.hardtrim5.is_some()`
+rather than a `&str` so the literal is written once.
+
+### 1.4 The generic error message's remediation advice is wrong on the hardtrim path
+
+The message the plan adopts ends:
+
+> Check that inputs produce distinct output paths (e.g., different source directories or `--output_dir`).
+
+On `--hardtrim5/3`, **both** suggested remedies fail, because the namer ignores the input's parent and
+`-o` joins the *stem-only* filename:
+
+```
+$ trim_galore --hardtrim5 20 -o e9out e3/dirA/same.fastq.gz e3/dirB/same.fastq.gz
+exit=0 → e9out/same.20bp_5prime.fq.gz, DIRA=0 BETA/DIRB=40
+```
+
+"Different source directories" is precisely the input state that fails, and `--output_dir` reproduces the
+collision inside the `-o` directory. After the fix the user gets a loud error whose two suggestions both
+lead back to the same error, with no hint that the real remedies are one invocation per input, distinct
+input basenames, or `cd`-ing between runs.
+
+This matters more than a wording nit because the docs advertise multi-file hardtrim:
+`docs/src/content/docs/modes/hardtrim.md` and the v0.6.x changelog text carried in
+`docs/src/content/docs/reference/changelog.md:955`/`:997` both say the mode "processes **one or more
+files**", and neither mentions that output lands in the CWD rather than beside the input. So
+`--hardtrim5 20 */*.fastq.gz` over a per-sample-directory layout is a documented pattern that becomes a
+hard failure. Rejecting it is right (it silently loses data today). Rejecting it with unusable advice is
+not. §7 (Downstream) checks `ci.yml` but not `docs/` — it should.
+
+**Recommendation:** give the hardtrim insertion its own message, or pass a remediation hint into the
+helper. One line, e.g. `"…; hard-trimmed output is written to the current working directory, so identical
+input basenames collide regardless of --output_dir — run one invocation per input."`
+
+### 1.5 A6's rejection lands in the wrong layer and inherits the wrong message
+
+For `trim_galore x.fastq.gz x.fastq.gz` the planned helper emits the same path twice —
+"`x_trimmed.fq.gz` and `x_trimmed.fq.gz` would be written to the same file" — plus the
+different-source-directories advice, which is inapplicable. The codebase has already decided against
+exactly this: `cli.rs:504-516`'s doc-comment says the cross-pair duplicate check exists to "emit a
+precise error rather than the case-insensitive output-collision pre-flight's APFS/NTFS message".
+
+The consistent placement is `Cli::validate`, beside `cli.rs:534-558`, as a single-end analogue of the
+duplicate-pair check. Three benefits over doing it in the pre-flight: a precise message; it runs before
+`ensure_output_dir`, so A7's empty-directory residue does not apply to this case; and it covers
+`--hardtrim`, `--clock`, `--implicon` and `--clump_only` in one place instead of per dispatch path. It
+also makes A6 a *CLI-validation* decision rather than a side effect of the collision helper, which is
+easier to revisit if a user objects.
+
+I agree with the **decision** to reject (a duplicated positional is a mistyped glob in every realistic
+case, and de-duplicating would need `fs::canonicalize`). Only the placement and the message need moving.
+
+### 1.6 Smaller logic notes
+
+- **A7 / §3.4.** Consistent with the paired contract and correct for the SE `-o` case. But the hardtrim
+  V2 cases run with `current_dir(tempdir)` and no `-o`, so `ensure_output_dir` is a no-op there and the
+  strongest available assertion is "the temp dir is empty" — stronger than the plan's "the prospective
+  output file does not exist", and it also pins the absence of reports, which was #383's most confusing
+  artifact (two reports, both claiming 100 % written). Worth upgrading V2 to that.
+- **Step 7 will not compile as written.** `main.rs` imports `std::path::Path` but **not** `PathBuf`
+  (`main.rs:5`); the existing helper spells it `std::path::PathBuf` in full. `let planned: Vec<PathBuf>`
+  in Step 7 and `-> Vec<PathBuf>` in §4.3 need either the full path or a new import. Trivial, but the plan
+  presents these as paste-ready.
+- **`--basename` + `--hardtrim`** is accepted for a 2-file `--paired --hardtrim5` invocation
+  (`cli.rs:620` only fires for `!paired`, `:625` only for `>2`), and the hardtrim namers ignore
+  `basename` entirely. Pre-existing silent no-op, unrelated to collisions, and consistent between the
+  check and the writer — so it does not affect this plan. Not worth fixing here; worth not being surprised by.
+
+---
+
+## 2. Assumptions
+
+- **A1 (case-fold).** Sound, inherited, and CI-pinned (`ci.yml:634`). No comment.
+- **A2 (primary output is a sufficient collision key) — FALSE as worded.** See §3 below. The
+  *implementation* is unaffected; the *claim* and V6 need narrowing.
+- **A3.** Verified. `main.rs:367` returns; no CLI conflict rule exists, so Open 4 is real.
+- **A4.** Verified, and stronger than the plan claims: because `gzip` is global, argument *order* cannot
+  produce a false accept. `x.fastq.gz x.fastq.bgz` → both `x_trimmed.fq.gz`; reversed → both
+  `x_trimmed.fq`. Both collide, both get caught.
+- **A5.** Verified.
+- **A6.** Decision endorsed, placement and message disputed (§1.5).
+- **A7.** Verified against `ci.yml:615`/`:640`.
+- **Unstated assumption worth adding:** that the candidate expression and the writer's expression stay in
+  sync. It holds by construction for SE (identical calls) and by convention for hardtrim (duplicated
+  literal, §1.3). This is the assumption whose violation is *invisible to every rejection test*, so it
+  deserves to be named.
+- **Unstated assumption worth adding:** that no planned output path aliases a declared input (§1.1). It is
+  false today.
+
+---
+
+## 3. Assumption A2 under test — one verified counterexample
+
+The plan's reasoning about `report_name` is correct: reports key on the full input filename and the
+trimmed output on the stripped stem, both resolving the directory the same way
+(`output_dir` → else `input.parent()`), so `report_name(a) == report_name(b)` implies
+`single_end_output_name(a) == single_end_output_name(b)`. I checked the same property for
+`json_report_name` (identical shape, `io.rs:417-430`), for `single_end_bam_output_name` (`:109-123`), and
+for `--demux` (`demux.rs:142-147` derives its directory as `output_dir` → else `trimmed_file.parent()`,
+and its base name from the trimmed file's own name — so distinct primaries give distinct demux outputs).
+All hold.
+
+**FastQC does not.** `fastqc.rs:91-96` lets `--fastqc_args` override the output directory:
+
+```rust
+"-o" | "--outdir" => { config.output_dir = Some(PathBuf::from(v)); }
+```
+
+so the FastQC artifacts' directory is decoupled from the analysed file's directory, while the *filename*
+is still derived from the trimmed output's file name. Two inputs whose primaries do not collide therefore
+can, and do, produce colliding FastQC output:
+
+```
+$ trim_galore --fastqc --fastqc_args "-o e5/shared" e5/dirA/same.fastq.gz e5/dirB/same.fastq.gz
+exit=0
+primaries: e5/dirA/same_trimmed.fq.gz AND e5/dirB/same_trimmed.fq.gz   ← distinct, accepted
+e5/shared: same_trimmed_fastqc.zip, same_trimmed_fastqc.html           ← ONE pair; dirA's was overwritten
+```
+
+Negative control (the check was capable of failing): same command with distinct stems `x`/`y` into the
+same `-o` yields **four** files — `x_trimmed_fastqc.{zip,html}` and `y_trimmed_fastqc.{zip,html}`.
+
+Assessment. The lost artifact is a QC report — derived and regenerable, not reads — and the hole is
+pre-existing on every path including `--paired` (the #216 pre-flight does not hash FastQC paths either).
+So this is **not** a reason to widen the candidate list, and I would not add `--fastqc_args`-aware entries:
+that would mean parsing `--fastqc_args` twice and would still miss whatever the next `FastQCConfig` field
+does. It *is* a reason to fix the plan's text, because A2 is stated as **(fixed)** and V6 is offered as its
+test.
+
+**Recommendation:** reword A2 to the property that is actually true and load-bearing — *for every
+secondary output whose directory is resolved by the same `output_dir`-else-parent rule as the primary,
+primary-path distinctness implies secondary-path distinctness* — and add the `--fastqc_args -o/--outdir`
+override as a named, accepted exception (with the note that it costs a QC report, not reads, and pre-dates
+this change on all paths). Then §10 gains one out-of-scope entry.
+
+### V6 as specified is close to vacuous
+
+V6 proposes asserting that where `report_name(a) == report_name(b)`, `single_end_output_name(a) ==
+single_end_output_name(b)`. The only way to satisfy the premise with `a != b` is equal `file_name()` plus
+a directory rule that erases the parent — i.e. `output_dir = Some(_)` — in which case both sides are equal
+by construction. The test can essentially only pass, and it does not test A2's actual claim (that no
+*secondary* collides while the primary does not).
+
+A test that can fail, and that would have caught the FastQC case, is the contrapositive over a table:
+for path pairs whose primaries differ, assert that every secondary name also differs — report, JSON
+report, demux base, and `format!("{}_fastqc.zip", primary_stem)` in the *default* (no-`--fastqc_args`)
+configuration — across `--basename` / `--dont_gzip` / `-o` on and off. Then add one comment naming the
+`--fastqc_args --outdir` exception so a future reader does not "fix" the table by deleting the row.
+
+---
+
+## 4. Validation sufficiency
+
+### 4.1 The claimed pairing property does not hold for two of the six guarded combinations
+
+§9 asserts that every rejection test is paired with an acceptance test *on the same dispatch path*, so an
+unconditionally-rejecting helper would fail the suite. Mapping the proposed tests:
+
+| Guarded combination | Rejection (V2/V4) | Acceptance | Verdict |
+|---|---|---|---|
+| SE trim FASTQ | ✅ | ✅ V3 ×2 (one with read attribution) | pairing holds |
+| SE trim uBAM | ✅ | ❌ none in the plan | relies on pre-existing single-input tests |
+| `--hardtrim5` FASTQ | ✅ | ✅ V3 bullet 3 | holds |
+| `--hardtrim3` FASTQ | ✅ | ❌ **none anywhere** | gap |
+| `--hardtrim5` uBAM | ✅ | ✅ existing `ubam_out_hardtrim5_writes_bam` (single input) | holds |
+| `--hardtrim3` uBAM | ❌ none | ❌ none | untested both ways |
+
+`--hardtrim3` has **zero** output-producing coverage in the repository today: the only hits in `tests/`
+are `integration_adapter2.rs:377-382`, which asserts a `-a2` rejection *message*. Nothing asserts that
+`--hardtrim3 N` writes `*.{N}bp_3prime.*` at all. That is precisely the blind spot §1.3 describes, and
+Step 6 is a fresh copy-paste of Step 5 into it.
+
+For SE trim uBAM the practical risk is lower (existing single-input tests in `integration_ubam_out.rs`
+would fail against a truly unconditional rejecter), but the plan's own stated property is not met, and
+neither the plan nor the existing suite has a **multi-input** SE uBAM acceptance case — which is what
+catches an over-rejecting candidate list, e.g. hashing the input path instead of the output path.
+
+**Recommendation:** add three acceptance cases, each asserting the *expected output filename*, not just
+"two files exist":
+1. `--hardtrim3 20` with two distinct stems, `-o <tmp>` → exit 0, both `*.20bp_3prime.fq.gz` present.
+2. `--hardtrim3 20 --output-format ubam` (rejection + acceptance) → both `*.20bp_3prime.bam`.
+3. SE `--output-format ubam` with two distinct stems → exit 0, both `<stem>_trimmed.bam`.
+
+### 4.2 V2's hardtrim cases need absolute input paths
+
+The plan correctly pins `Command::current_dir(tempdir)` (and §11 records that the first draft littered the
+repo root). It does not say that the fixtures must then be addressed absolutely: `test_files/…` is
+relative to the crate root, so with `current_dir(tempdir)` the input is not found and the run fails with
+"Input file not found". The rejection assertion (`!ok`) would pass for the wrong reason; only the
+`stderr.contains("Output path collision")` grep saves the test. Worth one sentence in Step 10 —
+`fixture()` must return an absolutised path (or the fixture must be copied into the tempdir) for any case
+that sets `current_dir`.
+
+### 4.3 Other validation notes
+
+- **V2** should assert the output directory is *empty* rather than only that the primary is absent
+  (§1.6); that also pins the two-reports artifact that made #383 hard to spot.
+- **V3 bullet 1** is the right assertion and the right reason. Keep the read-attribution form.
+- **V4** is well chosen: `.gz` + `.bgz` is the newest way to reach the bug (#382 shipped yesterday's
+  stem-stripping widening) and pins `strip_fastq_extensions` against a future regression.
+- **V5** mirrors the existing guards' shape correctly, including `rc=${PIPESTATUS[0]}` and the
+  `test -z "$(ls -A …)"` residue check. The SE step should use the *same* file copied under two names
+  (`sample.fastq.gz` + `sample.fq.gz`) as stated — note that the hardtrim CI step must `cd` or pass `-o`
+  for the same CWD reason as V2, and since `-o` does not rescue the collision (§1.4), `-o` is the right
+  choice there.
+- **Missing from V7:** re-running the four §2.2 reproductions is right, but add the *positive* control
+  from E2 above (SE, same basename, two directories, no `-o` → exit 0, two outputs, correct attribution).
+  That is the one existing behaviour this change is most likely to break by over-rejecting, and it is not
+  covered by any CI step.
+- **No test covers the A6 rejection.** §9 lists no case for "same file listed twice", even though it is
+  the plan's only intentional behaviour change. Add one (and if A6 moves to `Cli::validate` per §1.5, it
+  belongs in `cli.rs`'s `mod tests` with the other validation cases).
+
+---
+
+## 5. Efficiency
+
+Nothing to dispute. O(n) over a command line's worth of paths, one `String` + one `PathBuf` clone each, no
+syscalls; `planned_hardtrim_outputs` allocates one short-lived `Vec`. The observation that the check
+precedes the 1 M-record adapter scan is correct and is the only performance statement that matters — a
+colliding invocation now fails in microseconds instead of after a full auto-detection pass.
+
+Two micro-notes, neither worth acting on: the map could be a `HashSet<String>` if the error only named the
+duplicate (it names both, so the `PathBuf` value is needed); and if the §1.1 input-alias check is added,
+build the input `HashSet` once and share it across all four insertion points rather than per block.
+
+---
+
+## 6. Alternatives
+
+1. **One candidate-list builder in `main()` instead of four insertion points.** Compute the full
+   prospective-output list immediately after `ensure_output_dir`, dispatching on mode in one `match`, and
+   check once. Cost: a chunky `match` in an already-long `main()`. Benefit: a *fifth* dispatch path cannot
+   be added without the compiler forcing a decision about its outputs — which is exactly how #383 and the
+   three sibling holes came to exist (each new mode grew its own loop, and three of eight remembered the
+   check). Given that the plan is fixing the fourth instance of one omission, the structural fix deserves
+   at least a paragraph in §10 rather than silence. I would still ship the plan's version now — four
+   local checks are reviewable and match the existing idiom — but note the direction.
+
+2. **A writer-level backstop.** A process-global registry of paths already opened for writing, consulted
+   in `FastqWriter::create` / `BamWriter::create`, would have caught #383, the hardtrim CWD case, the
+   FastQC `--outdir` case in §3, *and* the input-alias case in §1.1, at one choke point that no future
+   mode can bypass. Its weakness is fatal for the primary role: it fires after the first file has been
+   written, so it cannot deliver the "nothing written" contract the CI guards assert. Correct framing is
+   complement, not replacement: keep the fail-fast pre-flight as the user-facing contract, and consider
+   the registry later as a defence-in-depth assertion. Explicitly *not* a reason to change this plan.
+
+3. **De-duplicating rather than rejecting for A6.** The plan's rejection of this (canonicalisation cost,
+   symlink/bind-mount ambiguity) is well argued and I agree. Worth recording that a `HashSet` fold over
+   byte-equal paths — no `canonicalize`, so no syscall — would silently accept `x.fq.gz x.fq.gz` while
+   still rejecting `x.fq.gz ./x.fq.gz`, i.e. an inconsistency that is worse than either clean choice.
+   That strengthens the plan's position; it is the reason not to take the "three-line change" escape hatch
+   offered at the end of A6.
+
+---
+
+## 7. Action items
+
+### Critical
+
+1. **The plan does not close #383's failure class: an output path can alias an *input* of the same
+   invocation.** Verified: `trim_galore s.fastq.gz s_trimmed.fq.gz` (reachable via `trim_galore *.gz`
+   after a previous run) exits 0, loses 100 % of the second input's reads, and writes a
+   `s_trimmed_trimmed.fq.gz` populated with the *first* input's reads. The planned pre-flight accepts it,
+   because the two output paths differ. §10 Out of scope 2 is written about a `--force`/no-clobber policy
+   and will not be read as covering this. Either intersect the planned outputs with `naming::norm_path`
+   over `cli.input` and bail with a distinct message (~6 lines, same helper, applies to `--paired` too), or
+   split Out of scope 2 into two entries and name this case explicitly with its own issue number. (§1.1)
+
+### Important
+
+2. **Assumption A2 is false for `--fastqc_args -o/--outdir`.** Verified: two inputs with distinct primary
+   outputs produce a single `same_trimmed_fastqc.{zip,html}` in the overridden directory; the first is
+   overwritten. Narrow A2 to secondaries that share the primary's `output_dir`-else-parent directory rule,
+   record the FastQC override as an accepted exception (a QC artifact, not reads; pre-existing on all
+   paths including `--paired`), and add the corresponding §10 entry. Do **not** widen the candidate list.
+   (§3)
+
+3. **V6 as specified cannot fail.** Its premise (`report_name(a) == report_name(b)` with `a != b`) forces
+   the conclusion by construction. Replace with the contrapositive over a path table — primaries differ ⇒
+   report, JSON, demux base and default-configuration `_fastqc.zip` names all differ — across
+   `--basename` / `--dont_gzip` / `-o`, with the `--fastqc_args --outdir` exception noted in a comment.
+   (§3)
+
+4. **The adopted error message's remediation advice is wrong on the hardtrim path.** Verified: with
+   `--hardtrim5 20 -o out dirA/same.fastq.gz dirB/same.fastq.gz` the collision persists inside `-o`, so
+   both suggestions ("different source directories", "`--output_dir`") lead back to the same error. Give
+   the hardtrim insertion a mode-specific hint. Also extend §7 (Downstream) to `docs/` — the hardtrim page
+   and the carried v0.6.x changelog text both advertise "one or more files", so
+   `--hardtrim5 N */*.fastq.gz` is a documented pattern that becomes a hard failure. (§1.4)
+
+5. **Move A6's duplicate-input rejection to `Cli::validate`** beside the duplicate-pair check
+   (`cli.rs:534-558`), with its own message. As planned, a duplicated positional produces
+   "`x_trimmed.fq.gz` and `x_trimmed.fq.gz` would be written to the same file" plus inapplicable advice —
+   and `cli.rs:504-516`'s own doc-comment states that duplicate inputs should get a precise error
+   "rather than the case-insensitive output-collision pre-flight's APFS/NTFS message". Validating there
+   also puts it ahead of `ensure_output_dir` (no empty-dir residue) and covers every mode at once. Add a
+   test — §9 currently has none for the plan's only intentional behaviour change. (§1.5)
+
+6. **Close the §9 pairing gaps.** `--hardtrim3` has zero output-producing coverage in the repo today
+   (`integration_adapter2.rs:377-382` only checks a rejection message), and `--hardtrim3 --output-format
+   ubam` gets neither a rejection nor an acceptance test. Because the `"5prime"`/`"3prime"` literal is now
+   duplicated between the collision candidate and the writer, a Step 6 copy-paste slip would pass every
+   proposed rejection test undetected. Add filename-asserting acceptance cases for hardtrim3 FASTQ,
+   hardtrim3 uBAM (plus its rejection), and multi-input SE uBAM — or eliminate the duplicated literal.
+   (§1.3, §4.1)
+
+### Optional
+
+7. §2.4: four hand-rolled copies, not five (`:482` and `:486` are the same block). Out of scope 3's
+   framing should also note that consolidating them fixes a real user-facing bug: two of them advise
+   `--output-dir`, which `cli.rs:152` does not define — the flag does not parse.
+8. §3.1 point 1: "before any reader is opened" is not literally true; `sanity_check_any` (`main.rs:153`)
+   and `detect_input_format` over all inputs (`:159`) precede dispatch. Use §7's phrasing, and note in
+   §3.3 that sanity/format errors take precedence over collision errors.
+9. Step 7 / §4.3 will not compile: `main.rs` does not import `PathBuf` (only `Path`, `main.rs:5`). Spell
+   it `std::path::PathBuf` as the existing helper does.
+10. Step 10: for any test that sets `Command::current_dir`, the fixture path must be absolutised —
+    otherwise the run fails with "Input file not found" and the `!ok` half of the assertion passes for the
+    wrong reason.
+11. V2: assert the output directory is empty rather than only that the primary is absent — that pins the
+    absence of the two misleading reports, which is #383's most confusing artifact.
+12. V7: add the E2 positive control (SE, same basename in two directories, no `-o` → exit 0, two outputs,
+    correct read attribution). It is the behaviour most at risk from an over-broad candidate list and no
+    CI step covers it.
+13. §3.4 anchors: the `test -z "$(ls -A …)"` assertions are at `ci.yml:615`/`:640`; `:604`/`:628` are the
+    invocation lines.
+14. Consider recording alternative 1 (single candidate-list builder in `main()`) in §10 as the structural
+    direction, given that this plan is fixing the fourth instance of the same omission.
+
+---
+
+## 8. What the plan gets notably right
+
+Worth saying, because these are the parts a reviewer would otherwise re-derive: the hole map is complete
+(I enumerated all ten `cli.input` loops independently and found no fifth gap); the two naming asymmetries
+in §2.3 are real and correctly characterised; the SE candidate expressions are character-identical to what
+the writers use, which removes the largest class of pre-flight bug; V3's insistence on read attribution
+over file existence is exactly the right lesson from #383; and the decision to move the helper into
+`io.rs` is correct for the stated reason — the case-fold assertion is unreachable from any portable
+integration test, since two case-variant paths cannot coexist on APFS.

--- a/plans/08062026_se-output-collision-preflight/PROGRESS.md
+++ b/plans/08062026_se-output-collision-preflight/PROGRESS.md
@@ -1,0 +1,77 @@
+# Progress: Output-collision pre-flight for the four uncovered dispatch paths (#383)
+
+**Last updated:** 2026-08-07
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | `PLAN.md` v2; §13 carries deviations D1–D12 |
+| Plan Review | ✅ Complete | Two independent Criticals, both reproduced before adoption |
+| Impl Plan | ❌ Excluded | No separate `IMPL.md`; `PLAN.md` §5 is the 13-step outline |
+| Implementation | ✅ Complete | 530 tests, fmt + clippy clean, no new doc warnings |
+| Code Review | ✅ Complete | 4 passes, 3 reports. 0 Critical, 1 unanimous High — **applied** |
+| Coverage | ✅ Complete (see caveat) | 3 audits, all COMPLETE. `COVERAGE.md` authoritative |
+
+## What shipped
+
+Four dispatch paths gained the #216 output-collision pre-flight — SE trim (FASTQ + uBAM) and
+`--hardtrim5/3` (FASTQ + uBAM) — and all collision checks now route through one helper,
+`io::preflight_output_collisions`, at 11 call sites. Four defects in the check itself were fixed
+along the way, three of them found by review rather than by the plan:
+
+1. the key was a raw path string, so `./x` and `x` named one file under two keys (defect 1);
+2. outputs were never compared against the run's own inputs (defect 2);
+3. `..` still defeated the key, so #383 reproduced verbatim through its own fix (D7);
+4. only *primary* outputs were compared against inputs, so a report or a `--demux` per-barcode
+   file could still overwrite a named input while every primary stayed distinct (D9 — the
+   unanimous review finding).
+
+`collision_key` is now the crate's single definition of "the same file", used by the pre-flight
+and by all four `cli.rs` identity checks (D8).
+
+## Coverage-audit index
+
+| File | Items | Verdict |
+|---|---|---|
+| `COVERAGE.md` — **authoritative** | 65 | COMPLETE (1 DEVIATED, documented) |
+| `COVERAGE_round2.md` | 25 | COMPLETE |
+| `COVERAGE_round3.md` | 67 | COMPLETE (4 DEVIATED, documented or covered) |
+| `COVERAGE_round1.md` | — | INCOMPLETE, 2 items — both closed same day |
+
+**Caveat:** all three COMPLETE audits ran against the tree *before* the post-code-review round
+(they report 521 tests; the tree now has 530). That round is documented as D7–D12 in `PLAN.md`
+§13 with its own gates and reproductions, but **no independent coverage audit has run against the
+final state.** The one deviation `COVERAGE_round3.md` raised — hardtrim's `-o` test shape — is
+exactly what D12's new no-`-o` test closes.
+
+## Code-review index
+
+| File | Author | Independence |
+|---|---|---|
+| `CODE_REVIEW_A.md` | Reviewer A | independent; its H3 pre-dates the round-1 gap fixes |
+| `CODE_REVIEW_B.md` | blind Reviewer B, plus Appendix B from a second B pass | blind — read the plan only |
+| `CODE_REVIEW_A_supplementary.md` | warm agent (audited the plan first) | anchored — discount agreement with the plan |
+
+A fourth pass — the one that found `..` and the `--clock`/`--implicon` hint gap — was overwritten
+before it could be snapshotted, because several failed agents resumed hours later and rewrote the
+report paths they had been given. Its findings survive in `PLAN.md` §13 (D7, D10) and two were
+reproduced against the binary before adoption; its report file is lost.
+
+## Outstanding
+
+- Symlink aliasing — the sole remaining residual of A8, disclosed in the CHANGELOG with its cost.
+- `--fastqc_args "-o DIR"` — A2's named exception; costs a regenerable QC artifact, not reads.
+- `PLAN.md` §11 Open 3 (`--hardtrim5 N --hardtrim3 M` silently ignores the 3′ trim) and Open 4
+  (a `modes/hardtrim.md` sentence about CWD output) — both want their own issue.
+- A coverage audit against the final tree.
+
+## History
+
+- 2026-08-07: Post-review round applied (D7–D12: `..` folded, one identity definition, secondary
+  outputs guarded, CWD hint generalised, V5 fixture made falsifiable); 530 tests
+- 2026-08-07: Coverage → ✅ COMPLETE ×3; Code Review → ✅ Complete (4 passes, 0 Critical)
+- 2026-08-07: Round-1 coverage gaps closed; D6 recorded
+- 2026-08-06: Implementation → ✅ Complete (13 steps; D1–D5, 4 negative controls)
+- 2026-08-06: Plan → v2; Plan Review → ✅ Complete (two independent Criticals)
+- 2026-08-06: Plan → ✅ Complete

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -532,7 +532,9 @@ impl Cli {
             );
         }
         for chunk in self.input.chunks(2) {
-            if chunk[0] == chunk[1] {
+            // #383 — keyed like the output-collision pre-flight, so `./r1.fq r1.fq`
+            // cannot pass as a pair. Raw `==` let two spellings of one file through.
+            if crate::io::collision_key(&chunk[0]) == crate::io::collision_key(&chunk[1]) {
                 anyhow::bail!(
                     "Read 1 and Read 2 appear to be the same file: {}. \
                      Did you mean to pass distinct R1 and R2 files?",
@@ -544,7 +546,9 @@ impl Cli {
             self.input.chunks(2).map(|c| (&c[0], &c[1])).collect();
         for (i, (r1, r2)) in pairs.iter().enumerate() {
             for (j, (pr1, pr2)) in pairs.iter().enumerate().take(i) {
-                if r1 == pr1 && r2 == pr2 {
+                if crate::io::collision_key(r1) == crate::io::collision_key(pr1)
+                    && crate::io::collision_key(r2) == crate::io::collision_key(pr2)
+                {
                     anyhow::bail!(
                         "Pair {} ({}, {}) is a duplicate of pair {}. \
                          Did you mean to pass different files?",
@@ -621,6 +625,28 @@ impl Cli {
             anyhow::bail!(
                 "--basename cannot be used with multiple input files (ambiguous output naming)"
             );
+        }
+        // #383 — caught here, not in the output-collision pre-flight, so the message can
+        // be precise (see validate_paired_input's rationale for the paired equivalent).
+        // `--clock`/`--implicon` are paired but never set `paired`, and own a more
+        // specific R1==R2 message, so they are excluded rather than pre-empted.
+        if !self.paired && !self.clock && self.implicon.is_none() {
+            for (i, path) in self.input.iter().enumerate() {
+                let key = crate::io::collision_key(path);
+                if let Some(j) = self.input[..i]
+                    .iter()
+                    .position(|other| crate::io::collision_key(other) == key)
+                {
+                    anyhow::bail!(
+                        "Input file {} was given more than once (arguments {} and {}). \
+                         List each input once — trimming it twice would write the same \
+                         output file twice.",
+                        path.display(),
+                        j + 1,
+                        i + 1
+                    );
+                }
+            }
         }
         if self.paired && self.input.len() > 2 && self.basename.is_some() {
             anyhow::bail!(
@@ -858,7 +884,7 @@ impl Cli {
 
         // --passthrough: 9-item compatibility envelope. Layout mirrors --clumpify
         // above. Each rejection has a precise user-facing message; case-folded
-        // collision check (1.ix) uses crate::io::norm_path to share the same
+        // collision check (1.ix) uses crate::io::collision_key to share the same
         // APFS/NTFS-aware normalisation as the output-collision pre-flight in
         // main.rs (issue #216 protection).
         if let Some(ref pt) = self.passthrough {
@@ -910,9 +936,9 @@ impl Cli {
             // where --passthrough silently dual-consumes one input on a case-insensitive
             // filesystem.
             if self.input.len() == 2 {
-                let pt_norm = crate::io::norm_path(pt);
-                if pt_norm == crate::io::norm_path(&self.input[0])
-                    || pt_norm == crate::io::norm_path(&self.input[1])
+                let pt_norm = crate::io::collision_key(pt);
+                if pt_norm == crate::io::collision_key(&self.input[0])
+                    || pt_norm == crate::io::collision_key(&self.input[1])
                 {
                     anyhow::bail!(
                         "--passthrough cannot point at R1 or R2 (case-insensitive match \
@@ -1178,6 +1204,41 @@ mod tests {
         // Regression guard: the 2-file golden path must keep working.
         let cli = Cli::parse_from(["trim_galore", "--paired", R1, R2]);
         cli.validate().expect("two-file paired-end should validate");
+    }
+
+    /// #383. A duplicated positional would write one output twice. Rejected in
+    /// `validate()` so the message is precise, not the APFS/NTFS collision text.
+    #[test]
+    fn test_validate_single_end_duplicate_input_rejected() {
+        let cli = Cli::parse_from(["trim_galore", R1, R1]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("was given more than once"),
+            "expected duplicate-input rejection, got: {err}"
+        );
+        assert!(
+            !err.contains("APFS/NTFS"),
+            "must not defer to the collision pre-flight's message: {err}"
+        );
+    }
+
+    /// The same guard covers the specialty modes, which never consult `--paired`.
+    #[test]
+    fn test_validate_hardtrim_duplicate_input_rejected() {
+        let cli = Cli::parse_from(["trim_galore", "--hardtrim5", "20", R1, R1]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("was given more than once"),
+            "expected duplicate-input rejection under --hardtrim5, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_single_end_distinct_inputs_accepted() {
+        // Negative control for the two tests above: distinct SE inputs still validate.
+        let cli = Cli::parse_from(["trim_galore", R1, ALT_R1]);
+        cli.validate()
+            .expect("distinct single-end inputs should validate");
     }
 
     // ── Multi-pair widening for --clock and --implicon ──

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -534,7 +534,7 @@ impl Cli {
         for chunk in self.input.chunks(2) {
             // #383 — keyed like the output-collision pre-flight, so `./r1.fq r1.fq`
             // cannot pass as a pair. Raw `==` let two spellings of one file through.
-            if crate::io::collision_key(&chunk[0]) == crate::io::collision_key(&chunk[1]) {
+            if crate::io::path_identity_key(&chunk[0]) == crate::io::path_identity_key(&chunk[1]) {
                 anyhow::bail!(
                     "Read 1 and Read 2 appear to be the same file: {}. \
                      Did you mean to pass distinct R1 and R2 files?",
@@ -546,8 +546,8 @@ impl Cli {
             self.input.chunks(2).map(|c| (&c[0], &c[1])).collect();
         for (i, (r1, r2)) in pairs.iter().enumerate() {
             for (j, (pr1, pr2)) in pairs.iter().enumerate().take(i) {
-                if crate::io::collision_key(r1) == crate::io::collision_key(pr1)
-                    && crate::io::collision_key(r2) == crate::io::collision_key(pr2)
+                if crate::io::path_identity_key(r1) == crate::io::path_identity_key(pr1)
+                    && crate::io::path_identity_key(r2) == crate::io::path_identity_key(pr2)
                 {
                     anyhow::bail!(
                         "Pair {} ({}, {}) is a duplicate of pair {}. \
@@ -632,10 +632,10 @@ impl Cli {
         // specific R1==R2 message, so they are excluded rather than pre-empted.
         if !self.paired && !self.clock && self.implicon.is_none() {
             for (i, path) in self.input.iter().enumerate() {
-                let key = crate::io::collision_key(path);
+                let key = crate::io::path_identity_key(path);
                 if let Some(j) = self.input[..i]
                     .iter()
-                    .position(|other| crate::io::collision_key(other) == key)
+                    .position(|other| crate::io::path_identity_key(other) == key)
                 {
                     anyhow::bail!(
                         "Input file {} was given more than once (arguments {} and {}). \

--- a/src/demux.rs
+++ b/src/demux.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::fastq::{FastqReader, FastqWriter};
 
@@ -103,6 +103,60 @@ pub fn read_barcode_file(path: &Path) -> Result<Vec<BarcodeEntry>> {
     Ok(entries)
 }
 
+/// Per-barcode output stem, derived from the trimmed file's own name
+/// (`sample_trimmed.fq.gz` → `sample_trimmed`).
+///
+/// Extracted so the #383 collision-key assumption (A2: distinct primary output
+/// paths imply distinct secondary paths) can be asserted against this code
+/// rather than a copy of it.
+pub fn demux_base_name(trimmed_file: &Path) -> String {
+    let mut base = trimmed_file
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    if base.ends_with(".gz") {
+        base = base[..base.len() - 3].to_string();
+    }
+    if base.ends_with(".fq") {
+        base = base[..base.len() - 3].to_string();
+    }
+    base
+}
+
+/// Directory the per-barcode outputs land in: `--output_dir` else the trimmed
+/// file's own parent. Shared with [`demux_output_paths`] so the pre-flight and
+/// the writer cannot disagree.
+fn demux_output_dir(trimmed_file: &Path, output_dir: Option<&Path>) -> PathBuf {
+    output_dir.map(|d| d.to_path_buf()).unwrap_or_else(|| {
+        trimmed_file
+            .parent()
+            .unwrap_or(Path::new("."))
+            .to_path_buf()
+    })
+}
+
+/// Every path [`demultiplex`] will write, for the #383 output-collision pre-flight.
+///
+/// Built from the same `demux_output_dir` / `output_filename` helpers the writer
+/// uses, so the two cannot drift; `demux_writes_exactly_the_planned_paths` pins it.
+pub fn demux_output_paths(
+    trimmed_file: &Path,
+    barcodes: &[BarcodeEntry],
+    gzip: bool,
+    output_dir: Option<&Path>,
+) -> Vec<PathBuf> {
+    let base = demux_base_name(trimmed_file);
+    let dir = demux_output_dir(trimmed_file, output_dir);
+    let mut paths: Vec<PathBuf> = barcodes
+        .iter()
+        .map(|e| dir.join(output_filename(&base, &e.sample_name, gzip)))
+        .collect();
+    paths.push(dir.join(output_filename(&base, "NoCode", gzip)));
+    paths.push(dir.join(format!("{}_demultiplexing_summary.txt", base)));
+    paths
+}
+
 /// Demultiplex a trimmed FASTQ file based on 3' inline barcodes.
 ///
 /// For each read:
@@ -124,27 +178,14 @@ pub fn demultiplex(
     let barcode_length = barcodes[0].barcode.len();
     eprintln!("Setting barcode length to {}", barcode_length);
 
-    // Derive base name for output files:
-    // trimmed file is e.g. "sample_trimmed.fq.gz" → strip .gz then .fq
     let trimmed_name = trimmed_file
         .file_name()
         .unwrap_or_default()
         .to_string_lossy()
         .to_string();
-    let mut base_name = trimmed_name.clone();
-    if base_name.ends_with(".gz") {
-        base_name = base_name[..base_name.len() - 3].to_string();
-    }
-    if base_name.ends_with(".fq") {
-        base_name = base_name[..base_name.len() - 3].to_string();
-    }
+    let base_name = demux_base_name(trimmed_file);
 
-    let dir = output_dir.map(|d| d.to_path_buf()).unwrap_or_else(|| {
-        trimmed_file
-            .parent()
-            .unwrap_or(Path::new("."))
-            .to_path_buf()
-    });
+    let dir = demux_output_dir(trimmed_file, output_dir);
 
     // Open per-sample output writers + NoCode
     let mut writers: HashMap<String, FastqWriter> = HashMap::new();

--- a/src/io.rs
+++ b/src/io.rs
@@ -7,7 +7,7 @@
 //! - Reports: *_trimming_report.txt
 
 use anyhow::{Context, Result};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 /// True iff `path` ends with a `.gz` extension.
 ///
@@ -34,15 +34,83 @@ pub fn is_gzipped(path: &Path) -> bool {
 /// on case-insensitive filesystems (APFS/NTFS). Used by:
 ///   * `Cli::validate()` to catch `--passthrough` aliasing R1 or R2 (e.g.
 ///     `--passthrough r1.fq.gz` while R1 is `R1.fq.gz`).
-///   * `main::run` paired-end output-collision pre-flight, which hashes
-///     prospective output paths so case-only aliases fail loudly rather
-///     than silently overwriting (issue #216).
+///   * `collision_key`, which absolutises first and is what every
+///     output-collision pre-flight in `main.rs` now hashes (issues #216, #383).
 ///
 /// Pragmatic trade-off: on opt-in case-sensitive APFS volumes this may
 /// false-positive, but the penalty is a loud early error rather than
 /// silent data loss.
 pub fn norm_path(p: &Path) -> String {
     p.to_string_lossy().to_ascii_lowercase()
+}
+
+/// Case-folded, lexically-normalised collision key (issues #216, #383).
+///
+/// Absolutises, then folds `..` against the component stack, so `./x`, `<cwd>/x` and
+/// `a/../x` all collapse to one key. Purely lexical — no filesystem access — so a
+/// symlinked path still aliases undetected (the remaining residual).
+pub fn collision_key(p: &Path) -> String {
+    let abs = std::path::absolute(p).unwrap_or_else(|_| p.to_path_buf());
+    let mut stack: Vec<Component> = Vec::new();
+    for c in abs.components() {
+        match c {
+            // `/..` is `/` on POSIX; `..` above a relative root has to be kept.
+            Component::ParentDir => match stack.last() {
+                Some(Component::Normal(_)) => {
+                    stack.pop();
+                }
+                Some(Component::RootDir) | Some(Component::Prefix(_)) => {}
+                _ => stack.push(c),
+            },
+            Component::CurDir => {}
+            other => stack.push(other),
+        }
+    }
+    norm_path(&stack.iter().collect::<PathBuf>())
+}
+
+/// Remediation offered when nothing mode-specific applies.
+const GENERIC_ADVICE: &str = "Check that inputs produce distinct output paths \
+                              (e.g., different source directories or `--output_dir`).";
+
+/// Reject duplicate output paths, or an output that would overwrite an input, before
+/// any file is opened. Called by every `main.rs` dispatch path that writes more than
+/// one file: SE trim, `--paired` trim, `--hardtrim5/3`, `--clock`/`--implicon` and
+/// `--clump_only` — all four output formats. A new dispatch path needs a call here too.
+pub fn preflight_output_collisions(
+    planned: &[PathBuf],
+    inputs: &[PathBuf],
+    hint: Option<&str>,
+) -> Result<()> {
+    let input_keys: std::collections::HashMap<String, &PathBuf> =
+        inputs.iter().map(|p| (collision_key(p), p)).collect();
+    let mut seen: std::collections::HashMap<String, PathBuf> =
+        std::collections::HashMap::with_capacity(planned.len());
+
+    for p in planned {
+        let key = collision_key(p);
+        if let Some(input) = input_keys.get(&key) {
+            anyhow::bail!(
+                "Output path collision (case-insensitive, for APFS/NTFS safety): \
+                 this run would write output to {}, which is also one of its inputs. \
+                 If that file is an earlier run's output, drop it from the input list; \
+                 otherwise use `--output_dir` to write elsewhere.",
+                input.display()
+            );
+        }
+        if let Some(existing) = seen.insert(key, p.clone()) {
+            // The hint replaces the generic advice; on CWD-naming modes the generic
+            // advice is false, so appending would contradict itself.
+            anyhow::bail!(
+                "Output path collision (case-insensitive, for APFS/NTFS safety): \
+                 {} and {} would be written to the same file. {}",
+                existing.display(),
+                p.display(),
+                hint.unwrap_or(GENERIC_ADVICE)
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Ensure the user-supplied `--output_dir` exists, creating it (and any
@@ -878,5 +946,265 @@ mod tests {
         // Heuristic is extension-based (matches FastqReader's gzip detection),
         // so a misnamed file doesn't trigger.
         assert!(!is_gzipped(Path::new("sample.gz.fastq")));
+    }
+
+    // --- preflight_output_collisions (issues #216, #383) ---
+    //
+    // Lexical throughout, so none of these touch the filesystem.
+
+    fn pb(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    #[test]
+    fn preflight_accepts_distinct_outputs() {
+        let planned = [pb("a_trimmed.fq.gz"), pb("b_trimmed.fq.gz")];
+        let inputs = [pb("a.fastq.gz"), pb("b.fastq.gz")];
+        assert!(preflight_output_collisions(&planned, &inputs, None).is_ok());
+    }
+
+    #[test]
+    fn preflight_accepts_empty_and_single() {
+        assert!(preflight_output_collisions(&[], &[], None).is_ok());
+        assert!(
+            preflight_output_collisions(&[pb("a_trimmed.fq.gz")], &[pb("a.fastq.gz")], None)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn preflight_rejects_identical_outputs() {
+        let planned = [pb("x_trimmed.fq.gz"), pb("x_trimmed.fq.gz")];
+        let err = preflight_output_collisions(&planned, &[], None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("would be written to the same file"),
+            "got: {err}"
+        );
+        assert!(err.contains("x_trimmed.fq.gz"), "must name the path: {err}");
+    }
+
+    /// Issue #216. Unreachable from an integration test: two paths differing only
+    /// in case cannot coexist on APFS.
+    #[test]
+    fn preflight_rejects_case_only_variants() {
+        let planned = [pb("Sample_trimmed.fq.gz"), pb("SAMPLE_trimmed.fq.gz")];
+        let err = preflight_output_collisions(&planned, &[], None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("would be written to the same file"),
+            "got: {err}"
+        );
+    }
+
+    /// REGRESSION (#383). A raw-string key let `./x` and `x` through while naming
+    /// one file, so the reported bug survived its own fix.
+    #[test]
+    fn preflight_rejects_dot_slash_alias() {
+        let planned = [pb("./x_trimmed.fq.gz"), pb("x_trimmed.fq.gz")];
+        let err = preflight_output_collisions(&planned, &[], None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("would be written to the same file"),
+            "got: {err}"
+        );
+    }
+
+    /// REGRESSION (#383). Same defect via a mixed absolute/relative argument list.
+    #[test]
+    fn preflight_rejects_absolute_versus_relative_alias() {
+        let abs = std::env::current_dir().unwrap().join("x_trimmed.fq.gz");
+        let planned = [abs, pb("x_trimmed.fq.gz")];
+        let err = preflight_output_collisions(&planned, &[], None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("would be written to the same file"),
+            "got: {err}"
+        );
+    }
+
+    /// REGRESSION (#383). An output that would overwrite an input gets its own
+    /// message: "same file" is untrue here and its remedies do not apply.
+    #[test]
+    fn preflight_rejects_output_that_aliases_an_input() {
+        let planned = [pb("s_trimmed.fq.gz")];
+        let inputs = [pb("s.fastq.gz"), pb("s_trimmed.fq.gz")];
+        let err = preflight_output_collisions(&planned, &inputs, None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("which is also one of its inputs"),
+            "got: {err}"
+        );
+        assert!(
+            !err.contains("would be written to the same file"),
+            "must not fall back to the duplicate-output wording: {err}"
+        );
+    }
+
+    /// The alias check is keyed the same way, so a `./` spelling still catches it.
+    #[test]
+    fn preflight_rejects_input_alias_across_spellings() {
+        let planned = [pb("./s_trimmed.fq.gz")];
+        let inputs = [pb("s_trimmed.fq.gz")];
+        assert!(preflight_output_collisions(&planned, &inputs, None).is_err());
+    }
+
+    /// REGRESSION (#383). `..` used to defeat the key, so `trim_galore
+    /// ../data/s.fastq /abs/data/s.fq` lost one input's reads at exit 0 — the
+    /// reported bug reproducing through its own fix.
+    #[test]
+    fn preflight_rejects_dotdot_alias() {
+        let planned = [pb("a/../x_trimmed.fq.gz"), pb("x_trimmed.fq.gz")];
+        assert!(preflight_output_collisions(&planned, &[], None).is_err());
+    }
+
+    /// `..` that cannot be folded away must not be silently dropped: two paths
+    /// differing only below a kept `..` stay distinct.
+    #[test]
+    fn preflight_keeps_unfoldable_paths_distinct() {
+        let planned = [pb("../x_trimmed.fq.gz"), pb("../y_trimmed.fq.gz")];
+        assert!(preflight_output_collisions(&planned, &[], None).is_ok());
+    }
+
+    #[test]
+    fn preflight_appends_hint_only_when_given() {
+        let planned = [pb("x_trimmed.fq.gz"), pb("x_trimmed.fq.gz")];
+        let with = preflight_output_collisions(&planned, &[], Some("EXTRA-HINT."))
+            .unwrap_err()
+            .to_string();
+        assert!(with.contains("EXTRA-HINT."), "got: {with}");
+        let without = preflight_output_collisions(&planned, &[], None)
+            .unwrap_err()
+            .to_string();
+        assert!(!without.contains("EXTRA-HINT."), "got: {without}");
+        // ...and the generic advice appears only when no hint was given.
+        assert!(
+            without.contains("different source directories"),
+            "got: {without}"
+        );
+        assert!(
+            !with.contains("different source directories"),
+            "a hint must REPLACE the generic advice, not append to it: {with}"
+        );
+    }
+
+    /// Assumption A2, in the direction that makes the pre-flight sufficient:
+    /// where two inputs' PRIMARY output paths differ, every secondary output
+    /// path must differ too — so a secondary can never collide unless a primary
+    /// already has, and hashing primaries alone is enough.
+    ///
+    /// Checked across the flag matrix (`--basename` / `--dont_gzip` / `-o`, each
+    /// on and off) because `--basename` and `-o` are exactly the flags that
+    /// collapse distinct inputs onto one path.
+    ///
+    /// FastQC's `<stem>_fastqc.zip` is not asserted separately: the bundled
+    /// crate derives it from the primary path we hand it, so there is no second
+    /// key of ours to compare, and writing the formula out here would only test
+    /// the formula. Its one real exception — `--fastqc_args "-o DIR"`, which
+    /// overrides the output directory where the pre-flight cannot see it — is
+    /// recorded in the plan as a known residual, not covered here.
+    #[test]
+    fn distinct_primary_outputs_imply_distinct_secondary_outputs() {
+        // The last two share a basename across directories. Without that pair the
+        // assertion is a tautology: every namer embeds `file_name()`, so distinct
+        // basenames make it true regardless of whether a namer honours the directory.
+        let inputs = [
+            Path::new("d/alpha.fastq.gz"),
+            Path::new("d/beta.fastq.gz"),
+            Path::new("e/gamma.fq.gz"),
+            Path::new("d/same.fastq.gz"),
+            Path::new("e/same.fastq.gz"),
+        ];
+        let out = PathBuf::from("shared_out");
+
+        for basename in [None, Some("fixed")] {
+            for gzip in [true, false] {
+                for output_dir in [None, Some(out.as_path())] {
+                    let primaries: Vec<PathBuf> = inputs
+                        .iter()
+                        .map(|p| single_end_output_name(p, output_dir, basename, gzip))
+                        .collect();
+
+                    for (i, a) in primaries.iter().enumerate() {
+                        for (j, b) in primaries.iter().enumerate().take(i) {
+                            if a == b {
+                                // --basename collapses every input onto one primary; the
+                                // pre-flight rejects that, and cli.rs:620 rejects it earlier
+                                // still for multi-input SE. Nothing to prove here.
+                                continue;
+                            }
+                            // Primaries differ, so every secondary must differ too.
+                            for namer in [report_name, json_report_name, clumping_report_name] {
+                                assert_ne!(
+                                    namer(inputs[i], output_dir),
+                                    namer(inputs[j], output_dir),
+                                    "secondary collided while primaries {a:?} / {b:?} differ \
+                                     (basename={basename:?} gzip={gzip} out={output_dir:?})"
+                                );
+                            }
+                            // The demux stem, via the same function `demultiplex` uses.
+                            // Only meaningful when the two primaries share a directory:
+                            // demux resolves its output dir to `-o` else the primary's
+                            // parent, so differing parents already separate the paths and
+                            // the stem is allowed to repeat.
+                            if a.parent() == b.parent() {
+                                assert_ne!(
+                                    crate::demux::demux_base_name(a),
+                                    crate::demux::demux_base_name(b),
+                                    "demux stems collided in one directory while primaries \
+                                     differ: {a:?} / {b:?}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Complement to the above: the primary key is strictly *coarser* than the
+    /// report key, which is why checking primaries covers reports rather than
+    /// merely coinciding with them. Three spellings of one sample share a
+    /// primary while keeping three distinct report names.
+    #[test]
+    fn primary_output_key_is_coarser_than_secondary_keys() {
+        let variants = [
+            Path::new("d/sample.fastq.gz"),
+            Path::new("d/sample.fq.gz"),
+            Path::new("d/sample.fastq.bgz"),
+        ];
+
+        // All three collapse to one primary output...
+        let primaries: Vec<PathBuf> = variants
+            .iter()
+            .map(|p| single_end_output_name(p, None, None, true))
+            .collect();
+        assert!(
+            primaries.windows(2).all(|w| w[0] == w[1]),
+            "expected one shared primary, got {primaries:?}"
+        );
+
+        // ...while every secondary name stays distinct, so a secondary can never
+        // collide unless the primary already has.
+        for namer in [report_name, json_report_name, clumping_report_name] {
+            let secondaries: Vec<PathBuf> = variants.iter().map(|p| namer(p, None)).collect();
+            for (i, a) in secondaries.iter().enumerate() {
+                for b in &secondaries[..i] {
+                    assert_ne!(a, b, "secondary names must be distinct: {a:?} vs {b:?}");
+                }
+            }
+        }
+
+        // Same property for the uBAM primary.
+        let bam: Vec<PathBuf> = variants
+            .iter()
+            .map(|p| single_end_bam_output_name(p, None, None))
+            .collect();
+        assert!(bam.windows(2).all(|w| w[0] == w[1]), "got {bam:?}");
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -44,12 +44,10 @@ pub fn norm_path(p: &Path) -> String {
     p.to_string_lossy().to_ascii_lowercase()
 }
 
-/// Case-folded, lexically-normalised collision key (issues #216, #383).
-///
-/// Absolutises, then folds `..` against the component stack, so `./x`, `<cwd>/x` and
-/// `a/../x` all collapse to one key. Purely lexical — no filesystem access — so a
-/// symlinked path still aliases undetected (the remaining residual).
-pub fn collision_key(p: &Path) -> String {
+/// Lexically normalised path: absolutised, with `..` folded against the component
+/// stack, so `./x`, `<cwd>/x` and `a/../x` name one path. No filesystem access, so a
+/// symlinked path is not resolved.
+fn lexical_normalise(p: &Path) -> PathBuf {
     let abs = std::path::absolute(p).unwrap_or_else(|_| p.to_path_buf());
     let mut stack: Vec<Component> = Vec::new();
     for c in abs.components() {
@@ -66,7 +64,20 @@ pub fn collision_key(p: &Path) -> String {
             other => stack.push(other),
         }
     }
-    norm_path(&stack.iter().collect::<PathBuf>())
+    stack.iter().collect()
+}
+
+/// Is this the same file? Case-**sensitive**, because on a case-sensitive filesystem
+/// `X` and `x` are two files and calling them one would reject valid input. Used for
+/// input identity in `Cli::validate` (issue #383).
+pub fn path_identity_key(p: &Path) -> String {
+    lexical_normalise(p).to_string_lossy().into_owned()
+}
+
+/// Would these two paths be the same *output* file? Case-**folded**, because outputs
+/// differing only in case alias each other on APFS/NTFS (issues #216, #383).
+pub fn collision_key(p: &Path) -> String {
+    norm_path(&lexical_normalise(p))
 }
 
 /// Remediation offered when nothing mode-specific applies.
@@ -1091,6 +1102,44 @@ mod tests {
             !with.contains("different source directories"),
             "a hint must REPLACE the generic advice, not append to it: {with}"
         );
+    }
+
+    /// The two keys differ in exactly one respect, and that difference is load-bearing.
+    ///
+    /// REGRESSION: re-keying `Cli::validate`'s input-identity checks on the case-folded
+    /// key made the #216 CI guard fail — it feeds four genuinely distinct files
+    /// (`Sample_R1` / `SAMPLE_R1`) on a case-sensitive filesystem and asserts the
+    /// *output* pre-flight refuses them. Case-folding input identity called them
+    /// duplicates instead, which on Linux is false.
+    #[test]
+    fn identity_key_is_case_sensitive_but_collision_key_is_not() {
+        let lower = Path::new("Sample_R1.fastq.gz");
+        let upper = Path::new("SAMPLE_R1.fastq.gz");
+        assert_ne!(
+            path_identity_key(lower),
+            path_identity_key(upper),
+            "two files differing only in case are distinct files"
+        );
+        assert_eq!(
+            collision_key(lower),
+            collision_key(upper),
+            "but their outputs alias each other on APFS/NTFS"
+        );
+    }
+
+    /// Both keys normalise spelling — that is the part #383 needed.
+    #[test]
+    fn both_keys_normalise_spelling() {
+        for a in ["./x.fq", "a/../x.fq"] {
+            assert_eq!(
+                path_identity_key(Path::new(a)),
+                path_identity_key(Path::new("x.fq"))
+            );
+            assert_eq!(
+                collision_key(Path::new(a)),
+                collision_key(Path::new("x.fq"))
+            );
+        }
     }
 
     /// Assumption A2, in the direction that makes the pre-flight sufficient:

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,33 +52,83 @@ type AdapterList = Vec<(String, String)>;
 type SetupResult = Result<(String, AdapterList, AdapterList, trimmer::TrimConfig)>;
 type ResolvedAdapter = Result<(String, AdapterList, AdapterList, Option<(usize, usize)>)>;
 
+/// Replaces the generic advice for the modes that name output into the CWD
+/// (`--hardtrim5/3`, `--clock`, `--implicon`), where "use `--output_dir`" is false.
+const CWD_OUTPUT_HINT: &str = "This mode writes output to the current working directory, \
+                               so inputs sharing a basename collide whatever `--output_dir` \
+                               is set to — run one invocation per input, or give the inputs \
+                               distinct basenames.";
+
+/// Every file a run reads and must therefore never write over: the positionals,
+/// `--passthrough`, and `--demux`'s barcode file.
+fn guarded_inputs(cli: &Cli) -> Vec<std::path::PathBuf> {
+    let mut v = cli.input.clone();
+    if let Some(ref pt) = cli.passthrough {
+        v.push(pt.clone());
+    }
+    if let Some(ref bc) = cli.demux {
+        v.push(bc.clone());
+    }
+    v
+}
+
+/// Secondary outputs an SE FASTQ trim run writes besides the trimmed file: the two
+/// trimming reports, and — when `--demux` is set — every per-barcode file.
+///
+/// Needed because the pre-flight's output-vs-input check is only as complete as the
+/// path list it is given: assumption A2 argues that checking *primary* paths covers
+/// secondary paths for output-vs-**output** collisions, and says nothing about
+/// output-vs-**input**. A secondary output can equal a named input while every
+/// primary stays distinct.
+fn planned_secondary_outputs(
+    cli: &Cli,
+    output_dir: Option<&Path>,
+    gzip: bool,
+) -> Result<Vec<std::path::PathBuf>> {
+    let mut v = Vec::new();
+    for input in &cli.input {
+        if !cli.no_report_file {
+            v.push(naming::report_name(input, output_dir));
+            v.push(naming::json_report_name(input, output_dir));
+        }
+        if let Some(ref barcode_file) = cli.demux {
+            let barcodes = demux::read_barcode_file(barcode_file)?;
+            let trimmed =
+                naming::single_end_output_name(input, output_dir, cli.basename.as_deref(), gzip);
+            v.extend(demux::demux_output_paths(
+                &trimmed, &barcodes, gzip, output_dir,
+            ));
+        }
+    }
+    Ok(v)
+}
+
+/// Prospective hardtrim output paths for every input, per resolved output format.
+fn planned_hardtrim_outputs(
+    cli: &Cli,
+    keep: usize,
+    end: specialty::HardtrimEnd,
+    output_dir: Option<&Path>,
+    gzip: bool,
+) -> Vec<std::path::PathBuf> {
+    cli.input
+        .iter()
+        .map(|input| match cli.output_format {
+            trim_galore::cli::OutputFormat::Fastq => {
+                specialty::hardtrim_output_name(input, keep, end, output_dir, gzip)
+            }
+            trim_galore::cli::OutputFormat::UBam => {
+                specialty::hardtrim_bam_output_name(input, keep, end, output_dir)
+            }
+        })
+        .collect()
+}
+
 /// Resolve `--memory` into a `(n_bins, bin_byte_budget)` layout when
 /// `--clumpify` is set, and emit a one-line startup notice with the
 /// resolved values. Returns `None` if clumpify is off — or if the budget
 /// is below the floor, in which case we print a loud warning and fall back
 /// to plain mode rather than refusing to run.
-/// Case-folded (APFS/NTFS-safe) output-path collision pre-flight for the
-/// v2 uBAM output paths. Hashes each prospective path via `naming::norm_path`;
-/// bails on the first duplicate. Mirrors the SE FASTQ pre-flight pattern from
-/// the FASTQ path — same error message shape.
-fn preflight_collision_bam(paths: &[std::path::PathBuf]) -> Result<()> {
-    let mut seen: std::collections::HashMap<String, std::path::PathBuf> =
-        std::collections::HashMap::new();
-    for p in paths {
-        if let Some(existing) = seen.insert(naming::norm_path(p), p.clone()) {
-            anyhow::bail!(
-                "Output path collision (case-insensitive, for APFS/NTFS safety): \
-                 {} and {} would be written to the same file. \
-                 Check that inputs produce distinct output paths \
-                 (e.g., different source directories or `--output_dir`).",
-                existing.display(),
-                p.display()
-            );
-        }
-    }
-    Ok(())
-}
-
 fn resolve_clump_layout(cli: &Cli) -> Result<Option<clump::ClumpLayout>> {
     if !cli.clumpify {
         return Ok(None);
@@ -342,6 +392,12 @@ fn main() -> Result<()> {
 
     // Specialty modes — bypass normal trimming pipeline entirely
     if let Some(n) = cli.hardtrim5 {
+        // #383 — collide across all inputs before the first write.
+        naming::preflight_output_collisions(
+            &planned_hardtrim_outputs(&cli, n, specialty::HardtrimEnd::Five, output_dir, gzip),
+            &guarded_inputs(&cli),
+            Some(CWD_OUTPUT_HINT),
+        )?;
         for input in &cli.input {
             match cli.output_format {
                 trim_galore::cli::OutputFormat::Fastq => specialty::hardtrim5(
@@ -367,6 +423,12 @@ fn main() -> Result<()> {
         return Ok(());
     }
     if let Some(n) = cli.hardtrim3 {
+        // #383 — collide across all inputs before the first write.
+        naming::preflight_output_collisions(
+            &planned_hardtrim_outputs(&cli, n, specialty::HardtrimEnd::Three, output_dir, gzip),
+            &guarded_inputs(&cli),
+            Some(CWD_OUTPUT_HINT),
+        )?;
         for input in &cli.input {
             match cli.output_format {
                 trim_galore::cli::OutputFormat::Fastq => specialty::hardtrim3(
@@ -395,6 +457,7 @@ fn main() -> Result<()> {
         run_specialty_paired(
             &cli,
             "Clock",
+            Some(CWD_OUTPUT_HINT),
             |r1, r2| {
                 (
                     specialty::clock_output_name(r1, "R1", output_dir, gzip),
@@ -409,6 +472,7 @@ fn main() -> Result<()> {
         run_specialty_paired(
             &cli,
             "IMPLICON",
+            Some(CWD_OUTPUT_HINT),
             |r1, r2| {
                 (
                     specialty::implicon_output_name(r1, umi_len, "R1", output_dir, gzip),
@@ -457,6 +521,7 @@ fn main() -> Result<()> {
                     run_specialty_paired(
                         &cli,
                         "--clump_only",
+                        None, // clumped_paired_output_names uses input.parent(), not the CWD
                         |r1, r2| {
                             naming::clumped_paired_output_names(r1, r2, output_dir, basename, gzip)
                         },
@@ -478,24 +543,13 @@ fn main() -> Result<()> {
                         },
                     )?;
                 } else {
-                    // SE FASTQ pre-flight (case-folded per issue #216).
-                    let mut out_paths: std::collections::HashMap<String, std::path::PathBuf> =
-                        std::collections::HashMap::new();
-                    for input in &cli.input {
-                        let out = naming::clumped_output_name(input, output_dir, basename, gzip);
-                        if let Some(existing) =
-                            out_paths.insert(naming::norm_path(&out), out.clone())
-                        {
-                            anyhow::bail!(
-                                "Output path collision (case-insensitive, for APFS/NTFS safety): \
-                                 {} and {} would be written to the same file. \
-                                 Check that inputs produce distinct output paths \
-                                 (e.g., different source directories or `--output_dir`).",
-                                existing.display(),
-                                out.display()
-                            );
-                        }
-                    }
+                    // SE FASTQ pre-flight (issues #216, #383).
+                    let planned: Vec<std::path::PathBuf> = cli
+                        .input
+                        .iter()
+                        .map(|input| naming::clumped_output_name(input, output_dir, basename, gzip))
+                        .collect();
+                    naming::preflight_output_collisions(&planned, &guarded_inputs(&cli), None)?;
                     for input in &cli.input {
                         clump_only::clump_only_single(
                             input,
@@ -530,7 +584,11 @@ fn main() -> Result<()> {
                             output_dir,
                             basename,
                         );
-                        preflight_collision_bam(&[planned])?;
+                        naming::preflight_output_collisions(
+                            &[planned],
+                            &guarded_inputs(&cli),
+                            None,
+                        )?;
                         clump_only::clump_only_paired_to_bam_one_pair(
                             &cli.input,
                             output_dir,
@@ -563,7 +621,7 @@ fn main() -> Result<()> {
                                 basename,
                             ));
                         }
-                        preflight_collision_bam(&planned)?;
+                        naming::preflight_output_collisions(&planned, &guarded_inputs(&cli), None)?;
                         // Per-pair iteration. Mirrors the trim FASTQ multi-pair
                         // shape (main.rs:651-669) with pair-progress banner +
                         // per-pair sanity-checks + `.with_context()` error
@@ -611,7 +669,7 @@ fn main() -> Result<()> {
                     for input in &cli.input {
                         planned.push(naming::clumped_bam_output_name(input, output_dir, basename));
                     }
-                    preflight_collision_bam(&planned)?;
+                    naming::preflight_output_collisions(&planned, &guarded_inputs(&cli), None)?;
                     for input in &cli.input {
                         clump_only::clump_only_single_to_bam(
                             input,
@@ -670,16 +728,8 @@ fn main() -> Result<()> {
     }
 
     if cli.paired {
-        // Pre-flight: detect output-path collisions across pairs before any I/O.
-        // Hash key is the full path, case-folded (ASCII lowercase) so that paths
-        // differing only in letter-case — which alias the same file on APFS/NTFS
-        // — collide here rather than silently overwriting on disk (issue #216).
-        // Pragmatic trade-off: on opt-in case-sensitive APFS volumes this may
-        // false-positive, but the penalty is a loud early error rather than
-        // silent data loss.
-        let mut out_paths: std::collections::HashMap<String, std::path::PathBuf> =
-            std::collections::HashMap::new();
-        let norm = |p: &std::path::Path| -> String { p.to_string_lossy().to_ascii_lowercase() };
+        // Pre-flight across pairs before any I/O; see io::collision_key for the key.
+        let mut planned: Vec<std::path::PathBuf> = Vec::new();
         for chunk in cli.input.chunks(2) {
             let (o1, o2) = naming::paired_end_output_names(
                 &chunk[0],
@@ -712,19 +762,9 @@ fn main() -> Result<()> {
                     gzip,
                 ));
             }
-            for p in candidates {
-                if let Some(existing) = out_paths.insert(norm(&p), p.clone()) {
-                    anyhow::bail!(
-                        "Output path collision (case-insensitive, for APFS/NTFS safety): \
-                         {} and {} would be written to the same file. \
-                         Check that input pairs produce distinct output paths \
-                         (e.g., different source directories or `--output-dir`).",
-                        existing.display(),
-                        p.display()
-                    );
-                }
-            }
+            planned.extend(candidates);
         }
+        naming::preflight_output_collisions(&planned, &guarded_inputs(&cli), None)?;
 
         // Adapter detection runs PER PAIR — intentional deviation from Perl
         // v0.6.x (which detected once on $ARGV[0] at trim_galore:2455). Shell-
@@ -781,6 +821,17 @@ fn main() -> Result<()> {
     } else {
         // Single-end: process each input file independently
         // (matches Perl TrimGalore behavior of looping over all positional args)
+        // #383 — SE trim was the only trim path without the #216 pre-flight.
+        let planned: Vec<std::path::PathBuf> = cli
+            .input
+            .iter()
+            .map(|input| {
+                naming::single_end_output_name(input, output_dir, cli.basename.as_deref(), gzip)
+            })
+            .collect();
+        let mut planned = planned;
+        planned.extend(planned_secondary_outputs(&cli, output_dir, gzip)?);
+        naming::preflight_output_collisions(&planned, &guarded_inputs(&cli), None)?;
         for (i, input) in cli.input.iter().enumerate() {
             if i > 0 {
                 eprintln!("\n--------------------------------------------------");
@@ -1797,27 +1848,16 @@ fn run_ubam_output(cli: &Cli, output_dir: Option<&Path>, command_line: &str) -> 
         // two-BAM case from the mixed case (#363). The per-pair loop that used to
         // stand here emitted the two-BAM message for either.
         // Pre-flight: one BAM output per pair; collision on case-folded path.
-        let mut out_paths: std::collections::HashMap<String, std::path::PathBuf> =
-            std::collections::HashMap::new();
-        let norm = |p: &std::path::Path| -> String { p.to_string_lossy().to_ascii_lowercase() };
+        let mut planned: Vec<std::path::PathBuf> = Vec::new();
         for chunk in cli.input.chunks(2) {
-            let out = naming::paired_bam_output_name(
+            planned.push(naming::paired_bam_output_name(
                 &chunk[0],
                 &chunk[1],
                 output_dir,
                 cli.basename.as_deref(),
-            );
-            if let Some(existing) = out_paths.insert(norm(&out), out.clone()) {
-                anyhow::bail!(
-                    "Output path collision (case-insensitive, for APFS/NTFS safety): \
-                     {} and {} would be written to the same file. \
-                     Check that input pairs produce distinct output paths \
-                     (e.g., different source directories or `--output-dir`).",
-                    existing.display(),
-                    out.display()
-                );
-            }
+            ));
         }
+        naming::preflight_output_collisions(&planned, &guarded_inputs(cli), None)?;
 
         let total_pairs = cli.input.len() / 2;
         for (pair_idx, chunk) in cli.input.chunks(2).enumerate() {
@@ -1855,6 +1895,13 @@ fn run_ubam_output(cli: &Cli, output_dir: Option<&Path>, command_line: &str) -> 
     }
 
     // Single-end loop.
+    // #383 — same hole as the FASTQ SE loop.
+    let planned: Vec<std::path::PathBuf> = cli
+        .input
+        .iter()
+        .map(|input| naming::single_end_bam_output_name(input, output_dir, cli.basename.as_deref()))
+        .collect();
+    naming::preflight_output_collisions(&planned, &guarded_inputs(cli), None)?;
     for (i, input) in cli.input.iter().enumerate() {
         if i > 0 {
             eprintln!("\n--------------------------------------------------");
@@ -2400,6 +2447,7 @@ fn pct(part: usize, total: usize) -> f64 {
 fn run_specialty_paired<NameFn, RunFn>(
     cli: &Cli,
     mode_label: &str,
+    hint: Option<&str>,
     mut output_names: NameFn,
     mut run_pair: RunFn,
 ) -> Result<()>
@@ -2407,26 +2455,14 @@ where
     NameFn: FnMut(&Path, &Path) -> (std::path::PathBuf, std::path::PathBuf),
     RunFn: FnMut(&Path, &Path) -> Result<()>,
 {
-    // Pre-flight: detect output-path collisions across pairs (same shape
-    // as the --paired pre-flight at lines 82–125).
-    let mut out_paths: std::collections::HashMap<String, std::path::PathBuf> =
-        std::collections::HashMap::new();
-    let norm = |p: &std::path::Path| -> String { p.to_string_lossy().to_ascii_lowercase() };
+    // Pre-flight across pairs before any I/O; see io::collision_key for the key.
+    let mut planned: Vec<std::path::PathBuf> = Vec::new();
     for chunk in cli.input.chunks(2) {
         let (o1, o2) = output_names(&chunk[0], &chunk[1]);
-        for p in [o1, o2] {
-            if let Some(existing) = out_paths.insert(norm(&p), p.clone()) {
-                anyhow::bail!(
-                    "Output path collision (case-insensitive, for APFS/NTFS safety): \
-                     {} and {} would be written to the same file. \
-                     Check that input pairs produce distinct output paths \
-                     (e.g., different source directories or `--output_dir`).",
-                    existing.display(),
-                    p.display()
-                );
-            }
-        }
+        planned.push(o1);
+        planned.push(o2);
     }
+    naming::preflight_output_collisions(&planned, &guarded_inputs(cli), hint)?;
 
     let total_pairs = cli.input.len() / 2;
     for (pair_idx, chunk) in cli.input.chunks(2).enumerate() {

--- a/src/specialty.rs
+++ b/src/specialty.rs
@@ -11,6 +11,25 @@ use crate::fastq::FastqWriter;
 use crate::format::{InputFormat, detect_input_format};
 use crate::io as naming;
 
+/// Which end `--hardtrim5`/`--hardtrim3` keeps, as it appears in the output filename.
+///
+/// A type rather than a `&str` because the discriminator is written twice per mode
+/// since #383 — once building the collision candidates, once naming the output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HardtrimEnd {
+    Five,
+    Three,
+}
+
+impl HardtrimEnd {
+    fn as_str(self) -> &'static str {
+        match self {
+            HardtrimEnd::Five => "5prime",
+            HardtrimEnd::Three => "3prime",
+        }
+    }
+}
+
 /// Hard-trim every read to keep only the first `keep` bases from the 5' end.
 ///
 /// Output filename: `*.{keep}bp_5prime.fq(.gz)`
@@ -23,7 +42,7 @@ pub fn hardtrim5(
     cores: usize,
     gzip_level: u32,
 ) -> Result<()> {
-    let output_path = hardtrim_output_name(input, keep, "5prime", output_dir, gzip);
+    let output_path = hardtrim_output_name(input, keep, HardtrimEnd::Five, output_dir, gzip);
     eprintln!(
         "Writing hard-trimmed (first {}bp) version of '{}' to '{}'",
         keep,
@@ -66,7 +85,7 @@ pub fn hardtrim3(
     cores: usize,
     gzip_level: u32,
 ) -> Result<()> {
-    let output_path = hardtrim_output_name(input, keep, "3prime", output_dir, gzip);
+    let output_path = hardtrim_output_name(input, keep, HardtrimEnd::Three, output_dir, gzip);
     eprintln!(
         "Writing hard-trimmed (last {}bp) version of '{}' to '{}'",
         keep,
@@ -117,7 +136,7 @@ pub fn hardtrim5_to_bam(
     command_line: &str,
     input_phred_offset: u8,
 ) -> Result<()> {
-    let output_path = hardtrim_bam_output_name(input, keep, "5prime", output_dir);
+    let output_path = hardtrim_bam_output_name(input, keep, HardtrimEnd::Five, output_dir);
     eprintln!(
         "Writing hard-trimmed (first {}bp) version of '{}' to '{}'",
         keep,
@@ -169,7 +188,7 @@ pub fn hardtrim3_to_bam(
     command_line: &str,
     input_phred_offset: u8,
 ) -> Result<()> {
-    let output_path = hardtrim_bam_output_name(input, keep, "3prime", output_dir);
+    let output_path = hardtrim_bam_output_name(input, keep, HardtrimEnd::Three, output_dir);
     eprintln!(
         "Writing hard-trimmed (last {}bp) version of '{}' to '{}'",
         keep,
@@ -420,16 +439,16 @@ pub fn implicon(
 
 // --- Output naming helpers ---
 
-fn hardtrim_output_name(
+pub fn hardtrim_output_name(
     input: &Path,
     keep: usize,
-    end: &str,
+    end: HardtrimEnd,
     output_dir: Option<&Path>,
     gzip: bool,
 ) -> PathBuf {
     let stem = naming::strip_fastq_extensions(input);
     let ext = if gzip { ".fq.gz" } else { ".fq" };
-    let filename = format!("{}.{}bp_{}{}", stem, keep, end, ext);
+    let filename = format!("{}.{}bp_{}{}", stem, keep, end.as_str(), ext);
     match output_dir {
         Some(dir) => dir.join(filename),
         None => PathBuf::from(filename),
@@ -443,14 +462,14 @@ fn hardtrim_output_name(
 /// 5'- and 3'-outputs from the same input. The deliberate departure here
 /// preserves the `5prime` / `3prime` discriminator from the FASTQ scheme
 /// — a v2.1 spec-correction documented inline.
-fn hardtrim_bam_output_name(
+pub fn hardtrim_bam_output_name(
     input: &Path,
     keep: usize,
-    end: &str,
+    end: HardtrimEnd,
     output_dir: Option<&Path>,
 ) -> PathBuf {
     let stem = naming::strip_fastq_extensions(input);
-    let filename = format!("{}.{}bp_{}.bam", stem, keep, end);
+    let filename = format!("{}.{}bp_{}.bam", stem, keep, end.as_str());
     match output_dir {
         Some(dir) => dir.join(filename),
         None => PathBuf::from(filename),
@@ -819,7 +838,13 @@ mod tests {
             PathBuf::from("sample_8bp_UMI_R2.fastq")
         );
         assert_eq!(
-            hardtrim_output_name(Path::new("sample.fastq.bgz"), 50, "5prime", None, false),
+            hardtrim_output_name(
+                Path::new("sample.fastq.bgz"),
+                50,
+                HardtrimEnd::Five,
+                None,
+                false
+            ),
             PathBuf::from("sample.50bp_5prime.fq")
         );
         assert_eq!(

--- a/tests/integration_output_collision.rs
+++ b/tests/integration_output_collision.rs
@@ -1,0 +1,848 @@
+//! Binary-driven tests for the output-collision pre-flight
+//! (issues [#216](https://github.com/FelixKrueger/TrimGalore/issues/216),
+//! [#383](https://github.com/FelixKrueger/TrimGalore/issues/383)).
+//!
+//! Before #383, four dispatch paths looped over `cli.input` with no pre-flight:
+//! single-end trim (FASTQ and uBAM) and `--hardtrim5/3` (FASTQ and uBAM). Two
+//! inputs whose output stems collided produced one output file at exit 0, with
+//! the first input's reads gone and *two* trimming reports each claiming 100 %
+//! written — which is why it went unnoticed.
+//!
+//! Every rejection case here is paired with an acceptance case on the same
+//! dispatch path and output format, and the acceptance cases assert content or
+//! filename rather than mere existence: a pre-flight that rejected everything,
+//! or a candidate list built from the wrong namer, would otherwise pass.
+//!
+//! Fixtures are built in-test as plain FASTQ so read IDs identify their source
+//! file, and so no case needs a fixture path relative to the crate root — the
+//! hardtrim cases set `current_dir`, under which `test_files/…` would not resolve.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_trim_galore"))
+}
+
+/// Canonicalised on purpose: the collision key is lexical (assumption A8), and on
+/// macOS `std::env::temp_dir()` yields `/tmp/…` while the child's `getcwd` yields
+/// `/private/tmp/…`. Without this the absolute-vs-relative case compares two
+/// spellings that differ by a symlink the key cannot see, and passes vacuously.
+fn tempdir(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir().join(format!("tg_coll_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).unwrap();
+    std::fs::canonicalize(&d).unwrap_or(d)
+}
+
+/// 40 reads whose IDs all carry `prefix`, so survivors are attributable.
+fn write_fastq(path: &Path, prefix: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut s = String::new();
+    for i in 0..40 {
+        s.push_str(&format!(
+            "@{prefix}_read{i}\nACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n+\nIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII\n"
+        ));
+    }
+    std::fs::write(path, s).unwrap();
+}
+
+/// Run from `cwd` (matters for the specialty modes, which name output into the
+/// current directory) and return (success, stderr).
+fn run_in(cwd: &Path, args: &[&str]) -> (bool, String) {
+    let out = Command::new(binary())
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .expect("failed to run trim_galore");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn count_reads_from(path: &Path, prefix: &str) -> usize {
+    let body =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+    body.lines()
+        .filter(|l| l.starts_with(&format!("@{prefix}_")))
+        .count()
+}
+
+/// After a rejected run, `dir` must contain exactly `expected` — nothing written.
+/// Used where output would land beside the inputs (no `--output_dir`), so the
+/// "directory is empty" form does not apply.
+fn assert_dir_holds_only(dir: &Path, expected: &[&str]) {
+    let mut found: Vec<String> = std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    found.sort();
+    let mut want: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+    want.sort();
+    assert_eq!(found, want, "a rejected run must write nothing");
+}
+
+const DUP_MSG: &str = "would be written to the same file";
+const ALIAS_MSG: &str = "which is also one of its inputs";
+const PREFIX: &str = "Output path collision (case-insensitive, for APFS/NTFS safety)";
+
+/// A rejected run must write nothing at all — not just no primary output. Two
+/// reports beside one data file was #383's most misleading artifact.
+fn assert_rejected_cleanly(dir: &Path, ok: bool, stderr: &str, expect: &str) {
+    assert!(
+        !ok,
+        "expected a non-zero exit, got success. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(PREFIX),
+        "missing collision prefix:\n{stderr}"
+    );
+    assert!(stderr.contains(expect), "expected {expect:?} in:\n{stderr}");
+    // `.expect`, not `unwrap_or_default`: a read_dir failure would otherwise yield an
+    // empty list and pass the assertion vacuously.
+    let leftovers: Vec<String> = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()))
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "a rejected run must write nothing, found {leftovers:?}"
+    );
+}
+
+// ── single-end trim, FASTQ ────────────────────────────────────────────────
+
+/// The reported bug: one stem, two FASTQ extensions.
+#[test]
+fn se_trim_rejects_shared_stem() {
+    let dir = tempdir("se_stem");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("sample.fastq"), "ALPHA");
+    write_fastq(&dir.join("sample.fq"), "BETA");
+    let (ok, stderr) = run_in(
+        &dir,
+        &["-o", out.to_str().unwrap(), "sample.fastq", "sample.fq"],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+}
+
+/// REGRESSION (#383). A `./` prefix on one argument used to defeat the guard,
+/// because the key was a raw string while both paths named one file.
+#[test]
+fn se_trim_rejects_dot_slash_alias() {
+    let dir = tempdir("se_dot");
+    write_fastq(&dir.join("sample.fastq"), "ALPHA");
+    write_fastq(&dir.join("sample.fq"), "BETA");
+    // No `-o`: the output path inherits the input's spelling, which is what makes
+    // the two keys differ textually while naming one file.
+    let (ok, stderr) = run_in(&dir, &["./sample.fastq", "sample.fq"]);
+    assert!(!ok, "expected rejection, got success:\n{stderr}");
+    assert!(
+        stderr.contains(DUP_MSG),
+        "expected duplicate wording:\n{stderr}"
+    );
+    assert_dir_holds_only(&dir, &["sample.fastq", "sample.fq"]);
+}
+
+/// REGRESSION (#383). Same defect through a mixed absolute/relative list, the
+/// shape `find`/`xargs` and pipeline staging produce.
+#[test]
+fn se_trim_rejects_absolute_versus_relative_alias() {
+    let dir = tempdir("se_abs");
+    write_fastq(&dir.join("sample.fastq"), "ALPHA");
+    write_fastq(&dir.join("sample.fq"), "BETA");
+    let abs = dir.join("sample.fastq");
+    // No `-o`, for the same reason as the `./` case above.
+    let (ok, stderr) = run_in(&dir, &[abs.to_str().unwrap(), "sample.fq"]);
+    assert!(!ok, "expected rejection, got success:\n{stderr}");
+    assert!(
+        stderr.contains(DUP_MSG),
+        "expected duplicate wording:\n{stderr}"
+    );
+    assert_dir_holds_only(&dir, &["sample.fastq", "sample.fq"]);
+}
+
+/// The one slip nothing else would catch: passing `None` where `output_dir`
+/// belongs. Without `-o` these two inputs do NOT collide (they land beside their
+/// own inputs); with `-o` they must.
+#[test]
+fn se_trim_rejects_same_basename_across_dirs_with_output_dir() {
+    let dir = tempdir("se_odir");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("dirA/same.fastq"), "DIRA");
+    write_fastq(&dir.join("dirB/same.fastq"), "DIRB");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "-o",
+            out.to_str().unwrap(),
+            "dirA/same.fastq",
+            "dirB/same.fastq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+}
+
+/// REGRESSION (#382 widening). `.bgz` began sharing a stem with `.gz` when the
+/// suffix stripping was fixed, turning a naming inconsistency into data loss.
+#[test]
+fn se_trim_rejects_gz_and_bgz_sharing_a_stem() {
+    let dir = tempdir("se_bgz");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    // Content is irrelevant: the pre-flight runs before any read.
+    write_fastq(&dir.join("wide.fastq.gz"), "GZA");
+    write_fastq(&dir.join("wide.fastq.bgz"), "BGZB");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "-o",
+            out.to_str().unwrap(),
+            "wide.fastq.gz",
+            "wide.fastq.bgz",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+}
+
+/// REGRESSION (#383). A planned output that IS an input: the run would destroy
+/// that input's reads and emit a second file holding the wrong sample.
+#[test]
+fn se_trim_rejects_output_that_aliases_an_input() {
+    let dir = tempdir("se_alias");
+    write_fastq(&dir.join("s.fastq"), "SRC");
+    write_fastq(&dir.join("s_trimmed.fq"), "PRIOR");
+    let (ok, stderr) = run_in(&dir, &["s.fastq", "s_trimmed.fq"]);
+    assert!(!ok, "expected rejection, got success:\n{stderr}");
+    assert!(
+        stderr.contains(ALIAS_MSG),
+        "expected alias wording:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(DUP_MSG),
+        "must not use the duplicate-output wording:\n{stderr}"
+    );
+    // The named input must be untouched.
+    assert_eq!(count_reads_from(&dir.join("s_trimmed.fq"), "PRIOR"), 40);
+    assert_eq!(count_reads_from(&dir.join("s_trimmed.fq"), "SRC"), 0);
+}
+
+/// ACCEPTANCE. Same basename in different directories, no `-o`: outputs land
+/// beside their own inputs and are genuinely distinct. Asserts attribution, not
+/// existence — two files existed while #383 was live.
+#[test]
+fn se_trim_accepts_same_basename_across_dirs() {
+    let dir = tempdir("se_ok_dirs");
+    write_fastq(&dir.join("dirA/same.fastq"), "DIRA");
+    write_fastq(&dir.join("dirB/same.fastq"), "DIRB");
+    let (ok, stderr) = run_in(&dir, &["dirA/same.fastq", "dirB/same.fastq"]);
+    assert!(ok, "expected success, got failure:\n{stderr}");
+    let a = dir.join("dirA/same_trimmed.fq");
+    let b = dir.join("dirB/same_trimmed.fq");
+    assert_eq!(
+        count_reads_from(&a, "DIRA"),
+        40,
+        "dirA must hold its own reads"
+    );
+    assert_eq!(
+        count_reads_from(&a, "DIRB"),
+        0,
+        "dirA must not hold dirB's reads"
+    );
+    assert_eq!(
+        count_reads_from(&b, "DIRB"),
+        40,
+        "dirB must hold its own reads"
+    );
+    assert_eq!(
+        count_reads_from(&b, "DIRA"),
+        0,
+        "dirB must not hold dirA's reads"
+    );
+}
+
+/// ACCEPTANCE. A single input must never trip the check.
+#[test]
+fn se_trim_accepts_single_input() {
+    let dir = tempdir("se_ok_one");
+    write_fastq(&dir.join("only.fastq"), "ONLY");
+    let (ok, stderr) = run_in(&dir, &["only.fastq"]);
+    assert!(ok, "expected success:\n{stderr}");
+    assert_eq!(count_reads_from(&dir.join("only_trimmed.fq"), "ONLY"), 40);
+}
+
+// ── single-end trim, uBAM output ──────────────────────────────────────────
+
+#[test]
+fn se_trim_ubam_rejects_shared_stem() {
+    let dir = tempdir("ubam_stem");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("sample.fastq"), "ALPHA");
+    write_fastq(&dir.join("sample.fq"), "BETA");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--output-format",
+            "ubam",
+            "-o",
+            out.to_str().unwrap(),
+            "sample.fastq",
+            "sample.fq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+}
+
+/// ACCEPTANCE. Catches an over-rejecting candidate list — e.g. one built from
+/// the input paths, or from the FASTQ namer on the BAM arm.
+#[test]
+fn se_trim_ubam_accepts_distinct_stems() {
+    let dir = tempdir("ubam_ok");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("x.fastq"), "XX");
+    write_fastq(&dir.join("y.fastq"), "YY");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--output-format",
+            "ubam",
+            "-o",
+            out.to_str().unwrap(),
+            "x.fastq",
+            "y.fastq",
+        ],
+    );
+    assert!(ok, "expected success:\n{stderr}");
+    assert!(out.join("x_trimmed.bam").is_file(), "missing x_trimmed.bam");
+    assert!(out.join("y_trimmed.bam").is_file(), "missing y_trimmed.bam");
+}
+
+// ── --hardtrim5 / --hardtrim3 ─────────────────────────────────────────────
+//
+// These name output into the CWD, so their collision class is wider than SE
+// trim's: identical basenames collide even from different directories, and
+// `--output_dir` does not rescue it. Hence the mode-specific hint.
+
+#[test]
+fn hardtrim5_rejects_same_basename_across_dirs() {
+    let dir = tempdir("ht5");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("dirA/same.fastq"), "DIRA");
+    write_fastq(&dir.join("dirB/same.fastq"), "DIRB");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--hardtrim5",
+            "20",
+            "-o",
+            out.to_str().unwrap(),
+            "dirA/same.fastq",
+            "dirB/same.fastq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+    assert!(
+        stderr.contains("one invocation per input"),
+        "hardtrim needs its own remediation — the generic advice does not work here:\n{stderr}"
+    );
+}
+
+#[test]
+fn hardtrim3_rejects_same_basename_across_dirs() {
+    let dir = tempdir("ht3");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("dirA/same.fastq"), "DIRA");
+    write_fastq(&dir.join("dirB/same.fastq"), "DIRB");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--hardtrim3",
+            "20",
+            "-o",
+            out.to_str().unwrap(),
+            "dirA/same.fastq",
+            "dirB/same.fastq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+}
+
+#[test]
+fn hardtrim5_ubam_rejects_shared_stem() {
+    let dir = tempdir("ht5_ubam");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("sample.fastq"), "ALPHA");
+    write_fastq(&dir.join("sample.fq"), "BETA");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--hardtrim5",
+            "20",
+            "--output-format",
+            "ubam",
+            "-o",
+            out.to_str().unwrap(),
+            "sample.fastq",
+            "sample.fq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+}
+
+#[test]
+fn hardtrim3_ubam_rejects_shared_stem() {
+    let dir = tempdir("ht3_ubam");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("sample.fastq"), "ALPHA");
+    write_fastq(&dir.join("sample.fq"), "BETA");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--hardtrim3",
+            "20",
+            "--output-format",
+            "ubam",
+            "-o",
+            out.to_str().unwrap(),
+            "sample.fastq",
+            "sample.fq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+}
+
+/// ACCEPTANCE, and the only coverage in the repository that `--hardtrim5`
+/// produces `*.{N}bp_5prime.*` at all. Asserting the filename is what catches a
+/// candidate list built with the wrong end discriminator.
+#[test]
+fn hardtrim5_accepts_distinct_stems_and_names_output() {
+    let dir = tempdir("ht5_ok");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("x.fastq"), "XX");
+    write_fastq(&dir.join("y.fastq"), "YY");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--hardtrim5",
+            "20",
+            "-o",
+            out.to_str().unwrap(),
+            "x.fastq",
+            "y.fastq",
+        ],
+    );
+    assert!(ok, "expected success:\n{stderr}");
+    assert!(
+        out.join("x.20bp_5prime.fq").is_file(),
+        "missing x.20bp_5prime.fq"
+    );
+    assert!(
+        out.join("y.20bp_5prime.fq").is_file(),
+        "missing y.20bp_5prime.fq"
+    );
+}
+
+/// ACCEPTANCE. `--hardtrim3` had no output-producing coverage before #383, and
+/// its guard is a copy of `--hardtrim5`'s — so the `3prime` filename is the
+/// assertion that matters.
+#[test]
+fn hardtrim3_accepts_distinct_stems_and_names_output() {
+    let dir = tempdir("ht3_ok");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("x.fastq"), "XX");
+    write_fastq(&dir.join("y.fastq"), "YY");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--hardtrim3",
+            "20",
+            "-o",
+            out.to_str().unwrap(),
+            "x.fastq",
+            "y.fastq",
+        ],
+    );
+    assert!(ok, "expected success:\n{stderr}");
+    assert!(
+        out.join("x.20bp_3prime.fq").is_file(),
+        "missing x.20bp_3prime.fq"
+    );
+    assert!(
+        out.join("y.20bp_3prime.fq").is_file(),
+        "missing y.20bp_3prime.fq"
+    );
+}
+
+#[test]
+fn hardtrim3_ubam_accepts_distinct_stems_and_names_output() {
+    let dir = tempdir("ht3_ubam_ok");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("x.fastq"), "XX");
+    write_fastq(&dir.join("y.fastq"), "YY");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--hardtrim3",
+            "20",
+            "--output-format",
+            "ubam",
+            "-o",
+            out.to_str().unwrap(),
+            "x.fastq",
+            "y.fastq",
+        ],
+    );
+    assert!(ok, "expected success:\n{stderr}");
+    assert!(
+        out.join("x.20bp_3prime.bam").is_file(),
+        "missing x.20bp_3prime.bam"
+    );
+    assert!(
+        out.join("y.20bp_3prime.bam").is_file(),
+        "missing y.20bp_3prime.bam"
+    );
+}
+
+// ── --paired: gained the input-alias check by sharing the helper ──────────
+
+/// REGRESSION (#383). `--paired` had the #216 duplicate-output pre-flight since
+/// 2.0 but no input-alias check, so a second pair naming the first pair's
+/// prospective outputs destroyed them.
+#[test]
+fn paired_rejects_output_that_aliases_an_input() {
+    let dir = tempdir("pe_alias");
+    write_fastq(&dir.join("a_R1.fq"), "NEW1");
+    write_fastq(&dir.join("a_R2.fq"), "NEW2");
+    write_fastq(&dir.join("a_R1_val_1.fq"), "OLD1");
+    write_fastq(&dir.join("a_R2_val_2.fq"), "OLD2");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--paired",
+            "a_R1.fq",
+            "a_R2.fq",
+            "a_R1_val_1.fq",
+            "a_R2_val_2.fq",
+        ],
+    );
+    assert!(!ok, "expected rejection, got success:\n{stderr}");
+    assert!(
+        stderr.contains(ALIAS_MSG),
+        "expected alias wording:\n{stderr}"
+    );
+    assert_eq!(count_reads_from(&dir.join("a_R1_val_1.fq"), "OLD1"), 40);
+}
+
+/// ACCEPTANCE. Regression guard on the converted `--paired` pre-flight: two
+/// ordinary pairs must still run to completion.
+#[test]
+fn paired_accepts_two_distinct_pairs() {
+    let dir = tempdir("pe_ok");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    for (stem, tag) in [("p", "P"), ("q", "Q")] {
+        write_fastq(&dir.join(format!("{stem}_R1.fq")), &format!("{tag}1"));
+        write_fastq(&dir.join(format!("{stem}_R2.fq")), &format!("{tag}2"));
+    }
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--paired",
+            "-o",
+            out.to_str().unwrap(),
+            "p_R1.fq",
+            "p_R2.fq",
+            "q_R1.fq",
+            "q_R2.fq",
+        ],
+    );
+    assert!(ok, "expected success:\n{stderr}");
+    for f in [
+        "p_R1_val_1.fq",
+        "p_R2_val_2.fq",
+        "q_R1_val_1.fq",
+        "q_R2_val_2.fq",
+    ] {
+        assert!(out.join(f).is_file(), "missing {f}");
+    }
+}
+
+// ── duplicate positional (rejected in Cli::validate, not the pre-flight) ──
+
+#[test]
+fn duplicate_input_gets_a_precise_message() {
+    let dir = tempdir("dup");
+    write_fastq(&dir.join("dup.fastq"), "DUP");
+    let (ok, stderr) = run_in(&dir, &["dup.fastq", "dup.fastq"]);
+    assert!(!ok, "expected rejection, got success:\n{stderr}");
+    assert!(
+        stderr.contains("was given more than once"),
+        "expected the precise duplicate-input message:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("APFS/NTFS"),
+        "must not defer to the collision message:\n{stderr}"
+    );
+    // Rejected in validate(), before ensure_output_dir — nothing written.
+    assert!(!dir.join("dup_trimmed.fq").exists());
+}
+
+// ── the widest hardtrim class: no `--output_dir`, so output lands in the CWD ──
+
+/// The shape `--hardtrim5 30 */*.fastq.gz` takes. Every other hardtrim test passes
+/// `-o`, which is the narrower class; this is the one that loses data today.
+#[test]
+fn hardtrim5_rejects_same_basename_across_dirs_without_output_dir() {
+    let dir = tempdir("ht5_nocwd");
+    write_fastq(&dir.join("dirA/same.fastq"), "DIRA");
+    write_fastq(&dir.join("dirB/same.fastq"), "DIRB");
+    let (ok, stderr) = run_in(
+        &dir,
+        &["--hardtrim5", "20", "dirA/same.fastq", "dirB/same.fastq"],
+    );
+    assert!(!ok, "expected rejection, got success:\n{stderr}");
+    assert!(
+        stderr.contains(DUP_MSG),
+        "expected duplicate wording:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("current working directory"),
+        "the CWD hint must replace the generic advice here:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("different source directories"),
+        "generic advice is false for this mode and must not appear:\n{stderr}"
+    );
+    // Nothing written into the CWD the run was launched from.
+    assert!(!dir.join("same.20bp_5prime.fq").exists());
+}
+
+/// `--clock` names output into the CWD exactly as hardtrim does, so it needs the
+/// same hint — `-o` cannot rescue the collision.
+#[test]
+fn clock_collision_gets_the_cwd_hint_not_the_false_advice() {
+    let dir = tempdir("clock_hint");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    for d in ["dirA", "dirB"] {
+        write_fastq(&dir.join(format!("{d}/same_R1.fq")), "R1");
+        write_fastq(&dir.join(format!("{d}/same_R2.fq")), "R2");
+    }
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clock",
+            "-o",
+            out.to_str().unwrap(),
+            "dirA/same_R1.fq",
+            "dirA/same_R2.fq",
+            "dirB/same_R1.fq",
+            "dirB/same_R2.fq",
+        ],
+    );
+    assert!(!ok, "expected rejection:\n{stderr}");
+    assert!(
+        stderr.contains("current working directory"),
+        "missing hint:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("different source directories"),
+        "the user already supplied -o; that advice is false here:\n{stderr}"
+    );
+}
+
+// ── secondary outputs may not overwrite an input (all three reproduced routes) ──
+
+/// A previous run's trimming report fed back in as an input.
+#[test]
+fn se_trim_rejects_output_that_aliases_a_report_input() {
+    let dir = tempdir("alias_report");
+    write_fastq(&dir.join("sample.fastq"), "SRC");
+    write_fastq(&dir.join("sample.fastq_trimming_report.txt"), "REPORTY");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--dont_gzip",
+            "sample.fastq",
+            "sample.fastq_trimming_report.txt",
+        ],
+    );
+    assert!(!ok, "expected rejection:\n{stderr}");
+    assert!(
+        stderr.contains(ALIAS_MSG),
+        "expected alias wording:\n{stderr}"
+    );
+    assert_eq!(
+        count_reads_from(&dir.join("sample.fastq_trimming_report.txt"), "REPORTY"),
+        40
+    );
+}
+
+/// `--demux`'s barcode file, named like the prospective trim output.
+#[test]
+fn demux_rejects_output_that_aliases_the_barcode_file() {
+    let dir = tempdir("alias_bc");
+    write_fastq(&dir.join("sample.fastq"), "SRC");
+    std::fs::write(
+        dir.join("sample_trimmed.fq"),
+        "sample1\tACGT\nsample2\tTGCA\n",
+    )
+    .unwrap();
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--dont_gzip",
+            "--demux",
+            "sample_trimmed.fq",
+            "sample.fastq",
+        ],
+    );
+    assert!(!ok, "expected rejection:\n{stderr}");
+    assert!(
+        stderr.contains(ALIAS_MSG),
+        "expected alias wording:\n{stderr}"
+    );
+    let bc = std::fs::read_to_string(dir.join("sample_trimmed.fq")).unwrap();
+    assert!(
+        bc.starts_with("sample1\t"),
+        "barcode file was modified: {bc:?}"
+    );
+}
+
+/// A previous demux run's per-barcode output fed back in as an input. This is the
+/// route that needs the *secondary* output paths in the candidate list — every
+/// primary stays distinct here.
+#[test]
+fn demux_rejects_output_that_aliases_a_per_barcode_input() {
+    let dir = tempdir("alias_bcout");
+    write_fastq(&dir.join("sample.fastq"), "SRC");
+    write_fastq(&dir.join("sample_trimmed_sample1.fq"), "PRECIOUS");
+    std::fs::write(dir.join("bc.txt"), "sample1\tACGT\nsample2\tTGCA\n").unwrap();
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--dont_gzip",
+            "--demux",
+            "bc.txt",
+            "sample.fastq",
+            "sample_trimmed_sample1.fq",
+        ],
+    );
+    assert!(!ok, "expected rejection:\n{stderr}");
+    assert!(
+        stderr.contains(ALIAS_MSG),
+        "expected alias wording:\n{stderr}"
+    );
+    assert_eq!(
+        count_reads_from(&dir.join("sample_trimmed_sample1.fq"), "PRECIOUS"),
+        40
+    );
+}
+
+/// REGRESSION (#383). `..` used to defeat the key: the reported bug reproduced
+/// through its own fix whenever one argument carried a `..` component.
+#[test]
+fn se_trim_rejects_dotdot_alias() {
+    let dir = tempdir("dotdot");
+    write_fastq(&dir.join("data/s.fastq"), "ALPHA");
+    write_fastq(&dir.join("data/s.fq"), "BETA");
+    std::fs::create_dir_all(dir.join("work")).unwrap();
+    let abs = dir.join("data/s.fq");
+    let (ok, stderr) = run_in(
+        &dir.join("work"),
+        &["../data/s.fastq", abs.to_str().unwrap()],
+    );
+    assert!(!ok, "expected rejection, got success:\n{stderr}");
+    assert!(
+        stderr.contains(DUP_MSG),
+        "expected duplicate wording:\n{stderr}"
+    );
+    assert!(
+        !dir.join("data/s_trimmed.fq").exists(),
+        "nothing may be written"
+    );
+}
+
+/// `--paired` accepted one file as its own mate when the two spellings differed,
+/// emitting two byte-identical files labelled a validated pair.
+#[test]
+fn paired_rejects_one_file_as_its_own_mate_across_spellings() {
+    let dir = tempdir("selfpair");
+    write_fastq(&dir.join("a_R1.fq"), "PAIR");
+    let (ok, stderr) = run_in(&dir, &["--paired", "./a_R1.fq", "a_R1.fq"]);
+    assert!(!ok, "expected rejection, got success:\n{stderr}");
+    assert!(
+        stderr.contains("appear to be the same file"),
+        "expected the precise R1==R2 message:\n{stderr}"
+    );
+    assert!(!dir.join("a_R1_val_1.fq").exists());
+}
+
+/// Pins `demux::demux_output_paths` against what `demultiplex` actually writes.
+/// The pre-flight guards the planned set, so if the two ever drift the guard would
+/// silently protect paths the run never touches — invisible to every rejection test.
+#[test]
+fn demux_writes_exactly_the_planned_paths() {
+    let dir = tempdir("demux_pin");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("m.fastq"), "SRC");
+    std::fs::write(dir.join("bc.txt"), "sample1\tACGT\nsample2\tTGCA\n").unwrap();
+
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--dont_gzip",
+            "--no_poly_g",
+            "--demux",
+            "bc.txt",
+            "-o",
+            out.to_str().unwrap(),
+            "m.fastq",
+        ],
+    );
+    assert!(ok, "demux run should succeed:\n{stderr}");
+
+    let barcodes = trim_galore::demux::read_barcode_file(&dir.join("bc.txt")).unwrap();
+    let trimmed = out.join("m_trimmed.fq");
+    let mut planned: Vec<String> =
+        trim_galore::demux::demux_output_paths(&trimmed, &barcodes, false, Some(out.as_path()))
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+    planned.sort();
+
+    // Everything demux itself produced: the per-barcode files, NoCode, the summary.
+    let mut actual: Vec<String> = std::fs::read_dir(&out)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|n| n.starts_with("m_trimmed_"))
+        .collect();
+    actual.sort();
+
+    assert_eq!(
+        planned, actual,
+        "demux_output_paths must predict exactly what demultiplex writes"
+    );
+    assert!(
+        !planned.is_empty(),
+        "precondition: the planned set must be non-empty"
+    );
+}


### PR DESCRIPTION
Fixes #383. Two single-end inputs whose output stems collided — `sample.fastq.gz` and `sample.fq.gz`, say — produced one output file and exit 0, with the first input's reads gone and two trimming reports each claiming all its reads were written. The output-collision pre-flight from #216 already refused this under `--paired`, `--clock`, `--implicon` and `--clump_only`; four dispatch paths lacked it, all sharing one shape. Those four now check, and every collision check in the binary routes through a single helper.

`--hardtrim5/3` were the wider case: they name output into the current working directory, so identical basenames collided even from different directories, and `--hardtrim5 30 */*.fastq.gz` over a per-sample layout kept only the last sample. `--output_dir` cannot resolve that, so those modes — and `--clock`/`--implicon`, which name output the same way — now give their own remediation instead of advice that does not work.

Behaviour changes: colliding invocations that previously exited 0 now exit 1 having written nothing, and a file listed twice on one command line is rejected during argument validation. No flags added or removed.

<details>
<summary>Detail on the four defects in the check itself (AI-assisted; bin freely)</summary>

Three of these were found by code review rather than by the plan.

1. **The key was a raw path string**, so `./x` and `x`, or an argument list mixing absolute and relative paths, named one file under two keys and passed.
2. **`..` defeated the key** even after absolutising — so #383 reproduced verbatim through its own fix whenever one argument carried a `..` component, which is what a workflow manager's relative-to-workdir input looks like. The key now folds `ParentDir` against the component stack. Symlink aliasing remains, disclosed in the CHANGELOG with its cost.
3. **Outputs were compared only against other outputs**, never against the run's own inputs. An output path can *be* an input: `trim_galore sample.fastq.gz sample_trimmed.fq.gz`, reachable by re-running over a directory holding an earlier run's output, destroyed the second input's reads and wrote a third file containing the first sample's.
4. **Once that was fixed, only *primary* outputs were compared.** A trimming report, or a `--demux` per-barcode file, could still overwrite a named input while every primary output stayed distinct — because the assumption justifying a primary-only check is about output-vs-output distinctness and says nothing about output-vs-input. Reports and `--demux` outputs now join the checked set, and `--demux`'s barcode file counts as an input.

`io::collision_key` is now the crate's single definition of "the same file". `--paired`'s R1≠R2 check, its duplicate-pair check, the duplicate-input check and the `--passthrough` alias check all previously compared paths more weakly than the pre-flight did, so `trim_galore --paired ./a_R1.fq a_R1.fq` exited 0 and wrote two byte-identical files labelled a validated R1/R2 pair. All four now use the same key.

Also fixes two collision messages that advised `--output-dir`, which is not a valid flag.

**Verification.** 530 tests (28 new integration cases, 12 new unit cases) and three new CI validation steps. Every rejection case is paired with an acceptance case on the same dispatch path, and the acceptance cases assert read attribution or output filename rather than mere existence — a pre-flight that rejected everything would otherwise pass. Negative controls were run for each defect fix: reverting the key to a raw string, emptying the input-key set, making `report_name` directory-blind, and omitting a path from the demux planned set each make the corresponding test fail.

The Perl 0.6.11 byte-identity matrix is untouched: every `trim_galore` invocation in the validation job is single-input or distinct-stemmed. `--demux` was re-verified end-to-end after its naming was refactored.

**Artefacts** in `plans/08062026_se-output-collision-preflight/` — plan, two plan reviews, four code-review passes and three coverage audits (all COMPLETE). Deviations D1–D12 are logged in `PLAN.md` §13, including why the `..` decision was reversed. Known residuals are listed there and in `PROGRESS.md`: symlink aliasing, and `--fastqc_args "-o DIR"` overriding a directory the pre-flight cannot see (costs a regenerable QC artefact, not reads).

</details>
