### PR TITLE
fix(io): match FASTQ extensions case-insensitively (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,35 @@
 - **Two collision messages advised `--output-dir`, which is not a valid flag**
   (only `--output_dir` and `-o` are). Both now name `--output_dir`.
 
+- **FASTQ extensions now match case-insensitively**
+  ([#384](https://github.com/FelixKrueger/TrimGalore/issues/384)).
+  `SAMPLE.FASTQ.GZ` previously kept an inner `.FASTQ` in its output stem while the
+  report used the full filename, so the two disagreed about the sample name. The
+  extension match (`.fastq`/`.fq`, `.gz`/`.bgz`/`.bgzf`) now folds ASCII case;
+  the rest of the name keeps its case. Four visible consequences for
+  uppercase-named input:
+
+  - `SAMPLE.FASTQ.GZ` now produces `SAMPLE_trimmed.fq.gz` where it produced
+    `SAMPLE.FASTQ_trimmed.fq`.
+  - Output for `.GZ`-named input is now **gzip-compressed**, mirroring `.gz`.
+    Perl v0.6.11's compression test was case-sensitive, so this knowingly departs
+    from v0.6.11 for uppercase names — the alternative was output named like the
+    gzipped convention but written plain.
+  - Some multi-input runs that used to succeed are now refused: inputs whose
+    extensions differ in spelling but whose stems now agree (`SAMPLE.FASTQ.GZ`
+    alongside `sample.fq.gz`) collide on the output path and fail loudly before
+    any file is written.
+  - `--clump_only` reports for `.GZ`-named input now label the input `gzip` and
+    include the `Compression ratio:` line; its output stem folds the same way.
+  - The specialty modes (`--hardtrim5/3`, `--clock`, `--implicon`) rename and
+    newly compress the same way — `SAMPLE_R1.FASTQ.GZ` under `--implicon` now
+    yields `SAMPLE_8bp_UMI_R1.fastq.gz`, with the `_R1` de-duplication newly
+    applying because the stem now ends in `_R1` (the same mechanism the `.bgz`
+    fix documented in #381).
+
+  This makes uppercase output internally consistent; it does not change the
+  report filename, which keeps the full input name as before.
+
 - **`--hardtrim5/3`, `--clock` and `--implicon` name output into the current
   working directory**, so on a collision the usual advice — use different source
   directories, or `--output_dir` — is false for them: neither changes the

--- a/plans/08072026_uppercase-fastq-extensions/CODE_REVIEW_A.md
+++ b/plans/08072026_uppercase-fastq-extensions/CODE_REVIEW_A.md
@@ -1,0 +1,174 @@
+# Code Review A — #384 case-insensitive FASTQ extensions
+
+**Target:** `fix/384-uppercase-extensions` off `dev` @ `533582a`, uncommitted.
+`src/io.rs` (+70/−3), `tests/integration_gzip_non_gz_extension.rs` (+111), `CHANGELOG.md` (+24).
+**Plan:** `plans/08072026_uppercase-fastq-extensions/PLAN.md` v2 (§13 implementation notes).
+**Reviewer:** A, fresh context, independent of Reviewer B.
+
+**Nothing was fixed.** The tree is shared with a concurrent reviewer; this file is my only write.
+Every finding below is a recommendation.
+
+**Method.** I did not re-run the suite (already green, proves little). Instead I drove the built
+binary through 15 constructed invocations from
+`/private/tmp/…/scratchpad/crev384a/` and hand-verified every assertion the three new
+integration tests make, plus the cases the plan reasons about but does not test. Findings marked
+*verified* were observed, not inferred.
+
+**Verdict: no Critical, no High.** The change is correct and does what §3.1 says. Two Medium
+(one CHANGELOG completeness, one test-matrix convention) and seven Low.
+
+---
+
+## What holds up
+
+**The helper's boundary argument is airtight — and more general than its comment claims.**
+
+```rust
+fn strip_suffix_ignore_ascii_case<'a>(name: &'a str, suffix: &str) -> Option<&'a str> {
+    let idx = name.len().checked_sub(suffix.len())?;
+    name.as_bytes()[idx..].eq_ignore_ascii_case(suffix.as_bytes()).then(|| &name[..idx])
+}
+```
+
+The comment argues from "a matched all-ASCII tail". The stronger statement also holds: for **any**
+valid `&str` suffix, a byte-wise match forces `idx` to be a char boundary. `suffix`'s first byte is
+either ASCII or a UTF-8 *leading* byte; a non-boundary position in a valid `&str` is a
+*continuation* byte (0x80–0xBF), and `eq_ignore_ascii_case` folds only A–Z/a–z, i.e. ASCII→ASCII —
+it can never make a continuation byte compare equal to a leading byte. So `&name[..idx]` cannot
+panic, for any caller, present or future. `checked_sub` covers the short-name case. The slice is
+only reached after a match, so the failing probes never index at all.
+
+- **Non-ASCII lookalikes are immune** because the fold is byte-wise: no multi-byte sequence can
+  fold to an ASCII letter, so `ß` (C3 9F) and the Kelvin sign (E2 84 AA) cannot match `z`/`K`.
+  *Verified end-to-end:* `ß.FQ.GZ` → `ß_trimmed.fq.gz` (retained bytes preserved, gzipped);
+  `😀.FQ.GZ` and a bare `😀` both exit 0.
+- **The naive `&str` form really would panic**, so `test_…_non_ascii_and_short_names` guards
+  something real: `"😀"` with `".gz"` gives `idx = 1`, a continuation byte. And `"é.fq"` exercises a
+  *successful* strip whose retained part is multi-byte — the better of the two cases.
+- **All four `is_gzipped` call sites fold together** (`main.rs:345`, `clump_only.rs:277`, `:414`,
+  `:1107`). I re-ran the plan's §2.4 sweep over `src/*.rs`; the only other filename-driven
+  decisions are `main.rs:1646`/`:2219` (interleaved-uBAM `file_stem()`, agrees with the fallback)
+  and `specialty.rs:505-512` (`_R1`/`R2` mate token, case-sensitive — pre-existing, orthogonal,
+  and the fold *improves* it: `S_R1.FASTQ.GZ` now reaches the `_R1` strip at all).
+- **`demux.rs`'s dead-code claim (§2.4) checks out.** `demux_base_name` consumes the *generated*
+  trimmed path, which this code always names lowercase `.fq`/`.fq.gz` — including under
+  `--basename`, where the user string is a prefix, never the extension.
+- **The Perl byte-identity matrix is untouched.** No fixture in `test_files/` and no
+  `trim_galore` invocation in `ci.yml` carries an uppercase extension; no existing assertion pins
+  the old uppercase behaviour.
+- **All three new tests' assertions reproduce by hand.** V5: `out/SAMPLE_trimmed.fq.gz` with
+  `1f 8b` beside `SAMPLE.FASTQ.GZ_trimming_report.txt`. V4: both pairs exit non-zero with
+  `Output path collision …`, `out/` empty. V8: report reads `Input:  … (gzip, 110 bytes)`,
+  `Compression ratio: 1.22x`, output `SAMPLE_clumped.fq.gz`.
+- **The documented asymmetry stays put.** `SAMPLE.FASTQ.BGZ` → `SAMPLE_trimmed.fq`, plain
+  (*verified*) — same as lowercase `.bgz`, exactly as A4 says.
+- **Positive control for V4:** `SAMPLE.FASTQ.GZ` + `B.fq.gz` still succeeds, so the refusal is
+  caused by stem equality, not by uppercase input per se.
+
+---
+
+## Medium
+
+### M1 — the CHANGELOG enumerates "Four visible consequences" but four is not all of them
+
+The entry lists SE naming, compression, new refusals, and `--clump_only`. It omits the four
+specialty namers and `--passthrough`, which all derive their stem from `strip_fastq_extensions`
+(`specialty.rs:449/471/485/501`, `io.rs:329`) and therefore also rename for uppercase input.
+*Verified:*
+
+| invocation on `P_R1.FASTQ.GZ` | before | after |
+|---|---|---|
+| `--hardtrim5 10 --paired` | `P_R1.FASTQ.10bp_5prime.fq` | `P_R1.10bp_5prime.fq.gz` |
+| `--clock` | `P_R1.FASTQ.clock_UMI.R1.fq` | `P_R1.clock_UMI.R1.fq.gz` |
+
+These three modes name output into the **current working directory** (the CHANGELOG says so 20
+lines further down), which is where a positional `ls`/glob is most likely to be depended on — so
+this is the sharper half of the rename, not the softer one. `--implicon` and `--passthrough` are
+the same shape.
+
+**Recommend:** a fifth bullet, or replace "Four visible consequences" with "Visible consequences"
+and add one line covering the specialty and passthrough namers. Cheap, and it removes an
+exhaustiveness claim that is currently false.
+
+### M2 — the new tests skip the dispatch paths this file exists to cover
+
+`tests/integration_gzip_non_gz_extension.rs`'s own module docstring states the selection rule and
+why: tests are chosen *by dispatch path*, because in #374 "nine green checks … missed a
+`--paired --cores 1` regression". Its table is SE / paired `--cores 1` / paired `--cores 2` /
+`--clump_only`. #384 adds SE and `--clump_only` only — no paired, no specialty.
+
+The risk here is genuinely lower than in #374 (that change altered reader construction *per path*;
+this one changes two pure functions every path consumes), and I confirmed the paths by hand:
+`--paired P_R1.FASTQ.GZ P_R2.FASTQ.GZ` → `P_R1_val_1.fq.gz` / `P_R2_val_2.fq.gz`, and a mixed-case
+pair (`MIX_R1.fastq.gz` + `MIX_R2.FASTQ.GZ`) → `MIX_R1_val_1.fq.gz` / `MIX_R2_val_2.fq.gz`. Both
+correct. So this is a coverage-convention gap, not a suspected bug.
+
+**Recommend:** one `--paired` uppercase case (~8 lines, reusing `write_gz`/`sample_reads`), which
+restores the file's stated matrix and pins the `input[0]`-drives-the-run-wide-`gzip` coupling that
+paired mode adds. A specialty case is optional — note that `--hardtrim5/--clock` write into the
+CWD, so such a test must set `current_dir`.
+
+---
+
+## Low
+
+**L1 — the V4 fixture is silently lossy on a case-insensitive filesystem.** *Verified on this APFS
+volume:* `sample.fq.gz` and `SAMPLE.FQ.GZ` are **one file**. The third `write_gz` reopens it, the
+`"B"` body is overwritten by `"C"`, and the directory entry keeps the first-created spelling
+(`ls` shows two files, not three). Consequences: the loop's second iteration feeds the same inode
+under a different spelling, so on macOS it fires the *duplicate-output* branch
+(`out/SAMPLE_trimmed.fq.gz and out/SAMPLE_trimmed.fq.gz`) rather than testing two distinct inputs;
+on Linux all three files exist and it tests what the docstring says. **Both iterations still refuse
+on both filesystems** (verified), so the test as written cannot be fooled — but the next person to
+add a content assertion will be. One comment noting the APFS aliasing is enough.
+
+**L2 — the newly-reachable refusals include the output-vs-input branch, which §3.1 and the
+CHANGELOG do not mention.** *Verified:* `trim_galore -o . A.FASTQ.GZ a_trimmed.fq.gz` now fails
+with "…would write output to `a_trimmed.fq.gz`, which is also one of its inputs"; before the fold
+the planned output was `A.FASTQ_trimmed.fq` and the run was accepted. Correct on APFS (they alias);
+a case-folded false positive on a case-sensitive filesystem — the trade-off `norm_path`'s
+doc-comment already accepts. Worth half a clause in §3.1 since all three of its "newly rejected"
+rows are output-vs-output.
+
+**L3 — `is_gzipped`'s new "must stay in step with `strip_fastq_extensions`" comment overstates what
+the code enforces.** The two use different matchers (`Path::extension()` vs byte-suffix strip) and
+already disagree on dotfile names: `strip_fastq_extensions(".GZ")` treats `.GZ` as a gz suffix and
+returns `""`, while `is_gzipped(".GZ")` is false because `extension()` is `None`. *Verified:* a file
+named `.FQ.GZ` yields `out/_trimmed.fq.gz` (empty stem) where it used to yield `.FQ_trimmed.fq`.
+Pathological, and identical in shape for lowercase `.gz` today — so not a regression — but the
+comment now asserts a lockstep that holds only for the non-degenerate cases (and explicitly not for
+`.bgz`). Recommend narrowing it to "the `gz` decision must agree with the `gz`-family strip".
+
+**L4 — V8's substring assertions are matched against a report that embeds the full temp path.**
+`report.contains("gzip")` / `!report.contains("plain")` would false-fail if `std::env::temp_dir()`
+ever contained either word. The discrimination is carried by `!contains("plain")` and
+`Compression ratio:` (`contains("gzip")` is satisfied by the `Output:` label too). Anchoring on the
+line — e.g. `report.contains("(gzip, ")` — is both tighter and immune.
+
+**L5 — `assert_eq!(&bytes[..2], …)` in V5 panics with a slice-index message, not the assert's, if
+the output is <2 bytes.** Can't happen today (`clump_only.rs:343` and the gzip writer always emit a
+member), but `bytes.starts_with(&[0x1f, 0x8b])` reads the same and fails legibly.
+
+**L6 — the plan's V2 asks for a lowercase `.bgz` false case; nothing asserts it.** The pre-existing
+`test_is_gzipped` (io.rs:965-977) never covered `.bgz`; the new test covers `.BGZ` only. Same code
+path, so this is a one-line completeness item, not a hole.
+
+**L7 — a reader primed by #381/#382 could misread the CHANGELOG on `.BGZ`.** Bullet 1 names
+`.gz`/`.bgz`/`.bgzf` as the folded set; bullet 2 says `.GZ` output is now gzip-compressed. `.BGZ`
+output is still plain (*verified*), matching lowercase `.bgz`. Half a sentence closes it.
+
+---
+
+## Efficiency
+
+Nothing to raise. Five `eq_ignore_ascii_case` probes per input filename, once per file, no
+allocation beyond the pre-existing `name: String`. `is_gzipped` swaps one `OsStr` compare for
+another. Unmeasurable, as §6 says.
+
+## Structure
+
+The helper sits beside its only consumer, mirrors `str::strip_suffix` + `eq_ignore_ascii_case` in
+name and signature, and is correctly private. Comments are one line each per house style, with the
+non-obvious part (why byte-wise) in the doc-comment where it belongs. `.then(||…)` rather than
+`then_some(…)` is not a style choice — `then_some` would evaluate the slice unconditionally and
+reintroduce the panic. Test names are declarative and each carries the issue number.

--- a/plans/08072026_uppercase-fastq-extensions/CODE_REVIEW_B.md
+++ b/plans/08072026_uppercase-fastq-extensions/CODE_REVIEW_B.md
@@ -1,0 +1,212 @@
+# Code Review B — case-insensitive FASTQ extensions (#384)
+
+**Reviewer:** B (independent; Reviewer A reviews the same diff in parallel, no shared state)
+**Target:** `fix/384-uppercase-extensions` off `dev` @ `533582a`, **uncommitted**
+**Diff:** `src/io.rs` (+70/−3), `tests/integration_gzip_non_gz_extension.rs` (+111), `CHANGELOG.md` (+24)
+**Plan:** `plans/08072026_uppercase-fastq-extensions/PLAN.md` (v2, §13 implementation notes)
+
+> **Nothing was fixed.** The tree is shared with a concurrent reviewer, so every item below is a
+> recommendation only. My single write is this file.
+
+**Method.** I did not re-run the suite (it is green per §13 and proves little). Instead I probed
+the built `target/release/trim_galore` (verified post-change: `SAMPLE.FASTQ.GZ` → `SAMPLE_trimmed.fq.gz`,
+`1f8b`) with constructed invocations, and compiled a standalone `rustc` probe of the helper.
+Scratch: `…/scratchpad/crev384b/`. No repo writes, no CWD-naming modes from the repo root.
+
+---
+
+## Summary
+
+The change is correct and the helper is sound — I could not break it. No Critical or High findings.
+Product behaviour matches the plan on every path I could reach, including the ones the plan
+predicted would newly refuse. What I did find is **two Medium items about the change's edges rather
+than its core**: one integration assertion that does not discriminate what the plan says it pins,
+and one user-visible consequence class (the four specialty modes) missing from the CHANGELOG's
+explicitly-enumerated list. Everything else is Low.
+
+---
+
+## 1. The helper — `strip_suffix_ignore_ascii_case` (`src/io.rs:521`)
+
+**The char-boundary argument is airtight, and in fact stronger than the doc-comment claims.**
+
+On a match, every byte of `name[idx..]` equals the corresponding suffix byte *after ASCII folding*.
+Folding maps ASCII→ASCII and leaves ≥0x80 bytes untouched, so a non-ASCII name byte can only match
+a non-ASCII suffix byte exactly. The suffix is itself a valid `&str`, so its first byte is never a
+UTF-8 continuation byte; therefore the name byte at `idx` is never a continuation byte either, and
+`idx` is a char boundary. This holds for *any* valid `&str` suffix, not just all-ASCII ones — the
+all-ASCII framing in the doc-comment is a sufficient condition, not the necessary one. No change
+needed; noted so a future maintainer adding a suffix does not think they are on thin ice.
+
+`checked_sub` covers name-shorter-than-suffix; `name.as_bytes()[idx..]` cannot panic because
+`idx ≤ len`; the `&str` slice is reached only on a match. Lifetimes tie the result to `name`. Clean.
+
+**Folding is immune to non-ASCII lookalikes** — probed directly, all correctly `None`:
+`x.ＦＱ` (fullwidth), `x.fı` (dotless i), `x.ß`, `x.G\u{212A}` (Kelvin sign) against `.fq`/`.gz`.
+`straße.fq` → `straße` and `KELVIN\u{212A}.fq` → `KELVIN\u{212A}`: retained case and non-ASCII
+bytes preserved intact.
+
+**The naive form really does panic**, so the byte-wise choice is load-bearing rather than defensive:
+`naive("😀", ".fq")` → `start byte index 1 is not a char boundary`. End-to-end confirmation that
+this input is live: `😀.FASTQ.GZ` and `é.FQ.GZ` both trim to exit 0, producing `😀_trimmed.fq.gz`
+and `é_trimmed.fq.gz`. The third unit test (`io.rs:1017`) therefore guards something real.
+
+**Structure.** Two different mechanisms now express one idea: `OsStr::eq_ignore_ascii_case` in
+`is_gzipped` (line 33) and the byte helper 490 lines away. That is the right call — the types differ,
+and `is_gzipped` must keep working on non-UTF-8 `OsStr` — and the doc-comment cross-reference
+carries the coupling. Naming mirrors `str::strip_suffix`. Placement beside its only caller is right.
+
+## 2. Callers that must stay in step
+
+I re-derived the caller set rather than trusting §2.3, and found no inconsistency beyond the
+documented `.BGZ` asymmetry (confirmed live: `SAMPLE.FASTQ.BGZ` → `SAMPLE_trimmed.fq` plain, beside
+`SAMPLE.FASTQ.BGZ_trimming_report.txt`).
+
+- **`is_gzipped` → one decision producer.** `main.rs:345` is the sole `let gzip = …`; every namer
+  (`io.rs`: SE/PE/unpaired/passthrough/clumped; `specialty.rs`: all four) takes `gzip: bool` as a
+  parameter. Nothing recomputes it locally, so the fold cannot half-apply.
+- **`clump_only.rs:277`/`:414`** now agree with the FASTQ-output path. Verified live (§3 below).
+  `:1107` is a test helper. Note `clump_only.rs:781`/`:1019` set the same field from
+  `input_is_compressed(fmt)` (content-based) on the uBAM-output path — a pre-existing
+  name-vs-content split that the fold *narrows* for genuinely-gzipped uppercase files.
+- **`demux.rs:118-121`** (case-sensitive `.gz`/`.fq` strips) is genuinely dead to this change: its
+  argument is the trimmed output path, which this code always names lowercase — including under
+  `--basename FOO`, where the stem is uppercase but the extension is still ours.
+- **`specialty.rs:501-515`** — the `_R1`/`R2` strip. Newly *reachable* for uppercase input: before,
+  the stem ended `.FASTQ` so the strip always missed. See L4/M2.
+- **`main.rs:1645`, `:2219`** (interleaved-uBAM stems) use raw `file_stem()`. See L5.
+
+## 3. The new tests
+
+All three assert real, verified behaviour. I reproduced each with a constructed invocation:
+
+| Test | Reproduced | Result |
+|---|---|---|
+| V5 `uppercase_extension_names_and_compresses_like_lowercase` | `-o out SAMPLE.FASTQ.GZ` | `SAMPLE_trimmed.fq.gz` (`1f8b`) + `SAMPLE.FASTQ.GZ_trimming_report.txt`, exit 0 |
+| V4 `uppercase_and_lowercase_spellings_of_one_stem_now_collide` | both iterations | exit 1, `Output path collision …` **on stderr**, `out/` empty |
+| V8 `clump_only_uppercase_gz_reports_gzip_and_ratio` | `--clump_only -o out SAMPLE.FASTQ.GZ` | `SAMPLE_clumped.fq.gz`; report `Input: … (gzip, 273332 bytes)` + `Compression ratio: 0.77x` |
+
+**Discrimination spot-check (V2/`is_gzipped`), by inspection:** under `ext == "gz"`,
+`is_gzipped("SAMPLE.FASTQ.GZ")` is `false`, so `io.rs:983` fails on its first line. Airtight — no
+build needed. Same for V5: an unfolded stem names the file `SAMPLE.FASTQ_trimmed.fq*`, so
+`trimmed.is_file()` fails at path resolution, exactly as §13 records.
+
+**V4 on this machine's APFS:** the three `write_gz` calls create only **two** files —
+`SAMPLE.FQ.GZ` truncates the existing `sample.fq.gz` in place, leaving one entry named
+`sample.fq.gz` whose content is `"C"` (verified). The test still passes and still discriminates
+on both platforms, because `preflight_output_collisions` is lexical and runs before any input is
+opened; iteration 2's `SAMPLE.FQ.GZ` argument need not exist as a directory entry. See L3.
+
+## 4. Interaction with #383/#385's collision keys
+
+No surprise beyond the plan's §3.1 table. `path_identity_key` stays case-sensitive, so
+`SAMPLE.FASTQ.GZ` + `SAMPLE.FQ.GZ` are two inputs, not a duplicate; the refusal comes from
+`collision_key` on the outputs, which is the intended route and the message the test asserts.
+Nothing in the diff can create a new *self*-overwrite (output ⊂ input) class: every namer appends
+`_trimmed`/`_clumped`/`_val_*` to the stem, so a planned output can never fold onto its own input.
+
+One class the §3.1 table does not cover, because it is out of a per-run pre-flight's reach: see L6.
+
+---
+
+## Findings by priority
+
+### Critical — none
+
+### High — none
+
+### Medium
+
+**M1 — V8's positive assertion cannot fail for the reason the plan gives it.**
+`tests/integration_gzip_non_gz_extension.rs:454`, `assert!(report.contains("gzip"))`. The real
+report (captured above) contains `Output: … (gzip level 1, …)`, so that substring is present
+regardless of the `Input:` label — the assertion is satisfied by the output half. The complementary
+`!report.contains("plain")` (`:457`) is likewise driven by the *output* label: under the §13
+negative control (`is_gzipped` reverted) `gzip_output` is false, so the Output line reads `plain`
+and the assertion fails for the output reason, not the input one. Net effect: **V8 pins the stem
+and the output compression, but nothing in it pins C1's `Input: plain → gzip` shift**, which the
+plan (§9 V8, §12 I6) names as its purpose. Recommend asserting the line, not the file:
+
+```rust
+let input_line = report.lines().find(|l| l.starts_with("Input:")).unwrap();
+assert!(input_line.contains("(gzip,"), "{input_line}");
+```
+
+**M2 — the CHANGELOG's "Four visible consequences" omits a fifth: the specialty modes.**
+`--hardtrim5/3`, `--clock` and `--implicon` all derive their stems from `strip_fastq_extensions`
+(`specialty.rs:449`, `:471`, `:485`, `:501`) and their compression from the same `gzip` flag, so
+uppercase input is renamed *and* newly compressed there too. Verified with the real binary
+(run from scratch, `-o` given):
+
+- `--hardtrim5 30 SAMPLE_R1.FASTQ.GZ` → `SAMPLE_R1.30bp_5prime.fq.gz`
+  (was `SAMPLE_R1.FASTQ.30bp_5prime.fq`, plain).
+- `--implicon SAMPLE_R1.FASTQ.GZ SAMPLE_R2.FASTQ.GZ` → `SAMPLE_8bp_UMI_R1.fastq.gz` /
+  `…_R2.fastq.gz` (was `SAMPLE_R1.FASTQ_8bp_UMI_R1.fastq`) — note this name changes **twice**:
+  the extension folds *and* the `_R1` strip at `specialty.rs:505` becomes newly reachable, which
+  is a second, unmentioned improvement.
+
+These four modes default to naming output into the **CWD** (the very next CHANGELOG bullet is about
+that), so a renamed output there is the least recoverable of the set. Recommend either generalising
+bullet 1 or adding a fifth. Also the shallower half of the same gap: no committed test covers a
+specialty namer under uppercase input — the shared helper is unit-tested, which is defensible, but
+the `_R1`-strip interaction is not covered anywhere.
+
+### Low
+
+**L1 — names that are *only* an extension yield an empty stem.** `.FQ.GZ` → `_trimmed.fq.gz`
+(verified, exit 0; report `.FQ.GZ_trimming_report.txt`). Pre-existing for lowercase `.fq.gz`; the
+fold makes a second spelling class reach it. Multi-input is caught, if oddly worded:
+`Output path collision …: out/_trimmed.fq.gz and out/_trimmed.fq.gz`. No committed test pins it.
+
+**L2 — stale comment adjacent to the new code.** `io.rs:975`: "Heuristic is extension-based
+(matches FastqReader's gzip detection)". Since #374 the reader sniffs content, and `is_gzipped`'s
+own doc-comment (lines 13-17) says so explicitly — the two now contradict each other, and the new
+`test_is_gzipped_folds_case` was added directly beneath the stale line. Drive-by one-liner.
+
+**L3 — V4's fixture set is filesystem-dependent, undocumented.** Only two of its three files exist
+on a case-insensitive volume (§3). Harmless today; recommend one line in the test comment, because
+adding any *content*-based assertion there later would pass on Linux and fail on macOS.
+(Separately, `fresh_tmpdir` uses a fixed path per slug — pre-existing in this file, but three more
+slugs now share the hazard of two concurrent `cargo test` runs.)
+
+**L4 — `--implicon`'s `_R1` strip stays case-sensitive** (`specialty.rs:505-515`), so
+`sample_r1.FQ.GZ` folds its extension but keeps the lowercase `_r1` marker. Pre-existing
+asymmetry, but the fold is what makes the strip reachable at all for uppercase-extension input, so
+this is the moment it becomes visible. Out of scope for #384; worth an issue.
+
+**L5 — the plan's "cannot diverge" for `main.rs`'s `file_stem()` sites is slightly overstated.**
+`main.rs:1645` / `:2219` (interleaved-uBAM → FASTQ / uBAM out) use raw `file_stem()`, so a
+content-detected uBAM named `data.FASTQ.GZ` yields `data.FASTQ_val_1.fq.gz` there while the SE
+dispatch yields `data_trimmed.*`. The divergence is **pre-existing** (lowercase `data.fastq.gz`
+already split `data` from `data.fastq`); the fold only extends it to uppercase names. Contrived
+input, no action needed — recorded because §2.4 asserts the opposite.
+
+**L6 — cross-invocation aliasing on case-insensitive filesystems.** `-o out d1/sample.fq.gz` then
+`-o out d2/SAMPLE.FQ.GZ` now target one file (`out/sample_trimmed.fq.gz` ≡ `out/SAMPLE_trimmed.fq.gz`
+on APFS) where before the second wrote `SAMPLE.FQ_trimmed.fq`. The per-run pre-flight cannot see
+across invocations. The class is pre-existing (`d1/sample.fq.gz` + `d2/SAMPLE.fq.gz` already
+aliased); the fold adds mixed-*spelling* members. Inherent to the goal, not a defect.
+
+**L7 — compression is run-wide, and the CHANGELOG bullet reads per-file.**
+`gzip` comes from `input[0]` only, so `trim_galore A.FASTQ.GZ b.fastq` now gzips `b`'s output too
+(it was plain before the fold). Pre-existing "first input decides" rule, new trigger. One clause in
+bullet 2 would cover it.
+
+**L8 — `.then(…)` must stay lazy.** `then_some(&name[..idx])` would evaluate the slice on the
+non-matching path and reintroduce the `😀` panic. Clippy's `unnecessary_lazy_evaluations` does not
+fire on indexing, so the risk is low and the doc-comment covers the reasoning; no action.
+
+**L9 — `test_is_gzipped_folds_case` drops one plan V2 case:** lowercase `.bgz` → false is asserted
+nowhere (only `.BGZ`). Substantively covered, since `.BGZ` false implies `.bgz` false under
+folding. Cosmetic.
+
+---
+
+## Verification of the plan's own claims
+
+- **Validation matrix unaffected** — re-confirmed by grep as §7 asked: no uppercase extension in
+  `.github/workflows/ci.yml`, and no fixture in `test_files/` carries one (`PolyA.fastq.gz` and
+  friends have uppercase *stems*, which the fold preserves — pinned by the `Sample.FastQ.Gz` case).
+- **Report filename unchanged** — confirmed on every probe; the CHANGELOG's closing sentence and
+  its refusal to claim MultiQC grouping are both accurate.
+- **§13's six §5 steps** are all present in the diff as described; I found no undocumented deviation.

--- a/plans/08072026_uppercase-fastq-extensions/COVERAGE.md
+++ b/plans/08072026_uppercase-fastq-extensions/COVERAGE.md
@@ -1,0 +1,125 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs. plan — §5 steps, §9 validation, §3.1 edge cases, §13, CHANGELOG)
+**Plan(s):** `plans/08072026_uppercase-fastq-extensions/PLAN.md` (v2 + §13)
+**Date:** 2026-08-07
+**Verdict:** INCOMPLETE — 1 item unresolved
+
+## Summary
+
+- Total items: 29
+- DONE: 28
+- PARTIAL: 1
+- MISSING: 0
+- DEVIATED: 0
+
+Branch `fix/384-uppercase-extensions`, uncommitted working tree on `dev` @ `533582a`.
+Diff is exactly the 3 files §13 claims. `cargo test`: **538 passed, 0 failed** (exit 0),
+matching §13. `cargo fmt --check` clean, `cargo clippy --all-targets --release -D warnings`
+clean. The single PARTIAL is one absent named assertion inside an otherwise-complete test;
+no behavioural gap.
+
+## Coverage ledger
+
+### §5 implementation outline
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `strip_suffix_ignore_ascii_case` added beside `strip_fastq_extensions`, byte-wise form | §5 Step 1 / §4 / §12 C3 | DONE | `src/io.rs:516-526`, body identical to §4's listing (`checked_sub` + `eq_ignore_ascii_case` on bytes + `.then()`); 3-line doc-comment states the multi-byte-panic reason |
+| 2 | `strip_fastq_extensions` uses the helper for both suffix lists; `file_stem` fallback and two-sequential-strips structure intact | §5 Step 2 | DONE | `src/io.rs:548-557`; only the two `find_map`/`strip_suffix` calls changed, list contents and order preserved |
+| 3 | `is_gzipped` → `eq_ignore_ascii_case("gz")`, doc-comment extended with the must-agree rationale | §5 Step 3 | DONE | `src/io.rs:29-36`; comment names #384 and the fold-one-not-the-other failure mode |
+| 4 | Unit tests V1–V3 in `io.rs` | §5 Step 4 | DONE | 3 tests added; see V1/V2/V3 rows for per-case verification |
+| 5 | Integration test in `tests/integration_gzip_non_gz_extension.rs` | §5 Step 5 | DONE | 3 tests added (V5, V4, V8) in the file #374/#382 use |
+| 6 | CHANGELOG entry under `#### Changes` | §5 Step 6 | DONE | `CHANGELOG.md:125-148`, under the `#### Changes` heading at line 112 (not `#### Bug fixes` at line 6) |
+
+### §9 validation
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 7 | V1 — 7 named stems fold, retained case preserved | §9 V1 | DONE | `test_strip_fastq_extensions_folds_case`: all 7 named inputs present, plus `SAMPLE.FASTQ.BGZF` (superset). `Sample.FastQ.Gz`→`Sample` and `sample_R1.FQ.GZ`→`sample_R1` pin the no-lowercasing property |
+| 8 | V2 — `is_gzipped` true for `.gz`/`.GZ`/`.Gz`; false for `.fastq`, `.bgz`, `.BGZ`, `sample.gz.fastq` | §9 V2 | **PARTIAL** | 6 of 7 named cases asserted. **Lowercase `.bgz` is asserted nowhere** — not in `test_is_gzipped_folds_case` (which has `.BGZ`) nor in pre-existing `test_is_gzipped`. See Gaps |
+| 9 | V3 — existing strip tests unchanged; `.bam`/`.txt` fallback un-folded; non-ASCII + shorter-than-suffix names | §9 V3 | DONE | `test_strip_fastq_extensions` / `_bgz` absent from the diff ⇒ unchanged, and pass. `test_strip_fastq_extensions_non_ascii_and_short_names`: `😀` (the §4 panic input, idx 1 mid-character), `é.fq`, `a` (shorter than any suffix), `sample.bam`, `sample.txt` |
+| 10 | V4 — the two mixed-spelling refusals, not pure case-variants | §9 V4 | DONE | `uppercase_and_lowercase_spellings_of_one_stem_now_collide` loops `sample.fq.gz` then `SAMPLE.FQ.GZ` against `SAMPLE.FASTQ.GZ`; asserts non-zero exit, `Output path collision` on stderr, and an empty output dir. Both discriminate: pre-fold stems differ (`SAMPLE.FASTQ` vs `SAMPLE`/`sample`), post-fold they collide. Filesystem-independent as required |
+| 11 | V5 — literal filenames, no `--dont_gzip`, halves fail independently | §9 V5 | DONE | `uppercase_extension_names_and_compresses_like_lowercase`: no `--dont_gzip`; literal `SAMPLE_trimmed.fq.gz` + `SAMPLE.FASTQ.GZ_trimming_report.txt`, no function-under-test in the expectations; `is_file()` resolution (with dir listing in the failure message) precedes the `1F 8B` byte check |
+| 12 | V6 — manual one-offs; §13 records both controls discriminating | §9 V6 / §13 | DONE | §13 table: stem-fold reverted → V1+V5 both FAILED; `is_gzipped` reverted → V2+V5+V8 all three FAILED; both reverted-to-green. V5 failing at path resolution under control 2 recorded as predicted. Committed guard for the compression half correctly identified as V2 |
+| 13 | V7 — fmt, clippy, cargo test, §2.1 re-run | §9 V7 | DONE | Re-run in this audit: `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --release -- -D warnings` exit 0, zero warnings (fingerprints post-date `src/io.rs`, so the cached pass covers this source); `cargo test` 538 passed / 0 failed. §2.1 reproduction without `--dont_gzip` recorded in §13 and equivalently covered by V5 |
+| 14 | V8 — `--clump_only` report content and stem for `.GZ` input | §9 V8 | DONE | `clump_only_uppercase_gz_reports_gzip_and_ratio`: `SAMPLE_clumped.fq.gz` exists, report contains `gzip`, does **not** contain `plain`, contains `Compression ratio:`. The `!contains("plain")` assertion is what discriminates the label flip; §13 confirms it failed under control 2 |
+
+### §3.1 edge-case table
+
+| # | Input row | Traces to | Status | Notes |
+|---|-----------|-----------|--------|-------|
+| 15 | `sample.fastq.gz` → unchanged | pre-existing `test_strip_fastq_extensions` | DONE | unchanged and passing |
+| 16 | `SAMPLE.FASTQ.GZ` → `SAMPLE_trimmed.fq.gz` | V1 unit + V5 integration | DONE | both halves (stem, compression) asserted |
+| 17 | `Sample.FastQ.Gz` → `Sample` | V1 unit | DONE | the retained-case case |
+| 18 | `SAMPLE.FQ` → `SAMPLE`, plain in / plain out | V1 unit | DONE | stem asserted; the plain-out half rests on `!is_gzipped("SAMPLE.FASTQ")` — the same branch, `.FQ` itself not asserted |
+| 19 | `SAMPLE.FASTQ.BGZ` → `SAMPLE`, still plain | V1 unit + V2 unit | DONE | both directions of A4's asymmetry pinned for the uppercase spelling |
+| 20 | `sample.BAM` → `file_stem` fallback, unchanged | §3.1 rationale + V3 test | DONE | test uses lowercase `sample.bam`; `file_stem` is case-agnostic and `.bam` is in neither suffix list, so the uppercase variant cannot diverge |
+| 21 | `sample.txt` → fallback, unchanged | V3 test | DONE | asserted |
+| 22 | `SAMPLE.FASTQ.GZ` + `sample.fastq.gz` → **already** rejected, fold changes nothing | §3.1 rationale + §12 C2 | DONE | load-bearing row; §12 C2 records the pre-change verification (exit 1 on `dev`, same inode on APFS). V4 explicitly forbids using it as a test — correctly absent |
+| 23 | `SAMPLE.FASTQ.GZ` + `sample.fq.gz` → **newly** rejected | V4 test, case 1 | DONE | load-bearing row |
+| 24 | `SAMPLE.FASTQ.GZ` + `SAMPLE.FQ.GZ` → **newly** rejected | V4 test, case 2 | DONE | load-bearing row; not case-dependent, so it holds on case-sensitive filesystems too |
+
+### §13 notes and CHANGELOG (§7)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 25 | §13 "all six §5 steps done as specified — no deviations" holds against the diff | §13 | DONE | `git status`/`git diff` touch exactly `src/io.rs`, `tests/integration_gzip_non_gz_extension.rs`, `CHANGELOG.md`. No undocumented deviation found: helper body, both folds, doc-comment, test placement and test count all as §5/§4 specify. Bookkeeping nit only — §13 says io.rs `+70/−3`; `git diff --numstat` gives `67/3` (70 is the `--stat` total). CHANGELOG `+24` and tests `+111` exact |
+| 26 | §7's instruction to re-confirm by grep that the validation matrix is unaffected | §7 | DONE | Verified in this audit rather than in §13: no uppercase FASTQ/FQ/GZ extension in `.github/workflows/ci.yml` or `test_files/`. Requirement holds; §13 does not record having run the grep |
+| 27 | CHANGELOG has four bullets: rename, compression flip, new refusals, `--clump_only` | §7 / §12 | DONE | all four present as sub-bullets under the #384 entry |
+| 28 | Perl-parity departure stated (B's I2) | §7 / §12 | DONE | "Perl v0.6.11's compression test was case-sensitive, so this knowingly departs from v0.6.11 for uppercase names" |
+| 29 | No MultiQC-grouping claim (B's I4) | §7 / §12 | DONE | Entry claims only internal consistency and explicitly notes the report filename is unchanged. No mention of MultiQC or downstream grouping anywhere in the diff |
+
+## Gaps (detail)
+
+### Item 8: V2's lowercase `.bgz` false-assertion
+
+**Expected:** V2 names seven cases for `is_gzipped` — true for `.gz`, `.GZ`, `.Gz`; false for
+`.fastq`, `.bgz`, `.BGZ`, `sample.gz.fastq`.
+
+**Found:** Six. Every `is_gzipped` assertion in `src/io.rs` (lines 967-976 pre-existing,
+983-989 new) was enumerated: no assertion takes a lowercase `.bgz` path. The pre-existing
+`test_is_gzipped` covers `.gz` true and `.fastq`/`sample.gz.fastq` false but never `.bgz`;
+the new `test_is_gzipped_folds_case` covers `.BGZ` only.
+
+**Gap:** one assertion, e.g. `assert!(!is_gzipped(Path::new("sample.fq.bgz")));` in
+`test_is_gzipped_folds_case`.
+
+**Severity:** documentation-level. `.BGZ` exercises the identical branch, so A4's
+"`.bgz` does not imply gzipped output" asymmetry is already guarded against regression —
+just for the uppercase spelling rather than the lowercase anchor the plan named. No
+behaviour is unverified.
+
+## Test verification
+
+| Test | File | Status |
+|------|------|--------|
+| `io::tests::test_strip_fastq_extensions_folds_case` (V1) | `src/io.rs:982` | PASS |
+| `io::tests::test_is_gzipped_folds_case` (V2) | `src/io.rs:982` | PASS (1 named case absent) |
+| `io::tests::test_strip_fastq_extensions_non_ascii_and_short_names` (V3) | `src/io.rs:1015` | PASS |
+| `io::tests::test_strip_fastq_extensions` (V3 regression) | `src/io.rs` | PASS, unchanged |
+| `io::tests::test_strip_fastq_extensions_bgz` (V3 regression) | `src/io.rs` | PASS, unchanged |
+| `io::tests::test_is_gzipped` (V3 regression) | `src/io.rs:965` | PASS, unchanged |
+| `uppercase_extension_names_and_compresses_like_lowercase` (V5) | `tests/integration_gzip_non_gz_extension.rs:352` | PASS |
+| `uppercase_and_lowercase_spellings_of_one_stem_now_collide` (V4) | `tests/integration_gzip_non_gz_extension.rs:388` | PASS |
+| `clump_only_uppercase_gz_reports_gzip_and_ratio` (V8) | `tests/integration_gzip_non_gz_extension.rs:421` | PASS |
+| **Suite total** | — | **538 passed, 0 failed, 0 ignored** (exit 0) |
+
+Gates: `cargo fmt --all -- --check` clean · `cargo clippy --all-targets --release -- -D warnings`
+exit 0, zero warnings · `cargo test` exit 0.
+
+## Verdict
+
+**INCOMPLETE — 1 item unresolved.**
+
+One item remains, and it is a single line of test code:
+
+1. **Item 8 (V2)** — add the lowercase `.bgz` false-assertion to
+   `test_is_gzipped_folds_case` in `src/io.rs`, e.g.
+   `assert!(!is_gzipped(Path::new("sample.fq.bgz")));`
+
+Everything else in §5, §9, §3.1, §13 and the §7 CHANGELOG requirements is DONE. In
+particular the load-bearing §3.1 rows (items 22-24) are all accounted for — the
+already-rejected pair by verified rationale, both newly-rejected pairs by V4 — §13's
+"no deviations" claim holds against the diff, and the CHANGELOG carries four bullets with
+the Perl compression-parity departure stated and no MultiQC-grouping claim.

--- a/plans/08072026_uppercase-fastq-extensions/PLAN.md
+++ b/plans/08072026_uppercase-fastq-extensions/PLAN.md
@@ -1,0 +1,417 @@
+# Plan — Match FASTQ extensions case-insensitively (#384)
+
+**Issue:** [#384](https://github.com/FelixKrueger/TrimGalore/issues/384)
+**Branch point:** `dev` @ `533582a`
+**Revision:** v2 (2026-08-07) — see §12
+
+---
+
+## 1. Goal
+
+Make an uppercase FASTQ extension behave exactly like its lowercase equivalent:
+`SAMPLE.FASTQ.GZ` should produce `SAMPLE_trimmed.fq.gz` and
+`SAMPLE.FASTQ.GZ_trimming_report.txt`, mirroring
+`sample.fastq.gz` → `sample_trimmed.fq.gz`. One rule, no case-dependent behaviour to
+document or remember.
+
+Decision already recorded on the issue: fold case, rather than pin the current behaviour.
+The reason both #382 reviewers gave for pinning — byte-identity with Perl v0.6.11 — does not
+apply, because the current output is not Perl's either (§2.2).
+
+---
+
+## 2. Context
+
+### 2.1 What is wrong today
+
+Verified on `dev` @ `533582a`:
+
+```
+$ trim_galore -o out --dont_gzip SAMPLE.FASTQ.GZ
+out/SAMPLE.FASTQ_trimmed.fq
+out/SAMPLE.FASTQ.GZ_trimming_report.txt      ← disagree about the sample name
+```
+
+`strip_fastq_extensions` (`io.rs`) matches `[".gz", ".bgz", ".bgzf"]` and `[".fastq", ".fq"]`
+with `strip_suffix`, which is case-sensitive. `.FASTQ.GZ` matches none, so the function falls
+through to `Path::file_stem()`, which removes only the final component and leaves `SAMPLE.FASTQ`.
+
+The file is *read* correctly — since #374 gzip-ness comes from the first three bytes, not the
+name — which is why the run succeeds and the inconsistency is visible rather than fatal.
+
+### 2.2 Perl v0.6.11 did not produce this mismatch
+
+Its output naming (`trim_galore` lines 909-923) tests four suffixes case-sensitively and then
+falls through to `else { s/$/_trimmed.fq/ }`, appending to the **full** filename; the report
+(line 611) appends the same way. So Perl wrote `SAMPLE.FASTQ.GZ_trimmed.fq` beside
+`SAMPLE.FASTQ.GZ_trimming_report.txt` — ugly but consistent.
+
+Perl was case-sensitive, and its case-sensitivity still produced agreeing names, because its
+fallback appended where ours strips. **The naming mismatch is ours**, and on naming, parity is
+already lost.
+
+Compression is the opposite case, and the plan must say so plainly: Perl's decision (line 925,
+`if ($gzip or $filename =~ /\.gz$/)`, no `/i`) is case-sensitive, so Perl wrote `.GZ`-named
+output **plain** — exactly what `dev` does today. Folding `is_gzipped` therefore *breaks* a
+parity that currently holds, while folding the stem restores nothing Perl had. The fold is
+chosen on internal consistency (§2.3), with the parity cost stated rather than leaned past.
+The CI byte-identity matrix is unaffected only because no fixture is uppercase.
+
+Restoring Perl's append-fallback would be both parity-correct and consistent, but is
+unavailable: the fallback now also serves uBAM input, where `file_stem` is right
+(`sample.bam` → `sample_trimmed.bam`, not `sample.bam_trimmed.bam`), and uBAM is a v2 feature
+Perl never had. Separating the two populations requires deciding the case question anyway.
+
+### 2.3 The adjacent function that makes this more than a one-liner
+
+`is_gzipped` (`io.rs:29-31`) is also case-sensitive:
+
+```rust
+path.extension().is_some_and(|ext| ext == "gz")
+```
+
+It decides **output compression** — `gzip = !cli.dont_gzip && naming::is_gzipped(&cli.input[0])`
+(`main.rs:345`) — and it has three more call sites, all in `clump_only.rs`: `:277` (SE) and
+`:414` (PE) set `input_compressed`, which drives the `Input: … (gzip|plain)` label and gates the
+`Compression ratio:` line in the `--clump_only` report; `:1107` is a test helper that
+gzip-encodes by name. So folding also changes `--clump_only` **report content** for `.GZ`-named
+input — `plain` → `gzip`, plus a ratio line. Benign in direction (the input genuinely is gzip)
+but user-visible, so it goes in the CHANGELOG. Its doc-comment is explicit that it is
+filename-based on purpose: it answers
+"should the output be compressed", mirroring the input's name, not "is the input compressed",
+which `format.rs` decides from content.
+
+So folding only `strip_fastq_extensions` would trade the naming mismatch for a compression
+mismatch:
+
+| input | stem | output today | stem-fold only | both folded |
+|---|---|---|---|---|
+| `sample.fastq.gz` | `sample` | `sample_trimmed.fq.gz` | unchanged | unchanged |
+| `SAMPLE.FASTQ.GZ` | `SAMPLE.FASTQ` | `SAMPLE.FASTQ_trimmed.fq` (plain) | `SAMPLE_trimmed.fq` (**still plain**) | `SAMPLE_trimmed.fq.gz` |
+
+A silently uncompressed output is a worse surprise than a mismatched stem, particularly at
+whole-run scale. Both functions fold, or neither. **This plan folds both.**
+
+### 2.4 Extension handling elsewhere, deliberately untouched
+
+- `demux.rs:118-121` strips `.gz` then `.fq` case-sensitively, but its input is the *trimmed
+  output path*, which this code generates and always names with lowercase `.fq` / `.fq.gz`.
+  Folding there would be dead code.
+- `format.rs` decides input format from content (gzip magic, `BAM\1`), not names. Unaffected.
+- `clump_only.rs` is **affected**, not cleared — v1 cited a test assertion (`:1469`) and missed
+  the real consumers at `:277`/`:414` (§2.3). `clumped_output_name` also derives its stem via
+  `strip_fastq_extensions` while `clumping_report_name` uses the full filename, so `--clump_only`
+  carries the same stem/report mismatch #384 reports, and this change fixes it there too.
+- Reviewer sweep (`grep -rn 'extension()\|file_stem()\|strip_suffix\|ends_with("' src/*.rs`)
+  found no further filename-driven decision that could disagree with the fold: `main.rs:1646` /
+  `:2219` and `--basename` read names but cannot diverge.
+
+---
+
+## 3. Behavior
+
+1. `strip_fastq_extensions` matches the gzip-family suffixes and the FASTQ extensions
+   case-insensitively, preserving the **rest** of the name's case: `SAMPLE.FASTQ.GZ` → `SAMPLE`,
+   `MySample.FastQ.Gz` → `MySample`.
+2. `is_gzipped` returns true for any ASCII-case variant of `gz`.
+3. Everything not matching a FASTQ extension keeps `Path::file_stem()`, so `.bam` and unrelated
+   extensions are untouched.
+4. Output extensions this code *writes* stay lowercase (`_trimmed.fq.gz`), as now. Only
+   *matching* becomes case-insensitive; nothing starts emitting uppercase.
+
+### 3.1 Edge cases
+
+| Input | Stem | Output | Note |
+|---|---|---|---|
+| `sample.fastq.gz` | `sample` | `sample_trimmed.fq.gz` | unchanged — the common path |
+| `SAMPLE.FASTQ.GZ` | `SAMPLE` | `SAMPLE_trimmed.fq.gz` | **changed**: was `SAMPLE.FASTQ_trimmed.fq` |
+| `Sample.FastQ.Gz` | `Sample` | `Sample_trimmed.fq.gz` | mixed case folds too |
+| `SAMPLE.FQ` | `SAMPLE` | `SAMPLE_trimmed.fq` | plain in, plain out |
+| `SAMPLE.FASTQ.BGZ` | `SAMPLE` | `SAMPLE_trimmed.fq` | `.BGZ` is not `.gz`, so still plain — consistent with `.bgz` today (#374/#381) |
+| `sample.BAM` | `sample` | per uBAM naming | fallback keeps `file_stem`; unchanged |
+| `sample.txt` | `sample` | `sample_trimmed.fq` | fallback; unchanged |
+| `SAMPLE.FASTQ.GZ` + `sample.fastq.gz` in one run | — | rejected **already** | report names fold to equal keys today; the fold changes nothing (and on APFS the two names are one file) |
+| `SAMPLE.FASTQ.GZ` + `sample.fq.gz` in one run | `SAMPLE` / `sample` | **newly rejected** | accepted today (report names differ); after the fold both trimmed outputs collide, on every filesystem |
+| `SAMPLE.FASTQ.GZ` + `SAMPLE.FQ.GZ` in one run | `SAMPLE` / `SAMPLE` | **newly rejected** | same mechanism, not even case-dependent — a true duplicate output |
+
+v1's claim that pure case-variants become "reachable where they were not before" was false —
+they are already refused via the folded *report* keys, so a V4 built on them could never fail.
+The genuinely new refusals are the mixed-spelling pairs above, which are integration-testable on
+any filesystem; they are user-visible and belong in the CHANGELOG (a run that succeeded now
+errors).
+
+---
+
+## 4. Signatures
+
+No signature changes. Two bodies change:
+
+```rust
+pub fn is_gzipped(path: &Path) -> bool
+pub fn strip_fastq_extensions(path: &Path) -> String
+```
+
+A small private helper keeps the matching in one place:
+
+```rust
+/// ASCII-case-insensitive suffix strip, preserving the case of what remains.
+fn strip_suffix_ignore_ascii_case<'a>(name: &'a str, suffix: &str) -> Option<&'a str>
+```
+
+Implemented on **bytes**, slicing only after a successful match:
+
+```rust
+fn strip_suffix_ignore_ascii_case<'a>(name: &'a str, suffix: &str) -> Option<&'a str> {
+    let idx = name.len().checked_sub(suffix.len())?;
+    name.as_bytes()[idx..]
+        .eq_ignore_ascii_case(suffix.as_bytes())
+        .then(|| &name[..idx])
+}
+```
+
+The naive `&str` form (`name[idx..].eq_ignore_ascii_case(...)`) panics when `idx` lands inside a
+multi-byte character — verified with a probe: a file named `😀` works end-to-end today
+(`😀_trimmed.fq`, exit 0) and would panic under the naive helper. Matching all-ASCII suffix bytes
+guarantees `idx` is a char boundary, and `checked_sub` covers name-shorter-than-suffix. The
+retained part keeps its original case. ASCII-only, matching `norm_path`'s convention (A1).
+
+---
+
+## 5. Implementation outline
+
+**Step 1 — `src/io.rs`: add `strip_suffix_ignore_ascii_case`** beside `strip_fastq_extensions`.
+
+**Step 2 — `strip_fastq_extensions`** uses it for both lists, leaving the `file_stem` fallback
+and the two-sequential-strips structure (#382, @BenjaminDEMAILLE) intact.
+
+**Step 3 — `is_gzipped`**: `ext.eq_ignore_ascii_case("gz")`. Extend its doc-comment to say
+matching is case-insensitive and why it must agree with `strip_fastq_extensions` (§2.3).
+
+**Step 4 — unit tests** in `io.rs`: §5 V1–V3 below.
+
+**Step 5 — integration test** in `tests/integration_gzip_non_gz_extension.rs` (where #374/#382
+put the related cases): one end-to-end uppercase run asserting the trimmed file and the report
+share a stem, and that the output is gzipped.
+
+**Step 6 — CHANGELOG** under `#### Changes`: the rename, the compression change, and the note
+that this does not restore v0.6.11 parity either.
+
+**Comment discipline:** one line per new comment; reasoning goes in the commit message.
+
+---
+
+## 6. Efficiency
+
+`eq_ignore_ascii_case` on a suffix is O(len(suffix)) with no allocation, against
+`strip_suffix`'s O(len(suffix)) memcmp. Five suffix probes per filename, once per input file.
+Unmeasurable.
+
+---
+
+## 7. Integration
+
+**Validation matrix — unaffected.** No fixture in `test_files/` and no `trim_galore` invocation
+in `ci.yml` uses an uppercase extension, so no Perl byte-identity comparison changes. Worth
+re-confirming by grep during implementation rather than trusting this sentence.
+
+**Downstream:** a pipeline passing uppercase input gets differently-named *and* newly-compressed
+output; some previously-successful multi-input runs become refusals (§3.1); and `--clump_only`
+report content shifts for `.GZ` input (§2.3). All corrections, all visible: four bullets under
+`#### Changes`, not two.
+
+**MultiQC, stated honestly:** the fold makes uppercase output *internally* consistent; it does
+not deliver downstream grouping. The report filename still carries `.FASTQ.GZ` (by design — full
+input filename), so a case-sensitive extension-cleaner still derives a different sample name from
+the report than from the trimmed file. Do not claim grouping is fixed in the CHANGELOG.
+
+**#383's pre-flight:** gains reachable collisions it could not previously see (§3.1 last row).
+That is the pre-flight working as designed.
+
+---
+
+## 8. Assumptions
+
+- **A1 (fixed).** ASCII case folding only, consistent with `norm_path` and the rest of the crate.
+  A Turkish-locale `İ` or similar is out of scope; FASTQ extensions are ASCII.
+- **A2 (fixed).** Only *matching* becomes case-insensitive. Names this code writes stay
+  lowercase, so no output filename gains uppercase.
+- **A3 (fixed, weakened in v2).** Folding the stem without folding `is_gzipped` produces
+  silently uncompressed output and is worse than folding neither — that direction is firm. The
+  converse is softer: folding `is_gzipped` alone would be coherent but does not fix #384. And
+  "both or neither" is not the whole option space — sourcing the compression decision from
+  detected *content* (the follow-up #374/#381 deferred) would retire this coupling entirely;
+  recorded in §10 as the direction, out of scope here.
+- **A4 (fixed).** `.BGZ`/`.BGZF` fold as part of the gzip-family list, but — like lowercase
+  `.bgz` — do not imply gzipped *output*, because `is_gzipped` tests only `gz`. That asymmetry
+  is pre-existing and documented in `is_gzipped`'s doc-comment; this change does not widen it.
+- **A5 (decision).** The renamed outputs are accepted as a behaviour change. The affected users
+  are those currently receiving a mismatched pair.
+
+---
+
+## 9. Validation
+
+**V1 — unit, `strip_fastq_extensions`.** `SAMPLE.FASTQ.GZ`, `Sample.FastQ.Gz`, `SAMPLE.FQ`,
+`SAMPLE.FASTQ`, `SAMPLE.FQ.GZ`, `SAMPLE.FASTQ.BGZ`, `sample_R1.FQ.GZ` → stems `SAMPLE`,
+`Sample`, `SAMPLE`, `SAMPLE`, `SAMPLE`, `SAMPLE`, `sample_R1`. The mixed-case case is the one
+that proves the *retained* part keeps its case rather than being lowercased.
+
+**V2 — unit, `is_gzipped`.** True for `.gz`, `.GZ`, `.Gz`; false for `.fastq`, `.bgz`, `.BGZ`,
+and `sample.gz.fastq`.
+
+**V3 — unit, regression guards.** Every existing `test_strip_fastq_extensions` and
+`test_strip_fastq_extensions_bgz` case still passes unchanged; `sample.bam` / `sample.txt` keep
+their current stems (the fallback must not start folding); and a non-ASCII name (`😀`, and one
+shorter than the suffix) returns unchanged rather than panicking — the naive slice form panics
+on exactly this input (§4), so this case is the guard against reintroducing it.
+
+**V4 — integration, the new refusals.** `SAMPLE.FASTQ.GZ` + `sample.fq.gz` (accepted today,
+verified) exits non-zero after the fold with the collision message; same for
+`SAMPLE.FASTQ.GZ` + `SAMPLE.FQ.GZ`. Both run on any filesystem. v1's pair (pure case-variants)
+is already rejected today via folded report keys and cannot discriminate — do not use it.
+
+**V5 — integration, end-to-end.** Run **without** `--dont_gzip` (v1's §2.1 reproduction used it,
+which hides the compression half). Assert exact literal filenames with no call to any function
+under test in computing the expectations: `SAMPLE_trimmed.fq.gz` exists,
+`SAMPLE.FASTQ.GZ_trimming_report.txt` exists, and the trimmed file's first two bytes are
+`1F 8B`. Resolve which candidate path exists before the magic-byte check, so the naming half and
+the compression half fail independently and legibly. ("Share a stem" is not assertable literally:
+the report keeps the full input filename by design — see §7 note on MultiQC.)
+
+**V6 — negative controls (manual one-offs, not committed guards).** Revert the stem fold alone →
+V1 fails on its first case. Revert `is_gzipped` alone → V5 fails (via its path-resolution step —
+the split assertion in V5 exists so the failure is legible). The *committed* guard for the
+`is_gzipped` half is V2's `is_gzipped(".GZ") == true`; say so, so V6 is not mistaken for a
+regression test.
+
+**V8 — integration, `--clump_only` (the least-guarded consumer).** A `.GZ`-named input: the
+report's `Input:` line says `gzip`, a `Compression ratio:` line is present, and the output is
+`<stem>_clumped.fq.gz`. Pins C1's report-content change and the `--clump_only` stem fix.
+
+**V7 — gates.** `cargo fmt --all -- --check`; `cargo clippy --all-targets --release -- -D
+warnings`; `cargo test`; then rebuild and re-run the §2.1 reproduction.
+
+---
+
+## 10. Questions and ambiguities
+
+**Open 1 — resolved.** Both reviewers independently answered **fold both**, with the same two
+qualifications: (a) B found the compression half currently *has* Perl parity (§2.2), so the fold
+knowingly breaks a parity the naming half never had — stated, not hidden; (b) both name
+content-sourced compression as the follow-up that retires the coupling (out of scope, recorded
+here as the direction).
+
+**Open 2 — `#### Changes` or a minor version note?** Two visible changes for uppercase users.
+The CHANGELOG entry is written either way; flagging in case a release note is wanted.
+
+**Out of scope:** `demux.rs`'s case-sensitive strips (§2.4, would be dead code); restoring
+Perl's append-fallback (§2.2, collides with uBAM naming); non-ASCII case folding (A1).
+
+---
+
+## 11. Self-Review
+
+**Logic.** Traced both functions to their callers: `strip_fastq_extensions` feeds every output
+namer in `io.rs` and all four in `specialty.rs`; `is_gzipped` feeds only `main.rs:295`'s `gzip`
+flag, which is threaded to writers and namers alike. Folding both keeps them consistent, which
+§2.3 shows is the actual requirement.
+
+**Adjusted during review.** The first draft folded `strip_fastq_extensions` only — which was the
+scope stated on the issue and in my own comment. Tracing `is_gzipped` showed that would leave
+uppercase input producing silently uncompressed output, a worse outcome than the mismatch being
+fixed. §2.3, A3 and V6 exist because of that.
+
+**Edge cases.** §3.1, including the new collision the fold makes reachable, and the `.BGZ`
+row where folding the stem does *not* imply folding compression.
+
+**Remaining risks.** Open 1 is the real one. Beyond that, the change is small and its blast
+radius is bounded by two functions whose callers are enumerated above.
+
+---
+
+## 12. Revision history
+
+**v1 → v2**, after dual independent plan review (`PLAN_REVIEW_A.md`, `PLAN_REVIEW_B.md`); the
+two load-bearing findings were re-verified against the binary and the v0.6.11 source before
+adoption.
+
+Adopted from **A**: C1 — v1's caller enumeration for `is_gzipped` missed all three
+`clump_only.rs` sites and mis-cited the `main.rs` line, and §2.4 had "cleared" `clump_only.rs`
+by checking a test assertion instead of the consumers (the exact §2.4-incompleteness failure the
+reviewers were asked to hunt); C2 — v1's "newly reachable collision" was already rejected today
+via folded report keys, so V4 could never fail (verified: exit 1 on dev, same inode on APFS);
+C3 — the naive helper panics on a multi-byte boundary for filenames that work today (byte-wise
+form adopted, non-ASCII case added to V3).
+
+Adopted from **B**: I2 — Perl's *compression* decision is case-sensitive too, so `dev` is
+parity-correct on compression and the fold breaks that parity knowingly (§2.2 rewritten; the
+"parity is already lost" argument held for naming only); I1 — the genuinely new refusals are
+mixed-spelling pairs, integration-testable everywhere (V4 rewritten); I3/I5 — V5 asserts literal
+filenames without `--dont_gzip`, split so the two halves fail independently; I4 — MultiQC
+grouping is *not* delivered and the CHANGELOG must not claim it; I6/V8 — `--clump_only` report
+content pinned; V6 relabelled a manual one-off with V2 as the committed guard.
+
+Adopted from **both**: A3 weakened from a biconditional to the one direction the argument
+supports, with content-sourced compression recorded as the retiring follow-up; the CHANGELOG
+grows to four bullets (rename, compression flip, new refusals, `--clump_only` shifts).
+
+**Open 1 was put to both reviewers independently: both said fold both.**
+
+---
+
+## 13. Implementation notes
+
+Implemented on branch `fix/384-uppercase-extensions` off `dev` @ `533582a`. All six §5 steps
+done as specified in v2 — no deviations. Gates: `cargo fmt --check` clean,
+`clippy -D warnings` clean, **538 tests pass** (533 prior + 3 unit + 3 integration, minus one
+superseded count drift — 6 new tests total).
+
+Diff: `src/io.rs` (+70/−3: the byte-wise helper, both folds, doc-comment, 3 unit tests),
+`tests/integration_gzip_non_gz_extension.rs` (+111: V5 literal-filename/magic-byte,
+V4 mixed-spelling refusals ×2, V8 `--clump_only` report), `CHANGELOG.md` (+24: four-bullet
+entry under `#### Changes`, with the Perl compression-parity departure stated per B's I2 and
+no MultiQC grouping claim per B's I4).
+
+### Negative controls (V6), both run and both discriminating
+
+| Control | Expected failures | Result |
+|---|---|---|
+| stem fold reverted alone | V1 unit + V5 integration | both FAILED; reverted → green |
+| `is_gzipped` reverted alone | V2 unit + V5 + V8 | all three FAILED; reverted → green |
+
+V5 failed at path resolution under control 2, as B's I6 predicted — legible because the naming
+and compression assertions are split.
+
+§2.1's reproduction re-run **without** `--dont_gzip` (B's I5): `SAMPLE_trimmed.fq.gz` with
+`1f 8b` magic beside `SAMPLE.FASTQ.GZ_trimming_report.txt`, exit 0.
+
+### Post-code-review round
+
+Dual code review + coverage audit on the implementation. **0 Critical, 0 High** from both
+reviewers; coverage INCOMPLETE by exactly one item. All findings applied:
+
+- **Coverage / A-L6 (found by three passes independently):** V2's lowercase-`.bgz` false case
+  was asserted nowhere — added, with the comment stating what it guards (the fold must not
+  widen `is_gzipped` to the stem's gzip-family list).
+- **B-M1 (verified against the real report):** V8's `contains("gzip")` was satisfied by the
+  *Output* line (`gzip level 1`) regardless of the Input label. Now asserts the `Input:` line
+  itself contains `(gzip,`.
+- **A-M1 ≡ B-M2:** the CHANGELOG omitted the specialty modes — fifth bullet added, naming the
+  newly-reachable `--implicon` `_R1` strip (same mechanism as #381's `.bgz` note).
+- **A-M2:** paired uppercase integration test added, restoring the test file's stated
+  dispatch-path matrix and pinning the `input[0]`-drives-run-wide-`gzip` coupling.
+- **B-M2 (second half):** `uppercase_stem_reaches_specialty_output_names` unit test pins the
+  implicon/hardtrim/clock namers, beside the #382 `.bgz` pin.
+- **A-L1:** comment on the V4 fixture recording that two of its three names alias one file on
+  APFS (both iterations still refuse on both filesystem kinds; content assertions forbidden).
+- **A-L5:** V5's magic-byte check uses `starts_with`, so a short file fails the assert rather
+  than panicking on the slice.
+- **B-L2 / A-L3:** the stale "matches FastqReader's gzip detection" comment corrected.
+
+One iteration during the batch: the specialty-test insertion anchored on the `fn` line and
+landed between the existing test's `#[test]` attribute and its function — duplicated attribute
+plus dead code, caught by clippy at the gate. The first repair then re-parented the #381
+doc-comment onto the new test (the same defect #385's D6 introduced in `demux.rs`); restructured
+so each test keeps its own doc-comment.
+
+Final gates: **540 tests**, fmt clean, `clippy -D warnings` clean. Diff: 4 files, +269/−5.

--- a/plans/08072026_uppercase-fastq-extensions/PLAN_REVIEW_A.md
+++ b/plans/08072026_uppercase-fastq-extensions/PLAN_REVIEW_A.md
@@ -1,0 +1,331 @@
+# Plan Review A — Match FASTQ extensions case-insensitively (#384)
+
+**Plan:** `plans/08072026_uppercase-fastq-extensions/PLAN.md` (v1, 2026-08-07)
+**Target:** `dev` @ `533582a`, clean tree
+**Reviewer:** A (independent; no coordination with Reviewer B)
+**Method:** read `src/io.rs`, `src/main.rs`, `src/clump_only.rs`, `src/specialty.rs`,
+`src/demux.rs`, `src/cli.rs`, `tests/integration_gzip_non_gz_extension.rs`, `CHANGELOG.md`;
+grepped the caller sets; ran `target/release/trim_galore` (build `080c1d0`, current with `dev`)
+on constructed uppercase inputs; compiled a standalone `rustc` probe for the §4 helper.
+
+Verdict: **the decision is right and the change is small, but three of the plan's checkable
+claims are wrong**, and two of them sit underneath validation items — V4 as specified cannot
+fail, and §4's helper as specified panics on input that works today.
+
+---
+
+## 1. Logic review
+
+### C1 — §11's caller enumeration for `is_gzipped` is wrong (Critical)
+
+§2.3 and §11 both state `is_gzipped` "feeds only `main.rs:295`'s `gzip` flag". Two errors:
+
+- The flag is at **`main.rs:345`**, not 295.
+- There are **three more call sites**, all in `src/clump_only.rs`:
+  - `:277` — `let input_compressed = naming::is_gzipped(input);` (SE `--clump_only`)
+  - `:414` — `naming::is_gzipped(input_r1) || naming::is_gzipped(input_r2)` (PE `--clump_only`)
+  - `:1107` — test helper `write_synthetic_fastq`, which gzip-*encodes* based on the name
+
+`input_compressed` lands in `ClumpOnlyStats` (`:305`, `:451`) and drives two things in the
+`--clump_only` text report: the `Input: … (gzip|plain, N bytes)` label (`:596`) and the gate on
+the `Compression ratio: N.NNx` line (`:640`, emitted only when input *and* output are
+compressed). So folding changes **report content** on the `--clump_only` FASTQ path for a
+`.GZ`-named input: `plain` → `gzip`, and a ratio line appears where none did.
+
+Direction is benign — the input genuinely *is* gzip, so both are corrections, in the same
+direction as the rest of the change. Nothing silently wrong results. But:
+
+- It is a user-visible change the plan does not list, and §7/§5 Step 6 chose `#### Changes`
+  precisely because visible changes get enumerated. This one is missing.
+- §2.4 "clears" `clump_only.rs` by checking **the wrong line**: it cites `:1469`
+  (`assert_eq!(out.extension(), Some("fq"))`, a test assertion on a lowercase-named input) and
+  concludes "Unaffected". The exposure is at `:277`/`:414`, which §2.4 never looks at.
+- `clumped_output_name` (`io.rs:362`) also calls `strip_fastq_extensions`, while
+  `clumping_report_name` (`io.rs:464`) uses the full input filename — so `--clump_only` carries
+  the *same* stem/report mismatch #384 reports, and the same fix resolves it. Also unlisted.
+
+§11's closing sentence — "blast radius is bounded by two functions whose callers are enumerated
+above" — is unsound as written, because the enumeration is incomplete.
+
+**Fix:** correct the line number, add the three sites, state the report-label and ratio-line
+change in §7, and mention the `--clump_only` stem fix in the CHANGELOG entry.
+
+### C2 — §3.1's last row is false; V4 as specified cannot fail (Critical)
+
+§3.1's last row and V4 both assert that `SAMPLE.FASTQ.GZ` + `sample.fastq.gz` in one run
+becomes newly rejected — "this makes the collision reachable where it was not before", and V4
+"pins §3.1's last row deliberately rather than leaving it to be discovered".
+
+**That pair is already rejected on `dev` @ `533582a`.** Verified:
+
+```
+$ trim_galore -o out_coll SAMPLE.FASTQ.GZ sample.fastq.gz     # exit 1
+Error: Output path collision (case-insensitive, for APFS/NTFS safety):
+out_coll/SAMPLE.FASTQ.GZ_trimming_report.txt and out_coll/sample.fastq.gz_trimming_report.txt
+would be written to the same file. …
+```
+
+The reason: `report_name` / `json_report_name` (`io.rs:480`, `:496`) build their filename from
+the **full input filename**, not the stem, and `collision_key` folds case. So two inputs that
+differ only in case already produce case-folded-equal *report* paths and are refused before the
+trimmed names are ever compared. The fold changes nothing here. V4 as written would pass
+identically before and after the change — a non-discriminating test resting on a false premise.
+
+The fold *does* create newly-reachable collisions, but only for inputs that differ in
+**extension spelling as well as case**, where the report names stay distinct. Verified accepted
+today:
+
+```
+$ trim_galore -o out A.FASTQ.GZ a.fq.gz       # exit 0, no collision
+out/A.FASTQ_trimmed.fq   out/a_trimmed.fq
+out/A.FASTQ.GZ_trimming_report.txt   out/a.fq.gz_trimming_report.txt
+```
+
+After the fold both stems become `A`/`a` and both are gzipped → `A_trimmed.fq.gz` and
+`a_trimmed.fq.gz` → `collision_key`-equal → refused. **Fix:** replace §3.1's last row and V4's
+inputs with `A.FASTQ.GZ` + `a.fq.gz` (or `SAMPLE.FASTQ.GZ` + `sample.fq.gz`), and drop the
+"reachable where it was not before" claim for pure case-variants.
+
+Note also that on a case-**insensitive** filesystem (default APFS, i.e. the dev machine) the two
+pure case-variants cannot coexist on disk at all — passing both spellings addresses one file
+twice. The `A.FASTQ.GZ`/`a.fq.gz` pair works on both filesystem kinds, which is a second reason
+to prefer it.
+
+### C3 — §4's helper, as described, panics on filenames that work today (Critical)
+
+§4 specifies "a length check plus `eq_ignore_ascii_case` on the tail, returning the untouched
+prefix". Implemented the obvious way on `&str`:
+
+```rust
+let idx = name.len() - suffix.len();
+if name[idx..].eq_ignore_ascii_case(suffix) { Some(&name[..idx]) } else { None }
+```
+
+`str` slicing panics when the index is not a UTF-8 char boundary, and
+`name.len() - suffix.len()` can land inside a multi-byte character. Verified with a standalone
+`rustc` probe — name `😀` (4 bytes), suffix `".gz"` (3 bytes), idx 1:
+
+```
+thread 'main' panicked: start byte index 1 is not a char boundary;
+it is inside '😀' (bytes 0..4) of `😀`
+```
+
+Today's `str::strip_suffix` returns `None` safely for the same input, and the binary handles
+such a file end-to-end — verified: a gzipped FASTQ named `😀` (no extension) gives
+`😀_trimmed.fq` + both reports, exit 0. So the naive form converts a **working** input into a
+**panic**. `strip_fastq_extensions` reads `file_name().to_string_lossy()`, so any non-ASCII or
+invalid-UTF-8 filename is a candidate, and extensionless inputs are explicitly supported
+(`io.rs:617` pins `sample` → `sample`).
+
+**Fix:** compare on bytes and slice only after a successful match (a matched all-ASCII tail
+guarantees the index is a boundary):
+
+```rust
+fn strip_suffix_ignore_ascii_case<'a>(name: &'a str, suffix: &str) -> Option<&'a str> {
+    let idx = name.len().checked_sub(suffix.len())?;
+    name.as_bytes()[idx..]
+        .eq_ignore_ascii_case(suffix.as_bytes())
+        .then(|| &name[..idx])
+}
+```
+
+`checked_sub` also removes the `name.len() < suffix.len()` underflow case. Add a non-ASCII
+regression case to V3.
+
+### I1 — V5 will be vacuous if it follows the precedent in its named home (Important)
+
+§5 Step 5 puts the integration test in `tests/integration_gzip_non_gz_extension.rs` "where
+#374/#382 put the related cases". That file already contains the exact precedent —
+`bgz_output_and_report_agree_on_the_stem` (`:304`) — and it passes **`--dont_gzip`** (`:317`),
+deliberately, so the expected output name does not depend on `is_gzipped`. A copy-paste of that
+shape for the uppercase case would assert only the stem and never observe compression, which
+makes **V6's first negative control vacuous**: reverting `is_gzipped` would not fail it.
+
+**Fix:** V5 must run *without* `--dont_gzip` and assert three things: the trimmed file is at
+`SAMPLE_trimmed.fq.gz` (name — proving the retained case is preserved end-to-end), its first
+two bytes are `1f 8b`, and **both** reports exist as `SAMPLE.FASTQ.GZ_trimming_report.txt` and
+`…json` (the precedent checks both; V5 says "a report").
+
+### I2 — "share a stem" is not literally true (Important)
+
+§5 Step 5 and V5 say the trimmed file and the report must "share a stem". They never do:
+`report_name` uses the full input filename, so even in the fully-correct lowercase case the pair
+is `sample_trimmed.fq.gz` + `sample.fastq.gz_trimming_report.txt`. §1's concrete expected names
+are right; the wording in §5/V5 is not, and an implementer who asserts
+`strip_fastq_extensions(report) == stem` will write a test that cannot pass. State the invariant
+the precedent states: trimmed == `{folded_stem}_trimmed.fq[.gz]`, report ==
+`{input_filename}_trimming_report.*` — i.e. the report filename *begins with* the trimmed stem.
+
+### I3 — Specialty-mode renames are neither tabulated nor validated (Important)
+
+All four `specialty.rs` namers take the stem (`:449`, `:471`, `:485`, `:501`), so
+`--hardtrim5/3`, `--clock` and `--implicon` outputs all rename for uppercase input. §11 knows
+this; §3.1 tabulates SE trim only, and V1–V7 contain no specialty assertion. Verified today:
+
+```
+$ trim_galore --hardtrim5 30 -o out SAMPLE_R1.FASTQ.GZ
+out/SAMPLE_R1.FASTQ.30bp_5prime.fq        → after the fold: SAMPLE_R1.30bp_5prime.fq.gz
+```
+
+`--implicon` changes **twice over**. Its `_R1` / `R1` / `_R2`… suffix strip (`:505-517`) runs on
+the stem, so for uppercase input it is currently *unreachable* (the stem ends `.FASTQ`) and
+becomes reachable after the fold: `SAMPLE_R1.FASTQ.GZ` goes from
+`SAMPLE_R1.FASTQ_8bp_UMI_R1.fastq` to `SAMPLE_8bp_UMI_R1.fastq.gz` — stem, double-R avoidance,
+and compression all change together. Add a §3.1 row and a unit assertion on
+`implicon_output_name`; `--hardtrim5` and `--clock` are in the CI validation matrix, so a
+reader will want the "no uppercase fixture, therefore unaffected" reasoning (§7) attached to
+them explicitly.
+
+### I4 — §1's "one rule" is overstated: `_R1` matching stays case-sensitive (Important)
+
+Because that suffix strip is not an extension, it keeps case sensitivity: `SAMPLE_r1.FASTQ.GZ`
+under `--implicon` retains `_r1` in the output while `SAMPLE_R1.FASTQ.GZ` does not. §1 promises
+"One rule, no case-dependent behaviour to document or remember"; that is not delivered. Either
+fold it too or name it in §10's out-of-scope list beside `demux.rs`. Recommend out-of-scope but
+**stated** — an unstated residual case-sensitivity is what produced #384.
+
+### I5 — A3's biconditional is stronger than the argument supports (Important)
+
+§2.3 establishes one direction soundly: folding `strip_fastq_extensions` *requires* folding
+`is_gzipped`, else uppercase input yields silently plain output. The converse is not
+established. Folding `is_gzipped` alone is coherent — `SAMPLE.FASTQ.GZ` →
+`SAMPLE.FASTQ_trimmed.fq.gz`, where name and framing agree — it simply does not fix #384,
+which is the stem mismatch. §2.3's table omits that fourth column. Stating the implication
+rather than "both or neither" makes the argument airtight and pre-empts exactly that
+counter-proposal.
+
+### I6 — V2/V3's case lists miss the cases the fold actually moves (Important)
+
+- `sample.txt.GZ`: today → `sample.txt` (`file_stem` drops `.GZ`); after the fold → `sample`
+  (the `.GZ` strips, no FASTQ ext, then `file_stem` drops `.txt`). §3.1 lists `sample.txt`
+  ("unchanged", true) but not the changed uppercase-gz spelling; io.rs:616 already pins the
+  lowercase form, so this is the fold making the two agree — desirable, but it is a stem change
+  *outside* the FASTQ list and belongs in V3.
+- V2's false-list has `.bgz` and `.BGZ` but not `.BGZF`.
+- V1 has `SAMPLE.FASTQ.BGZ` but not `.BGZF` uppercase.
+- Add the C3 non-ASCII case.
+
+---
+
+## 2. Claims verified as correct
+
+| Claim | Verdict |
+|---|---|
+| §2.1 reproduction | **Correct.** `-o out SAMPLE.FASTQ.GZ` → `SAMPLE.FASTQ_trimmed.fq` + `SAMPLE.FASTQ.GZ_trimming_report.{txt,json}` |
+| §2.3 `is_gzipped` body and doc-comment intent | Correct (`io.rs:29-31`; doc `:12-28`) |
+| §7 no uppercase fixture in `test_files/`, none in `ci.yml` | **Correct.** My regex was capable of failing — it found the one uppercase literal that exists, `io.rs:756`'s `norm_path(Path::new("FOO.FQ.GZ"))` |
+| §2.4 `demux.rs` sees only paths this code names | Correct. `demux_base_name` (`:112`) takes the trimmed output path; extensions there are always ours and lowercase, including under `--basename` (which replaces the stem only) |
+| §2.4 `format.rs` unaffected | Correct — content-based; no filename-extension decision in it |
+| §2.4 `clump_only.rs:1469` itself unaffected | Correct **about that line** — but the file is not unaffected, see C1 |
+| §3.1 `.BGZ` row (`SAMPLE` / `SAMPLE_trimmed.fq`) | **Correct.** `.BGZ` folds in the stem list; `is_gzipped` tests only `gz`, so output stays plain |
+| A4's citation | Correct — the `.bgz`/output asymmetry is already documented at `io.rs:23-28` and in the CHANGELOG's Unreleased §Bug fixes |
+| `strip_fastq_extensions`'s "disjoint list" comment survives folding | Correct — `.BGZ`'s 3-byte tail is `BGZ`, which does not ASCII-fold-match `.gz`, so list order still does not matter |
+| §5 Step 3 compiles | Correct — `OsStr::eq_ignore_ascii_case` is stable since 1.53, below the 1.88 floor |
+| `#### Changes` exists under Unreleased | Correct |
+| No new filename-based decision sites beyond the two | Correct — `cli.rs` uses only `path_identity_key` (case-**sensitive**, input identity, `:537-638`), deliberately unfolded and unaffected |
+
+On A4's sharper question — does folding *change* anything for `.BGZ` inputs? **Yes**: the stem
+moves from `SAMPLE.FASTQ` to `SAMPLE`, so the trimmed file is renamed. Only compression is
+unchanged. §3.1's note ("still plain — consistent with `.bgz` today") reads as "nothing
+changes"; say "renamed, still plain".
+
+---
+
+## 3. V6's negative controls — do they discriminate?
+
+- **"Revert `is_gzipped` alone → V5's compression assertion fails."** Discriminates *only if*
+  V5 omits `--dont_gzip` (I1). Even then, the failure surfaces as the missing-file assertion
+  (`SAMPLE_trimmed.fq.gz` absent, because the plain name is used) *before* the magic-byte
+  check. Reword to "confirm V5 fails". Note this control is partly redundant with V2, but it
+  earns its place by proving the `main.rs:345` → writer wiring is live.
+- **"Revert the fold in `strip_fastq_extensions` alone → V1 fails."** Discriminates cleanly —
+  `SAMPLE.FASTQ.GZ` yields `SAMPLE.FASTQ`, not `SAMPLE`.
+- **Missing control:** nothing fails for an implementation that lowercases the *whole* name
+  (`name.to_ascii_lowercase()` then `strip_suffix`). V1's `Sample.FastQ.Gz` row catches it and
+  the plan says so — but V5 must also assert the output *filename* is exactly
+  `SAMPLE_trimmed.fq.gz`, or the end-to-end path has no such guard (I1).
+- **V4:** does not discriminate at all as specified (C2).
+
+---
+
+## 4. Efficiency
+
+§6 is right and the section is proportionate: five suffix probes per input file, no allocation,
+once per file. `checked_sub` + a byte compare is no slower than `strip_suffix`. Nothing further.
+
+---
+
+## 5. Alternatives
+
+- **Fold neither, close #384 won't-fix.** Coherent but leaves a real defect: the trimmed file
+  and its report disagree about the sample name, and MultiQC takes the sample name from the
+  report filename — the same reasoning the #381 CHANGELOG entry and the precedent test's doc
+  comment (`tests/integration_gzip_non_gz_extension.rs:298`) already give. Reject.
+- **Fold `is_gzipped` only.** Fixes compression, not the reported bug. See I5.
+- **Converge output compression on `format::detect_input_format` instead of the filename.** The
+  honest larger fix; it would subsume A4's `.BGZ` asymmetry and retire the "known limitation"
+  paragraph already recorded in the Unreleased CHANGELOG. Blast radius is every run, including
+  a plain file misnamed `.gz` — which is exactly why #374/#381 deferred it. Not for this plan,
+  but §10 should link the two deferrals so they stay visibly connected; folding now does not
+  foreclose it.
+
+---
+
+## 6. Action items
+
+### Critical
+
+1. **C1** — Fix §2.3/§11's `is_gzipped` caller list: `main.rs:345` (not 295) plus
+   `clump_only.rs:277`, `:414`, `:1107`. Add the `--clump_only` report-label and
+   `Compression ratio` change to §7 and the CHANGELOG. Re-check §2.4's `clump_only.rs` line
+   (it cites `:1469`; the exposure is `:277`/`:414`).
+2. **C2** — §3.1's last row and V4 are false: `SAMPLE.FASTQ.GZ` + `sample.fastq.gz` is already
+   rejected today via the report paths. Replace with `A.FASTQ.GZ` + `a.fq.gz` (verified
+   accepted today, collides after the fold) or drop the "newly reachable" claim.
+3. **C3** — Specify the helper on bytes with `checked_sub`. The `&str`-slicing form panics on a
+   filename like `😀`, which works today (verified both ways). Add a non-ASCII case to V3.
+
+### Important
+
+4. **I1** — V5 must omit `--dont_gzip` (the precedent test at `:304` uses it and would silence
+   the compression half, making V6's first control vacuous); assert the exact output name, the
+   `1f 8b` magic, and both report files.
+5. **I2** — Replace "share a stem" with the actual invariant; `report_name` keeps the full
+   input filename.
+6. **I3** — Tabulate the specialty-mode renames in §3.1 and add a unit assertion on
+   `implicon_output_name`, whose `_R1` strip becomes newly reachable.
+7. **I4** — Name the residual case-sensitive `_R1`/`_R2` matching in §10's out-of-scope list, or
+   soften §1's "one rule" claim.
+8. **I5** — State A3 as an implication, not a biconditional; add the missing fourth column to
+   §2.3's table.
+9. **I6** — Extend V2/V3 with `sample.txt.GZ`, `.BGZF` uppercase, and the non-ASCII case.
+
+### Optional
+
+10. **O1** — Drop `--dont_gzip` from §2.1's repro; the output is plain anyway, which is the
+    stronger demonstration and makes §2.3 self-evident.
+11. **O2** — Cite MultiQC in §7 as the downstream stake, matching the #381 entry's wording.
+12. **O3** — Link the content-based-compression deferral in §10.
+13. **O4** — One line noting `--basename` bypasses the stem function entirely, so it is
+    correctly unaffected.
+14. **O5** — No edit needed to
+    `tests/integration_gzip_non_gz_extension.rs:74-82` ("still looks at the input *filename*"
+    stays true after folding); say so in §5 so an implementer does not have to work it out.
+
+---
+
+## 7. Answer to Open 1
+
+**Fold both, as the plan does.** §2.3's argument is sound in the direction that matters:
+folding the stem without folding compression makes uppercase input produce silently
+uncompressed output, which is strictly worse than the mismatch being fixed. The middle ground
+the plan missed (fold `is_gzipped` only) is coherent but does not fix #384, so it is not an
+alternative to this plan — and the genuinely better long-term answer (drive compression from
+detected content) is out of scope for the same reason #374/#381 deferred it. Folding neither
+would leave a defect that is the rewrite's own, with a concrete downstream cost in MultiQC
+sample naming. I would not fold neither.
+
+**Open 2:** `#### Changes` is right. The audience is narrow (uppercase-extension users only)
+and both effects are corrections toward the documented lowercase behaviour; a release note is
+not warranted, but the entry should name the `--clump_only` and specialty-mode renames (C1, I3)
+so the affected surface is complete.

--- a/plans/08072026_uppercase-fastq-extensions/PLAN_REVIEW_B.md
+++ b/plans/08072026_uppercase-fastq-extensions/PLAN_REVIEW_B.md
@@ -1,0 +1,311 @@
+# Plan Review B — Match FASTQ extensions case-insensitively (#384)
+
+**Plan:** `plans/08072026_uppercase-fastq-extensions/PLAN.md` (v1, 2026-08-07)
+**Target:** `dev` @ `533582a`, clean tree
+**Reviewer:** B (independent; no coordination with Reviewer A)
+
+**Verdict:** the approach is right and the plan is unusually careful, but its blast-radius
+statement is wrong in one place (`is_gzipped` has four call sites, not one), and the parity
+argument that licences folding `is_gzipped` does not survive reading the Perl source.
+1 Critical, 6 Important, 6 Optional.
+
+---
+
+## What I verified (and that the checks could fail)
+
+| Claim | Result |
+|---|---|
+| §2.1 reproduction | **Confirmed**, and stronger than stated — see I5 |
+| `is_gzipped` feeds only `main.rs:295` (§2.3, §11) | **False.** 4 call sites; line is 345 → **C1** |
+| `strip_fastq_extensions` callers (§11) | 12 in `io.rs`, 4 in `specialty.rs`; two namers bypass it → O2 |
+| §2.4: `demux.rs` sees only self-named paths | **Confirmed** (`main.rs:97-99` → `demux_base_name`, `demux.rs:111`) |
+| §2.4: `format.rs`, `clump_only.rs:1469` unaffected | **Confirmed** |
+| §7: no uppercase extension in `test_files/` or `ci.yml` | **Confirmed**, and extended to `src/`+`tests/`+`docs/`: one hit, `io.rs:756` (`norm_path("FOO.FQ.GZ")`), which folding cannot affect. The grep found a hit, so it was capable of finding others. |
+| §3.1: `SAMPLE.FASTQ.GZ` + `sample.fastq.gz` rejected after fold | **True by construction** (`collision_key` = lowercased absolute path; SE `planned` covers all inputs, `main.rs:825-834`) — but the scenario is unreachable on APFS → **I1** |
+| §3.1 `.BGZ` row | **Accurate**; stem changes, compression does not → O1 |
+| §2.2 Perl naming (`trim_galore` 909-923, 611) | **Confirmed verbatim** from `git show 0.6.11:trim_galore` — and line 925 adds something the plan missed → **I2** |
+
+Reproduction, run in the scratchpad with `target/release/trim_galore` (built from `080c1d0`,
+the pre-merge commit of #383; `git diff 080c1d0 HEAD -- src/io.rs` touches only
+`collision_key`/`path_identity_key` and tests, leaving all three functions under review
+byte-identical, so it is valid for these observations):
+
+```
+SAMPLE.FASTQ.GZ  → SAMPLE.FASTQ_trimmed.fq (ASCII text)  + SAMPLE.FASTQ.GZ_trimming_report.{txt,json}
+SAMPLE.FASTQ.BGZ → SAMPLE.FASTQ_trimmed.fq (ASCII text)  + SAMPLE.FASTQ.BGZ_trimming_report.{txt,json}
+ref.fastq.gz     → ref_trimmed.fq.gz                     + ref.fastq.gz_trimming_report.{txt,json}
+```
+
+---
+
+## Critical
+
+### C1 — `is_gzipped` has four call sites, and `--clump_only`'s report is one of them
+
+§2.3 and §11 both assert `is_gzipped` "feeds only `main.rs:295`'s `gzip` flag". The call sites are:
+
+- `src/main.rs:345` — the `gzip` flag (the line number in the plan is also stale)
+- `src/clump_only.rs:277` — `input_compressed`, single-end `--clump_only`
+- `src/clump_only.rs:414` — `input_compressed`, paired `--clump_only`
+- `src/clump_only.rs:1107` — a test helper (`write_synthetic_fastq`), harmless
+
+`input_compressed` is not cosmetic. In `write_clump_only_report` it selects the report's
+input label (`clump_only.rs:596`: `"gzip"` vs `"plain"`) and gates the compression-ratio
+line entirely (`clump_only.rs:640`: `input_compressed && output_compressed && output_bytes > 0`).
+`gzip_output` on that path is the same folded `gzip` flag (`main.rs:526/534`, `550/558`). So for
+a `.GZ`-named input under `--clump_only`, folding changes **three** things at once:
+
+```
+Input:  SAMPLE.FASTQ.GZ (plain, N bytes)   →   Input:  SAMPLE.FASTQ.GZ (gzip, N bytes)
+Output: SAMPLE.FASTQ_clumped.fq (plain…)   →   Output: SAMPLE_clumped.fq.gz (gzip level 1…)
+(no ratio line)                            →   Compression ratio: X.XXx
+```
+
+None of this is wrong — the label becomes *more* truthful, since a `.GZ` file really is gzip —
+but it is an output-content change to a second mode that the plan does not enumerate, does not
+put in the CHANGELOG (Step 6), and does not validate. Nothing catches it if it regresses: §7
+confirmed no test anywhere uses an uppercase extension, so the whole clump path is dark here.
+
+**Action:** correct §2.3/§11's enumeration; add the `--clump_only` report change to §3.1, §7
+and Step 6; add a validation (see V8 below).
+
+---
+
+## Important
+
+### I2 — the compression half *does* have a parity defence, contra §2.2
+
+§2.2's load-bearing sentence is "parity cannot arbitrate this decision because parity is already
+lost". Verified against `git show 0.6.11:trim_galore`: for the **name**, that is exactly right —
+line 923's `else { s/$/_trimmed.fq/ }` appends to the full filename and line 611's report does the
+same, so Perl agreed with itself and we do not.
+
+But eighteen lines later, Perl decides compression:
+
+```perl
+if ($gzip or $filename =~ /\.gz$/){
+```
+
+No `/i`. Perl wrote `SAMPLE.FASTQ.GZ_trimmed.fq` **plain** — which is what `dev` does today.
+So today's Rust is *parity-correct on compression* for `.GZ` input, and folding `is_gzipped`
+breaks a parity that currently holds, while folding `strip_fastq_extensions` restores nothing
+Perl had either. §2.2's "parity is already lost" is true of the naming half only; the plan
+generalises it to license the compression half, which is the one place the argument is unearned.
+
+This does not change my recommendation (see Open 1), but the plan should say so plainly rather
+than leaning on a parity claim that inverts between the two functions — the CI validation matrix
+is unaffected only because no fixture is uppercase, not because parity is irrelevant here.
+
+### I1 — the new refusal §3.1 picks cannot happen on APFS; the one that can is missing
+
+§3.1's last row and V4 use `SAMPLE.FASTQ.GZ` + `sample.fastq.gz`. Those two names are **one file**
+on APFS — verified: the second `cp` prompted to overwrite the first. The row is therefore a
+Linux/case-sensitive-FS-only scenario, correctly scoped as a *unit* test (the plan gets that
+right) but it must never be promoted to an integration test, and it should be labelled as what
+it is: a case-folding **false positive** on case-sensitive filesystems — two genuinely distinct
+outputs refused. That is the trade-off `norm_path`'s own doc-comment (`io.rs:39-42`) already
+accepts ("a loud early error rather than silent data loss"), so it is defensible; "the pre-flight
+working as designed" undersells it.
+
+Meanwhile the collision users will actually hit is absent from the plan. Verified on `dev` today:
+
+```
+$ trim_galore -o out_c1 SAMPLE.FASTQ.GZ SAMPLE.FQ.GZ     # succeeds, 6 output files
+$ trim_galore -o out_c2 s2.fastq.gz     s2.fq.gz         # Error: Output path collision …
+```
+
+After the fold both uppercase inputs stem to `SAMPLE`, so the first command becomes a hard
+error — on **every** filesystem, no case-sensitivity required, and not a false positive (the two
+outputs really are one path). Same for `.FASTQ.GZ` + `.FASTQ.BGZ`. This is the row that belongs
+in §3.1 and in the CHANGELOG, and it is integration-testable anywhere.
+
+### I3 — V5's "share a stem" is either self-referential or false as written
+
+`report_name` (`io.rs:480-492`) formats `{full input filename}_trimming_report.txt`. So the
+trimmed file and the report never *literally* share a stem, in any case — verified above,
+lowercase included (`ref_trimmed.fq.gz` vs `ref.fastq.gz_trimming_report.txt`). "Share a stem"
+only holds under a stripping rule, and the only rule under which it holds is
+`strip_fastq_extensions` itself — the function under test. A V5 implemented as
+`strip_fastq_extensions(report_input_part) == trimmed_stem` passes for *any* self-consistent
+fold, including a wrong one (e.g. one that lowercases the retained part: `sample` == `sample`).
+
+**Action:** V5 asserts exact literal filenames — `SAMPLE_trimmed.fq.gz` exists,
+`SAMPLE.FASTQ.GZ_trimming_report.txt` exists, and the first two bytes of the trimmed file are
+`1F 8B` — with no call to any function under test in computing the expectations.
+
+### I4 — the change does not deliver the MultiQC grouping §2.1 invokes
+
+§2.1 and the #381 precedent frame the mismatch as "disagree about the sample name (which is what
+MultiQC groups on)". After the fold, the report filename still carries `.FASTQ.GZ`, and
+`report.rs` writes the input filename verbatim into the report body (`input_filename`,
+`input_filenames`). A consumer stripping extensions case-sensitively — which is how MultiQC's
+`fn_clean_exts` list works, worth confirming before writing this in the CHANGELOG — still
+derives `SAMPLE.FASTQ.GZ` from the report and `SAMPLE` from the trimmed file. Two sample names,
+as before.
+
+The §1 goal (one rule, uppercase behaves as lowercase) *is* delivered, and that is a good enough
+reason. But §2.1/§7 should not imply downstream grouping is fixed, because it is not — only the
+lowercase path was ever groupable, and the fold makes uppercase internally consistent, not
+downstream-clean.
+
+### I5 — the §2.1 reproduction hides the compression symptom, so V7's re-run can't see it
+
+§2.1 (and V7's "re-run the §2.1 reproduction") passes `--dont_gzip`, which forces plain output
+and makes the compression half invisible. Verified without it: current output is still
+`SAMPLE.FASTQ_trimmed.fq`, plain ASCII text — because `is_gzipped` returned false. Drop
+`--dont_gzip` and the one command demonstrates both halves before and after. As written, V7's
+final gate cannot observe the change C1/Open 1 are about.
+
+### I6 — V6's negative controls: one discriminates, one is redundant and mis-aimed
+
+Worked through both as specified:
+
+- **"revert the fold in `strip_fastq_extensions`, confirm V1 fails"** — genuinely
+  discriminating. `SAMPLE.FASTQ.GZ` → `SAMPLE.FASTQ` ≠ `SAMPLE`; V1 fails on its first case. ✅
+- **"revert `is_gzipped`, confirm V5's compression assertion fails"** — the test does fail, but
+  not where claimed. With the stem folded and `is_gzipped` reverted, the output is
+  `SAMPLE_trimmed.fq`; V5 fails at *path resolution*, never reaching the magic-byte assertion.
+  It discriminates, but not on the compression axis, and the failure message will point at a
+  missing file. Fix by having V5 resolve whichever of the two candidate paths exists, then assert
+  on the magic bytes separately — so the two halves fail independently and legibly.
+
+Two further points. V6 is a **manual one-off**, not a committed guard; the permanent guard against
+re-losing the `is_gzipped` half is V2, which already pins `is_gzipped(".GZ") == true`. Say that,
+so V6 is not mistaken for a regression test. And no control covers C1's `--clump_only` report
+path, which is currently the least-guarded consequence of the change.
+
+**V8 (new):** `--clump_only` on a `.GZ`-named input — assert the report's `Input:` line says
+`gzip`, that a `Compression ratio:` line is present, and that the output is
+`<stem>_clumped.fq.gz`. This is the only proposed test that would catch a regression in C1's
+newly-identified consumer.
+
+---
+
+## Optional
+
+- **O1.** §3.1's `.BGZ` row is accurate on the Output column (verified: plain before *and* after)
+  but is not marked as changed, though its stem moves `SAMPLE.FASTQ` → `SAMPLE`. Only the `.GZ`
+  row carries a **changed** marker. One word.
+- **O2.** §11's "every output namer" overstates: `main.rs:1646` and `main.rs:2219` (interleaved-uBAM
+  paired FASTQ and BAM output) name from a raw `input.file_stem()` and bypass
+  `strip_fastq_extensions` entirely. Both are BAM-input-only, so nothing to fold, but the
+  enumeration should carry the exception so a later reader does not read it as a bug.
+- **O3.** `--basename` substitutes for the stem (`io.rs:169`, `195`, `222`, …), bypassing
+  `strip_fastq_extensions`, so `--basename SAMPLE.FASTQ` is unaffected by the fold. Consistent
+  with A2; one line in §2.4 stops it being reported later as a residual inconsistency.
+- **O4.** V1/V3 have no uppercase *non*-FASTQ cases. Two are worth pinning: `SAMPLE.TXT.GZ`
+  (stem `SAMPLE.TXT` → `SAMPLE`, mirroring the existing lowercase assertion at `io.rs:616`) and
+  bare `SAMPLE.GZ` (stem stays `SAMPLE`, but compression flips plain → gzip). The second is the
+  only input class where compression changes while the name does not — exactly the case a reader
+  of the CHANGELOG will not predict.
+- **O5.** The disjointness comment at `io.rs:530-531` ("`.bgz` does not end in `.gz`") still holds
+  under ASCII-insensitive matching, and `.bgzf` ends in neither, so `find_map` order stays
+  irrelevant. Worth stating in the commit message rather than leaving the next reader to re-derive it.
+- **O6.** Implementation nit for Step 2: the current chain is
+  `find_map(|ext| name.strip_suffix(ext)).unwrap_or(&name)`, so the helper must return a
+  `&'a str` borrowed from `name` (as §4's signature does) and the second stage must borrow from
+  that same chain — not from a `String` temporary — or it will not borrow-check. §4 has this
+  right; flagging only because it is the one place the implementation can trip.
+
+---
+
+## Assumptions
+
+- **A1 (ASCII-only)** — sound, and consistent with `norm_path` (`io.rs:44`), which the collision
+  pre-flight already relies on. Non-ASCII would additionally desynchronise the fold from
+  `collision_key`, so ASCII is not just convenient, it is required for §3.1 to hold.
+- **A2 (only matching folds)** — verified: every namer composes `format!` with lowercase literals.
+  Nothing emits uppercase. Add O3 for completeness.
+- **A3 (both or neither)** — sound in the direction the plan argues (see Open 1) but stated too
+  strongly; there is a third option it does not name, and I2 weakens the parity ground it stands on.
+- **A4 (`.BGZ` folds the stem but not compression)** — accurate. Verified that folding changes
+  nothing about `.BGZ` compression: `extension()` is `BGZ`, and `eq_ignore_ascii_case("gz")` is
+  false for it before and after. The asymmetry is genuinely pre-existing (`is_gzipped`'s own
+  doc-comment, `io.rs:24-28`, already confesses it for lowercase `.bgz`).
+- **A5 (renames accepted)** — the affected population is wider than "those currently receiving a
+  mismatched pair": it also includes `--clump_only` users (C1) and multi-input runs that will now
+  be refused (I1).
+
+**Unstated assumption worth surfacing:** that `gzip` is derived from `cli.input[0]` alone
+(`main.rs:345`). A run mixing `sample.fastq.gz` and `SAMPLE2.FASTQ.GZ` inherits the *first*
+file's compression for both, before and after the fold. Pre-existing and documented in the
+comment at `main.rs:338-344`, but the fold changes *which* runs are affected, so it is worth one
+line rather than a surprise.
+
+---
+
+## Efficiency
+
+Agreed and uncontroversial: `eq_ignore_ascii_case` over a ≤5-byte suffix, five probes, once per
+input file, no allocation. Same order as `strip_suffix`'s memcmp. Nothing further.
+
+---
+
+## Alternatives
+
+**The middle ground §2.3 misses.** `is_gzipped`'s doc-comment (`io.rs:24-28`) already names the
+real fix and defers it: source the output-compression decision from `format.rs`'s *detected*
+format instead of the filename. That resolves `.GZ`, `.BGZ`, `.BGZF` and a mis-named plain `.gz`
+in one move, and it dissolves A3 — with compression sourced from content, folding
+`strip_fastq_extensions` alone is safe and complete. The reason it is deferred is real (a plain
+file misnamed `.gz` currently gets gzipped output and would stop), which is why I would not do it
+under #384. But it should appear in §10 as the destination, so this fold reads as an interim step
+rather than the end state.
+
+**Restore Perl's append-fallback** — §2.2 rejects it on uBAM grounds and that reasoning holds
+(`sample.bam_trimmed.bam` is indefensible). Agreed, no need to revisit.
+
+**Fold neither, close won't-fix** — leaves a rule with no defence: the naming half is not Perl's
+either (verified), so "we match Perl" would be false as stated. Rejecting this is right.
+
+---
+
+## Answers to the four questions put to me
+
+1. **Open 1 — is A3 sound?** Directionally yes: folding the stem alone yields `SAMPLE_trimmed.fq`,
+   a name that *looks* like the gzipped convention's sibling but is silently plain, which is worse
+   than today's honest mismatch. But "both or neither" is false — the content-sourced compression
+   decision above is a coherent third option, and I2 shows the compression half is the one place
+   parity currently favours *not* folding. **Fold both**, as the plan proposes, and say in §10
+   that the format-sourced decision is the follow-up that makes A3 unnecessary.
+2. **A4 / `.BGZ`** — folding changes the `.BGZ` stem (`SAMPLE.FASTQ` → `SAMPLE`, verified) and
+   changes nothing about its compression. §3.1's `.BGZ` row is what the code will do; it is only
+   mislabelled as unchanged (O1). Refusing to widen the asymmetry is right.
+3. **V6's controls** — one discriminates cleanly, one discriminates for the wrong reason and is
+   redundant with V2; neither covers C1. See I6, including V8.
+4. **Anything else reading the input filename** — §2.4's list is incomplete: `clump_only.rs:277`
+   and `:414` (C1) are the material omissions. `main.rs:1646`/`:2219` and `--basename` read names
+   but cannot disagree with the fold (O2, O3). `format.rs`, `fastq.rs`, `cli.rs`, `fastqc.rs`,
+   `report.rs` and `demux.rs` are clean — swept with
+   `grep -rn "extension()\|file_stem()\|strip_suffix\|ends_with(\"" src/*.rs`.
+
+**Open 2** — `#### Changes` is right; no separate release note. But the entry needs three bullets,
+not two: the rename, the compression flip, and the newly-refused multi-input runs (I1). Plus the
+`--clump_only` report shift if C1 is accepted.
+
+---
+
+## Action items
+
+**Critical**
+1. Correct §2.3/§11: `is_gzipped` has four call sites (`main.rs:345`, `clump_only.rs:277`, `:414`,
+   `:1107`), not one. Document the `--clump_only` report consequence in §3.1/§7/Step 6 and add
+   V8 to cover it. (C1)
+
+**Important**
+2. Fix §2.2/§2.3's parity argument: Perl's `if ($gzip or $filename =~ /\.gz$/)` is case-sensitive,
+   so today's compression behaviour *is* Perl-identical and folding departs from it. (I2)
+3. Add the `SAMPLE.FASTQ.GZ` + `SAMPLE.FQ.GZ` collision to §3.1 and the CHANGELOG; relabel the
+   existing last row as a case-sensitive-FS-only false positive and keep V4 a unit test. (I1)
+4. Restate V5 as exact literal filenames plus a magic-byte check, computing no expectation from a
+   function under test. (I3)
+5. Drop the MultiQC-grouping implication, or state that it is not fixed for uppercase input. (I4)
+6. Drop `--dont_gzip` from §2.1 / V7's reproduction. (I5)
+7. Re-scope V6: split V5's path and compression assertions so each half-revert fails legibly; note
+   V2 is the committed guard. (I6)
+
+**Optional**
+8. O1 — mark §3.1's `.BGZ` row as changed. 9. O2 — note the two uBAM namers that bypass the strip.
+10. O3 — note `--basename` bypasses it too. 11. O4 — add `SAMPLE.TXT.GZ` and bare `SAMPLE.GZ` to
+V1/V3. 12. O5 — record the disjointness argument in the commit message. 13. O6 — lifetime note for
+Step 2.

--- a/plans/08072026_uppercase-fastq-extensions/PROGRESS.md
+++ b/plans/08072026_uppercase-fastq-extensions/PROGRESS.md
@@ -1,0 +1,21 @@
+# Progress: Match FASTQ extensions case-insensitively (#384)
+
+**Last updated:** 2026-08-07
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | `PLAN.md` v2 — 3 Criticals + 8 Importants folded in |
+| Plan Review | ✅ Complete | `PLAN_REVIEW_A.md`, `PLAN_REVIEW_B.md`; Open 1 answered fold-both by both, independently |
+| Impl Plan | ❌ Excluded | `PLAN.md` §5 is the outline; too small for a separate `IMPL.md` |
+| Implementation | ✅ Complete | 538 tests, fmt + clippy clean; V6 controls both discriminate; notes in `PLAN.md` §13 |
+| Code Review | ✅ Complete | A + B: 0 Critical, 0 High; all Mediums applied |
+| Coverage | ✅ Complete | INCOMPLETE→resolved: the one PARTIAL (missing `.bgz` assertion) applied same session |
+
+## History
+
+- 2026-08-07: Plan → v2. A: caller enumeration missed all three `clump_only.rs` sites; v1's V4 collision was already rejected today (couldn't fail); naive helper panics on multi-byte names. B: Perl parity *holds* on compression and the fold breaks it knowingly; the real new refusals are mixed-spelling pairs; V5 was self-referential. Both: fold both on Open 1.
+
+- 2026-08-07: Plan → ✅ Complete. Scope grew during planning: `is_gzipped` is case-sensitive too and decides output *compression*, so folding only `strip_fastq_extensions` would trade a naming mismatch for silently uncompressed output (`PLAN.md` §2.3, A3).
+- 2026-08-07: Decision recorded on #384 — fold case rather than pin, because Perl v0.6.11 produced *agreeing* names here and the current mismatch is the rewrite's own.

--- a/src/io.rs
+++ b/src/io.rs
@@ -26,8 +26,13 @@ use std::path::{Component, Path, PathBuf};
 /// false for it. Moving the output decision to the detected format would
 /// change behaviour for every run, including a plain file misnamed `.gz`, so
 /// it is deliberately left for a separate change. See the CHANGELOG.
+///
+/// Matching is ASCII-case-insensitive (#384) and must stay in step with
+/// `strip_fastq_extensions`: folding one but not the other names the output
+/// like the gzipped convention while writing it plain, or vice versa.
 pub fn is_gzipped(path: &Path) -> bool {
-    path.extension().is_some_and(|ext| ext == "gz")
+    path.extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("gz"))
 }
 
 /// Case-folded (ASCII lowercase) string view of a path for collision detection
@@ -508,6 +513,18 @@ pub fn json_report_name(input: &Path, output_dir: Option<&Path>) -> PathBuf {
     }
 }
 
+/// ASCII-case-insensitive suffix strip, preserving the case of what remains (#384).
+///
+/// Byte-wise on purpose: slicing `&str` at `len - suffix.len()` panics when the
+/// index lands inside a multi-byte character, and extensionless non-ASCII names
+/// are valid input. A matched all-ASCII tail guarantees the index is a boundary.
+fn strip_suffix_ignore_ascii_case<'a>(name: &'a str, suffix: &str) -> Option<&'a str> {
+    let idx = name.len().checked_sub(suffix.len())?;
+    name.as_bytes()[idx..]
+        .eq_ignore_ascii_case(suffix.as_bytes())
+        .then(|| &name[..idx])
+}
+
 /// Strip FASTQ extensions from a filename, returning just the base stem.
 ///
 /// Handles `.fastq` / `.fq`, each optionally followed by a gzip-family
@@ -531,12 +548,12 @@ pub fn strip_fastq_extensions(path: &Path) -> String {
     // does not end in `.gz`, so the order within the list does not matter.
     let stem = [".gz", ".bgz", ".bgzf"]
         .iter()
-        .find_map(|ext| name.strip_suffix(ext))
+        .find_map(|ext| strip_suffix_ignore_ascii_case(&name, ext))
         .unwrap_or(&name);
 
     // Then the FASTQ extension itself, longest first.
     for ext in [".fastq", ".fq"] {
-        if let Some(base) = stem.strip_suffix(ext) {
+        if let Some(base) = strip_suffix_ignore_ascii_case(stem, ext) {
             return base.to_string();
         }
     }
@@ -954,9 +971,58 @@ mod tests {
         assert!(!is_gzipped(Path::new("sample.fastq")));
         assert!(!is_gzipped(Path::new("sample.fq")));
         assert!(!is_gzipped(Path::new("/some/dir/x")));
-        // Heuristic is extension-based (matches FastqReader's gzip detection),
-        // so a misnamed file doesn't trigger.
+        // Heuristic is extension-based on purpose (the reader sniffs content;
+        // this names the output), so a misnamed file doesn't trigger.
         assert!(!is_gzipped(Path::new("sample.gz.fastq")));
+    }
+
+    /// #384. Case variants of `.gz` must fold; nothing else may start matching.
+    /// This is the committed guard for the compression half of the change.
+    #[test]
+    fn test_is_gzipped_folds_case() {
+        assert!(is_gzipped(Path::new("SAMPLE.FASTQ.GZ")));
+        assert!(is_gzipped(Path::new("sample.fastq.Gz")));
+        assert!(is_gzipped(Path::new("SAMPLE.FQ.gz")));
+        // .bgz is not .gz in ANY case — the pre-existing bgz asymmetry stays,
+        // and the fold must not widen is_gzipped to the stem's gzip-family list.
+        assert!(!is_gzipped(Path::new("sample.fastq.bgz")));
+        assert!(!is_gzipped(Path::new("SAMPLE.FASTQ.BGZ")));
+        assert!(!is_gzipped(Path::new("SAMPLE.FASTQ")));
+        assert!(!is_gzipped(Path::new("sample.GZ.fastq")));
+    }
+
+    /// #384. Extension matching folds; the retained part of the name must not.
+    #[test]
+    fn test_strip_fastq_extensions_folds_case() {
+        for (input, stem) in [
+            ("SAMPLE.FASTQ.GZ", "SAMPLE"),
+            ("Sample.FastQ.Gz", "Sample"),
+            ("SAMPLE.FQ", "SAMPLE"),
+            ("SAMPLE.FASTQ", "SAMPLE"),
+            ("SAMPLE.FQ.GZ", "SAMPLE"),
+            ("SAMPLE.FASTQ.BGZ", "SAMPLE"),
+            ("SAMPLE.FASTQ.BGZF", "SAMPLE"),
+            ("sample_R1.FQ.GZ", "sample_R1"),
+        ] {
+            assert_eq!(
+                strip_fastq_extensions(Path::new(input)),
+                stem,
+                "input {input}"
+            );
+        }
+    }
+
+    /// #384 regression. The naive slice form of the case-insensitive strip
+    /// panics mid-character on multi-byte names; these inputs work end-to-end
+    /// today and must keep doing so.
+    #[test]
+    fn test_strip_fastq_extensions_non_ascii_and_short_names() {
+        assert_eq!(strip_fastq_extensions(Path::new("😀")), "😀");
+        assert_eq!(strip_fastq_extensions(Path::new("é.fq")), "é");
+        assert_eq!(strip_fastq_extensions(Path::new("a")), "a");
+        // Non-FASTQ extensions keep the file_stem fallback, un-folded.
+        assert_eq!(strip_fastq_extensions(Path::new("sample.bam")), "sample");
+        assert_eq!(strip_fastq_extensions(Path::new("sample.txt")), "sample");
     }
 
     // --- preflight_output_collisions (issues #216, #383) ---

--- a/src/specialty.rs
+++ b/src/specialty.rs
@@ -817,6 +817,31 @@ mod tests {
 
     // --- Output naming on `.bgz` input (#381) ---
 
+    /// #384. Uppercase extensions fold in the specialty namers too, and the
+    /// `--implicon` `_R1` strip becomes newly reachable — the same second-fault
+    /// mechanism `bgz_stem_reaches_specialty_output_names` documents for `.bgz`.
+    #[test]
+    fn uppercase_stem_reaches_specialty_output_names() {
+        assert_eq!(
+            implicon_output_name(Path::new("SAMPLE_R1.FASTQ.GZ"), 8, "R1", None, false),
+            PathBuf::from("SAMPLE_8bp_UMI_R1.fastq")
+        );
+        assert_eq!(
+            hardtrim_output_name(
+                Path::new("SAMPLE.FASTQ.GZ"),
+                30,
+                HardtrimEnd::Five,
+                None,
+                true
+            ),
+            PathBuf::from("SAMPLE.30bp_5prime.fq.gz")
+        );
+        assert_eq!(
+            clock_output_name(Path::new("SAMPLE_R1.FQ.GZ"), "R1", None, false),
+            PathBuf::from("SAMPLE_R1.clock_UMI.R1.fq")
+        );
+    }
+
     /// REGRESSION ([#381](https://github.com/FelixKrueger/TrimGalore/issues/381)).
     /// Every specialty mode names its output from the same stripped stem, so
     /// teaching the stripper about `.bgz` moves these filenames too.

--- a/tests/integration_gzip_non_gz_extension.rs
+++ b/tests/integration_gzip_non_gz_extension.rs
@@ -349,3 +349,147 @@ fn bgz_output_and_report_agree_on_the_stem() {
         }
     }
 }
+
+// ── #384: uppercase extensions behave as their lowercase equivalents ──────
+
+/// V5. Literal filename assertions, computed without calling any function under
+/// test; no `--dont_gzip`, so both halves of the change are observable. The two
+/// halves fail independently: a wrong stem fails at path resolution, a wrong
+/// compression decision fails on the magic bytes.
+#[test]
+fn uppercase_extension_names_and_compresses_like_lowercase() {
+    let dir = fresh_tmpdir("tg_384_upper");
+    let input = dir.join("SAMPLE.FASTQ.GZ");
+    write_gz(&input, &sample_reads("U"));
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    let status = Command::new(binary())
+        .args(["-o", out.to_str().unwrap(), input.to_str().unwrap()])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    // Naming half: exact literals. Before #384 the stem kept `.FASTQ` and the
+    // output was plain (`SAMPLE.FASTQ_trimmed.fq`).
+    let trimmed = out.join("SAMPLE_trimmed.fq.gz");
+    assert!(
+        trimmed.is_file(),
+        "expected SAMPLE_trimmed.fq.gz, found: {:?}",
+        std::fs::read_dir(&out)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .collect::<Vec<_>>()
+    );
+    assert!(out.join("SAMPLE.FASTQ.GZ_trimming_report.txt").is_file());
+
+    // Compression half: gzip magic, checked on bytes — the name is what is under test.
+    let bytes = std::fs::read(&trimmed).unwrap();
+    assert!(
+        bytes.starts_with(&[0x1f, 0x8b]),
+        "output must be gzip-compressed, got {:02x?}",
+        &bytes[..bytes.len().min(4)]
+    );
+}
+
+/// V4. The refusals the fold newly creates: mixed extension *spellings* whose
+/// stems now agree. (Pure case-variants are already refused today via the
+/// case-folded report keys, so they cannot discriminate — see the #384 plan.)
+#[test]
+fn uppercase_and_lowercase_spellings_of_one_stem_now_collide() {
+    let dir = fresh_tmpdir("tg_384_collide");
+    // On case-insensitive filesystems (default APFS) the last two names alias ONE
+    // file, so the second write_gz overwrites the first and the loop's second
+    // iteration feeds the same inode under a different spelling. Both iterations
+    // still refuse on both filesystem kinds; do not add content assertions here.
+    write_gz(&dir.join("SAMPLE.FASTQ.GZ"), &sample_reads("A"));
+    write_gz(&dir.join("sample.fq.gz"), &sample_reads("B"));
+    write_gz(&dir.join("SAMPLE.FQ.GZ"), &sample_reads("C"));
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    for second in ["sample.fq.gz", "SAMPLE.FQ.GZ"] {
+        let output = Command::new(binary())
+            .current_dir(&dir)
+            .args(["-o", "out", "SAMPLE.FASTQ.GZ", second])
+            .output()
+            .unwrap();
+        assert!(
+            !output.status.success(),
+            "{second}: expected collision refusal"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("Output path collision"),
+            "{second}: {stderr}"
+        );
+        assert!(
+            std::fs::read_dir(&out).unwrap().next().is_none(),
+            "{second}: a refused run must write nothing"
+        );
+    }
+}
+
+/// V8. The least-guarded consumer: `--clump_only`'s report derives its
+/// `Input: … (gzip|plain)` label and its `Compression ratio:` gate from
+/// `is_gzipped`. Before #384 a `.GZ`-named input read `plain` with no ratio line.
+#[test]
+fn clump_only_uppercase_gz_reports_gzip_and_ratio() {
+    let dir = fresh_tmpdir("tg_384_clump");
+    let input = dir.join("SAMPLE.FASTQ.GZ");
+    write_gz(&input, &sample_reads("K"));
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    let status = Command::new(binary())
+        .args([
+            "--clump_only",
+            "-o",
+            out.to_str().unwrap(),
+            input.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    assert!(
+        out.join("SAMPLE_clumped.fq.gz").is_file(),
+        "clump stem must fold too"
+    );
+    let report = std::fs::read_to_string(out.join("SAMPLE.FASTQ.GZ_clumping_report.txt")).unwrap();
+    assert!(
+        report.contains("gzip"),
+        "Input label must say gzip:\n{report}"
+    );
+    assert!(!report.contains("plain"), "must not say plain:\n{report}");
+    assert!(
+        report.contains("Compression ratio:"),
+        "ratio line must appear:\n{report}"
+    );
+}
+
+/// #384 on the paired path, restoring this file's dispatch-path matrix: paired
+/// mode adds the coupling that `input[0]` drives the run-wide `gzip` flag.
+#[test]
+fn paired_uppercase_extensions_name_and_compress_like_lowercase() {
+    let dir = fresh_tmpdir("tg_384_paired");
+    write_gz(&dir.join("P_R1.FASTQ.GZ"), &sample_reads("R1"));
+    write_gz(&dir.join("P_R2.FASTQ.GZ"), &sample_reads("R2"));
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    let status = Command::new(binary())
+        .current_dir(&dir)
+        .args(["--paired", "-o", "out", "P_R1.FASTQ.GZ", "P_R2.FASTQ.GZ"])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    for stem in ["P_R1_val_1", "P_R2_val_2"] {
+        let f = out.join(format!("{stem}.fq.gz"));
+        assert!(f.is_file(), "missing {stem}.fq.gz");
+        let bytes = std::fs::read(&f).unwrap();
+        assert!(bytes.starts_with(&[0x1f, 0x8b]), "{stem} must be gzip");
+    }
+}


### PR DESCRIPTION
Fixes #384. `SAMPLE.FASTQ.GZ` kept an inner `.FASTQ` in its output stem while the report used the full filename, so the two disagreed about the sample name. Extension matching (`.fastq`/`.fq`, `.gz`/`.bgz`/`.bgzf`) now folds ASCII case, so uppercase input behaves exactly like lowercase: `SAMPLE_trimmed.fq.gz` beside `SAMPLE.FASTQ.GZ_trimming_report.txt`.

Behaviour changes for uppercase-named input, all listed in the CHANGELOG: output is renamed and now gzip-compressed; multi-input runs whose extensions differ in spelling but whose stems now agree are refused before any file is written; `--clump_only` report labels shift; the specialty modes rename the same way. Perl v0.6.11 had no naming mismatch here (its fallback appended to the full name), so pinning the old output would have preserved a rewrite-only defect — the reasoning is recorded on the issue.

<details>
<summary>Detail (AI-assisted; bin freely)</summary>

Two functions fold, deliberately together: `strip_fastq_extensions` (output stem) and `is_gzipped` (output compression). Folding only the stem would name uppercase output like the gzipped convention while writing it plain. On compression this knowingly departs from v0.6.11 (whose test was also case-sensitive); on naming, parity was already lost to the `file_stem()` fallback.

The suffix strip is byte-wise — the naive `&str` slice panics mid-character on multi-byte filenames that work end-to-end today. Caught at plan review, along with two more Criticals: the first draft's collision test asserted a refusal that already happens via the case-folded report keys (so it could never fail), and three `is_gzipped` call sites in `clump_only.rs` were missing from the caller enumeration.

**Verification.** 540 tests (10 new), fmt + clippy clean. Both negative controls discriminate: reverting either half alone fails that half's tests. The V8 report assertion targets the `Input:` line specifically, because the `Output:` line contains "gzip level N" unconditionally and a whole-report substring match cannot pin the input label. Pure case-variant pairs are already refused today and are deliberately not used as test fixtures.

No fixture in `test_files/` and no CI invocation uses an uppercase extension, so the Perl byte-identity matrix is untouched.

**Artefacts** in `plans/08072026_uppercase-fastq-extensions/`: plan (v2), two plan reviews (3 Criticals, all pre-implementation), two code reviews (0 Critical / 0 High), coverage audit (one gap, closed).

</details>
