### PR TITLE
fix(main): paired report paths join the collision pre-flight (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,23 @@
   A rejected run still writes nothing, and the diagnostic keeps naming the paths
   as the user spelled them.
 
+- **Paired-end trimming reports can no longer silently overwrite each other**
+  ([#388](https://github.com/FelixKrueger/TrimGalore/issues/388)). Paired output
+  names carry a positional discriminator (`_val_1`/`_val_2`) that report names do
+  not, so two inputs with distinct trimmed outputs could still collide on their
+  reports: `--paired -o out A/reads.fq B/reads.fq` exited 0 with one report pair
+  for two inputs, and re-using a filename across pairs lost a report the same
+  way. The report paths (text and JSON, for both sides of every pair) now join
+  the collision pre-flight on the paired FASTQ and paired uBAM-output paths,
+  skipped under `--no_report_file` to match the writers.
+
+  Two behaviour changes follow. A pair whose R1 and R2 share a filename written
+  to a common output directory is now refused on every filesystem — that run
+  previously lost a report. And two genuinely distinct inputs whose filenames
+  differ only in case are refused even on a case-sensitive filesystem, where
+  both reports could in fact coexist: the same loud-error-over-silent-loss trade
+  the pre-flight has made since #216, now extended to paired reports.
+
 #### Changes
 
 - **A file given twice on one command line is now rejected**

--- a/plans/08072026_paired-report-preflight/CODE_REVIEW_A.md
+++ b/plans/08072026_paired-report-preflight/CODE_REVIEW_A.md
@@ -1,0 +1,171 @@
+# Code Review A — #388 paired report pre-flight
+
+**Reviewer A** (independent; Reviewer B reviewed the same diff in parallel).
+**Target:** `fix/388-paired-report-preflight` off `dev` @ `c4599f5`, uncommitted.
+**Diff:** `src/main.rs` (two blocks), `tests/integration_output_collision.rs` (T1–T6), `CHANGELOG.md`.
+**Nothing was fixed.** The tree is shared and uncommitted — every item below is a recommendation only.
+**Repro binaries:** patched = `target/release/trim_galore` (verified to contain the fix);
+baseline = scratch build of `HEAD` (= pre-change) at
+`…/scratchpad/crev388a/btarget/release/trim_galore`, built from `git archive HEAD` (no repo writes).
+
+## Verdict
+
+The change is correct and does what it claims. Candidate expressions match the writers exactly at
+both sites, the gate matches, no over-rejection was found in a five-shape sweep, and all four
+rejection tests were confirmed discriminating against a real pre-change binary. Findings are one
+scope/completeness item (a live sibling of the same defect on another paired path), and test/
+diagnostic strengthening.
+
+## Verified correct
+
+- **Candidates == writers, FASTQ path.** New block `src/main.rs:765-772` pushes
+  `report_name`/`json_report_name` for `chunk[0]`/`chunk[1]` with `output_dir`; the writer builds the
+  identical four paths at `src/main.rs:1578-1585` from the same `output_dir` passed into `run_paired`,
+  under the same `!cli.no_report_file` gate (`:1566`). Report names ignore `--basename`, so no
+  discriminator is missed.
+- **Candidates == writers, uBAM path.** New block `src/main.rs:1867-1873` vs writer
+  `src/main.rs:2178-2185`, gate `:2164`. Same namers, same `output_dir`.
+- **All four rejections fire on the report path, not a primary.** Each error message names
+  `…_trimming_report.txt`, so the new candidates are what trip: T1/T4 `out/reads.fq_trimming_report.txt`,
+  T2 `out/r1.fq… and out/R1.fq…`, T3 `out/r2.fq… and out/R2.fq…`.
+- **Single-file interleaved paths correctly out of scope.** `run_paired_ubam_single_file`
+  (`src/main.rs:1794-1803`) and `run_ubam_output_paired_single_file` write stem-derived
+  `_R1`/`_R2` report names and take exactly one input, so neither a cross-input nor a self collision
+  is constructible; they also have no pre-flight at all, consistently.
+- **Specialty paired modes write no trimming reports** (`grep` of `src/specialty.rs`) — no hole there.
+- **A4 (uBAM SE residual) is sound.** For SE, a report collision implies fold-equal filenames, which
+  implies fold-equal stems, which collides `_trimmed.bam` first. No report-only hole exists there.
+- **`guarded_inputs` / output-vs-input interaction is clean**, and strictly an improvement — see L3.
+- **Efficiency:** four extra `PathBuf`s per pair into a list the pre-flight already hashes. Nothing.
+
+## Negative controls (reproduced independently, all four)
+
+Run against the baseline binary, i.e. the plan's §8 claim re-derived rather than trusted:
+
+| shape | baseline | patched |
+|---|---|---|
+| T1 `--paired -o out A/reads.fq B/reads.fq` | exit 0, 2 `_val_` + **one** report pair | exit 1, 0 files |
+| T2 `--paired -o out a/r1.fq b/R1.fq` | exit 0, surviving report says `Input filename: R1.fq` | exit 1 |
+| T3 4-file cross-pair | exit 0, **3** reports for 4 inputs | exit 1 |
+| T4 same as T1 + `--output-format ubam` | exit 0, `reads_val.bam` + one report pair | exit 1 |
+
+T5/T6 pass on both, as guards should.
+
+## High
+
+### H1 — the identical defect is still live on `--clump_only --paired` (FASTQ)
+
+Pre-existing, not introduced by this diff, but it is the same signature the fix exists to close:
+two per-side reports whose names lack the positional discriminator the primaries carry. Verified
+against the **patched** binary:
+
+```
+cd <scratch>/c1   # A/reads.fq and B/reads.fq, both plain FASTQ
+trim_galore --clump_only --paired -o out A/reads.fq B/reads.fq   # exit 0
+out/reads_clumped_1.fq
+out/reads_clumped_2.fq
+out/reads.fq_clumping_report.txt      # "Input: B/reads.fq" — R1's report is gone
+```
+
+`--clump_only --paired` routes through `run_specialty_paired` with `clumped_paired_output_names` as
+the namer (`src/main.rs:521-544`), so only the two primaries are hashed, while
+`clump_only::clump_only_paired` writes two reports (`src/clump_only.rs:535-536`).
+
+Not affected, checked: the uBAM clump paired path writes **one** report per pair derived from R1
+(`src/clump_only.rs:1082-1086`), a key finer than its BAM primary's, so the existing primary check
+covers it.
+
+Recommendation: either extend this branch to that path, or add it to §5 next to A4 as a named
+residual with the reproducer. The CHANGELOG entry is literally accurate (clumping reports are a
+distinct artifact), so no CHANGELOG change is needed if it stays out of scope — but leaving it
+unnamed invites the same blind spot #388 came from.
+
+## Medium
+
+### M1 — the diagnostic is uninformative for the flagship shape
+
+T1's own error:
+
+```
+Output path collision (…): out/reads.fq_trimming_report.txt and out/reads.fq_trimming_report.txt
+would be written to the same file. Check that inputs produce distinct output paths
+(e.g., different source directories or `--output_dir`).
+```
+
+The path is printed twice, neither colliding **input** is named, and the advice recommends the two
+things that cannot help: the inputs already are in different source directories, and `--output_dir`
+is what causes the collision. `preflight_output_collisions` takes a `hint` (used by the specialty
+modes via `CWD_OUTPUT_HINT`); both new call sites pass `None`. Partly pre-existing for primary
+collisions, but T1 and `--basename foo -o out A/reads.fq B/reads.fq` (also newly refused, verified)
+now fail *only* for this reason, so it is the first thing a user will hit.
+Recommendation: pass a hint on the two paired sites naming the actual remedy (rename one input, or
+drop `--output_dir`), or have the message name the two inputs when the two planned paths are equal.
+
+### M2 — T2/T3/T4 bypass the file's own rejection helper
+
+`assert_rejected_cleanly` (`tests/integration_output_collision.rs:93`) asserts the `PREFIX`, the
+expected wording, **and** that nothing was written — the module doc calls two reports beside one data
+file "#383's most misleading artifact". T1 hand-rolls a weaker version of it; T2/T3/T4 assert only
+exit status and `DUP_MSG`, so they would pass a refusal that had already written files. Recommendation:
+`assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG)` in all four. (Empirically 0 leftovers today, so
+this is future-proofing, not a live gap.)
+
+### M3 — T6's acceptance cases don't assert what they claim to guard
+
+The module doc states acceptance cases "assert content or filename rather than mere existence".
+T6's second case asserts only `ok` — no filename at all; the first asserts only `foo_val_1.fq`.
+Both comments claim a property about *report* names that neither test checks. Recommendation: assert
+`r1.fq_trimming_report.txt` + `r2.fq_trimming_report.txt` in the basename case, and
+`sample.fq_trimming_report.txt` + `sample.fastq_trimming_report.txt` in the same-stem case. That is
+exactly the "report keys differ (full filename)" claim, and it would fail if `report_name` ever
+became stem-based.
+
+### M4 — the nearest true negative to T1 is untested
+
+T1 minus `-o`: same filename as R1/R2 in different directories, no `--output_dir`. Verified accepted
+(exit 0; reports land beside their own inputs in `A/` and `B/`, primaries both in `A/`). This is the
+only shape that pins the new candidates honouring `output_dir = None`; an implementation that
+resolved reports into one directory — as `run_paired_ubam_single_file` legitimately does with its own
+`dir` — would over-reject a valid run and no test would notice. Recommendation: add it to T6.
+
+### M5 — the premise #388 disproved is still stated unqualified, next to the fix
+
+Three comments assert the SE argument in general terms:
+
+- `src/io.rs:1211` "Assumption A2, in the direction that makes the pre-flight sufficient: where two
+  inputs' PRIMARY output paths differ, every secondary output path must differ too … hashing
+  primaries alone is enough."
+- `src/io.rs:1285-1287` "the primary key is strictly *coarser* than the report key, which is why
+  checking primaries covers reports".
+- `src/main.rs:79` "assumption A2 argues that checking *primary* paths covers secondary paths".
+
+All three are true only for single-end naming; `_val_1`/`_val_2` is the counterexample this branch
+exists for. Recommendation: one line each, e.g. `(single-end naming only; paired `_val_N` primaries
+break this — #388)`. Cheap, and it is the reasoning trap that produced the bug.
+
+## Low
+
+- **L1 — duplication.** The two new blocks are near-identical, and `planned_secondary_outputs`
+  (`src/main.rs:83`) already computes the same pair for SE, so three sites must now stay in step with
+  the writers. A `report_names(input, output_dir) -> [PathBuf; 2]` in `src/io.rs` beside `report_name`
+  / `json_report_name` would give one. Acceptable as-is under the house pattern of explicit
+  per-dispatch-path pre-flights; noted, not urged.
+- **L2 — T5's `read_dir().count() == 2`** is correct and robust (verified: plain input ⇒ plain output,
+  no FastQC, no extra artifacts), but on failure it can only say `2 != 3`. `assert_dir_holds_only`
+  already exists in the file and names the intruder.
+- **L3 — the CHANGELOG undersells the fix by one repair.** The paired report path was also missing
+  from the output-vs-**input** check, so a report could overwrite a named input. Verified:
+  `--paired r1.fq r1.fq_trimming_report.txt` (FASTQ content in the second file) on the baseline exits
+  0, writes `r1.fq_trimming_report_val_2.fq`, then **overwrites its own R2 input** with R1's report —
+  that input's reads are gone at exit 0. Patched refuses with the alias message. This makes the
+  earlier unreleased entry's claim ("This affected `--paired` as well, and is now refused on every
+  path") true, which it was not before this diff. Worth one sentence in the #388 entry.
+- **L4 — placement.** The two newly-refused shapes are behaviour changes sitting under
+  `#### Bug fixes` while the file has a `#### Changes` section. Consistent with the #383/#385 entry
+  above it, so arguably fine; flagging for the author's call.
+
+## Not findings
+
+CHANGELOG claims checked line by line against the baseline and all hold, including "one report pair
+for two inputs" and "re-using a filename across pairs lost a report the same way". Plan §8's
+"no deviations" is accurate: the committed blocks are byte-identical to §4's listing.

--- a/plans/08072026_paired-report-preflight/CODE_REVIEW_B.md
+++ b/plans/08072026_paired-report-preflight/CODE_REVIEW_B.md
@@ -1,0 +1,235 @@
+# Code Review B — paired report pre-flight (#388)
+
+**Reviewer:** B (independent; Reviewer A reviews the same diff in parallel, no shared state)
+**Target:** `fix/388-paired-report-preflight` off `dev` @ `c4599f5`, **uncommitted**
+**Diff:** `src/main.rs` (2 blocks, +15), `tests/integration_output_collision.rs` (+151, T1–T6), `CHANGELOG.md` (+17)
+**Plan:** `plans/08072026_paired-report-preflight/PLAN.md` (v2 + §8)
+
+**Nothing was fixed.** The tree is shared and uncommitted, so this report is recommend-only.
+Every behavioural claim below was run against `target/release/trim_galore` (up to date with
+the diff); harness in
+`/private/tmp/claude-501/-Users-fkrueger-Github-TrimGalore/d0ee0171-fc72-476b-bdba-c46c90a5bacd/scratchpad/crev388b/`.
+
+---
+
+## Verdict
+
+**Correct and complete for the two paths it touches.** Candidates match the writers exactly,
+the pre-flight sites are the right ones, the tests are discriminating, and no over-rejection
+shape survived a sweep. No Critical or High finding on the diff.
+
+One **Medium** is adjacent rather than in-diff: the identical defect — positionally
+discriminated primaries plus non-discriminated per-input reports — is live on
+`--clump_only --paired`, reproduced below. PLAN §5 A4 records the uBAM-SE residual but not
+this one, so it currently reads as covered when it is not.
+
+---
+
+## Focus item 1 — do the candidates match the writers? **Yes, exactly.**
+
+| | candidate site | writer site |
+|---|---|---|
+| paired FASTQ | `main.rs:765-772` | `run_paired`, `main.rs:1566-1607`; paths at `:1578-1585` |
+| paired uBAM out | `main.rs:1867-1873` | `run_ubam_output_paired_two_files`, `main.rs:2164-2202`; paths at `:2178-2185` |
+
+- **Same namers, same arguments.** Both writers call `naming::report_name(input, output_dir)`
+  / `json_report_name(input, output_dir)` — the same two-argument form. Notably **neither
+  writer applies `cli.basename`** to report paths, and neither does the candidate block:
+  no mismatch. (`io.rs:485-514`: both namers key on the *full input filename*, not the stem,
+  and ignore `basename` entirely.)
+- **Both sides, both formats.** `write_paired_reports` loops `[(stats_r1, &r1), (stats_r2, &r2)]`
+  (`main.rs:2382`) writing `txt_path` then `json_path` each — four paths per pair, four
+  candidates.
+- **Same gate.** Writers gate at `:1566` / `:2164` on `!cli.no_report_file`; candidates use
+  the same expression. Confirmed empirically under Focus item 4.
+- **No writer left uncovered on these paths.** The paired FASTQ write set is `_val_{1,2}`,
+  `_unpaired_{1,2}` under `--retain_unpaired`, the passthrough output (all pre-existing), the
+  four reports (now added), and FastQC artifacts (excluded per A3). `--passthrough` folds its
+  stats into the **R2** report (`main.rs:2416-2418`) rather than writing a third, so there is
+  no fifth path; `--clumpify` on the trim path writes no clumping report
+  (`clumping_report_name` is referenced only from `clump_only.rs`). The uBAM paired path
+  writes one `_val.bam` plus the same four reports.
+
+## Focus item 2 — single-file interleaved-uBAM paired paths: **correctly out of scope**
+
+`run_paired_ubam_single_file` (`main.rs:1643`, BAM in → FASTQ out) and
+`run_ubam_output_paired_single_file` (`:2222`, BAM in → BAM out) do both write reports
+(`:1786-1810`, `:2292-2311`) and neither has a pre-flight at all — but both are reached only
+under `cli.paired && cli.input.len() == 1` (`:716`, `:1839`), i.e. **one** input. One input
+yields one report pair, so no output-vs-output collision is constructible, and
+`<bam-filename>_trimming_report.txt` cannot equal the `.bam` input, so the output-vs-input
+branch has nothing to catch either. Adding candidates there would be dead code. No finding.
+
+## Focus item 3 — `guarded_inputs` / output-vs-input: **no wrongly-tripped alias branch**
+
+The new candidates are also matched against `guarded_inputs` (`main.rs:64` = inputs +
+`--passthrough` + `--demux`; the latter two are single-pair-only / SE-only). A report
+candidate can only alias an input if one input is literally named
+`<other-input-filename>_trimming_report.txt` — a shape already rejected today, by
+`sanity_check_any` on `input[0]` before the pre-flight and on `chunk[1]` at `:795` after it.
+So the only change is *which* message `--paired a.fq a.fq_trimming_report.txt` gets (now the
+accurate "also one of its inputs" + "drop it from the input list"). Diagnostic improvement,
+not a regression.
+
+Over-rejection sweep — A1 holds on every shape I could construct:
+
+```
+n1  --paired A/reads.fq B/reads.fq                  → exit 0; T1's inputs minus -o. Both
+                                                      report pairs written beside their inputs.
+n2  --paired -o out a/w.fq a/x.fq b/y.fq b/z.fq     → exit 0; 4 _val_ + 8 reports in one dir.
+n3  --paired -o out a/w.fq a/dup.fq b/y.fq b/dup.fq → exit 1; correct: two inputs named
+                                                      dup.fq would write one report path.
+t6a --paired --basename foo r1.fq r2.fq             → exit 0; foo_val_{1,2} + r1/r2 reports.
+t6b --paired sample.fq sample.fastq                 → exit 0; sample_val_{1,2} + 4 reports.
+```
+
+`n1` is the important one: T1 with `-o out` removed still runs, so the new candidates reject
+on the shared *output directory*, not on the shared filename.
+
+## Focus item 4 — the six tests: **all six can fail; both acceptance cases are at the boundary**
+
+**Negative-control spot-check without touching the tree.** Commenting the block out is
+impossible on a shared tree, so I re-ran each rejection shape with `--no_report_file` added —
+the only input that disables the new block. Each flips to exit 0, proving the rejection is
+caused by the new candidates and nothing else:
+
+```
+t1  --paired -o out A/reads.fq B/reads.fq                           → exit 1, dup-msg
+t2  --paired -o out a/r1.fq b/R1.fq                                 → exit 1, dup-msg
+t2b --paired --no_report_file -o out a/r1.fq b/R1.fq                → exit 0, r1_val_1 + R1_val_2
+t3b --paired --no_report_file -o out a/r1.fq a/r2.fq b/R2.fq b/x.fq → exit 0, 4 _val_ files
+t4b --paired --output-format ubam --no_report_file -o out A/… B/…    → exit 0, reads_val.bam
+```
+
+This is *stronger* than §6's comment-out for T1–T4: it also proves the gate is wired to the
+same flag as the writers (A2). It confirms §8's claim.
+
+- **T1** is genuinely case-free — primaries differ by the positional digit under any fold, so
+  only the reports can collide. **T4** is its uBAM twin; `t4b` shows the FASTQ block cannot be
+  what rejects it (single `_val.bam` primary).
+- **T2 / T3** depend on case-folding but assert only the *rejection*, so they are
+  filesystem-independent as documented. Neither rejects for the wrong reason: T2's primaries
+  fold to `r1_val_1`/`r1_val_2`, T3's to four distinct keys, so the reports are the sole
+  colliding pair in both.
+- **T5**'s `read_dir(&out).count() == 2` is **robust here**: `out` is a fresh subdirectory of a
+  per-tag temp dir, and with reports off and FastQC unrequested the run's entire write set
+  into `-o` is the two `_val_` files — confirmed by `find -type f` on `t2b` yielding exactly
+  two. The two `is_file()` assertions pin *which* two, so a wrong-namer regression cannot
+  satisfy the count alone.
+- **T6 case 1** (`--basename foo`, no `-o`) catches a candidate list keyed on `basename` like
+  the primaries: both reports would then be `foo…` and collide. Real boundary — `t6a`
+  confirms the primaries are `foo_val_{1,2}` while the reports keep `r1.fq`/`r2.fq`.
+- **T6 case 2** (`sample.fq` + `sample.fastq`) catches a candidate list keyed on the *stem*:
+  both stems are `sample`, so a stem-keyed list would reject a legal pair. Real boundary, and
+  the only case in the suite separating `report_name` from `single_end_output_name` semantics.
+
+Gaps, all minor: L-1, L-2, L-4.
+
+## Focus item 5 — duplication: see M-2.
+
+---
+
+## Findings
+
+### Medium
+
+**M-1 — the same defect is live on `--clump_only --paired`; not fixed, not scoped out.**
+
+`clumped_paired_output_names` (`io.rs:387-412`) appends the positional discriminator
+`_clumped_1`/`_clumped_2` while `clumping_report_name` (`io.rs:469-482`) keys on the full input
+filename with no discriminator — structurally identical to `_val_1`/`_val_2` vs `report_name`,
+i.e. **exactly** the §2 root cause. `clump_only_paired` writes two per-mate reports gated on
+`no_report_file` (`clump_only.rs:534-549`), but the mode dispatches through
+`run_specialty_paired` (`main.rs:2462`), whose pre-flight pushes **only** the two names the
+closure returns (`:2474-2480`). Reproduced on this branch:
+
+```
+$ trim_galore --clump_only --paired -o out A/reads.fq B/reads.fq
+exit=0
+out/reads_clumped_1.fq
+out/reads_clumped_2.fq
+out/reads.fq_clumping_report.txt        ← ONE report for two inputs
+$ head -3 out/reads.fq_clumping_report.txt
+… Input:  B/reads.fq                    ← the survivor is R2's; R1's was overwritten
+```
+
+Control: `--clump_only --paired -o out A/p1.fq B/p2.fq` writes both reports, so the mode is
+otherwise well-behaved. This is the #388 failure mode verbatim, one mode over. Out of the
+plan's literal scope, but §5 A4 records the uBAM-SE residual and is silent here.
+**Recommendation:** either give `run_specialty_paired` an optional secondary-name closure and
+pass the clumping-report names from the `--clump_only --paired` arm, or file a follow-up issue
+and add it to A4 as a known residual. Do not leave it undocumented.
+
+**M-2 — candidate-side report naming is now duplicated across two sites while the writer side
+is centralised.**
+
+The two inserted blocks are near-identical; the only difference is the vector pushed into
+(`candidates` vs `planned`). This matters more than seven duplicated lines suggest, because
+the *writer* side was deliberately centralised for exactly this reason —
+`write_paired_reports`'s doc comment says it exists "so we don't drift against
+`run_paired_ubam_single_file`'s identical block" (`main.rs:1564-1565`). The candidate side now
+carries the drift risk the writer side was refactored to remove: a change to report naming or
+to the gate must be mirrored twice, and a partial edit reintroduces #388 on whichever path is
+missed. There is also an in-repo precedent for the fix: `planned_secondary_outputs`
+(`main.rs:83-104`) already computes precisely these four paths for the SE FASTQ path with the
+identical gate. **Recommendation (structure, not a bug):** a small
+`fn paired_report_candidates(cli, r1, r2, output_dir) -> Vec<PathBuf>` called from both sites,
+or generalise `planned_secondary_outputs` to take an explicit input slice. Low risk, and it
+makes the two paths provably identical rather than identical by inspection.
+
+### Low
+
+**L-1 — T2/T3/T4 do not assert that a refused run wrote nothing.** T1 checks
+`read_dir(&out).next().is_none()`; T2–T4 assert only exit status and message. The file already
+has `assert_rejected_cleanly` (`tests/integration_output_collision.rs:95`), which asserts
+non-zero exit **plus** `PREFIX` **plus** an empty residue — and the module docstring at `:5-9`
+calls "two reports beside one data file" #383's most misleading artifact, which is the
+invariant those three leave unchecked. It would also restore the `PREFIX` assertion the new
+tests drop (they match only the `DUP_MSG` fragment, which still passes if the message loses its
+"case-insensitive, for APFS/NTFS safety" framing). **Recommendation:** route T1–T4 through
+`assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG)` — a drop-in for all four.
+
+**L-2 — T3's comment omits the filesystem caveat T2's states.** T3 relies on `a/r2.fq` vs
+`b/R2.fq` folding together, so on a case-sensitive filesystem it is the same #216-style false
+positive T2's comment carefully explains, but T3's one-liner ("the cross-pair route") does not
+say so. **Recommendation:** one clause, or make T3 case-free — verified working inputs:
+`--paired -o out a/w.fq a/dup.fq b/y.fq b/dup.fq` rejects on any filesystem (`n3` above).
+
+**L-3 — one CHANGELOG sentence overstates its scope.** "two genuinely distinct inputs whose
+filenames differ only in case are refused even on a case-sensitive filesystem" is true of
+paired *reports* but reads generally; SE has been like this since #385. Consider "…are refused
+as a paired pair even on…". Wording only — both §3 behaviour changes are disclosed, which is
+the part that matters.
+
+**L-4 — T1, the fix's raison d'être, has no acceptance twin.** The module docstring states the
+suite's own convention at `:11-14`: "Every rejection case here is paired with an acceptance
+case on the same dispatch path and output format." T1's nearest neighbour — the *same* two
+inputs with `-o out` removed — is asserted nowhere, and T6's two cases are different shapes.
+Without it, a candidate list that keyed reports on the filename while ignoring `output_dir`
+would reject a legal run and the suite would stay green. Verified the case passes today (`n1`:
+exit 0, `A/reads_val_{1,2}.fq` plus a report pair in each of `A/` and `B/`).
+**Recommendation:** add it as a third T6 case — four lines.
+
+### Efficiency / errors — no finding
+
+Four `PathBuf` allocations per pair in a loop that already allocates two to five, once before
+any I/O; `preflight_output_collisions` is O(n) over a pre-sized map (`io.rs:103`). No new panic
+path: `chunk[0]`/`chunk[1]` sit inside `cli.input.chunks(2)` loops whose length `Cli::validate`
+guarantees even, and the `len() == 1` paired case is diverted at `:716`/`:1839` before either
+block runs. No new error path: both namers are infallible (`unwrap_or_default` on `file_name`).
+
+---
+
+## Recommendation summary
+
+| ID | Priority | Action |
+|---|---|---|
+| M-1 | Medium | Fix `--clump_only --paired` too, **or** file a follow-up and record it in PLAN §5 A4 |
+| M-2 | Medium | Extract the duplicated candidate block into one helper (drift risk the writers were refactored to remove) |
+| L-1 | Low | Route T1–T4 through the existing `assert_rejected_cleanly` |
+| L-2 | Low | Note T3's filesystem sensitivity, or make it case-free |
+| L-3 | Low | Narrow one CHANGELOG sentence to the paired-report scope |
+| L-4 | Low | Add T1's acceptance twin (same inputs, no `-o`) as a third T6 case |
+
+None of these block the diff. M-1 is the one that should not stay silent, because it is the
+same bug class the plan says it is closing.

--- a/plans/08072026_paired-report-preflight/COVERAGE.md
+++ b/plans/08072026_paired-report-preflight/COVERAGE.md
@@ -1,0 +1,93 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs. plan §4 outline — no `IMPL.md` by design)
+**Plan(s):** `plans/08072026_paired-report-preflight/PLAN.md` (v2)
+**Date:** 2026-08-08
+**Verdict:** COMPLETE
+
+Audited: branch `fix/388-paired-report-preflight` off `dev` @ `c4599f5`, uncommitted working
+diff (`CHANGELOG.md`, `src/main.rs`, `tests/integration_output_collision.rs`; +183 lines).
+
+## Summary
+
+- Total items: 20
+- DONE: 20
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED: 0
+
+## Coverage ledger
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | Report candidates added to paired **FASTQ** pre-flight, inside the per-chunk loop after the passthrough block, gated `!cli.no_report_file`, pushed to `candidates` | §4 Step 1 | DONE | `src/main.rs:765-772`, inside `if cli.paired` (`:730`), after the passthrough block (`:757-764`), before `planned.extend(candidates)` (`:773`). Code matches the plan's snippet verbatim including the comment. |
+| 2 | Report candidates added to paired **uBAM-output** pre-flight, pushed to `planned`, same gate | §4 Step 2 | DONE | `src/main.rs:1867-1873`, in `run_ubam_output`'s `if cli.paired` loop (`:1852-1874`) after `paired_bam_output_name`. Pushes to `planned`, four paths per chunk, same gate. |
+| 3 | T1 — reproducer 1 (same filename R1+R2, shared `-o`) refused, collision message, nothing written | §4 Step 3 | DONE | `paired_rejects_same_filename_r1_r2_into_shared_output_dir` (`tests/integration_output_collision.rs:860`). Asserts `!ok`, `DUP_MSG`, and empty output dir. Case-free. |
+| 4 | T2 — reproducer 2 (fold-equal filenames as R1/R2) refused | §4 Step 3 | DONE | `paired_rejects_fold_equal_filenames_into_shared_output_dir` (`:883`). Asserts rejection only, so FS-independent as specified. |
+| 5 | T3 — reproducer 3 (cross-pair filename reuse) refused | §4 Step 3 | DONE | `paired_rejects_cross_pair_report_collision` (`:899`). Exact 4-input invocation from §2. |
+| 6 | T4 — uBAM twin: reproducer 1 with `--output-format ubam` refused | §4 Step 3 | DONE | `paired_ubam_rejects_same_filename_r1_r2_into_shared_output_dir` (`:922`). |
+| 7 | T5 — gate: reproducer 1 + `--no_report_file` succeeds, two `_val_` files, no reports | §4 Step 3 | DONE | `paired_same_filename_accepted_when_reports_disabled` (`:950`). Asserts `ok`, both `reads_val_{1,2}.fq`, and `read_dir(out).count() == 2`. |
+| 8 | T6 — over-rejection guards: `--basename` without `-o`; same-stem-different-extension R1/R2 | §4 Step 3 | DONE | `paired_report_candidates_do_not_over_reject` (`:979`). Both sub-cases present as specified (`r1.fq`+`r2.fq` with `--basename foo`; `sample.fq`+`sample.fastq`). |
+| 9 | CHANGELOG entry for the report-clobbering fix under `#### Bug fixes` | §4 Step 4 | DONE | `CHANGELOG.md:112-128`, inside `#### Bug fixes` (heading at `:6`), immediately before `#### Changes` (`:129`). Names #388, the `_val_` discriminator root cause, both collision routes, and the `--no_report_file` gate. |
+| 10 | CHANGELOG sentence for §3 behaviour change 1 (same-filename R1/R2 into shared `-o` newly refused on every filesystem) | §4 Step 4 / §3 | DONE | `CHANGELOG.md:119-121`: "A pair whose R1 and R2 share a filename written to a common output directory is now refused on every filesystem — that run previously lost a report." |
+| 11 | CHANGELOG sentence for §3 behaviour change 2 (case-differing distinct inputs refused on case-sensitive FS; the #216 trade) | §4 Step 4 / §3 | DONE | `CHANGELOG.md:121-124`: names the case-sensitive false positive explicitly and attributes it to the #216 loud-error-over-silent-loss trade. |
+| 12 | §6: T1–T6 all exist as named | §6 | DONE | Six new `#[test]` fns, one per T, at `:860/:883/:899/:922/:950/:979`. No T merged or dropped. |
+| 13 | §6/§8: negative-control claims match what the controls can show | §6, §8 | DONE | Verified empirically without mutating the source — see "Negative-control verification" below. Both controls discriminate exactly as §8 states. |
+| 14 | §6: the three §2 reproducers are covered by tests **and** refuse against the built binary | §6 | DONE | T1/T2/T3 are the three reproducers verbatim. Independently re-run against `target/debug/trim_galore`: all three exit 1, emit the collision message, and leave `find out -type f` = 0. Confirms §8's zero-residue claim. |
+| 15 | §6 gates: `fmt`, `clippy -D warnings`, full `cargo test` | §6 | DONE | `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --release -- -D warnings` clean; `cargo test` = **546 passed, 0 failed** across 14 binaries, matching §8's 546. |
+| 16 | A1 — newly-rejected set is exactly the colliding-report shapes; no over-rejection of adjacent shapes | §5 A1 | DONE | Traced to tests: T6 (two boundary shapes) plus pre-existing `paired_accepts_two_distinct_pairs` (`:555`, two pairs into a shared `-o`) which still passes. A1's remaining adjacent shapes are carried as documented reviewer-verified rationale, as the plan states. |
+| 17 | A2 — candidate gating equals writer gating at both sites | §5 A2 | DONE | FASTQ writers: `run_paired` `if !cli.no_report_file` (`:1566`) → `report_name`/`json_report_name` for `input_r1` and `input_r2` (`:1578-1584`). uBAM writers: `run_ubam_output_paired_two_files` `if !cli.no_report_file` (`:2164`) → same four calls (`:2178-2184`). Identical flag, identical four paths. T5 pins it. |
+| 18 | A3 — FastQC artifacts stay out of the candidate list | §5 A3 | DONE | Diff adds no FastQC paths at either site; the #385 rationale is unchanged. Verified by inspection of both hunks. |
+| 19 | A4 — uBAM **SE** path deliberately out of scope | §5 A4 | DONE | Scope honoured: the diff touches only the two paired sites. `run_ubam_output_single` (`:1934`) is untouched. Documented as a noted residual, not a gap. |
+| 20 | §8 claims "all four §4 steps as specified, no deviations" — verify against the diff | §8 | DONE | No code deviation found: both blocks match §4's specified site, container (`candidates` vs `planned`), path set and gate. See the one non-blocking prose inaccuracy below. |
+
+## Gaps (detail)
+
+None. No PARTIAL, MISSING or DEVIATED items.
+
+## Negative-control verification
+
+§6 prescribes source mutation; §8 reports both controls discriminating. I verified the same
+property **without editing the repo**, by using `--no_report_file` to switch off exactly the
+candidates each block contributes — behaviourally equivalent to removing the block:
+
+| Reproducer shape | With reports (as shipped) | Reports disabled | Conclusion |
+|---|---|---|---|
+| 1 — `A/reads.fq` + `B/reads.fq`, `-o out` | exit 1, collision msg, 0 files | exit 0 → `r1`/`reads_val_1.fq`, `reads_val_2.fq` | primaries do not collide; Step 1 is the sole cause of rejection |
+| 2 — `a/r1.fq` + `b/R1.fq`, `-o out` | exit 1, collision msg, 0 files | exit 0 → `r1_val_1.fq`, `R1_val_2.fq` | same |
+| 3 — cross-pair, `-o out` | exit 1, collision msg, 0 files | exit 0 → 4 distinct `_val_` files | same |
+| 4 — reproducer 1 + `--output-format ubam` | exit 1 (T4) | exit 0 → single `reads_val.bam` | `paired_bam_output_name` yields ONE primary per pair, so Step 2 is the sole cause |
+
+Corroborated by the naming code: `io::norm_path` (`src/io.rs:48-50`) lowercases, so keys are
+case-folded; `paired_end_output_names` (`:240-276`) appends per-input `_val_1`/`_val_2`, which
+keeps all primaries distinct in every shape above, while `report_name`/`json_report_name`
+(`:485`, `:501`) key on the full input filename and collide. So §8's table — "FASTQ block
+disabled → T1/T2/T3 FAIL while T4/T5/T6 pass; uBAM block disabled → T4 FAILs alone" — holds:
+T4 is on a different function, T5 is gated off, T6 asserts success only.
+
+## Test verification
+
+| Test name | File | Status |
+|-----------|------|--------|
+| T1 `paired_rejects_same_filename_r1_r2_into_shared_output_dir` | tests/integration_output_collision.rs:860 | PASS |
+| T2 `paired_rejects_fold_equal_filenames_into_shared_output_dir` | tests/integration_output_collision.rs:883 | PASS |
+| T3 `paired_rejects_cross_pair_report_collision` | tests/integration_output_collision.rs:899 | PASS |
+| T4 `paired_ubam_rejects_same_filename_r1_r2_into_shared_output_dir` | tests/integration_output_collision.rs:922 | PASS |
+| T5 `paired_same_filename_accepted_when_reports_disabled` | tests/integration_output_collision.rs:950 | PASS |
+| T6 `paired_report_candidates_do_not_over_reject` | tests/integration_output_collision.rs:979 | PASS |
+| `paired_accepts_two_distinct_pairs` (A1 baseline, pre-existing) | tests/integration_output_collision.rs:555 | PASS |
+| Full suite | `cargo test` | 546 passed, 0 failed, 0 ignored |
+
+## Non-blocking observations
+
+- §8 describes the `src/main.rs` change as "two blocks, **18 lines**". The diff adds **15**
+  (8 in the FASTQ block, 7 in the uBAM block). Prose-only inaccuracy in the notes; the code
+  itself matches §4 exactly. Not counted as a deviation.
+
+## Verdict
+
+**COMPLETE.** All four §4 steps are implemented at the sites the plan pins, T1–T6 all exist
+under the plan's names and pass, both §3 behaviour changes are stated in the CHANGELOG under
+`#### Bug fixes`, all four §5 assumptions trace to a test or to documented rationale, all
+three §2 reproducers refuse with zero residue, both negative controls discriminate, and the
+`fmt` / `clippy -D warnings` / 546-test gates are green. Nothing outstanding.

--- a/plans/08072026_paired-report-preflight/PLAN.md
+++ b/plans/08072026_paired-report-preflight/PLAN.md
@@ -1,0 +1,184 @@
+# Plan — Add report paths to the paired pre-flight (#388)
+
+**Issue:** [#388](https://github.com/FelixKrueger/TrimGalore/issues/388)
+**Branch point:** `dev` @ `c4599f5`
+**Revision:** v2 (2026-08-07) — see §7
+
+---
+
+## 1. Goal
+
+The `--paired` trim pre-flight checks `_val_`/`_unpaired_`/passthrough paths but not the
+four report paths per pair, so a trimming report can silently overwrite another report at
+exit 0. Add `report_name`/`json_report_name` for both sides of every pair to the candidate
+list — on the paired **FASTQ** path and the paired **uBAM-output** path, which has the
+identical live hole (verified) — gated on `!cli.no_report_file` to match the writers.
+
+## 2. The defect, stated correctly
+
+**Root cause (Reviewer B's formulation): paired primaries carry a positional discriminator
+(`_val_1`/`_val_2`) that report names do not.** #385's SE argument — report keys are finer
+than primary keys, so checking primaries suffices — held because SE has one primary per
+input. In paired mode two inputs can have distinct primaries and colliding reports. v1
+inherited the SE argument invalidly; every broken piece of v1 flowed from that.
+
+Three verified reproducers on `dev` @ `c4599f5`, all exit 0 with one report pair lost:
+
+1. **Within one pair, same filename, no case involved** (Reviewer B):
+   `--paired -o out A/reads.fq B/reads.fq` → `reads_val_1.fq`, `reads_val_2.fq`, ONE
+   report pair.
+2. **Within one pair, fold-equal filenames** (Reviewer A): `--paired -o out a/r1.fq
+   b/R1.fq` → surviving report says `Input filename: R1.fq`; R1's report gone.
+3. **Cross-pair** (Reviewer A): `--paired a/r1.fq a/r2.fq b/R2.fq b/x.fq -o out` →
+   3 report files for 4 inputs.
+
+The APFS self-pair case from the issue (`r1.fq` + `R1.fq` naming one file) is **already
+refused** by `Cli::validate`'s absolutising R1≠R2 check for same-spelling variants; the
+fix additionally covers the genuinely-two-files variants above, which validate correctly
+passes.
+
+## 3. Behaviour changes (deliberate, need sign-off)
+
+The fix converts all three reproducers from silent report loss into pre-flight refusals.
+Two of them are *currently-working invocations* in the sense of exiting 0:
+
+- **Same-filename R1/R2 into a shared output dir** (reproducer 1) — newly refused on
+  every filesystem. This matches the SE precedent already committed
+  (`se_trim_rejects_same_basename_across_dirs_with_output_dir`), and today's exit-0 run
+  loses a report, so refusal is the correct outcome — but it is a visible change and
+  gets its own CHANGELOG line.
+- **Case-differing distinct inputs on a case-sensitive filesystem** (reproducer 2 run on
+  ext4) — a true false positive there, since both reports could coexist. This is the
+  documented #216 trade (`io.rs:45-47`: loud error over silent loss on APFS/NTFS), now
+  extended to paired reports; stated, not denied.
+
+## 4. Implementation outline
+
+**Step 1 — paired FASTQ site.** `src/main.rs`, the `if cli.paired` FASTQ branch
+(`:730-767`; note the search token `Pre-flight across pairs before any I/O` is ambiguous —
+it also matches `run_specialty_paired` at `:2458`, which has no `candidates` binding and
+would fail to compile). Inside the per-chunk loop after the passthrough block:
+
+```rust
+// #388 — report names carry no _val_ discriminator, so two inputs with
+// distinct primaries can still collide on reports.
+if !cli.no_report_file {
+    for input in [&chunk[0], &chunk[1]] {
+        candidates.push(naming::report_name(input, output_dir));
+        candidates.push(naming::json_report_name(input, output_dir));
+    }
+}
+```
+
+**Step 2 — paired uBAM-output site.** `run_ubam_output`'s paired pre-flight loop
+(`:1851-1859`), which pushes to `planned` (not `candidates`); writers at `:2163-2169` are
+gated on the same flag. Same four paths per chunk, pushed to `planned`, same gate.
+
+**Step 3 — tests**, `tests/integration_output_collision.rs`:
+
+- **T1 (the fix's raison d'être):** reproducer 1 → non-zero exit, collision message,
+  nothing written. Case-free, runs identically everywhere.
+- **T2 (fold-equal):** reproducer 2 → refused. On case-insensitive FS this is a true
+  positive, on case-sensitive a documented false positive; either way the *rejection* is
+  asserted, so the test is filesystem-independent.
+- **T3 (cross-pair):** reproducer 3 → refused.
+- **T4 (uBAM twin):** reproducer 1 with `--output-format ubam` → refused.
+- **T5 (gate):** reproducer 1 plus `--no_report_file` → **succeeds**, two `_val_` files,
+  no reports (verified achievable today: validate passes these inputs). Pins that the
+  candidates cannot drift ahead of the writers.
+- **T6 (over-rejection guards, at the boundary):** single pair + `--basename` without
+  `-o` → succeeds; same-stem-different-extension R1/R2 (`sample.fq` + `sample.fastq`)
+  → succeeds. (Ordinary distinct pairs are already covered by
+  `paired_accepts_two_distinct_pairs`.)
+
+**Step 4 — CHANGELOG**, `#### Bug fixes`: the report-clobbering fix; plus the two §3
+behaviour-change sentences.
+
+## 5. Assumptions
+
+- **A1 (corrected).** The newly-rejected set is exactly: *pairs (or pair-sets) whose
+  report keys collide while primaries do not* — same-filename R1/R2 into one dir,
+  fold-equal filenames into one dir, and cross-pair repeats. Reviewer-verified sweep of
+  adjacent shapes found no other over-rejection: multi-pair repeated basenames + `-o`
+  already collide on primaries; `--basename` >1 pair already rejected by validate;
+  same-basename different dirs without `-o` keeps reports beside their inputs.
+- **A2.** Candidate gating must equal writer gating (`!cli.no_report_file`, both sites).
+  T5 pins it.
+- **A3.** FastQC artifacts stay out of the candidate list (unchanged #385 rationale).
+- **A4 (scope).** The uBAM **SE** path lacks `planned_secondary_outputs` too, but its
+  primaries (`_trimmed.bam`) fold and collide first (reviewer-verified exit 1), so only
+  a C2-class residual remains there; noted, not fixed here.
+- **A4b (residual, found by code review).** `--clump_only --paired` has the identical
+  defect — `_clumped_1`/`_clumped_2` primaries vs discriminator-free
+  `clumping_report_name` — reproduced on this branch and filed as
+  [#391](https://github.com/FelixKrueger/TrimGalore/issues/391). Not fixed here: the fix
+  restructures `run_specialty_paired`'s signature, which is scope growth at review time.
+
+## 6. Validation
+
+T1–T6; gates (`fmt`, `clippy -D warnings`, full `cargo test`); negative control: comment
+the Step-1 block → T1, T2, T3 must fail while T5, T6 still pass; comment the Step-2 block
+→ T4 must fail. The §2 reproducers re-run post-build must all refuse.
+
+## 7. Revision history
+
+**v1 → v2** after dual plan review (`PLAN_REVIEW_A.md`, `PLAN_REVIEW_B.md`) — the two
+reviews converged on near-identical findings, all verified by the orchestrator:
+
+- All four v1 tests were broken: V1/V4 could not pass (validate's absolutising R1≠R2
+  check fires first — a consequence of my own #385 D8/D13 change), V2 could not fail
+  (the format detector rejects report-named inputs before the pre-flight; a genuine
+  report is never valid FASTQ, so v1's "prior report fed back in" benefit was also
+  near-unreachable), V3 could not detect over-rejection.
+- v1's A1 ("report keys strictly finer, no new false positive possible") was false in
+  both halves; B's root-cause formulation replaces it (§2), and the behaviour changes
+  are now §3 items needing sign-off instead of being denied.
+- The paired-uBAM twin came in scope: both reviewers independently verified the
+  identical live bug there, and v1's exclusion reason ("mirrors the SE precedent") was
+  not a reason.
+- v1's insertion token was ambiguous (two hits); §4 pins the site by line range and
+  notes the second site's compile-failure property.
+- v1's §1 claim that "the SE path" gained secondary-output protection in #385 narrowed
+  to "the SE **FASTQ** path" (A's I4).
+
+---
+
+## 8. Implementation notes
+
+Implemented on `fix/388-paired-report-preflight` off `dev` @ `c4599f5`. All four §4 steps
+as specified in v2, no deviations. Diff: `src/main.rs` (two blocks, 18 lines),
+`tests/integration_output_collision.rs` (T1–T6), `CHANGELOG.md` (one entry naming both
+§3 behaviour changes).
+
+Gates: **546 tests** (was 540), fmt clean, `clippy -D warnings` clean. All three §2
+reproducers refuse against the rebuilt binary with zero files written (the residue
+counter first reported 2 — it was counting `ls`'s blank separator lines; `find -type f`
+confirms 0).
+
+Negative controls per §6, both discriminating: FASTQ block disabled → T1/T2/T3 FAIL
+while T4/T5/T6 pass; uBAM block disabled → T4 FAILs alone. Reverted to green both times.
+
+### Post-code-review round
+
+Coverage: **COMPLETE, 20/20, first pass** — no gaps. Code review: A 0 Critical / 1 High,
+B 0 Critical / 0 High; the High/Medium finding is the same on both sides
+(`--clump_only --paired`, verified, filed as #391 + A4b above). Applied in-round:
+
+- **A-M1:** both paired sites now pass `PAIRED_REPORT_HINT` — the generic advice
+  ("different source directories or `--output_dir`") recommends the two things that
+  cannot help for filename-keyed collisions. Same replace-don't-append mechanism as #384.
+- **A-M2 / B-L1:** T2/T3/T4 route through `assert_rejected_cleanly` (nothing-written now
+  asserted everywhere).
+- **A-M3 / A-M4:** T6 asserts the report filenames it claims are distinct, and gains the
+  T1-minus-`-o` acceptance case pinning `output_dir = None` handling.
+- **A-M5:** the three comments still stating the single-end A2 premise unqualified are
+  now scoped to SE naming with a #388 pointer — the reasoning trap that produced the bug.
+- **B-M2 (declined):** the two candidate blocks stay near-duplicates; extracting a helper
+  across `candidates`/`planned` buys little at two sites and the house precedent (eleven
+  call sites before #385 consolidated them for a functional reason) tolerates it.
+
+One iteration: the first test-patch script asserted against pre-rustfmt text and wrote
+nothing (the assert fired before the save — caught because the test count didn't move);
+re-applied against the on-disk shape with a count-verified regex.
+
+Final gates: 546 tests, fmt clean, clippy clean.

--- a/plans/08072026_paired-report-preflight/PLAN_REVIEW_A.md
+++ b/plans/08072026_paired-report-preflight/PLAN_REVIEW_A.md
@@ -1,0 +1,267 @@
+# Plan Review A — Add report paths to the paired pre-flight (#388)
+
+**Plan:** `plans/08072026_paired-report-preflight/PLAN.md` (v1, 2026-08-07)
+**Target:** `dev` @ `c4599f5`, clean tree
+**Reviewer:** A (independent; no coordination with B)
+**Method:** source read of `src/main.rs`, `src/io.rs`, `src/cli.rs` plus empirical runs of
+`target/release/trim_galore` (2.3.0, `533582a`) in
+`/private/tmp/claude-501/…/scratchpad/prev388a/`.
+
+**Verdict:** the *diagnosis* and *Step 1* are correct and land in the right place. The
+**validation section is broken**: three of the four proposed tests (V1, V2, V4) fail or
+are vacuous *even with the fix correctly applied*, because two earlier guards preempt
+the pre-flight. As written, the plan ships a correct 6-line fix with **no test that
+exercises it**, and its §5 negative control cannot hold. The real reproducer is not in
+the plan; it is given below, verified.
+
+---
+
+## 1. What checks out
+
+- **Insertion point exists as described.** `src/main.rs:730-767` is the `if cli.paired`
+  FASTQ pre-flight. `candidates` is declared at `:741`, the passthrough block ends at
+  `:764`, `planned.extend(candidates)` is at `:765`. Inserting Step 1's block between
+  `:764` and `:765` compiles: `output_dir` (used `:736`), `cli.no_report_file`, and the
+  `naming` alias are all in scope, and `&PathBuf` → `&Path` coerces at the call.
+- **Multi-pair really feeds ONE pre-flight call.** The `for chunk in cli.input.chunks(2)`
+  loop accumulates into `planned`; the single `preflight_output_collisions` is at `:767`,
+  after the loop. §6's cross-pair claim is structurally correct — and the cross-pair hole
+  is live today (§3.4 below).
+- **The writer's gate claim is exactly right, including JSON.** `main.rs:1558` is
+  `if !cli.no_report_file {`, the `write_paired_reports` call at `:1585` is inside it, and
+  the descriptors at `:1570-1576` use `report_name`/`json_report_name` for R1 and R2 —
+  the same four names Step 1 pushes. `write_paired_reports` writes txt (`:2392`) and json
+  (`:2417`) unconditionally *inside* that one gate; there is no separate JSON flag. A2 holds.
+- **The harm is real and worse than the plan claims.** Verified silent data loss on
+  current `dev` (§3.4).
+- **Step 3's CHANGELOG anchors exist** — `#### Bug fixes` at `CHANGELOG.md:6`, #383 at
+  `:64` and `:115`.
+
+---
+
+## 2. Critical findings
+
+### C1 — V1 cannot pass. `Cli::validate` rejects `--paired ./r1.fq r1.fq` today, before the pre-flight.
+
+`path_identity_key` (`io.rs:78`) calls `lexical_normalise`, which **absolutises**
+(`io.rs:55-56`). So `./r1.fq` and `r1.fq` are already ONE key, and `cli.rs:537` bails.
+The source comment at `cli.rs:535` states this outright:
+
+> `#383 — keyed like the output-collision pre-flight, so ./r1.fq r1.fq cannot pass as a pair.`
+
+Verified:
+
+```
+$ trim_galore --paired ./r1.fq r1.fq
+Error: Read 1 and Read 2 appear to be the same file: ./r1.fq. Did you mean to pass distinct R1 and R2 files?
+```
+
+V1 asserts "non-zero exit **with the collision message**". The actual message is the
+same-file message, so **V1 fails with the fix applied**, and §5's negative control
+("comment the block → V1 must fail") is meaningless — V1 fails either way.
+
+§2.1's parenthetical ("This also upgrades the D13-noted self-pair from silent to refused
+via a second, spelling-based route") and V1's "Runs on any filesystem" are the root
+error. The report-key arithmetic the plan asks to be traced *is* correct —
+`report_name(./r1.fq, None)` → `./r1.fq_trimming_report.txt` (parent of `./r1.fq` is
+`.`), `report_name(r1.fq, None)` → `r1.fq_trimming_report.txt` (parent is `""`, so the
+`unwrap_or(".")` never fires), and `collision_key` absolutises both to the same string —
+but it is unreachable: control never gets to `:767`.
+
+### C2 — V2 cannot fail. The format detector rejects `*_trimming_report.txt` before the pre-flight.
+
+`main.rs:212` maps `detect_input_format` over **all** inputs, well before `:767`.
+V2's exact shape, verified:
+
+```
+$ trim_galore --paired a_R1.fq a_R2.fq x.fq a_R1.fq_trimming_report.txt
+Error: Input 'a_R1.fq_trimming_report.txt' is not recognised as FASTQ (plain or gzipped) or unaligned BAM
+```
+
+Identical before and after the fix. V2 asserts "the alias wording", so it fails with the
+fix applied; had it asserted only "refused", it would be vacuous. Either way it cannot
+observe the new code.
+
+**Corollary — §2.1 ¶3's claimed benefit is near-unreachable.** For a report path to hit
+the output-vs-input branch, an *input* must be named `*_trimming_report.{txt,json}` **and**
+carry valid FASTQ/uBAM content. A genuine prior report never does. So "a prior run's
+report fed back in are refused instead of overwritten" is not the win the plan states;
+the only reachable case is a FASTQ file with a report-shaped name. Keep the fix (it is
+free), but drop the claim or restate it honestly.
+
+### C3 — V4 cannot pass, for C1's reason.
+
+`--no_report_file` does not reach `validate`'s same-file check. Verified:
+
+```
+$ trim_galore --paired --no_report_file ./r1.fq r1.fq
+Error: Read 1 and Read 2 appear to be the same file: ./r1.fq. …
+```
+
+V4's *intent* (pin the gate) is sound and A2 deserves a test — it just needs inputs that
+survive `validate`. With the reproducer from C4 it works today: verified exit 0, output
+dir holds only `r1_val_1.fq` + `R1_val_2.fq`, no reports.
+
+### C4 — No proposed test exercises the fix. Here is a verified reproducer.
+
+Two **genuinely distinct** input files whose filenames fold equal, sharing an output dir.
+`validate` passes (`path_identity_key` is case-sensitive), primaries differ
+(`_val_1` vs `_val_2`), reports collide. On current `dev`:
+
+```
+$ trim_galore --paired a/r1.fq b/R1.fq -o out ; echo $?
+0
+$ ls out
+r1_val_1.fq  R1_val_2.fq  r1.fq_trimming_report.json  r1.fq_trimming_report.txt
+$ grep 'Input filename' out/r1.fq_trimming_report.txt
+Input filename: R1.fq          # ← R2's report overwrote R1's. Two inputs, one report.
+```
+
+Exit 0, silent loss of R1's report. Step 1's code catches it: both candidates fold to
+`<abs>/out/r1.fq_trimming_report.txt`. This is the test V1 should have been. It requires
+a case-insensitive FS to be a *true* positive but is rejected unconditionally (see I1) —
+so as a **rejection** test it passes on Linux CI too.
+
+---
+
+## 3. Important findings
+
+### I1 — A1's "strictly finer" is wrong, and §2.1's "no new false positive is possible" is false.
+
+Primary keys encode **position** (`_val_1` vs `_val_2`); report keys do not. In that
+dimension the report key is *coarser*, which is precisely why C4's case exists — the
+plan's own headline scenario contradicts its assumption. The correct statement of the
+new rejection set is: *two inputs whose filenames fold equal in the same output dir*.
+
+`collision_key` (`io.rs:84`) always case-folds; the pre-flight has no filesystem
+awareness. So `--paired r1.fq R1.fq` with two genuinely distinct files **will be newly
+refused on a case-sensitive filesystem** — a real false positive. That is acceptable and
+already the documented design trade-off (`io.rs:45-47`: "on opt-in case-sensitive APFS
+volumes this may false-positive, but the penalty is a loud early error rather than silent
+data loss"), but the plan must say so instead of claiming immunity. Rewrite A1 accordingly.
+
+Checked the other over-rejection routes the plan should have considered, all benign:
+`--basename` (reports keep per-input names, but with one pair the primaries are always
+distinct and with multiple pairs the primaries *already* collide → no new rejection);
+`-o` absent (reports land next to each input, so cross-dir inputs stay distinct);
+R1/R2 of one pair sharing a *stem* but differing in extension (`sample.fq` + `sample.fastq`
+→ report names distinct). No over-rejection beyond I1's fold-equal family.
+
+### I2 — §2.2's out-of-scope call leaves an identical, live bug shipping.
+
+The paired-uBAM twin has the same hole, verified on current `dev`:
+
+```
+$ trim_galore --paired --output-format ubam a/r1.fq b/R1.fq -o out ; echo $?
+0
+$ ls out
+r1_val.bam  r1.fq_trimming_report.json  r1.fq_trimming_report.txt   # one report pair, two inputs
+```
+
+Its pre-flight is `main.rs:1851-1860` and its report names are at `:2163-2169`
+(`run_ubam_output_paired_two_files`), both using `report_name`/`json_report_name` on
+`input_r1`/`input_r2`. Deferring is a defensible scope call, but "out of scope because
+this mirrors the SE FASTQ precedent" is not a reason — the harm class §2.1 invokes is
+equally reachable here. Either cover it (four more lines, same shape) or say plainly
+that a known-live instance is being left for a follow-up issue.
+
+Two inaccuracies in that paragraph: the `:1825`-area pointer is the *dispatcher*
+(`run_ubam_output` starts at `:1829`; its paired pre-flight loop is `:1851-1859`), and
+**"the same four lines" will not compile verbatim** — that loop pushes to `planned`,
+not `candidates`.
+
+### I3 — The search token is ambiguous: two hits.
+
+`Pre-flight across pairs before any I/O` matches `main.rs:731` (intended) **and**
+`main.rs:2458` (`run_specialty_paired`, for `--clock`/`--implicon`). Since §2.2 gives the
+insertion point by token rather than line, pin it to `:730-767` / "the `if cli.paired`
+FASTQ branch". The `:2458` site has no `candidates` binding, so a wrong landing fails to
+compile rather than silently misbehaving — but it costs the implementer a cycle.
+
+### I4 — The asymmetry is wider than §1 states: the uBAM SE path has the hole too.
+
+`planned_secondary_outputs` is called **exactly once**, at `main.rs:833` — the FASTQ SE
+loop. The uBAM SE pre-flight (`:1899-1904`) plans only BAM names, while
+`run_ubam_output_single` writes reports at `:1929`/`:2017`. So #385 fixed FASTQ-SE only.
+§1's "the SE path gained `planned_secondary_outputs`" should read "the SE **FASTQ** path".
+(In practice the uBAM SE primaries catch the fold-equal case — verified `exit=1` for
+`--output-format ubam a/r1.fq b/R1.fq -o out`, because `_trimmed.bam` names fold too —
+so only the C2-class residual is exposed. Worth a sentence, not necessarily a fix here.)
+
+### I5 — V3 is too weak to be A1's guard, and no test covers the cross-pair route.
+
+"Two ordinary distinct pairs still run" cannot detect over-rejection: ordinary pairs have
+nothing near the fold-equal boundary. To actually guard A1, V3 should pin the shapes
+adjacent to it — `--basename` with one pair, and same-stem-different-extension R1/R2 —
+and the plan should state that the case-differing-distinct-inputs shape is now
+**rejected** (I1), not accepted.
+
+Separately, the cross-pair route §6 claims to cover is untested and live. Verified on
+current `dev` — four inputs, three report pairs, exit 0:
+
+```
+$ trim_galore --paired a/r1.fq a/r2.fq b/R2.fq b/x.fq -o out ; echo $?   # 0
+$ ls out | grep trimming_report.txt
+r1.fq_trimming_report.txt  r2.fq_trimming_report.txt  x.fq_trimming_report.txt
+# b/R2.fq's report overwrote a/r2.fq's
+```
+
+---
+
+## 4. Efficiency
+
+No concern. Four extra `PathBuf`s per pair; `preflight_output_collisions` is one
+`HashMap` pass over `planned`. `report_name`/`json_report_name` do no filesystem I/O
+(`io.rs:485-514` are pure string joins), so the pre-flight stays I/O-free as documented.
+
+## 5. Alternatives
+
+- **Preferred:** have the paired branch call a shared helper (the existing
+  `planned_secondary_outputs`, or a small `paired_secondary_outputs`) instead of
+  open-coding the push. That is the #384 "two functions reading one property must fold
+  together" lesson §6 invokes, applied properly — it makes writer/guard drift structural
+  rather than test-enforced, and gives I2/I4 a single place to fix.
+- Considered and rejected: adding `_val_1`/`_val_2`-style position to report names would
+  remove I1's false positives, but breaks the MultiQC-visible report naming and Perl
+  parity. Not worth it.
+
+---
+
+## 6. Action items
+
+### Critical
+1. **Rewrite V1** to C4's verified reproducer (`--paired a/r1.fq b/R1.fq -o out`,
+   distinct files, fold-equal names), asserting the *collision* wording. The
+   `./r1.fq r1.fq` scenario is already refused by `cli.rs:537` and must be dropped or
+   re-labelled as a pre-existing `validate` guard.
+2. **Drop or rebuild V2.** `main.rs:212` preempts any real `*_trimming_report.txt` input.
+   If kept, the fixture must be FASTQ *content* under a report-shaped *name*, and §2.1 ¶3's
+   benefit claim must be restated to match.
+3. **Rewrite V4** onto C4's inputs + `--no_report_file` (verified exit 0 today).
+4. **Re-derive §5's negative control** after 1–3; as written it cannot hold.
+
+### Important
+5. **Fix A1 and §2.1.** Report keys are coarser in the position dimension; new rejections
+   are exactly "fold-equal filenames in one output dir"; false positives on case-sensitive
+   filesystems **are** possible and are the accepted `io.rs:45-47` trade-off.
+6. **Resolve §2.2.** Cover the paired-uBAM twin (`:1851-1859` pre-flight, `planned` not
+   `candidates`) or state that a verified-live instance is being deferred, with an issue.
+   Fix the `:1825` pointer and the "same four lines" wording.
+7. **Add a cross-pair rejection test** (verified live hole) — it is what §6 claims.
+8. **Pin the insertion point by line** (`:730-767`), not the two-hit token.
+9. **Strengthen V3** per I5; correct §1 to "SE **FASTQ** path" per I4.
+
+### Optional
+10. Refactor toward a shared secondary-outputs helper (§5) rather than an open-coded push.
+11. Note the uBAM SE residual (I4) in §2.2's scope paragraph.
+
+---
+
+## 7. Harness confidence
+
+Every "pass" above was shown capable of failing: the same binary produced `exit=0` for
+the four accepted shapes and `exit=1`/error text for the rejected ones, and the data-loss
+claim is evidenced by `Input filename: R1.fq` inside a file named
+`r1.fq_trimming_report.txt` — not by a file count alone. Case-sensitive-filesystem
+behaviour (I1) is derived from `collision_key`/`norm_path` source, not executed; macOS
+APFS here is case-insensitive.

--- a/plans/08072026_paired-report-preflight/PLAN_REVIEW_B.md
+++ b/plans/08072026_paired-report-preflight/PLAN_REVIEW_B.md
@@ -1,0 +1,262 @@
+# Plan review B — #388 paired report pre-flight
+
+**Reviewer:** B (independent; no coordination with Reviewer A)
+**Target:** `plans/08072026_paired-report-preflight/PLAN.md` (v1, 2026-08-07)
+**Repo state:** `dev` @ `c4599f5`, clean tree, plan not implemented
+**Method:** read the cited source, then ran `target/release/trim_galore` (current with `dev`)
+against each scenario the plan asserts. Scratch:
+`/private/tmp/claude-501/.../scratchpad/prev388b/`. Filesystem here is
+case-**insensitive** (APFS), confirmed by `ls R1.fq` resolving to `r1.fq`.
+
+---
+
+## Verdict
+
+The **fix itself is right**: 6 lines in the right place, correct gate, and it closes a
+harm I reproduced. The **validation section is not**: three of the four listed tests
+cannot pass as specified, the negative control in §5 is void, and the one scenario the
+fix actually exists for is not tested at all. Assumption A1 is false, and its failure
+mode is a user-visible behaviour change the plan does not acknowledge.
+
+Root cause of most of the below, stated once: **paired primaries carry a positional
+discriminator (`_val_1` / `_val_2`) that report names do not.** #385's SE
+"reports-are-finer-than-primaries" argument held because SE has one primary per input.
+Inheriting it into paired mode is invalid. Every finding here flows from that.
+
+---
+
+## What checks out
+
+| Plan claim | Verdict |
+|---|---|
+| Insertion point: per-chunk `candidates`, token `Pre-flight across pairs before any I/O` | **Correct** — `src/main.rs:731`; `candidates` built per chunk (741–764), `planned.extend` at 765 |
+| Multi-pair feeds **one** `preflight_output_collisions` call | **Correct** — `planned` declared 732, extended in-loop, single call at `src/main.rs:767` |
+| Writer gate is `!cli.no_report_file` at `main.rs:1558` | **Correct**, line-accurate, and it covers **both** `.txt` and `.json` (1570–1578) |
+| SE precedent mirrors exactly | **Correct** — `main.rs:90-93` is `if !cli.no_report_file { report_name; json_report_name }`, identical shape |
+| Harm in §2.1 (`--paired r1.fq R1.fq` self-pairs, one report silently lost) | **Reproduced** — see below |
+| §2.2 "same four lines" for the uBAM twin | **Correct** — same four paths, same gate (verified in `run_ubam_output_paired_two_files`) |
+| A3 (FastQC out of scope) | Reasonable, unchanged from #385 |
+
+### The harm is real (§2.1 confirmed)
+
+```
+$ trim_galore --paired --dont_gzip r1.fq R1.fq     # only r1.fq on disk
+exit=0
+r1_val_1.fq  R1_val_2.fq  r1.fq  r1.fq_trimming_report.json  r1.fq_trimming_report.txt
+```
+
+Exit 0, self-paired, **one** report pair on disk — R1's report landed on r1's. Both
+`_val_` files exist because the suffix differs. This is the #383 harm class surviving,
+exactly as the plan says, and the fix does catch it (report keys fold to one
+`collision_key`). The fix is worth making.
+
+---
+
+## Critical
+
+### C1. V1 cannot pass, and cannot fail — `Cli::validate` gets there first
+
+The plan's V1 (`--paired ./r1.fq r1.fq`) never reaches the pre-flight.
+`cli.rs:537` compares `path_identity_key(chunk[0]) == path_identity_key(chunk[1])`, and
+`path_identity_key` **absolutises** (`lexical_normalise`, `io.rs:78`), so `./r1.fq` and
+`r1.fq` are already one key. Measured on today's binary, no fix applied:
+
+```
+$ trim_galore --paired ./r1.fq r1.fq
+exit=1
+Error: Read 1 and Read 2 appear to be the same file: ./r1.fq. ...
+```
+
+Consequences, all three fatal to V1 as written:
+
+1. It **already exits non-zero** → with loose assertions the test cannot fail, so it
+   guards nothing.
+2. Written in house style it **cannot pass even after the fix**:
+   `assert_rejected_cleanly` asserts `stderr.contains(PREFIX)` where `PREFIX =
+   "Output path collision (case-insensitive, for APFS/NTFS safety)"`
+   (`tests/integration_output_collision.rs:91,100-103`). Validate's message contains no
+   such prefix and short-circuits before the pre-flight.
+3. §5's negative control ("comment the block → V1 and V2 must fail") is therefore
+   **void** — V1 passes or fails identically with and without the change.
+
+§2.1's supporting claim is also wrong: "`./r1.fq_trimming_report.txt` and
+`r1.fq_trimming_report.txt` absolutise to one key" is *true* (I traced it: `Path::new
+("r1.fq").parent()` is `Some("")`, not `None`, so `report_name` joins onto empty and
+`collision_key` absolutises both to `<cwd>/r1.fq_trimming_report.txt`) — but it is
+unreachable, because the identical normalisation in `path_identity_key` rejects the
+inputs first. **There is no filesystem-independent two-spelling input that reaches the
+report route**: `path_identity_key` and `collision_key` differ *only* in case folding,
+so any pair of spellings that folds together in report space is also caught by validate
+unless they differ in case — and case-only aliasing is precisely the FS-dependent case.
+
+**Fix — replace V1 with the harm case, made portable by writing both spellings:**
+
+```rust
+write_fastq(&dir.join("r1.fq"), "R1");
+write_fastq(&dir.join("R1.fq"), "R2");   // one file on APFS, two on ext4
+let (ok, stderr) = run_in(&dir, &["--paired", "--dont_gzip", "r1.fq", "R1.fq"]);
+assert!(!ok); assert!(stderr.contains(PREFIX) && stderr.contains(DUP_MSG));
+```
+
+Portable because the pre-flight is purely lexical: on a case-insensitive FS the two
+names are one file (the reproduced harm); on a case-sensitive FS they are two files
+whose report keys still fold. Rejected on both after the fix; **accepted on both
+before** it (I verified the case-insensitive half above), so it can genuinely fail.
+Do not create only `r1.fq` and reference `R1.fq` — `main.rs:209-213` format-detects
+*every* input, so on a case-sensitive FS that dies on a missing file, not a collision.
+
+### C2. V4 is impossible as specified
+
+V4 expects `--no_report_file` + V1's inputs to **succeed**. It cannot: the same
+`cli.rs:537` check is gate-independent.
+
+```
+$ trim_galore --paired --no_report_file ./r1.fq r1.fq
+exit=1
+Error: Read 1 and Read 2 appear to be the same file: ./r1.fq. ...
+```
+
+Rebase V4 on C1's inputs instead: `--paired --no_report_file r1.fq R1.fq` must
+**succeed** (reports are the only colliding keys, so removing them from the candidate
+list must let it through). That version genuinely pins the gate — and note it pins it in
+the direction that matters, since a gate-less implementation would reject it.
+
+### C3. V2 is unreachable — the format guard precedes the pre-flight
+
+`main.rs:209-213` runs `detect_input_format` over **all** inputs, ~550 lines before the
+paired pre-flight. A fed-back report dies there:
+
+```
+$ trim_galore --paired a_R1.fq a_R2.fq x.fq a_R1.fq_trimming_report.txt
+exit=1
+Error: Input 'a_R1.fq_trimming_report.txt' is not recognised as FASTQ (plain or gzipped) or unaligned BAM
+report md5 before == after   # byte-intact
+```
+
+So V2 asserting `ALIAS_MSG` can never pass (wrong message, before *and* after the fix),
+and asserting only "refused + byte-intact" can never fail. **§2.1's third paragraph is
+factually wrong**: these inputs are *already* refused and were *never* overwritten, so
+the fix does not add the protection the plan credits it with. The output-vs-input half
+of the change is effectively dead on the paired path — a report path can only equal an
+input if that input is a valid FASTQ *named* `*_trimming_report.txt`, which the format
+guard otherwise excludes. Harmless to include (it mirrors SE, cheap), but **drop V2 or
+rewrite it around a valid-FASTQ file deliberately named `*_trimming_report.txt`**, and
+correct the §2.1 claim either way.
+
+### C4. A1 is false — a non-alias over-rejection exists, and it removes working runs
+
+A1 claims report candidates "cannot reject a pair the primaries would have accepted —
+except where two inputs alias one file or a report aliases an input". Counterexample,
+two genuinely distinct files, no aliasing:
+
+```
+$ trim_galore --paired --dont_gzip -o out A/reads.fq B/reads.fq
+exit=0
+out/: reads_val_1.fq  reads_val_2.fq  reads.fq_trimming_report.{txt,json}
+```
+
+Primaries are distinct (`_val_1` vs `_val_2`); the two reports are **not** — one report
+is silently lost today, and after the fix this invocation becomes a hard error. That is
+arguably the *right* outcome (the project already rejects the SE analogue on purpose —
+`se_trim_rejects_same_basename_across_dirs_with_output_dir`, test file line 175), but:
+
+- A1 as written is wrong and must be restated. The exact residual class is: **one pair
+  whose R1 and R2 share a filename in different directories, written to a common
+  directory** (via `-o`, or one input already in the cwd).
+- It **removes a currently-working invocation**, so it needs a CHANGELOG line and a
+  deliberate sign-off, not silence.
+- I checked the neighbouring cases the brief raised and they are all fine: multi-pair
+  with repeated basenames + `-o` is *already* rejected on primaries
+  (`out/r1_val_1.fq and out/r1_val_1.fq`); `--basename` with >1 pair is rejected by
+  validate ("ambiguous output naming"); single pair + `--basename` without `-o` still
+  succeeds; same-basename in different dirs *without* `-o` still succeeds (reports land
+  beside their own inputs). So the class above is the only one.
+- **V3 does not detect it.** "Two ordinary distinct pairs" have distinct report names
+  and pass with or without the fix. Add this case as its own test (expecting rejection).
+
+---
+
+## Important
+
+### I1. "No new false positive is possible" is wrong
+
+§2.1 asserts this from D13 test H. On a **case-sensitive** FS, `sample_R1.fq` and
+`sample_r1.fq` are two real files with two real distinct reports, yet `collision_key`
+folds case and the run is now rejected. That is a new false positive on Linux — the
+documented #385 trade-off (`io.rs:45-47`: "on opt-in case-sensitive volumes this may
+false-positive"), which is fine, but the plan claims *immunity*, and that claim is what
+justifies not testing the boundary. Restate as: residual false-positive class is inputs
+differing only in ASCII case on a case-sensitive FS, accepted per #385. (C1's test
+doubles as documentation of it.)
+
+### I2. The uBAM-out twin has the identical live bug — the scope call is incoherent
+
+§2.2 defers it. But §1 frames the whole plan as *closing* the asymmetry #385 left, and
+deferring here opens a new one of the same shape. Reproduced on today's binary:
+
+```
+$ trim_galore --paired --output-format ubam r1.fq R1.fq     # FASTQ in, uBAM out
+exit=0
+r1_val.bam  r1.fq  r1.fq_trimming_report.{txt,json}     # one report pair, one lost
+```
+
+It is *more* exposed than the FASTQ path, not less: its pre-flight plans only **one**
+primary per pair (`paired_bam_output_name`, `main.rs:1849-1860`), so fewer keys guard
+it. The plan's own "same four lines" is accurate (same paths, same `!cli.no_report_file`
+gate) and the gate is identical, so there is no technical reason to defer.
+**Recommend folding it in** — 4 lines at `main.rs:1849-1860`, one extra test.
+
+Two corrections to §2.2 while there: (a) the pointer `:1825` is the `run_ubam_output`
+function header, not the insertion site — that is the per-chunk loop at 1849–1860;
+(b) two-file *BAM input* is rejected upstream by `reject_bam_format_mismatch_in_pair`,
+so this path is reachable only with FASTQ input + `--output-format ubam` — worth saying,
+since it changes how the test is written. The single-file interleaved path is genuinely
+safe, but for a reason the plan does not give: it has one input, so its `.txt`/`.json`
+names cannot collide with each other or with the input.
+
+### I3. V3 is weaker than the file's own standard
+
+`tests/integration_output_collision.rs:11-14` requires acceptance cases to "assert
+content or filename rather than mere existence". V3 says "run to completion". Use
+`count_reads_from` on both `_val_` files and assert all four report files exist with
+distinct names — otherwise a candidate list built from the wrong namer still passes.
+
+### I4. No test covers the harm the fix exists for
+
+Following C1–C3, the plan's post-fix test set contains **zero** tests that fail without
+the change. Minimum viable set: C1's case-alias rejection, C2's rebased gate test, C4's
+same-basename-with-`-o` rejection, a strengthened V3, and (if I2 is accepted) the
+uBAM-out twin. Re-run the §5 negative control against *that* set.
+
+---
+
+## Optional
+
+- **O1.** CHANGELOG (Step 3): add the removed-invocation note from C4. The #383 entry
+  already sets this precedent; a bare "collisions are now refused" undersells it.
+- **O2.** The new comment says a report can "overwrite an input" — per C3 that is
+  unreachable on this path. Trim to the reachable half: reports are outputs too, and
+  two inputs differing only in case name one report.
+- **O3.** §6's self-review claims the multi-pair accumulation was checked and it was
+  right — worth keeping. But it also says "Risk: none identified beyond over-rejection,
+  which A1/V3 covers", and A1/V3 demonstrably do not cover it (C4). Update.
+- **O4.** Consider whether report names *should* carry the `_1`/`_2` discriminator, the
+  way primaries do. That would fix C4's over-rejection class at the source rather than
+  converting it into an error — but it breaks MultiQC's expected filenames, so I am
+  **not** recommending it; noting it so the trade-off is on the record.
+
+---
+
+## Summary of action items
+
+| # | Severity | Item |
+|---|---|---|
+| C1 | Critical | V1 unreachable (`validate` cli.rs:537 fires first); replace with case-alias harm test; §5 negative control void |
+| C2 | Critical | V4 impossible; rebase on `r1.fq R1.fq` inputs |
+| C3 | Critical | V2 unreachable (format guard `main.rs:209-213`); correct §2.1 ¶3's false claim |
+| C4 | Critical | A1 false; same-basename R1/R2 + `-o` is a non-alias over-rejection that removes working runs; V3 misses it |
+| I1 | Important | "No new false positive is possible" is wrong on case-sensitive filesystems |
+| I2 | Important | uBAM-out twin has the identical live bug (reproduced); fold in the 4 lines |
+| I3 | Important | V3 must assert content/filename per the test file's own standard |
+| I4 | Important | As specified, no test fails without the change |
+| O1–O4 | Optional | CHANGELOG note; comment wording; §6 update; report-naming trade-off on record |

--- a/plans/08072026_paired-report-preflight/PROGRESS.md
+++ b/plans/08072026_paired-report-preflight/PROGRESS.md
@@ -1,0 +1,20 @@
+# Progress: Add report paths to the paired pre-flight (#388)
+
+**Last updated:** 2026-08-07
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | `PLAN.md` v2 — validation section rebuilt; uBAM twin in scope |
+| Plan Review | ✅ Complete | A + B converged: 4 Criticals each (all four v1 tests broken, A1 false); 3 reproducers verified |
+| Impl Plan | ❌ Excluded | §3 is the outline; ~6 lines of source |
+| Implementation | ✅ Complete | 546 tests; both §6 controls discriminate; §8 notes |
+| Code Review | ✅ Complete | A + B: 0 Critical; shared High → #391 filed; M1–M5 applied |
+| Coverage | ✅ Complete | **COMPLETE 20/20, first pass** |
+
+## History
+
+- 2026-08-07: Plan → v2. Both reviewers: every v1 test unable to pass or fail (validate's absolutising R1≠R2 fires first; format detector precedes pre-flight); A1 false — paired primaries carry a positional discriminator reports lack, so the SE finer-than argument doesn't transfer. uBAM twin verified live, brought in scope. Two behaviour changes named for sign-off.
+
+- 2026-08-07: Plan → ✅ Complete

--- a/src/io.rs
+++ b/src/io.rs
@@ -1211,7 +1211,9 @@ mod tests {
     /// Assumption A2, in the direction that makes the pre-flight sufficient:
     /// where two inputs' PRIMARY output paths differ, every secondary output
     /// path must differ too — so a secondary can never collide unless a primary
-    /// already has, and hashing primaries alone is enough.
+    /// already has, and hashing primaries alone is enough. Single-end naming
+    /// only: paired `_val_N` primaries break this (#388), which is why the
+    /// paired pre-flight carries report candidates explicitly.
     ///
     /// Checked across the flag matrix (`--basename` / `--dont_gzip` / `-o`, each
     /// on and off) because `--basename` and `-o` are exactly the flags that
@@ -1283,8 +1285,9 @@ mod tests {
     }
 
     /// Complement to the above: the primary key is strictly *coarser* than the
-    /// report key, which is why checking primaries covers reports rather than
-    /// merely coinciding with them. Three spellings of one sample share a
+    /// report key (in single-end naming — paired `_val_N` inverts this, #388),
+    /// which is why checking SE primaries covers reports rather than merely
+    /// coinciding with them. Three spellings of one sample share a
     /// primary while keeping three distinct report names.
     #[test]
     fn primary_output_key_is_coarser_than_secondary_keys() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,12 @@ type ResolvedAdapter = Result<(String, AdapterList, AdapterList, Option<(usize, 
 
 /// Replaces the generic advice for the modes that name output into the CWD
 /// (`--hardtrim5/3`, `--clock`, `--implicon`), where "use `--output_dir`" is false.
+const PAIRED_REPORT_HINT: &str = "Paired outputs and reports are named from the input \
+                                  filename alone, so two inputs sharing a filename collide \
+                                  regardless of source directory — rename one input, or pass \
+                                  --no_report_file if only the reports collide.";
+
+/// CWD-output modes' remediation; see `PAIRED_REPORT_HINT` for the paired sites.
 const CWD_OUTPUT_HINT: &str = "This mode writes output to the current working directory, \
                                so inputs sharing a basename collide whatever `--output_dir` \
                                is set to — run one invocation per input, or give the inputs \
@@ -762,9 +768,21 @@ fn main() -> Result<()> {
                     gzip,
                 ));
             }
+            // #388 — report names carry no _val_ discriminator, so two inputs
+            // with distinct primaries can still collide on reports.
+            if !cli.no_report_file {
+                for input in [&chunk[0], &chunk[1]] {
+                    candidates.push(naming::report_name(input, output_dir));
+                    candidates.push(naming::json_report_name(input, output_dir));
+                }
+            }
             planned.extend(candidates);
         }
-        naming::preflight_output_collisions(&planned, &guarded_inputs(&cli), None)?;
+        naming::preflight_output_collisions(
+            &planned,
+            &guarded_inputs(&cli),
+            Some(PAIRED_REPORT_HINT),
+        )?;
 
         // Adapter detection runs PER PAIR — intentional deviation from Perl
         // v0.6.x (which detected once on $ARGV[0] at trim_galore:2455). Shell-
@@ -1856,8 +1874,19 @@ fn run_ubam_output(cli: &Cli, output_dir: Option<&Path>, command_line: &str) -> 
                 output_dir,
                 cli.basename.as_deref(),
             ));
+            // #388 — same report-collision hole as the FASTQ paired path.
+            if !cli.no_report_file {
+                for input in [&chunk[0], &chunk[1]] {
+                    planned.push(naming::report_name(input, output_dir));
+                    planned.push(naming::json_report_name(input, output_dir));
+                }
+            }
         }
-        naming::preflight_output_collisions(&planned, &guarded_inputs(cli), None)?;
+        naming::preflight_output_collisions(
+            &planned,
+            &guarded_inputs(cli),
+            Some(PAIRED_REPORT_HINT),
+        )?;
 
         let total_pairs = cli.input.len() / 2;
         for (pair_idx, chunk) in cli.input.chunks(2).enumerate() {

--- a/tests/integration_output_collision.rs
+++ b/tests/integration_output_collision.rs
@@ -846,3 +846,160 @@ fn demux_writes_exactly_the_planned_paths() {
         "precondition: the planned set must be non-empty"
     );
 }
+
+// ── #388: paired report paths join the pre-flight ─────────────────────────
+//
+// Paired primaries carry a positional discriminator (`_val_1`/`_val_2`) that
+// report names do not, so two inputs with distinct primaries can collide on
+// reports. Before #388 all three rejection shapes below exited 0 having
+// silently overwritten one report pair.
+
+/// T1 — the case-free shape: same filename as R1 AND R2 of one pair, shared
+/// output dir. Runs identically on every filesystem.
+#[test]
+fn paired_rejects_same_filename_r1_r2_into_shared_output_dir() {
+    let dir = tempdir("388_samename");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("A/reads.fq"), "R1SIDE");
+    write_fastq(&dir.join("B/reads.fq"), "R2SIDE");
+    let (ok, stderr) = run_in(&dir, &["--paired", "-o", "out", "A/reads.fq", "B/reads.fq"]);
+    assert!(!ok, "expected rejection, got success:\n{stderr}");
+    assert!(
+        stderr.contains(DUP_MSG),
+        "expected collision wording:\n{stderr}"
+    );
+    assert!(
+        std::fs::read_dir(&out).unwrap().next().is_none(),
+        "a refused run must write nothing"
+    );
+}
+
+/// T2 — fold-equal filenames as R1/R2. On a case-insensitive filesystem this is
+/// a true positive; on a case-sensitive one it is the documented #216-style
+/// false positive (loud error over silent loss). The REJECTION is asserted, so
+/// the test is filesystem-independent.
+#[test]
+fn paired_rejects_fold_equal_filenames_into_shared_output_dir() {
+    let dir = tempdir("388_foldeq");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("a/r1.fq"), "LOWER");
+    write_fastq(&dir.join("b/R1.fq"), "UPPER");
+    let (ok, stderr) = run_in(&dir, &["--paired", "-o", "out", "a/r1.fq", "b/R1.fq"]);
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+}
+
+/// T3 — the cross-pair route: pair 2 reuses a filename from pair 1.
+#[test]
+fn paired_rejects_cross_pair_report_collision() {
+    let dir = tempdir("388_crosspair");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("a/r1.fq"), "P1R1");
+    write_fastq(&dir.join("a/r2.fq"), "P1R2");
+    write_fastq(&dir.join("b/R2.fq"), "P2R1");
+    write_fastq(&dir.join("b/x.fq"), "P2R2");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--paired", "-o", "out", "a/r1.fq", "a/r2.fq", "b/R2.fq", "b/x.fq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+}
+
+/// T4 — the uBAM-output twin had the identical hole.
+#[test]
+fn paired_ubam_rejects_same_filename_r1_r2_into_shared_output_dir() {
+    let dir = tempdir("388_ubam");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("A/reads.fq"), "R1SIDE");
+    write_fastq(&dir.join("B/reads.fq"), "R2SIDE");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--paired",
+            "--output-format",
+            "ubam",
+            "-o",
+            "out",
+            "A/reads.fq",
+            "B/reads.fq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+}
+
+/// T5 — the gate: with --no_report_file no reports will be written, so the
+/// same inputs must run to completion. Pins candidates == writers.
+#[test]
+fn paired_same_filename_accepted_when_reports_disabled() {
+    let dir = tempdir("388_gate");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    write_fastq(&dir.join("A/reads.fq"), "R1SIDE");
+    write_fastq(&dir.join("B/reads.fq"), "R2SIDE");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--paired",
+            "--no_report_file",
+            "-o",
+            "out",
+            "A/reads.fq",
+            "B/reads.fq",
+        ],
+    );
+    assert!(ok, "expected success with reports disabled:\n{stderr}");
+    assert!(out.join("reads_val_1.fq").is_file());
+    assert!(out.join("reads_val_2.fq").is_file());
+    assert_eq!(
+        std::fs::read_dir(&out).unwrap().count(),
+        2,
+        "no reports may be written under --no_report_file"
+    );
+}
+
+/// T6 — over-rejection guards at the boundary A1 describes.
+#[test]
+fn paired_report_candidates_do_not_over_reject() {
+    // Single pair + --basename, no -o: reports keep per-input names beside
+    // their own inputs; primaries take the basename. Nothing collides.
+    let dir = tempdir("388_ok_basename");
+    write_fastq(&dir.join("r1.fq"), "B1");
+    write_fastq(&dir.join("r2.fq"), "B2");
+    let (ok, stderr) = run_in(&dir, &["--paired", "--basename", "foo", "r1.fq", "r2.fq"]);
+    assert!(ok, "basename pair must still run:\n{stderr}");
+    assert!(dir.join("foo_val_1.fq").is_file());
+    assert!(dir.join("r1.fq_trimming_report.txt").is_file());
+    assert!(dir.join("r2.fq_trimming_report.txt").is_file());
+
+    // Same stem, different extension as R1/R2: report keys differ (full
+    // filename), primaries differ (_val_1/_val_2). Nothing collides.
+    let dir2 = tempdir("388_ok_stem");
+    write_fastq(&dir2.join("sample.fq"), "S1");
+    write_fastq(&dir2.join("sample.fastq"), "S2");
+    let (ok, stderr) = run_in(&dir2, &["--paired", "sample.fq", "sample.fastq"]);
+    assert!(
+        ok,
+        "same-stem different-extension pair must still run:\n{stderr}"
+    );
+    assert!(dir2.join("sample.fq_trimming_report.txt").is_file());
+    assert!(dir2.join("sample.fastq_trimming_report.txt").is_file());
+
+    // T1 minus -o: same filename in different dirs, reports beside their own
+    // inputs. Pins that the candidates honour output_dir = None; a builder
+    // that resolved reports into one directory would over-reject this.
+    let dir3 = tempdir("388_ok_no_odir");
+    write_fastq(&dir3.join("A/reads.fq"), "N1");
+    write_fastq(&dir3.join("B/reads.fq"), "N2");
+    let (ok, stderr) = run_in(&dir3, &["--paired", "A/reads.fq", "B/reads.fq"]);
+    assert!(
+        ok,
+        "same filename in two dirs without -o must run:\n{stderr}"
+    );
+    assert!(dir3.join("A/reads.fq_trimming_report.txt").is_file());
+    assert!(dir3.join("B/reads.fq_trimming_report.txt").is_file());
+}


### PR DESCRIPTION
Fixes #388. Paired output names carry a positional discriminator (`_val_1`/`_val_2`) that report names do not, so two inputs with distinct trimmed outputs could still collide on their reports: `--paired -o out A/reads.fq B/reads.fq` exited 0 with one report pair for two inputs, R2's report having silently overwritten R1's. The four report paths per pair (text and JSON) now join the collision pre-flight on the paired FASTQ and paired uBAM-output paths, skipped under `--no_report_file` to match the writers.

Behaviour changes, both in the CHANGELOG: a pair whose R1 and R2 share a filename written to a common output directory is now refused on every filesystem (that run previously lost a report), and two distinct inputs whose filenames differ only in case are refused even on a case-sensitive filesystem — the #216 loud-error-over-silent-loss trade, extended to paired reports.

<details>
<summary>Detail (AI-assisted; bin freely)</summary>

The root cause is an argument that was true where it was written and false where it was reused: #385 established that report keys (full input filename) are finer than primary keys (stem) on the single-end path, so checking primaries suffices there. Paired primaries append `_val_N`, which report names lack — in that dimension the report key is *coarser*, and the SE argument does not transfer. The three comments stating that argument in general terms are now scoped to SE naming, so the trap is disarmed along with the bug.

Both paired sites also pass a remediation hint: the generic advice recommends different source directories or `--output_dir`, which are exactly the two things that cannot help a filename-keyed collision.

The same defect exists on `--clump_only --paired` (clumping reports) — found independently by both code reviewers, reproduced, and filed as #391 rather than grown into this diff, since that fix restructures `run_specialty_paired`'s signature.

**Verification.** 546 tests (6 new: three rejection shapes including a case-free one that exercises the fix on Linux CI, the uBAM twin, a `--no_report_file` gate test pinning candidates == writers, and boundary acceptance cases asserting the report filenames they claim are distinct). Both negative controls discriminate: disabling the FASTQ block fails its three rejection tests while acceptance and gate tests pass; disabling the uBAM block fails its test alone. Dual plan review rebuilt the entire first-draft validation section — all four original tests could neither pass nor fail as specified. Coverage audit: COMPLETE, 20/20, first pass.

Perl byte-identity matrix untouched (no CI invocation uses colliding paired filenames). Artefacts under `plans/08072026_paired-report-preflight/`.

</details>
