### PR TITLE
fix(cli): reject --hardtrim5 with --hardtrim3 (#386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,12 @@
   always had. `--clock` and `--implicon` keep their own more specific
   "Read 1 and Read 2 appear to be the same file" message.
 
+- **`--hardtrim5` and `--hardtrim3` together are now a usage error**
+  ([#386](https://github.com/FelixKrueger/TrimGalore/issues/386)). Previously the
+  pair was accepted and only the 5' trim ran — the 3' request was silently
+  dropped (Perl v0.6.x behaved the same way). Run the two trims as separate
+  invocations.
+
 - **Two collision messages advised `--output-dir`, which is not a valid flag**
   (only `--output_dir` and `-o` are). Both now name `--output_dir`.
 

--- a/docs/src/content/docs/modes/hardtrim.md
+++ b/docs/src/content/docs/modes/hardtrim.md
@@ -36,3 +36,5 @@ For everything else, prefer the fine-grained `--clip_R1`, `--clip_R2`, `--three_
 ## Compatibility
 
 Both modes accept multiple input files in a single invocation and process them sequentially. Paired-end mode is not required. `--hardtrim*` operates per-file independently.
+
+`--hardtrim5` and `--hardtrim3` cannot be combined in one invocation; to apply both, run two passes and feed the first trim's output to the second.

--- a/plans/08082026_hardtrim-conflict/CODE_REVIEW_A.md
+++ b/plans/08082026_hardtrim-conflict/CODE_REVIEW_A.md
@@ -1,0 +1,115 @@
+# Code Review A — Reject `--hardtrim5` + `--hardtrim3` together (#386)
+
+**Target:** `fix/386-hardtrim-conflict` off `dev` @ `c4599f5`, uncommitted (`src/cli.rs`, `CHANGELOG.md`).
+**Reviewer:** single reviewer. The usual dual-reviewer default was scaled down for diff size on the
+orchestrator's call (one clap attribute, two tests, one CHANGELOG entry).
+**Nothing was changed.** Recommendations only — the tree is uncommitted.
+
+## Summary
+
+Correct, minimal, and in the right layer. The exclusion is real (verified against the binary in both
+flag orders), no other code path depends on both flags being set, nothing shipped in the repo passes
+both, and the CHANGELOG's behavioural claim checks out against `main.rs`. No Critical or High findings.
+Three Low and two Medium items, all optional polish; the Mediums are a missing remediation hint in the
+error text and the docs page's `## Compatibility` section, which now omits the only hard
+incompatibility the mode has.
+
+## Verification performed
+
+**Parse-time behaviour** (release binary, `c4599f5`, rebuilt 07:51 after the 07:50 `cli.rs` edit; run
+from a scratch cwd, never the repo root):
+
+| Invocation | Result |
+| --- | --- |
+| `--hardtrim5 20 --hardtrim3 15 F` | exit 2, stderr: `the argument '--hardtrim5 <HARDTRIM5>' cannot be used with '--hardtrim3 <HARDTRIM3>'` |
+| `--hardtrim3 15 --hardtrim5 20 F` | exit 2, same message with the names swapped — **symmetry confirmed empirically**, not assumed |
+| `--hardtrim3=15 --hardtrim5=20 F` | exit 2, rejected in `=` form too |
+| `--hardtrim5 20 --hardtrim3 0 F` | exit 2 — the conflict wins over the `1..999` range check in `validate()`; still a usage error, message names both flags |
+| `--hardtrim5 20 F` | exit 0, writes `…​.20bp_5prime.fq.gz` |
+| `--hardtrim3 15 F` | exit 0, writes `…​.15bp_3prime.fq.gz` |
+| `--help` | exit 0, both entries render, no conflict noise |
+
+**Layer question (brief item 1).** Parse-time is the whole surface for the binary: `main.rs:175` is the
+only `Cli::try_parse_from` call, `Cli` is never constructed programmatically anywhere in `src/` or
+`tests/`, there are no `env = …` attributes, neither flag has a `default_value`, and there is no
+config-file or `@argfile` input path. `rewrite_perl_short_flags` only maps `-r1`/`-r2`/`-a2`, so it
+cannot manufacture or hide either flag. `main.rs`'s parse-error handler special-cases only
+`DisplayHelp`/`DisplayHelpOnMissingArgumentOrSubcommand`/`DisplayVersion` and sends everything else to
+`err.exit()` — so `ArgConflict` correctly lands on stderr with exit 2, as measured.
+
+**Sweep of every `hardtrim3` reader (brief item 2).** `main.rs:323-324` (paired-mode exemption,
+`hardtrim5.is_none() && hardtrim3.is_none()`), `main.rs:394`/`:425` (dispatch), `cli.rs:718-722`
+(`--clumpify`), `:851-855` (`--clump_only`), `:921-925` (`--passthrough`), `:952-960` (range check),
+`:986-987` (the `-a2`-unusable reason, `hardtrim5.is_some() || hardtrim3.is_some()`). None requires
+both to be set, and none changes meaning when only one can be: the `&&`/`||` forms stay correct with a
+strictly narrower input domain. No flag implies or defaults `hardtrim3`.
+
+**Nothing shipped breaks.** No test, CI step, README, or docs page passes both flags.
+`tests/integration_adapter2.rs:375-382` has cases *named* `hardtrim5`/`hardtrim3` but each passes one
+flag. `ci.yml:658-768` (collision pre-flight, Perl md5 parity) uses `--hardtrim5` alone.
+`tests/integration_output_collision.rs:329-431` uses one flag per case.
+
+**CHANGELOG accuracy (brief item 5).** Verified independently of the filing: `main.rs:394-422`'s
+`if let Some(n) = cli.hardtrim5` block ends in an unconditional `return Ok(())`, so the 3' request was
+dropped *regardless of CLI order* — the entry's "only the 5' trim ran" is exact, not order-dependent.
+The Perl claim is taken as given per the brief.
+
+**Gates.** `cargo fmt --all -- --check` clean (re-run, not taken on trust). `cargo test --lib hardtrim`
+→ 6/6 pass, including both new tests and the four pre-existing `hardtrim` guards. Tests run in the
+debug profile, so clap 4.6.4's arg-graph `debug_assert` is live — a typo'd conflict ID would panic
+rather than silently no-op; the ID `hardtrim3` is the derive field name and is correct.
+
+## Findings
+
+### Medium
+
+**M1 — the error carries no remediation, unlike every comparable refusal in this codebase.**
+clap's generic "cannot be used with" tells the user what is forbidden but not what to do. The
+CHANGELOG entry does say it ("Run the two trims as separate invocations") — the diagnostic doesn't.
+That is out of step with the surrounding work: `#379`'s non-restartable message ships a remediation
+command, `#383`/`#385`'s collision messages name `--output_dir`, and the *other* hardtrim exclusions
+bail from `validate()` with bespoke text (`--clump_only and --hardtrim5 are mutually exclusive`,
+`cli.rs:851-855`). Moving the check into `Cli::validate()` §3.4a alongside those would let the message
+carry the one-sentence fix.
+Trade-off, and I'd call it genuinely close: clap gives correct symmetric wording for free (measured
+above) and matches the 7 existing `conflicts_with` uses; `validate()` costs a hand-written both-order
+check plus tests for both orders, and loses the free symmetry. If the remediation sentence is not
+worth that, keeping clap is defensible — but then the CHANGELOG is the only place the fix is written
+down, and users hit the error before they read the CHANGELOG. **Recommend, user's call.**
+
+**M2 — `docs/src/content/docs/modes/hardtrim.md` documents both modes and, at line 36-38, has a
+`## Compatibility` section that now omits the only hard incompatibility.** Its current content
+("Both modes accept multiple input files … operates per-file independently") reads as permissive; a
+user could reasonably infer the two flags compose. One sentence at line 38 closes it. Plan §2 scoped
+docs out, so this is a follow-up rather than a defect in the diff — but the site auto-deploys from
+`dev`, so it ships as soon as this merges.
+Separately: `docs/src/content/docs/reference/changelog.md` is a hand-synced copy and already lags
+(`#383`/`#384` are absent, file last touched Aug 3). **Pre-existing, not this change's regression** —
+noted only so it isn't mistaken for one.
+
+### Low
+
+**L1 — `test_each_hardtrim_alone_still_accepted` uses `Cli::parse_from`, which calls
+`std::process::exit(2)` on a parse error rather than returning.** If a future over-broad conflict
+breaks the alone case, this test kills the whole test binary instead of failing one test — a
+confusing failure mode for the exact regression the test exists to catch.
+`try_parse_from(..).expect("…")` fails cleanly and matches the sibling test's style. Counter-argument
+that keeps this at Low: `parse_from` is the established idiom in this module (10+ call sites,
+`cli.rs:1148` onward), so the new test is consistent with the file. The `validate()` call itself is
+right — it does run, and the fixture path resolves because `cargo test` runs from the crate root.
+
+**L2 — `--help` doesn't state the exclusion.** The newer flags spell theirs out (`--clump_only` and
+`--passthrough` both enumerate incompatibilities in their doc comments); the five adapter presets set
+the opposite precedent (mutually conflicting, none documented). A clause on `--hardtrim5`'s doc
+comment would settle it in the newer direction. Optional.
+
+**L3 — the exclusion is not enforced for a programmatically-built `Cli`.** `pub struct Cli` with
+public fields in a library crate means a consumer (or future in-repo caller) can set both and get the
+old silent drop back. No live path today — `main.rs` is the only dispatcher — so this is only worth
+acting on if M1 moves the check into `validate()`, which closes it for free.
+
+## Recommendation
+
+Ship as-is if M1 is judged not worth the churn; the change is correct either way. The two items I'd
+actually action are **M2** (one sentence in `modes/hardtrim.md`) and, if the check moves to
+`validate()`, **M1 + L3** together. Nothing here blocks the commit.

--- a/plans/08082026_hardtrim-conflict/COVERAGE.md
+++ b/plans/08082026_hardtrim-conflict/COVERAGE.md
@@ -1,0 +1,63 @@
+# Plan Coverage Report
+
+**Mode:** B
+**Plan(s):** `plans/08082026_hardtrim-conflict/PLAN.md` (v1, 2026-08-08)
+**Date:** 2026-08-08
+**Verdict:** COMPLETE
+
+## Summary
+
+- Total items: 12
+- DONE: 12
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED: 0
+
+Audited against the uncommitted diff on `fix/386-hardtrim-conflict` (`CHANGELOG.md`,
+`src/cli.rs`; 31 insertions, 1 deletion — no other file touched).
+
+## Coverage ledger
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `conflicts_with = "hardtrim3"` on `--hardtrim5` | §2 Step 1 | DONE | `src/cli.rs:371`, exactly the planned line; one side only, as specified |
+| 2 | Conflict test: both flags → parse error naming both | §2 Step 2 | DONE | `test_hardtrim5_and_hardtrim3_together_rejected_at_parse`, `src/cli.rs:1228`; asserts both names via `try_parse_from().unwrap_err()` — parse level, as planned |
+| 3 | Regression guard: each flag alone parses **and** validates | §2 Step 2 | DONE | `test_each_hardtrim_alone_still_accepted`, `src/cli.rs:1239`; loops `--hardtrim5 20` and `--hardtrim3 15`, calls `validate()` |
+| 4 | CHANGELOG entry under `#### Changes` | §2 Step 3 | DONE | `CHANGELOG.md:122-127`, inside `### Unreleased` → `#### Changes` (heading at :112); states accepted-and-ignored → refused, links #386 |
+| 5 | Edge: either flag order → same clap error | §3 | DONE | Test covers one order (as the plan scopes it); both orders verified manually — exit 2 each, message names both, subject/other swap symmetrically |
+| 6 | Edge: each flag alone unchanged | §3 | DONE | Manual run wrote `BS-seq_10K_R1.20bp_5prime.fq.gz` and `…15bp_3prime.fq.gz`, exit 0 both |
+| 7 | Edge: hardtrim + `--paired`/uBAM unchanged | §3 | DONE | No dispatch code touched (diff is CHANGELOG + cli.rs only); pre-existing `hardtrim5_plus_ubam_runs_clean`, `ubam_out_hardtrim5_writes_bam`, `hardtrim_still_accepts_a_mixed_pair`, 8 collision tests all pass |
+| 8 | Edge: deliberate Perl v0.6.11 departure documented | §3 | DONE | Rationale stated in the CHANGELOG entry ("Perl v0.6.x behaved the same way") |
+| 9 | `cargo fmt --all -- --check` | §4 | DONE | Clean |
+| 10 | `cargo clippy --all-targets --release -- -D warnings` | §4 | DONE | Clean |
+| 11 | Full `cargo test` | §4 | DONE | **542 tests, 0 failed** (408 lib + 134 integration); matches §6's claimed 542 |
+| 12 | Negative control (§6 claim: remove attribute → conflict test fails, alone-tests pass) | §4 / §6 | DONE | Verified by construction, not re-executed (repo left unmodified): the clap attribute is the *sole* mutual-exclusion mechanism — `Cli::validate()` has no hardtrim5-vs-hardtrim3 check (`grep hardtrim src/cli.rs` shows only range/`--clumpify`/`--clump_only`/`--passthrough` guards), so removal makes the parse succeed and `unwrap_err()` panic, while items 3's asserts never touch the attribute |
+
+## Test verification
+
+| Test name | File | Status |
+|-----------|------|--------|
+| `test_hardtrim5_and_hardtrim3_together_rejected_at_parse` | `src/cli.rs:1228` | PASS |
+| `test_each_hardtrim_alone_still_accepted` | `src/cli.rs:1239` | PASS |
+| Full suite (542) | crate + `tests/` | PASS (0 failed) |
+
+## Manual reproduction (§4)
+
+| Invocation | Expected | Observed |
+|---|---|---|
+| `--hardtrim5 20 --hardtrim3 15 R1` | non-zero, both names | exit 2, `error: the argument '--hardtrim5 <HARDTRIM5>' cannot be used with '--hardtrim3 <HARDTRIM3>'` |
+| `--hardtrim3 15 --hardtrim5 20 R1` (reverse) | same error | exit 2, names swapped, otherwise identical |
+| `--hardtrim5 20 R1` | still trims | exit 0, `BS-seq_10K_R1.20bp_5prime.fq.gz` |
+| `--hardtrim3 15 R1` | still trims | exit 0, `BS-seq_10K_R1.15bp_3prime.fq.gz` |
+
+`.fq.gz` rather than the plan's `.fq` is the gzipped-fixture form of the documented
+`.<N>bp_5prime.fq(.gz)` pattern, not a deviation.
+
+## Verdict
+
+**Verdict:** COMPLETE
+
+All three §2 steps implemented as written, all four §3 edge-case rows trace to a test or a
+stated rationale, and all §4 validation items pass. §6's "no deviations" and its 542-test
+figure both check out against the working tree; the recorded skip of plan review was a
+user call and is not a coverage gap.

--- a/plans/08082026_hardtrim-conflict/PLAN.md
+++ b/plans/08082026_hardtrim-conflict/PLAN.md
@@ -1,0 +1,89 @@
+# Plan — Reject `--hardtrim5` + `--hardtrim3` together (#386)
+
+**Issue:** [#386](https://github.com/FelixKrueger/TrimGalore/issues/386)
+**Branch point:** `dev` @ `c4599f5` (or on top of #392's branch if not yet merged)
+**Revision:** v1 (2026-08-08)
+
+## 1. Goal
+
+`trim_galore --hardtrim5 20 --hardtrim3 15 x.fastq` exits 0 having written only the 5′
+output — the 3′ request is silently dropped, because `main()` dispatches on `--hardtrim5`
+first and returns (`main.rs`, the `if let Some(n) = cli.hardtrim5` block; #385's A3
+documented the early return). Turn the silent drop into a usage error.
+
+## 2. Implementation
+
+**Step 1 — `src/cli.rs:371`:** add `conflicts_with = "hardtrim3"` to `--hardtrim5`'s
+clap attribute. One side suffices; clap reports the conflict symmetrically whichever
+order the flags appear in. Precedent: `conflicts_with` is used 7× in `cli.rs` already.
+
+**Step 2 — tests, `src/cli.rs` mod tests:**
+- both flags → parse error mentioning both flag names (clap `try_parse_from` errors
+  before `validate()`, so test at parse level);
+- each flag alone still parses and validates (regression guards — `--hardtrim5 20` and
+  `--hardtrim3 15`).
+
+**Step 3 — CHANGELOG**, `#### Changes`: previously accepted-and-ignored, now refused.
+
+## 3. Edge cases
+
+- `--hardtrim5 20 --hardtrim3 15` in either order → same clap error. (Step 2 tests one
+  order; clap's conflict handling is symmetric and not ours to re-test exhaustively.)
+- Each flag alone, and each with `--paired`/uBAM output → unchanged; no dispatch code is
+  touched, so no behaviour beyond the parse-time rejection changes.
+- Perl v0.6.11 accepted both and also ran only one (verified in #386's filing) — this is
+  a deliberate departure identical in kind to the duplicate-input rejection (#383 A6):
+  refusing an invocation whose silent behaviour was a trap.
+
+## 4. Validation
+
+The two Step-2 tests; `cargo fmt --check`; `clippy -D warnings`; full `cargo test`;
+manual: the §1 reproduction must exit non-zero with both flag names in the message, and
+`--hardtrim5 20 x.fastq` alone must still produce `x.20bp_5prime.fq`. Negative control:
+remove the attribute → the conflict test fails, the alone-tests still pass.
+
+## 5. Self-review
+
+One attribute plus tests; no interaction with the #383/#388 pre-flights (rejection is at
+parse time, before validate and dispatch). The only judgement call is clap-level vs
+`Cli::validate()`-level rejection: clap chosen because the conflict is static (no
+cross-field logic needed), the message is free, and 7 existing conflicts set the
+precedent. Risk: none identified.
+
+## 6. Implementation notes
+
+Implemented on `fix/386-hardtrim-conflict` off `dev` @ `c4599f5`. All three steps as
+specified; no deviations. Plan review was skipped on the user's fast-track call (the
+implement trigger was given after reading the plan; option presented explicitly).
+
+Gates: **542 tests** (540 + 2 new), fmt clean, clippy clean. Negative control: attribute
+removed → conflict test FAILED, alone-tests passed; reverted → green. Manual: both flags
+→ exit 2, message names both; `--hardtrim5` alone still writes `x.20bp_5prime.fq`.
+
+### Post-code-review round
+
+Single reviewer (scaled for diff size, noted in its report) + coverage audit (**COMPLETE
+12/12**). Reviewer: 0 Critical/High, 2 Medium, 3 Low. Its verification exceeded the plan:
+both flag orders, `=` form, conflict-vs-range precedence, `--help` rendering, and a sweep
+proving parse-time is the binary's entire Cli construction surface.
+
+Applied:
+- **M1 — moved the rejection from clap to `Cli::validate()`**, reversing the plan's §5
+  placement call. The reviewer's decisive point: the *other* hardtrim exclusions
+  (`--clump_only`, `--passthrough`, `--clumpify`) are all validate-level with bespoke
+  text, so clap's generic message was the family-inconsistent choice — and the remedy
+  (sequential invocations feeding output to input) is genuinely non-obvious. A validate
+  check is symmetric by construction, so the reviewer's stated trade-off (losing clap's
+  free symmetry) does not in fact apply; both orders tested.
+- **M2 — the docs `## Compatibility` section** (which the site auto-deploys from `dev`)
+  now names the one hard incompatibility the mode has.
+
+Iteration log: the first M1 patch aborted on a stale (pre-rustfmt) test anchor, writing
+nothing — and its negative control then no-op'd against the unpatched tree and "passed"
+by disabling a check that did not exist. Caught because the control was expected to fail.
+Re-applied with disk-read anchors and an asserted control target; the real control fails
+the conflict test and the revert restores green.
+
+Final: **542 tests**, fmt clean, clippy clean; both orders exit 2 with the remedy in the
+message; each flag alone unaffected. The docs changelog copy lagging #383/#384 was noted
+by the reviewer as pre-existing, not this change's regression.

--- a/plans/08082026_hardtrim-conflict/PROGRESS.md
+++ b/plans/08082026_hardtrim-conflict/PROGRESS.md
@@ -1,0 +1,18 @@
+# Progress: Reject --hardtrim5 + --hardtrim3 together (#386)
+
+**Last updated:** 2026-08-08
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | `PLAN.md` v1 |
+| Plan Review | ❌ Excluded | User fast-track: implement trigger given after reading the plan |
+| Impl Plan | ❌ Excluded | One clap attribute |
+| Implementation | ✅ Complete | 542 tests; negative control discriminates; §6 notes |
+| Code Review | ✅ Complete | single reviewer (scaled): 0 Crit/High; M1+M2 applied |
+| Coverage | ✅ Complete | COMPLETE 12/12 (pre-M1 state; M1 changes the §2 placement) |
+
+## History
+
+- 2026-08-08: Implemented (one attribute + 2 tests + CHANGELOG)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -949,6 +949,15 @@ impl Cli {
             }
         }
 
+        // #386 — dispatch runs --hardtrim5 and returns, silently dropping a
+        // 3' request. Bespoke message per the family precedent (§3.4a).
+        if self.hardtrim5.is_some() && self.hardtrim3.is_some() {
+            anyhow::bail!(
+                "--hardtrim5 and --hardtrim3 cannot be combined in one invocation; \
+                 run the two trims as separate invocations, feeding the first trim's \
+                 output to the second."
+            );
+        }
         if let Some(n) = self.hardtrim5
             && (n == 0 || n >= 1000)
         {
@@ -1220,6 +1229,35 @@ mod tests {
             !err.contains("APFS/NTFS"),
             "must not defer to the collision pre-flight's message: {err}"
         );
+    }
+
+    /// #386. Both hardtrims together used to run only the 5' trim, silently
+    /// dropping the 3' request (the --hardtrim5 dispatch branch returns early).
+    #[test]
+    fn test_hardtrim5_and_hardtrim3_together_rejected() {
+        for args in [
+            vec!["trim_galore", "--hardtrim5", "20", "--hardtrim3", "15", R1],
+            vec!["trim_galore", "--hardtrim3", "15", "--hardtrim5", "20", R1],
+        ] {
+            let err = Cli::parse_from(&args).validate().unwrap_err().to_string();
+            assert!(err.contains("cannot be combined"), "got: {err}");
+            assert!(
+                err.contains("separate invocations"),
+                "must carry the remedy: {err}"
+            );
+        }
+    }
+
+    /// Regression guards: each flag alone must keep parsing and validating.
+    #[test]
+    fn test_each_hardtrim_alone_still_accepted() {
+        for args in [
+            vec!["trim_galore", "--hardtrim5", "20", R1],
+            vec!["trim_galore", "--hardtrim3", "15", R1],
+        ] {
+            let cli = Cli::parse_from(&args);
+            cli.validate().expect("single hardtrim flag must validate");
+        }
     }
 
     /// The same guard covers the specialty modes, which never consult `--paired`.


### PR DESCRIPTION
Fixes #386. `--hardtrim5 N --hardtrim3 M` was accepted and only the 5' trim ran — the 3' request was silently dropped at exit 0 (Perl v0.6.x behaved the same way). The pair is now rejected in `Cli::validate()` with the remedy in the message: run the two trims as separate invocations, feeding the first trim's output to the second. The hardtrim docs page's Compatibility section now names the incompatibility too.

<details>
<summary>Detail (AI-assisted; bin freely)</summary>

Validate-level rather than clap `conflicts_with`, on the code reviewer's argument: the other hardtrim exclusions (`--clump_only`, `--passthrough`, `--clumpify`) are all validate-level with bespoke messages, so the generic clap wording would have been the family-inconsistent choice — and the sequential-runs remedy is non-obvious enough to belong in the error text rather than only the CHANGELOG. A validate check is symmetric by construction; both flag orders are tested and verified against the binary.

548 tests on the rebased branch. Negative control: disabling the check fails the conflict test while the each-flag-alone guards pass. Artefacts under `plans/08082026_hardtrim-conflict/` (plan — fast-tracked past agent plan-review on the user's explicit call, recorded; one scaled code review; COMPLETE coverage audit).

</details>
