### PR TITLE
docs(modes): document basename-into-CWD output naming (#387)

### DIFF
--- a/docs/src/content/docs/modes/clock.md
+++ b/docs/src/content/docs/modes/clock.md
@@ -45,3 +45,5 @@ trim_galore --clock A_R1.fq.gz A_R2.fq.gz B_R1.fq.gz B_R2.fq.gz
 ```
 
 Each pair gets a header (`=== Clock pair N of M ===`) and the same output-collision pre-flight that `--paired` runs.
+
+Output files are named from the input's basename alone and written to the current working directory (or `--output_dir` if given), never beside the input. Two inputs sharing a basename therefore collide even when they come from different directories, and the run is refused before anything is written.

--- a/docs/src/content/docs/modes/hardtrim.md
+++ b/docs/src/content/docs/modes/hardtrim.md
@@ -38,3 +38,5 @@ For everything else, prefer the fine-grained `--clip_R1`, `--clip_R2`, `--three_
 Both modes accept multiple input files in a single invocation and process them sequentially. Paired-end mode is not required. `--hardtrim*` operates per-file independently.
 
 `--hardtrim5` and `--hardtrim3` cannot be combined in one invocation; to apply both, run two passes and feed the first trim's output to the second.
+
+Output files are named from the input's basename alone and written to the current working directory (or `--output_dir` if given), never beside the input. Two inputs sharing a basename therefore collide even when they come from different directories, and the run is refused before anything is written.

--- a/docs/src/content/docs/modes/implicon.md
+++ b/docs/src/content/docs/modes/implicon.md
@@ -28,3 +28,5 @@ trim_galore --implicon A_R1.fq.gz A_R2.fq.gz B_R1.fq.gz B_R2.fq.gz
 ```
 
 Each pair gets a header (`=== IMPLICON pair N of M ===`) and the same output-collision pre-flight (case-insensitive, full-path) that `--paired` runs. Pairwise (R1, R2, R1, R2, …) order is required; don't pass `*R1.fq.gz *R2.fq.gz` globs (those produce all-R1s-then-all-R2s).
+
+Output files are named from the input's basename alone and written to the current working directory (or `--output_dir` if given), never beside the input. Two inputs sharing a basename therefore collide even when they come from different directories, and the run is refused before anything is written.


### PR DESCRIPTION
The specialty run-and-exit modes (`--hardtrim5/3`, `--clock`, `--implicon`) name output from the input's basename alone and write into the CWD (or `--output_dir`), never beside the input — so inputs sharing a basename collide even across directories. This was undocumented; since #385 the collision fails loudly rather than losing data, making this a docs-only gap. Adds the same two-sentence note to all three mode pages.

Note for the record: the handoff claim that #393 already added this sentence to the hardtrim page was wrong — #393's addition was the `--hardtrim5`+`--hardtrim3` conflict sentence, so all three pages get the note here.

Closes #387 (manual close needed — dev is not the default branch).
