### PR TITLE
fix(cli): say what the --passthrough alias check actually checks (#389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,15 @@
 
 #### Changes
 
+- **The `--passthrough`-matches-R1/R2 message now says what it checks**
+  ([#389](https://github.com/FelixKrueger/TrimGalore/issues/389)). The old text
+  claimed the passthrough file "aliases an input file" unconditionally — false on
+  a case-sensitive filesystem, where the two spellings can be two real files. The
+  message is now subcase-specific: pointing at an input directly says the
+  passthrough must be a third file (e.g. the index read); a case-variant match
+  states the comparison is case-insensitive (APFS/NTFS safety) and suggests a
+  rename. Which runs are accepted or rejected is unchanged.
+
 - **A file given twice on one command line is now rejected**
   ([#383](https://github.com/FelixKrueger/TrimGalore/issues/383)).
   `trim_galore sample.fastq.gz sample.fastq.gz` previously trimmed the file

--- a/plans/08082026_passthrough-alias-wording/CODE_REVIEW_A.md
+++ b/plans/08082026_passthrough-alias-wording/CODE_REVIEW_A.md
@@ -1,0 +1,88 @@
+# Code Review A — #389 --passthrough alias-check wording (commit 1f43363)
+
+**Reviewer:** A (independent)
+**Base:** dev @ 7ea2741 · **Head:** 1f43363 (`fix/389-passthrough-wording`)
+**Files:** `src/cli.rs`, `src/io.rs`, `CHANGELOG.md` (diff stat matches plan scope; no stray changes)
+**Verification run:** `cargo test passthrough` → 26/26 green (incl. the two updated pins and the new case-variant test); `cargo fmt --all -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean (dev profile; impl notes report release clean); plan Validation greps 3/4 re-run and matched the documented deviations exactly.
+
+## Summary
+
+The implementation matches the approved plan (r2) including its documented deviations. The two-tier branch provably preserves the accept/reject surface, each message is truthful for its subcase, the `./`-spelling lands in the identity branch, and the new portable case-variant test is sound on both ext4 and APFS (verified by reading the validate() check order, not just the comment). The backslash continuations are correct at byte level and confirmed by rendering the real message through the built binary. Findings are three Lows, all polish: a matched-input selection corner on a pathological (and independently rejected) input, two 3-line test comments vs the ≤2-line house convention, and one word in the `norm_path` rustdoc. **Verdict: APPROVE — ship as-is; Lows are optional follow-ups.**
+
+## Issues by area
+
+### 1. Logic
+
+**L1 — Accept/reject surface preserved (verified, OK).**
+Old code bailed on `collision_key(pt) == collision_key(input[0]) || … input[1]`; new code bails iff `find` on the same predicate over the same two inputs returns `Some`, and both arms of the inner branch `bail!`. Key fact making the branch safe: `collision_key(p)` is exactly `path_identity_key(p).to_ascii_lowercase()` (both are string views of the same `lexical_normalise(p)` output — `io.rs:75-83`), so identity-equal ⇒ collision-equal and the discriminator can never widen or narrow the found set. Position in the chain is unchanged (after 1.viii, before the input-existence loop at `cli.rs:994-997`). The retained redundant `len == 2` guard is kept and explained per plan.
+
+**L2 — Message truthfulness per subcase (verified, OK).**
+Because collision-equal ∧ identity-differ ⟺ "differ only by ASCII letter case" (from the L1 identity above), the case-variant message's two claims — case-insensitive comparison, and "rename one so the paths differ by more than letter case" — are precise, not approximate. The identity branch fires exactly on lexical identity (absolutised, `.`/`..` folded, case preserved), which is the same file on every filesystem, so "{pt} is input {matched}" is truthful everywhere. `./R1.fq` vs `R1.fq` takes the identity branch (`lexical_normalise` folds `CurDir`, `io.rs:65`) and renders "./R1.fq is input R1.fq" — truthful. Symlink spellings never reach 1.ix (different names ⇒ different collision keys) — unchanged behaviour, correctly out of scope.
+
+**L3 — LOW: matched-input selection ignores a byte-identical second input (trivial fix).**
+`.find()` takes the *first* collision-key match and the identity discriminator is evaluated only against it. If the passthrough is byte-identical to input 2 but a case-variant of input 1, the case-variant branch fires and names input 1. Reproduced against the built binary:
+
+```
+$ trim_galore --paired --passthrough $D/r1.fq  $D/R1.fq  $D/r1.fq
+Error: --passthrough matches input $D/R1.fq case-insensitively (for APFS/NTFS safety): $D/r1.fq. … if they are genuinely two files, rename one …
+exit: 1
+```
+
+Here pt IS input 2, so the identity message ("must be a third file … is input $D/r1.fq") is the truthful one. Reachable because `validate_paired_input`'s within-pair check (`cli.rs:537`) is identity-based (case-sensitive), so a case-variant R1/r1 pair passes it. Impact bounded on three sides: the run is still rejected (exit 1, surface unchanged); the message's own "if they are genuinely two files" hedge partially covers it; and per the #388 CHANGELOG entry, a case-variant R1/R2 pair is refused by the report-collision pre-flight on every filesystem anyway — so this only mislabels the subcase of a doubly-invalid command line. **Trivial fix** (found set unchanged since identity-equal ⇒ collision-equal, so the surface is provably preserved):
+
+```rust
+let pt_id = crate::io::path_identity_key(pt);
+if let Some(matched) = self
+    .input
+    .iter()
+    .find(|p| crate::io::path_identity_key(p) == pt_id)
+    .or_else(|| self.input.iter().find(|p| crate::io::collision_key(p) == pt_key))
+```
+
+(the existing identity/case branch below then works unchanged).
+
+**L4 — New portable test is sound on BOTH ext4 and APFS (verified, OK).**
+Confirmed by reading the actual check order, not the test comment: (1) `validate_paired_input` at `cli.rs:621` runs first but its within-pair duplicate check is `path_identity_key`-based, so `<tmp>/R1.fq` vs the R2 fixture passes; (2) 1.i–1.vii don't apply; (3) 1.viii (`check_restartable_input`, `cli.rs:487-501`) is a pure `fs::metadata` stat of the *passthrough* file only, which the test writes; (4) 1.ix bails before the input-existence loop (`cli.rs:994-997`) ever sees the unwritten `<tmp>/R1.fq`. The comparison is lexical end-to-end, so whether the OS treats `R1.fq` as an existing alias of the written `r1.fq` (APFS) or as a nonexistent path (ext4) is irrelevant. Test observed green in this review's run (on APFS; impl notes same).
+
+**L5 — Informational (no action): test temp-dir hygiene.**
+If `validate()` unexpectedly returned `Ok`, `unwrap_err()` panics before `remove_dir_all`, leaking `<temp>/tg_pt_case_<pid>`. Pid-keyed naming is safe for the in-process parallel test runner (one test uses the prefix; threads share the pid). Acceptable for a unit test; noted only.
+
+### 2. Efficiency
+
+Nil, as the plan states. Error path only: the `find` performs the same ≤2 `collision_key` evaluations the old OR did; the found case adds two `path_identity_key` evaluations and one branch before the process exits. No hot-path change; no allocation change worth naming.
+
+### 3. Errors
+
+**E1 — Backslash continuations correct (verified, OK).**
+All four continuation lines (`cli.rs:942, 949, 950, 951`) carry the space *before* the `\`; checked at byte level (`awk` over the raw lines) and end-to-end by rendering the message through the built binary — "APFS/NTFS safety", "the same file", "genuinely two files" all correctly spaced. Neither pinned prefix ("--passthrough must be a third file", "case-insensitively") straddles a continuation, per plan Validation 4's rider.
+
+**E2 — Stale-pin sweep clean (verified, OK).**
+Plan Validation 3 grep over `src/ tests/ docs/ .github/ README.md CHANGELOG.md` returns exactly the three deliberate hits the implementation notes document: the two negative assertions (`cli.rs:1890, 1937`) and the CHANGELOG sentence describing the *old* text. `tests/integration_passthrough.rs` has no 1.ix pin (confirmed empty grep). Validation 4 counts match the documented deviation ("must be a third file" ×2 via the shared helper; "case-insensitively (for APFS/NTFS" ×1, bare adverb pinned in the new test).
+
+**E3 — No unhandled conditions introduced.** Both arms `bail!`; no new fallible operations on the error path (`display()` is infallible; `path_identity_key`/`collision_key` fall back to the raw path on `std::path::absolute` failure, pre-existing behaviour).
+
+### 4. Structure
+
+**S1 — LOW: two test comments exceed the ≤2-line house convention (trivial fix).**
+`cli.rs:1897-1899` (3 lines; the plan itself specified two) and `cli.rs:1914-1916` (3 lines). Both compress cleanly: drop "the case-variant branch has its own lexical test below" from the first (the adjacent test is self-evident), and the "(#389)" tail plus "input existence is validated later" clause from the second can merge into two lines. The rewritten preamble (`cli.rs:885-887`, 3 lines) is a pre-existing block *shortened* from five — fine.
+
+**S2 — LOW (nit, optional): `norm_path` rustdoc says collision_key "is what every collision check hashes" (`io.rs:39-40`).**
+1.ix compares via `find`, it doesn't hash. "uses" or "keys by" would be exact. One-word trivial fix; harmless as-is.
+
+**S3 — OK: naming and placement.** `pt_key` (was `pt_norm`) now matches the `*_key` family; `matched` naming follows the PR #219 both-paths precedent; helper name `assert_passthrough_identity_rejection` is accurately scoped to the identity branch and centralizes the three pins without over-abstracting (the case-variant test correctly does not reuse it — different prefix). CHANGELOG entry sits under Unreleased → `#### Changes` (not "Bug fixes"), above #383, modeled on the message-only entry style, and its behaviour claim ("Which runs are accepted or rejected is unchanged") is accurate per L1.
+
+**S4 — OK: companion sites.** `io.rs` rustdoc no longer claims direct use by `Cli::validate()` and drops the "aliasing" identity verb; the retained "pragmatic trade-off" paragraph stays accurate — and its case-sensitive-APFS false-positive reader is now exactly the audience the new "if they are genuinely two files" clause serves. The preamble's em-dash is comment-only (the CI em-dash grep targets `--version` output; the new user-facing strings contain none — no interference).
+
+## Recommendations
+
+| # | Priority | Item | Fix |
+|---|----------|------|-----|
+| 1 | Low | L3 — prefer an identity-equal input when selecting `matched`, so a passthrough byte-identical to input 2 but case-matching input 1 gets the identity message naming the right file | **Trivial fix** — `or_else` chain shown in L3; surface provably unchanged |
+| 2 | Low | S1 — trim the two 3-line test comments (`cli.rs:1897-1899`, `1914-1916`) to ≤2 lines per house convention | **Trivial fix** — deletions only |
+| 3 | Low | S2 — `io.rs:40` "hashes" → "uses" (1.ix compares, it doesn't hash) | **Trivial fix** — one word, optional |
+
+No Critical, High, or Medium findings.
+
+## Verdict
+
+**APPROVE.** The change does exactly what the plan promised — same accept/reject surface (provable from `collision_key = lowercase(identity_key)`), truthful subcase-specific messages, sound portable test, clean sweeps — and the three Low findings are polish that can land now as trivial fixes or ride a follow-up without risk.

--- a/plans/08082026_passthrough-alias-wording/CODE_REVIEW_B.md
+++ b/plans/08082026_passthrough-alias-wording/CODE_REVIEW_B.md
@@ -1,0 +1,57 @@
+# Code Review B — #389 `--passthrough` alias-check wording (commit `1f43363`)
+
+**Reviewer:** B (independent, fresh context)
+**Target:** branch `fix/389-passthrough-wording` @ `1f43363` vs base `dev` @ `7ea2741`
+**Plan:** `plans/08082026_passthrough-alias-wording/PLAN.md` (r2, incl. Implementation notes)
+**Files:** `src/cli.rs`, `src/io.rs`, `CHANGELOG.md` (confirmed via `git diff --stat` — no stray changes)
+
+## Summary
+
+The implementation matches the approved plan, including its two documented (non-behavioural) deviations. The accept/reject surface is provably unchanged: both arms of the new two-tier branch `bail!`, and the branch is reached only inside the pre-existing collision-key match under the retained `len == 2` guard — the reject set is identical to the old `||` check. Each message is truthful for its subcase, the `./`-spelling case lands in the identity branch (correctly), the new portable case-variant test is sound on both ext4 and APFS, and all four backslash-continuation joins were verified byte-level (`cat -A`) to carry the required space. Targeted tests (12 passthrough-filter tests, including the three at issue) pass; `cargo fmt --check` is clean; validation greps 3 and 4 reproduce exactly the counts the plan's Implementation notes document.
+
+**Verdict: APPROVE.** Four Low-priority recommendations, none blocking; three are trivial fixes.
+
+## Area 1 — Logic
+
+### Verified sound
+
+- **Accept/reject surface preserved.** Old: `pt_norm == key(input[0]) || pt_norm == key(input[1])` → bail. New: `find(|p| collision_key(p) == pt_key)` → `Some` → bail via either arm. Under the retained `self.input.len() == 2` guard these are extensionally identical; the inner `path_identity_key` comparison selects only the sentence (`src/cli.rs:933-957`).
+- **Case-variant branch is exactly "differs only by ASCII case".** `path_identity_key` = `lexical_normalise(p).to_string_lossy()`; `collision_key` = the same string `to_ascii_lowercase()`d (`src/io.rs:75-83`). Same lossy conversion of the same normalised `PathBuf`, so collision-equal + identity-different ⟺ ASCII-case-only difference (non-UTF-8 bytes become U+FFFD in both, consistently). The case-variant message's claims are therefore truthful for every path that reaches that arm.
+- **Identity branch truthful everywhere.** Identity-key equality means the two spellings lexically name one path; "{pt} is input {matched}" holds on every filesystem. `./`- and `..`-spellings fold in `lexical_normalise` (CurDir dropped, ParentDir popped, `src/io.rs:52-70`), so `./r1.fq` vs `r1.fq` takes the identity branch, where the message is truthful for it — as the plan requires.
+- **Portable case-variant test is sound on both filesystem families** (`src/cli.rs:1914-1941`). 1.ix is lexical end to end; the only file opened before the bail is the passthrough itself (1.viii `check_restartable_input(pt, …)` at `cli.rs:930`); input existence is checked later (`cli.rs:995-997`); the earlier duplicate-pair check (`cli.rs:537`) is identity-keyed, so temp `R1.fq` vs the R2 fixture passes it. On APFS the unwritten `R1.fq` would alias the written `r1.fq` on disk, but the test never opens it. The pid-suffixed temp dir is unique per test process and the prefix is unique in the suite; cleanup runs before the asserts, so an assertion failure does not leak the dir (only an unexpected `Ok` from `validate()` would, via the `unwrap_err` panic — acceptable in a test).
+
+### Findings
+
+- **L1 (Low): subcase mis-prioritisation when both inputs collision-match the passthrough.** Inputs `["R1.fq", "r1.fq"]` are legal (duplicate detection is identity-keyed per #383; on ext4 they are genuinely two files). With `--passthrough r1.fq` — byte-equal to input 2 — `find` returns the *first* collision match, input 1 (`R1.fq`), so the **case-variant** message fires with rename advice, masking that the passthrough *is* input 2 verbatim. Every sentence emitted is still factually true, and the run is still rejected, but the remediation is wrong for the situation (renaming `R1.fq` just moves the user to the identity error on the next run). Recommend preferring an identity match among collision matches, e.g. find on `path_identity_key` equality first, falling back to the collision match. Exotic input set; message-selection only; does not block.
+- **L2 (Low): the helper's matched-path assertion is not discriminating in the two identity tests.** In `test_passthrough_rejects_pointing_at_r1`/`_r2`, `matched` is textually equal to `pt`, so `err.contains(matched)` is satisfied by the `{pt}` placeholder alone — it cannot detect a swapped or omitted `{matched}` argument, which is the failure A§4.4's "discriminating assertion" was meant to catch. A `./`-spelled-pt test (`--passthrough ./test_files/BS-seq_10K_R1.fastq.gz R1 R2`) would (a) genuinely discriminate the two placeholders (`./…` ≠ `test_files/…` as displayed) and (b) pin the currently-untested plan/comment claim that `./`-spellings take the identity branch. Portable (fixture exists; unit tests run from crate root). Trivial fix — one added test.
+
+## Area 2 — Efficiency
+
+Nil, as the plan predicted. Error-path only: `find` short-circuits (marginally fewer `collision_key` evaluations than the old unconditional pair on an input-1 hit); the two `path_identity_key` evaluations occur only on the bail path, after which the process exits.
+
+## Area 3 — Errors
+
+- **Backslash-continuation whitespace verified byte-level** (`sed | cat -A` over `src/cli.rs:940-956`): all four joins carry a space before the `\` (`not·\`, `APFS/NTFS·\`, `same·\`, `genuinely·\`) → renders "not one", "APFS/NTFS safety", "same file", "genuinely two". No silently joined words. Both pinned prefixes (`"--passthrough must be a third file"`, `"case-insensitively"`) sit on single source lines, satisfying Validation 4's no-straddle requirement.
+- **No stale pins or framing in shipped text.** Validation 3's grep returns exactly the three plan-documented deliberate hits (two negative assertions at `cli.rs:1890/1937` + the CHANGELOG description of the old text). Validation 4 counts reproduce: `"must be a third file"` ×2 (message + shared helper), `"case-insensitively (for APFS/NTFS"` ×1 (message).
+- **No CI-grep interference.** `ci.yml:636-639` pins the *comma* form `"case-insensitive, for APFS/NTFS safety"` on an output-collision scenario; the new passthrough string uses the paren form `"case-insensitively (for APFS/NTFS safety)"` and is unreachable from that CI step. The plan's deliberate near-but-not-identical phrasing (B-O4) is honoured.
+- Targeted runs: 12 passthrough-filtered unit tests green (including all three at issue); `cargo fmt --all -- --check` clean. Full suite (549) + clippy `-D warnings` verified green before commit per the caller; not re-run in full here.
+
+## Area 4 — Structure
+
+- 1.ix comment is exactly the plan's two-liner, keeping the 1.ii clause for the retained redundant guard. Preamble (`cli.rs:885-887`) corrected — the false "#216 protection" label is gone, replaced with input-dual-consume framing and a pointer.
+- `norm_path` rustdoc (`io.rs:38-44`) now accurate: verified `norm_path` has no callers outside `collision_key` and its own tests, and both live collision checks (1.ix, `preflight_output_collisions`) hash `collision_key` — the "every collision check" claim holds.
+- Helper `assert_passthrough_identity_rejection` is well-named and centralizes the pins; the resulting count deviation from Validation 4 is documented in the plan's Implementation notes and is an improvement, not a gap.
+- CHANGELOG entry sits under Unreleased → `#### Changes` as directed, models the message-only entry style, states "Which runs are accepted or rejected is unchanged", and keeps the plain register.
+- **S1 (Low, trivial fix): two new 3-line test comments** exceed the house ≤2-line comment rule and the plan's own "two lines" spec for the shared test comment: `cli.rs:1897-1899` (byte-equal ⊂ case-folded) and `cli.rs:1915-1917` (case-variant test rationale). Each compresses to two lines without losing the load-bearing facts, e.g. `// Byte-equal ⊂ case-folded (fold pinned by io::tests::test_norm_path_case_folds); / // the case-variant branch has its own lexical test below.` and `// Lexical check: only the passthrough must exist (1.viii); input existence is / // validated later, so the unwritten case-variant behaves identically on ext4/APFS.`
+- **S2 (Low, trivial fix): `path_identity_key` rustdoc** (`io.rs:72-74`) cites only #383; check 1.ix (#389) is now its second caller. The sentence stays literally true ("input identity in `Cli::validate`"), so this is a completeness nit — append `#389`.
+
+## Recommendations (priority order)
+
+| # | Priority | What | Where | Trivial fix? |
+|---|----------|------|-------|--------------|
+| L1 | Low | Prefer identity match among collision matches so a passthrough byte-equal to input 2 isn't reported as a case-variant of input 1 | `src/cli.rs:935-938` | Near-trivial (identity-first `find`, collision fallback) |
+| L2 | Low | Add a `./`-spelled-pt identity test to discriminate `{pt}` vs `{matched}` and pin the `./`-spelling→identity-branch claim | `src/cli.rs` tests | Trivial fix |
+| S1 | Low | Compress the two 3-line test comments to 2 lines (house rule; plan spec) | `src/cli.rs:1897-1899`, `1915-1917` | Trivial fix |
+| S2 | Low | Append #389 to `path_identity_key`'s issue list | `src/io.rs:74` | Trivial fix |
+
+No Critical, High, or Medium findings. No fixes were applied (review-only worktree, per instructions).

--- a/plans/08082026_passthrough-alias-wording/COVERAGE.md
+++ b/plans/08082026_passthrough-alias-wording/COVERAGE.md
@@ -1,0 +1,76 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs design plan — no separate IMPL.md; ledger built from PLAN.md r2 Implementation outline [5 steps], Behavior [5 items], and Validation [6 rows])
+**Plan(s):** plans/08082026_passthrough-alias-wording/PLAN.md (r2, including Implementation notes recording deliberate deviations)
+**Implementation commit:** `1f43363` — fix(cli): say what the --passthrough alias check actually checks (#389); base: dev @ `7ea2741`
+**Date:** 2026-08-08
+**Verdict:** COMPLETE
+
+## Summary
+
+- Total items: 16
+- DONE: 14
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED (documented, non-behavioural): 2
+
+Test evidence: full `cargo test` = **549 passed, 0 failed** (matches the Implementation notes' "549 green"); `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --release -- -D warnings` clean (finished, zero diagnostics). Both 1.ix messages were additionally rendered end-to-end via the real binary and byte-match the plan's Behavior 2 texts.
+
+## Coverage ledger
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | 1.ix block rewrite: keep `len == 2` guard, `.iter().find(...)` on collision-key equality, branch on `path_identity_key`, two `bail!`s, new comment, trailing-space-before-`\` continuation | Outline 1 | DONE | `src/cli.rs:931-956`. Guard kept; `find` yields `matched`; identity branch first, case-variant branch second; both arms bail. Every continuation line carries a trailing space before `\` (verified with `cat -A`) — B-O3 satisfied; rendered output has correct spacing. |
+| 2 | Companion fixes: cli.rs preamble + io.rs `norm_path` rustdoc | Outline 2 / Behavior 4 | DONE | Preamble (`src/cli.rs:885-887`): "(issue #216 protection)" removed, replaced with "1.ix is the input dual-consume guard (#389) — see its own comment for the key choice". Rustdoc (`src/io.rs:38-40`): stale "Used by `Cli::validate()`" bullet dropped; `norm_path` now described as "the folding component of `collision_key`"; no "aliasing" verb anywhere in shipped text. |
+| 3 | Test updates: `_r1`/`_r2` pin identity-branch prefix + matched path + negative pin (helper allowed); new portable case-variant test; stale shared comment rewritten | Outline 3 | DONE | Helper `assert_passthrough_identity_rejection` (`src/cli.rs:1878-1893`) asserts prefix `"--passthrough must be a third file"`, `contains(matched)` (R1 in `_r1`, R2 in `_r2` — the discriminating assertion), and the negative `!contains("aliases an input")` with the plan's exact panic message. New `test_passthrough_rejects_case_variant_of_input` (`src/cli.rs:1912-1940`): writes only `<tmp>/r1.fq`, passes unwritten `<tmp>/R1.fq` as input 1; pins `"case-insensitively"` + negative pin. Rewritten comment states byte-equal ⊂ case-folded and points at `io::tests::test_norm_path_case_folds`; the forbidden "`collision_key` is a single `to_ascii_lowercase()`" substitution was not made (sentence removed). Note: the comment wraps to three physical lines (plan said two) and adds a pointer to the case-variant test — content matches the spec; cosmetic only. |
+| 4 | CHANGELOG entry under `#### Changes` (not Bug fixes/Fixes), modelled on the `--output-dir` message-only entry | Outline 4 | DONE | `CHANGELOG.md:131-139`, inside `### Unreleased` (line 4) → `#### Changes` (line 129). States the message is now subcase-specific and "Which runs are accepted or rejected is unchanged." |
+| 5 | Hygiene: fmt, clippy `-D warnings`, cargo test | Outline 5 | DONE | All three run in this audit: fmt clean, clippy clean, 549/549 tests pass. |
+| 6 | Rejection surface unchanged: 1.ix fires exactly when `collision_key(pt)` equals either input's key | Behavior 1 | DONE | Same key, same comparisons (`find` over the same two inputs), same position after 1.viii; both arms bail so the inner branch cannot change accept/reject. Acceptance path re-confirmed green (`test_passthrough_paired_pair_accepted`). |
+| 7 | Two-tier message discriminated by `path_identity_key`, exact texts | Behavior 2 | DONE | Both messages rendered via `cargo run` and byte-match the plan's texts, including "{pt} is input {matched}" ordering in the identity arm and "matches input {matched} case-insensitively (for APFS/NTFS safety): {pt}" plus rename advice in the case-variant arm. |
+| 8 | New two-line 1.ix comment keeping the 1.ii clause | Behavior 3 | DONE | `src/cli.rs:931-932` — verbatim match to the plan's specified two lines, including "len == 2 per 1.ii." |
+| 9 | Companion sites: no identity claim, no #216 mislabel | Behavior 4 | DONE | Same evidence as item 2; grep confirms no "aliasing R1 or R2" anywhere in shipped text. |
+| 10 | No new edge cases; pre-existing ordering artifact stands (not reordered) | Behavior 5 | DONE | 1.viii `check_restartable_input` still at `src/cli.rs:930` (before 1.ix); general input existence still checked later (`src/cli.rs:996`). No reordering in the diff. |
+| 11 | V1: `cargo test` all pass; three passthrough-rejection tests pin prefix, matched path, negative assertion | Validation 1 | DONE | 549 passed / 0 failed. `_r1`/`_r2` pin all three via the helper; the case-variant test pins adverb + negative (matched-path pin applies to the identity-branch tests per plan step 3). |
+| 12 | V2: case-only branch reachable and truthful on both filesystem families | Validation 2 | DONE | `test_passthrough_rejects_case_variant_of_input` passes (lexical check; verified here on APFS, ext4-identical by construction since neither key touches the filesystem). Runtime render of the branch confirmed. |
+| 13 | V3: stale-string grep over `src/ tests/ docs/ .github/ README.md CHANGELOG.md` — plan said zero hits | Validation 3 | DEVIATED (documented) | Actual: exactly 3 hits — `src/cli.rs:1890` and `:1937` (the two negative assertions `!err.contains("aliases an input")`) and `CHANGELOG.md:133` (describing the old text). Matches the Implementation notes' deviation verbatim; no live message, comment, or doc carries the old framing. |
+| 14 | V4: count greps — plan said `"must be a third file"` ×3 (message + 2 test pins) and `"case-insensitively (for APFS/NTFS"` ×2 (message + 1 test pin); pins must not straddle `\` breaks | Validation 4 | DEVIATED (documented) | Actual: ×2 (message + shared helper — pin centralized) and ×1 (message only; the test pins the bare adverb `"case-insensitively"`). Matches the Implementation notes' revised counts exactly. Both pin prefixes verified to sit on a single source line before any `\` continuation. |
+| 15 | V5: prose sanity — common case gets the third-file instruction, rare case gets rename advice, neither claims identity unconditionally | Validation 5 | DONE | Both messages rendered end-to-end (real binary, real files). Identity arm: names the matched input, normative "must be a third file (e.g. the index read)". Case-variant arm: states the case-insensitive comparison and its APFS/NTFS rationale, gives the rename remediation, and conditions the identity claim on "On a case-insensitive filesystem". |
+| 16 | V6: fmt + clippy `-D warnings` clean | Validation 6 | DONE | Both clean at `1f43363`. |
+
+## Gaps (detail)
+
+None. The two DEVIATED items (13, 14) are recorded in the plan's own Implementation notes with rationale ("the assertions ARE the enforcement"; "centralizing the pin means one test-side occurrence") and are non-behavioural; audit re-ran both greps and reproduced the documented results exactly.
+
+## Test verification
+
+| Test name | File | Status |
+|-----------|------|--------|
+| `cli::tests::test_passthrough_rejects_pointing_at_r1` | src/cli.rs | PASS |
+| `cli::tests::test_passthrough_rejects_pointing_at_r2` | src/cli.rs | PASS |
+| `cli::tests::test_passthrough_rejects_case_variant_of_input` (new) | src/cli.rs | PASS |
+| `cli::tests::test_passthrough_paired_pair_accepted` (accept surface) | src/cli.rs | PASS |
+| `io::tests::test_norm_path_case_folds` (fold pin, referenced by new comment) | src/io.rs | PASS |
+| `io::tests::identity_key_is_case_sensitive_but_collision_key_is_not` (key-contrast pin) | src/io.rs | PASS |
+| Full suite (`cargo test`, all targets + integration) | — | PASS — 549 passed, 0 failed, 0 ignored |
+| `cargo fmt --all -- --check` | — | PASS |
+| `cargo clippy --all-targets --release -- -D warnings` | — | PASS |
+
+Runtime renders (beyond unit pins):
+
+- Identity branch: `Error: --passthrough must be a third file (e.g. the index read), not one of the R1/R2 inputs: test_files/BS-seq_10K_R1.fastq.gz is input test_files/BS-seq_10K_R1.fastq.gz`
+- Case-variant branch: `Error: --passthrough matches input <tmp>/R1.fq case-insensitively (for APFS/NTFS safety): <tmp>/r1.fq. On a case-insensitive filesystem these are the same file and the stream would be consumed twice; if they are genuinely two files, rename one so the paths differ by more than letter case.`
+
+## Verdict
+
+**COMPLETE.** All 5 Implementation outline steps, all 5 Behavior items, and all 6 Validation rows are satisfied at `1f43363`. The two grep-count deviations (Validation 3 and 4) exactly match the deviations documented in the plan's Implementation notes and change no behaviour, message text, or enforcement — nothing remains to be addressed.
+
+---
+
+## Post-audit note (2026-08-08, caller)
+
+The audit's COMPLETE verdict covered commit `1f43363`. A follow-up review batch
+(`478e1d0`) then applied the dual code review's Low items: identity-first
+matched-input selection (rejection surface unchanged — identity-equal implies
+collision-equal), positional "is input {matched}" test pins plus a new
+./-spelled discrimination test, two comment trims, and two rustdoc touches.
+Suite green (14/14 binaries), fmt + clippy clean after the batch.

--- a/plans/08082026_passthrough-alias-wording/PLAN.md
+++ b/plans/08082026_passthrough-alias-wording/PLAN.md
@@ -1,0 +1,104 @@
+# Plan: `--passthrough` alias check — keep the fold, say what it checks (#389)
+
+**Issue:** [#389](https://github.com/FelixKrueger/TrimGalore/issues/389) — filed from the D13 focused review.
+**Decision (Felix, 2026-08-08):** keep `collision_key`; fix the words. Rationale: both keys are lexical and `path_identity_key` preserves case — on APFS/NTFS a case-variant spelling IS the input file, the case-preserving key can't see it, and `--passthrough` would silently dual-consume one stream at exit 0. Reviewer B additionally verified 1.ix is the **sole** guard for this (the output pre-flight checks output-vs-input and output-vs-output only, never input-vs-input).
+**Base:** `dev` @ `7ea2741`.
+
+## Revision history
+
+- **r2 (2026-08-08):** incorporates dual plan-review (PLAN_REVIEW_A.md, PLAN_REVIEW_B.md; both REVISE). Fixes the false `norm_path()` premise (A§1.1/B-C3); widens scope to `io.rs:38-47` and `cli.rs:885-889` (A§1.6/B-C2); replaces the single message with a two-tier message that names the matched input and gives each subcase its own remediation (A§1.4-1.5/5.3, B-I2/I3); hardens the test pins with a negative assertion (B-C1); adds a portable case-variant test (supersedes the "cross-case is untestable" caveat); scopes and extends the grep validations (B-I4/I5, A§4.3); shrinks the comment to two lines keeping the 1.ii clause (A§1.2-1.3/B-I1); restates the behaviour claim precisely (A#7/B§1.5). The single-plan-review suggestion is withdrawn — B's closing note ("small diff, not small review": three criticals hid in a two-string plan) is accepted.
+- r1 (2026-08-08): initial plan.
+
+## Goal
+
+Make check 1.ix's words match its semantics. `Cli::validate` §1.ix (`src/cli.rs:933-949`) compares `--passthrough` against R1/R2 with the case-folded `collision_key`, but its comment calls that catching "case-only INPUT aliases" and its message asserts "{} **aliases an input file**" — an identity claim that is false on a case-sensitive filesystem. **The accept/reject surface does not change**: same key, same comparisons, same position in the validate chain. What changes: the message text (now subcase-specific and naming the matched input), three comments, and the two rustdoc/preamble sites that carry the same mis-framing.
+
+## Context
+
+- `src/cli.rs:930-949` — check 1.ix. Runs after 1.viii (`check_restartable_input`), so the passthrough file always exists when 1.ix fires; R1/R2 existence is checked only later (`cli.rs:987-989`), so 1.ix is lexical end to end.
+- `io::collision_key` (`io.rs:84-86`) = `norm_path(&lexical_normalise(p))`. **`norm_path` (`io.rs:48-50`) is a live component function, not a stale name** — r1 got this wrong; both reviewers caught it. The fold is already pinned platform-independently by `io::tests::test_norm_path_case_folds` (`io.rs:768`) and `io::tests::identity_key_is_case_sensitive_but_collision_key_is_not` (`io.rs:1181`).
+- Message pins: only `src/cli.rs:1880/1887` (both `contains("cannot point at R1 or R2")`, byte-equal fixtures). No pins in `tests/integration_passthrough.rs` (its only stderr pin is 1.i), no CI grep (`ci.yml:638`'s grep targets the *output*-collision message, unreachable from a passthrough run), no docs/README copies. Verified independently by both reviewers.
+- **In-scope companion sites carrying the same mis-framing** (review scope finding):
+  - `src/io.rs:38-47` — `norm_path`'s rustdoc claims direct use by `Cli::validate()` (false post-#385: validate calls `collision_key`) and uses the "aliasing R1 or R2" identity verb.
+  - `src/cli.rs:885-889` — the passthrough-envelope preamble labels 1.ix "(issue #216 protection)"; #216 is the *output*-collision issue, 1.ix guards *input* dual-consume.
+
+## Behavior
+
+1. Rejection surface unchanged: 1.ix still fires exactly when `collision_key(pt)` equals the collision key of either input.
+2. **Two-tier message.** Inside the existing match, discriminate the subcase with `path_identity_key` (case-preserving; `./`/`..` spellings of one file compare equal, so they take the identity branch, which is truthful for them on every filesystem):
+   - **Same file (identity keys equal)** — the common slip (R1 passed where the I1 index read was meant): name the matched input, state the requirement, give the correct remediation:
+     `--passthrough must be a third file (e.g. the index read), not one of the R1/R2 inputs: {pt} is input {matched}`
+   - **Case-variant only (collision keys equal, identity keys differ)**: state the case-insensitive comparison honestly and give the rename remediation:
+     `--passthrough matches input {matched} case-insensitively (for APFS/NTFS safety): {pt}. On a case-insensitive filesystem these are the same file and the stream would be consumed twice; if they are genuinely two files, rename one so the paths differ by more than letter case.`
+   Both arms `bail!`; the branch chooses only the sentence. This satisfies: no unconditional identity claim; the matched input is named (PR #219 both-paths precedent); the common case keeps a normative, actionable instruction; the rare case gets truthful advice. Qualifier phrasing deliberately close to the house idiom but not byte-identical to the CI-pinned output-collision string (B-O4 noted; A-#10 accommodated).
+3. **New 1.ix comment**, two lines, fact-stated, keeping the invariant clause that explains the (deliberately retained) redundant `len == 2` guard:
+   ```rust
+   // 1.ix — case-folded on purpose, not an identity check (#389): a case-variant
+   // passthrough IS R1/R2 on APFS/NTFS and would be consumed twice. len == 2 per 1.ii.
+   ```
+   Derivation goes to the commit message and #389.
+4. **Companion fixes:** `io.rs:38-47` — drop the stale first "Used by" bullet; describe `norm_path` as the case-folding component of `collision_key` (no "aliasing" verb). `cli.rs:885-889` — replace "(issue #216 protection)" with input-dual-consume framing or a bare "see 1.ix" pointer.
+5. **Edge cases:** none new; the pre-existing ordering artifact stands (a missing R1 plus a case-variant passthrough yields the 1.ix message rather than "input not found", because input existence is checked later) — acknowledged, not reordered (B-O5).
+
+## Implementation outline
+
+1. `src/cli.rs` 1.ix block: keep the `len == 2` guard; find the matched input (`.iter().find(...)` on collision-key equality); branch on `path_identity_key` equality; the two `bail!`s from Behavior 2. Replace the comment per Behavior 3. Watch the `\` string-continuation whitespace (a trailing space belongs *before* each backslash — B-O3).
+2. `src/cli.rs:885-889` preamble and `src/io.rs:38-47` rustdoc per Behavior 4.
+3. **Tests** (`src/cli.rs` unit tests):
+   - `test_passthrough_rejects_pointing_at_r1` / `_r2`: pin the identity-branch prefix `"--passthrough must be a third file"`, pin the matched path (R1 in the first, R2 in the second — the discriminating assertion A§4.4 asked for), and add the negative pin `assert!(!err.contains("aliases an input"), "1.ix must not assert identity (#389); got: {err}")` (B-C1). Factor the shared asserts into a small helper if it reads better.
+   - **New, portable:** `test_passthrough_rejects_case_variant_of_input` — write only the passthrough file (`<tmp>/r1.fq`) and pass the unwritten case-variant `<tmp>/R1.fq` as input 1. The check is lexical, so this hits the case-only branch identically on ext4 and APFS (1.viii needs only the *passthrough* file to exist; input existence is checked later). Pin `contains("case-insensitively")` and the negative pin. This supersedes r1's "cross-case is untestable" framing — that limitation belonged to the fixture-reuse approach, not the check.
+   - Rewrite the stale shared test comment (do **not** substitute `collision_key` into the "single `to_ascii_lowercase()`" sentence — that would be false): two lines stating byte-equal ⊂ case-folded and pointing at `io::tests::test_norm_path_case_folds` for the fold.
+4. `CHANGELOG.md` — Unreleased → `#### Changes` (named explicitly; not "Bug fixes"/"Fixes"): 1.ix message reworded and made subcase-specific (#389); accept/reject behaviour unchanged. Model: the `--output-dir` message-only entry at `CHANGELOG.md:145-146`.
+5. `cargo fmt --all -- --check`, `cargo clippy --all-targets --release -- -D warnings`, `cargo test`.
+
+## Efficiency
+
+Error-path only: one extra `path_identity_key` evaluation and one branch, then the process exits. Nothing measurable.
+
+## Integration
+
+No keys, no ordering, no callers change. The diff is no longer string-only (a `find` + one `if` on the error path) — accepted by both reviewers as inside "wording" since both arms bail identically. Only the two named unit tests pin the message; both are updated in the same diff. `plans/` history files retain the old strings by design (see Validation).
+
+## Assumptions
+
+- **A1 (narrowed per B-I5):** no *test* pins of the old text outside `cli.rs:1880/1887` — verified by both reviewers across `src/ tests/ docs/ .github/ README.md CHANGELOG.md`.
+- **A2:** D13 taxonomy unchanged — no third key, no platform probe (rejected in #385: syscall/symlink semantics; a probe would also make the message platform-dependent and untestable).
+- **A3 (new):** nothing machine-parses TrimGalore stderr in-repo (verified) — what licenses a free-form rewrite; wrapper scripts grepping the old string are served by the CHANGELOG entry.
+- **A4 (new):** `pt.display()` naming paths as spelled (not normalised) is the codebase-wide diagnostic convention (`CHANGELOG.md:109-110`) — kept.
+
+## Validation
+
+| # | What | How | Expected |
+|---|------|-----|----------|
+| 1 | Behaviour unchanged + pins updated | `cargo test` | all pass; the three passthrough-rejection tests pin prefix, matched path, and the negative "aliases an input" assertion |
+| 2 | Case-only branch reachable and truthful | new portable unit test (impl step 3) | rejected via the case-variant message on both filesystem families |
+| 3 | No stale pins/framing left in shipped text | `grep -rn "cannot point at R1\|aliases an input\|aliasing R1 or R2" src/ tests/ docs/ .github/ README.md CHANGELOG.md` | zero hits (`plans/` deliberately excluded — historical artifacts keep the old strings; do not edit them) |
+| 4 | New text landed everywhere intended | grep `"must be a third file"` (expect: message + 2 test pins) and `"case-insensitively (for APFS/NTFS"` (expect: message + 1 test pin); chosen pin prefixes must not straddle a `\` line break | exact expected counts |
+| 5 | Prose sanity (human) | read both rendered messages against their subcases | common case gets the third-file instruction; rare case gets rename advice; neither claims identity unconditionally |
+| 6 | Hygiene | fmt + clippy `-D warnings` | clean |
+
+## Questions or ambiguities
+
+- **[Open] Message copy** is contract-shaped now (prefixes are pinned) but reviewers may still tighten words that aren't pinned.
+- **[Resolved r2]** Review weight: dual review ran; its findings are folded in here.
+
+## Follow-ups (out of scope, to file separately)
+
+- Consider making `norm_path` private or inlining it — `pub` with no callers outside `collision_key` and its own tests; the public name is what enabled r1's false-premise error (A-#12).
+
+## Implementation notes (2026-08-08, branch `fix/389-passthrough-wording` @ `1f43363`)
+
+Implemented as planned: two-tier message with `path_identity_key` branch, 2-line 1.ix comment keeping the 1.ii clause, preamble + `norm_path` rustdoc companions, shared test-assert helper, new portable `test_passthrough_rejects_case_variant_of_input` (verified green on APFS; lexical so ext4-identical), CHANGELOG under `#### Changes`. Full suite 549 green; fmt + clippy `-D warnings` clean.
+
+**Deviations (documented, none behavioural):**
+- Validation 3's grep returns three deliberate hits: the two negative assertions (`!err.contains("aliases an input")`) and the CHANGELOG entry describing the old text. The grep's intent — no *live* message or comment carries the framing — is met; the assertions ARE the enforcement.
+- Validation 4 counts: `"must be a third file"` ×2 (message + the shared assert helper — centralizing the pin means one test-side occurrence, not two); `"case-insensitively (for APFS/NTFS"` ×1 (message; the new test pins the bare adverb).
+
+**Iteration log:**
+- #1: initial implementation (`1f43363`); no failed iterations.
+- #2 (`478e1d0`): review batch per dual code review — identity-first matched-input selection (both reviewers' L1; surface unchanged), positional `is input {matched}` pins + `./`-spelled discrimination test (B-L2), two comment trims (A#2/B-S1), rustdoc verb fix (A#3) and #389 on `path_identity_key` (B-S2). Not taken: A's two-tier-vs-single message alternatives beyond what shipped (already satisfied), norm_path privatization (filed as follow-up).
+
+- **Logic:** the two-tier branch cannot change the rejection surface (both arms bail; the branch is reached only inside the existing match). The identity-branch discriminator (`path_identity_key`) deliberately groups `./`-spellings with byte-equal — truthful for them everywhere.
+- **Edge cases:** re-checked the new portable test's reachability — 1.viii requires only the passthrough file; input existence is validated later (`cli.rs:987-989`), so the unwritten case-variant input is fine on both platforms.
+- **Traps:** every reviewer-cited anchor re-verified against the tree before adoption (`io.rs:768/1181`, `CHANGELOG.md:129/145`); grep validations scoped so "zero hits" is achievable (B-I4).
+- **Remaining risks:** none beyond copy quality; the deliverable (honest text) is now held by a negative assertion, two positive pins, and a count-checked grep.

--- a/plans/08082026_passthrough-alias-wording/PLAN_REVIEW_A.md
+++ b/plans/08082026_passthrough-alias-wording/PLAN_REVIEW_A.md
@@ -1,0 +1,239 @@
+# Plan Review A — `--passthrough` alias check wording (#389)
+
+**Reviewer:** A (independent, fresh context)
+**Plan under review:** `plans/08082026_passthrough-alias-wording/PLAN.md`
+**Repo:** `/Users/fkrueger/Github/TrimGalore`, branch `dev`
+**Date:** 2026-08-08
+
+**Scope note:** the maintainer's decision — keep the case-folded `collision_key`, change wording only — is taken as given and is NOT relitigated here. This review asks whether the plan, *given that decision*, is correct, complete, and truthfully worded.
+
+**Verdict: REVISE before implementing.** The direction is right and most of the plan's factual claims check out against the code, but one instruction (Implementation step 3, the `norm_path()` → `collision_key` substitution) rests on a false premise and, if executed literally, would replace a *true* comment with a *false* one — the exact defect class #389 exists to remove. Details in §1.1.
+
+---
+
+## 1. Logic review
+
+### 1.1 CRITICAL — `norm_path()` is not a stale name, and the proposed substitution introduces a falsehood
+
+The plan asserts twice that `norm_path()` is dead nomenclature:
+
+> Context: "references **`norm_path()`**, a stale pre-D13 name for what is now `collision_key`."
+> Implementation step 3: "replace the stale `norm_path()` reference with `collision_key`".
+
+Both are wrong. `norm_path` still exists, is still `pub`, and is a *component* of `collision_key`, not a former name for it:
+
+- `src/io.rs:48-50` — `pub fn norm_path(p: &Path) -> String { p.to_string_lossy().to_ascii_lowercase() }`
+- `src/io.rs:84-86` — `pub fn collision_key(p: &Path) -> String { norm_path(&lexical_normalise(p)) }`
+
+So the existing test comment at `src/cli.rs:1874` — "norm_path() is a single `to_ascii_lowercase()` call which is trivially correct" — is **factually accurate as written**. Performing the substitution the plan asks for yields:
+
+> "collision_key() is a single `to_ascii_lowercase()` call which is trivially correct"
+
+which is false: `collision_key` is absolutise (`std::path::absolute`) + `..`-fold against the component stack + lowercase, three operations across `lexical_normalise` and `norm_path`. A wording-truthfulness fix that ships a new untrue comment 900 lines below the one it repaired is a self-inflicted repeat of #389.
+
+**Recommended fix.** Don't rename inside the sentence; re-anchor the sentence. The property the comment is trying to justify — that case-folded equality holds for case-variant spellings — is *already pinned by a real test*: `io::tests::identity_key_is_case_sensitive_but_collision_key_is_not` (`src/io.rs:1181-1194`) asserts `collision_key("Sample_R1.fastq.gz") == collision_key("SAMPLE_R1.fastq.gz")`. A truthful, shorter comment names that anchor instead of re-deriving the argument:
+
+```rust
+// Byte-equal spellings are a subset of case-folded equality; the fold itself is
+// pinned by io::tests::identity_key_is_case_sensitive_but_collision_key_is_not.
+```
+
+This also retires the plan's framing of cross-case coverage as an untested gap (see §4.2).
+
+### 1.2 IMPORTANT — the proposed comment breaks the repo's own comment rule
+
+The drafted comment (Behavior 2) is four lines of reasoning chain:
+
+```rust
+// 1.ix — case-folded on purpose (#389), NOT an identity check: a case-variant
+// passthrough IS R1/R2 on APFS/NTFS and would be consumed twice; on a
+// case-sensitive filesystem the (pathological) two-real-files shape is
+// refused loudly rather than risking silent dual-consume elsewhere.
+```
+
+The standing instruction for committed code in this project is: default to one line, two maximum with a reason, state the fact rather than the evidence, no reasoning chains — rationale belongs in the commit message or the linked issue. Four lines of derivation is what that rule exists to prevent, and shipping it inside a *wording-cleanup* diff invites the reviewer note the rule was written to pre-empt. The existing comment being five lines is not a defence; this change is the opportunity to fix that too.
+
+Also, "risking silent dual-consume **elsewhere**" is ambiguous as written — "elsewhere" reads as *another code location*, when the intended meaning is *under the alternative key*. Shortening removes the problem.
+
+Suggested two-liner, fact-stated, issue-anchored:
+
+```rust
+// 1.ix — case-folded, not an identity check: on APFS/NTFS a case-variant
+// passthrough IS R1/R2 and would be consumed twice (#389). len == 2 per 1.ii.
+```
+
+### 1.3 IMPORTANT — the new comment silently drops the `1.ii` invariant note
+
+The current comment carries "self.input.len() == 2 here per 1.ii" (`src/cli.rs:934`). That sentence is the *only* thing in the file explaining why the guard at `src/cli.rs:938` — `if self.input.len() == 2` — is not a bug: 1.ii at `src/cli.rs:896-902` already bailed when `len != 2`, so the condition is provably always true. The plan's replacement comment omits it. A future reader then meets an unexplained redundant branch, and the likely next move is either a puzzled review comment or a "simplification" that has to re-derive the invariant.
+
+Keep the clause (it fits in the two-line budget, as above), or take the Optional route in §5.4.
+
+### 1.4 IMPORTANT — the message does not say *which* input matched, though the code knows
+
+The drafted message interpolates only `pt.display()`. The user is told "matches R1 or R2" and left to work out which. The information is free — the code has already evaluated the two comparisons at `src/cli.rs:940-941`, so it can name the matched input and its on-disk spelling.
+
+This matters most in exactly the subcase the reword is about. `--passthrough r1.fq.gz` with inputs `R1.fq.gz R2.fq.gz` currently produces a message naming only `r1.fq.gz`; naming the counterpart (`… matches R1 (R1.fq.gz)`) makes the case-only nature of the match visible at a glance, which is the whole diagnostic point.
+
+There is direct precedent: PR #219 changed the sibling output-collision error specifically to name both colliding paths, and `.github/workflows/ci.yml:635-637` records that history. `io::preflight_output_collisions` (`src/io.rs:120-126`) names both. The passthrough message is the odd one out, and fixing it is inside "wording only" — no key change, no change to the rejection surface.
+
+### 1.5 IMPORTANT — the remediation advice is tuned to the rarer subcase and misleads on the commoner one
+
+Drafted remediation: "If these are genuinely two different files on a case-sensitive filesystem, rename one so the paths differ by more than letter case."
+
+The plan's Behavior 3 claims this "reads truthfully for both subcases", and the Self-Review calls the byte-equal reading "vacuous-but-true". Truthful, yes. *Useful*, no — and for the byte-equal case it is actively misdirecting.
+
+`--passthrough` exists to carry a third stream (the index / cell-barcode read; see the `BS-seq_10K_I1.fastq.gz` fixture and `tests/integration_passthrough.rs`). The overwhelmingly likely real-world trigger for 1.ix is therefore a byte-equal slip — a script or a hand-typed command that passes R1 where I1 was meant. For that user, the only actionable sentence in the message is "rename one so the paths differ by more than letter case", and following it literally *works*: renaming `R1.fq.gz` to `Q1.fq.gz` and re-passing it clears validation and produces a run whose passthrough output is a duplicate of R1. The check's advice has walked the user around the guard rather than to the fix.
+
+The correct byte-equal remediation is "the passthrough stream must be a third file (e.g. the index read), not one of the two reads being trimmed." Cover both subcases, and lead with the third-file point since it is the common one. §5.3 sketches the two-tier form that gets each subcase its own correct sentence at zero behavioural cost.
+
+### 1.6 IMPORTANT — scope is incomplete: two other comments mis-frame this same check
+
+The plan touches one comment and one message. Two further sites describe 1.ix in the terms #389 objects to, and neither is in the plan:
+
+1. **`src/cli.rs:885-889`** — the nine-item envelope preamble: "case-folded collision check (1.ix) uses `crate::io::collision_key` to share the same APFS/NTFS-aware normalisation as the output-collision pre-flight in main.rs (**issue #216 protection**)." #216 is the *output*-collision issue. 1.ix guards *input* dual-consume — a different failure with a different blast radius. Labelling it "#216 protection" and framing it as sharing the output pre-flight's purpose is the precise conflation this plan is fixing forty-five lines below. Leaving it means a reader who starts at the preamble arrives at the corrected comment already holding the wrong model.
+
+2. **`src/io.rs:38-47`** — `norm_path`'s doc comment: "Used by: `Cli::validate()` to catch `--passthrough` **aliasing** R1 or R2 (e.g. `--passthrough r1.fq.gz` while R1 is `R1.fq.gz`)". Two problems. It is stale as a direct-use claim — `Cli::validate` calls `collision_key`, and `norm_path` has no callers anywhere outside `collision_key` and its own tests (verified by repo-wide grep). And it uses the same identity verb ("aliasing") that #389 asks to be dropped from the user-facing string. This is the doc a reader lands on when chasing `collision_key` → `norm_path`, so it belongs in the same diff.
+
+Both are one-line edits. Including them makes the fix complete; excluding them means #389's "either switch the key or say what it actually checks" is only two-thirds done.
+
+### 1.7 Plan claims that check out
+
+Stated explicitly so the implementer does not redo the verification:
+
+- **Line numbers are accurate.** 1.ix comment `src/cli.rs:933-937`; guard and body `938-949`; message `943-947`; the two pinning tests `1870-1888` with the shared comment at `1872-1877`. All as the plan describes.
+- **Check ordering is as claimed.** `check_restartable_input` (1.viii) at `src/cli.rs:932` precedes 1.ix, so the passthrough file always exists when 1.ix fires. The plan's edge-case reasoning follows correctly: on a case-sensitive filesystem a *non-existent* case-variant yields "--passthrough file not found" from 1.viii, so 1.ix's false refusal fires only when both files genuinely exist — the pathological shape the decision knowingly accepts.
+- **Both platform subcases behave as the plan describes.** On APFS, `--passthrough r1.fq.gz` + input `R1.fq.gz`: 1.viii opens the same inode, 1.ix refuses — guard working. On ext4 with two real files: 1.viii passes, 1.ix refuses — the false refusal. Confirmed by reading the code path, not inferred.
+- **`..` / `./` spellings keep resolving** through `lexical_normalise` inside `collision_key`; `io::tests::both_keys_normalise_spelling` (`src/io.rs:1198-1209`) pins it.
+- **CHANGELOG has a home for the entry.** Unreleased → `#### Changes` at `CHANGELOG.md:129`. Precedent for a message-only entry exists in that very section (`CHANGELOG.md:145-146`, the `--output-dir` → `--output_dir` message fix), so step 4 is well-founded rather than over-reporting.
+
+---
+
+## 2. Assumptions
+
+### 2.1 A1 ("no test outside `cli.rs:1871-1888` pins the old text") — CONFIRMED
+
+Independently re-verified by repo-wide grep excluding `target/`, `plans/`, `.git/`:
+
+- `"cannot point at R1"` → three hits: `src/cli.rs:944` (the message), `src/cli.rs:1880`, `src/cli.rs:1887` (the two asserts).
+- `"aliases an input"` → one hit: `src/cli.rs:945`.
+- `tests/integration_passthrough.rs` asserts on `"--passthrough requires --paired"` (line 200) only — 1.i, not 1.ix.
+- No `.github/workflows/*.yml` mentions `passthrough` at all.
+- Docs and README carry no copy of this message.
+
+One near-miss worth recording so nobody re-flags it: `.github/workflows/ci.yml:638` does grep `"case-insensitive, for APFS/NTFS safety"`, and `ci.yml:635` names the string `"case-insensitive match"` in a comment. That grep targets `io::preflight_output_collisions`' *output*-collision message, reached by a `--paired` four-file run with no `--passthrough`. It cannot be tripped by this change. The plan's Integration claim ("the validation CI matrix does not exercise `--passthrough` message text") therefore holds — but it holds narrowly, and the reason it holds is worth one line in the plan rather than a bare assertion, because the qualifier string is shared vocabulary between the two messages.
+
+### 2.2 A2 (D13 taxonomy unchanged) — CONFIRMED, and consistent with the code
+
+`path_identity_key` (`src/io.rs:78-80`) and `collision_key` (`src/io.rs:84-86`) are both purely lexical; neither touches the filesystem, and the doc comment on `lexical_normalise` (`src/io.rs:52-54`) states the symlink consequence explicitly. No third key and no platform probe is introduced. Consistent with the plan.
+
+### 2.3 The "no behaviour change" claim — true as intended, imprecisely stated
+
+Same key, same comparisons, same position in the chain, same `bail!` → identical accept/reject sets and identical exit codes. The claim is sound in the sense that matters.
+
+But stderr text *is* observable behaviour to anything grepping it (wrapper scripts, pipeline log assertions). The plan states "**No behaviour change**" flatly, in bold, twice. Recommend restating as: *no change to which runs are accepted or rejected; the message text changes.* That phrasing is also what the CHANGELOG entry should say, so a user who greps for the old string learns why it vanished. This is a precision point, not a disagreement — and the project already treats message rewords as normal changelog-worthy changes (§1.7).
+
+### 2.4 Unstated assumption: "the byte-equal subcase is the portable one, therefore the representative one"
+
+The existing test comment and the plan both lean on byte-equal being the testable subcase. That is correct as a *testability* argument (§4.2). The plan then quietly carries it into the *wording* decision, drafting remediation for the case-variant subcase while calling the byte-equal reading "vacuous-but-true". The frequency ordering is the other way round (§1.5): byte-equal is both the testable subcase *and* the likely one. Worth making explicit, because it is the assumption that produces the message's weakest sentence.
+
+### 2.5 Unstated assumption: `pt.display()` is adequate identification
+
+`display()` is lossy for non-UTF-8 paths, and the message shows the path *as spelled*, not as normalised — so a `../x` spelling is echoed back unresolved while the match happened on the absolutised form. Both are pre-existing, both are consistent with the rest of the codebase's diagnostics ("keeps naming the paths as the user spelled them", `CHANGELOG.md:109-110`), and neither needs changing. Noted only so it is a recorded decision rather than an oversight.
+
+---
+
+## 3. Efficiency analysis
+
+Nil, and the plan's one-line dismissal is the right amount of attention. For completeness: 1.ix performs three `collision_key` calls (one for the passthrough, two for the inputs) once per run at argument-validation time, each `std::path::absolute` + a component walk + one `to_ascii_lowercase` allocation over a path-length string. Adding a second interpolation to the message (§1.4) or a second sentence (§1.5) costs nothing measurable — it is on the error path, which formats once and then the process exits.
+
+Nothing in the plan touches an allocation, a loop, or an I/O boundary. No scalability surface. Confirmed there is nothing missed here.
+
+---
+
+## 4. Validation sufficiency
+
+### 4.1 The pin-update risk is adequately covered
+
+Validations 1 and 3 together close the failure mode the plan worried about. A partial pin update — message changed, one assert missed — is caught twice over: the missed assert leaves a `"cannot point at R1"` hit so Validation 3 is non-zero, *and* `cargo test` fails that test. The plan's Self-Review note about adding Validation 3 for exactly this reason is well-judged.
+
+### 4.2 The "cross-case testing is impossible" claim is right about `validate()` and wrong about the property
+
+The retained test comment says true cross-case testing needs a case-insensitive filesystem CI does not guarantee. For the **full `Cli::validate` path** that is correct, and I confirmed the mechanism: on a case-sensitive filesystem a case-variant fixture path does not exist, so 1.viii (`src/cli.rs:932`) fires "--passthrough file not found" and 1.ix is never reached. You cannot drive 1.ix cross-case on Linux CI without creating a real second file.
+
+But the **property 1.ix depends on** — that the key folds case — is already pinned, platform-independently, by `io::tests::identity_key_is_case_sensitive_but_collision_key_is_not` (`src/io.rs:1181-1194`). So there is no coverage gap to apologise for, and no new key-level test to write. The plan should stop describing this as a limitation and instead cite the io test; that is both more accurate and the truthful replacement for the `norm_path` sentence (§1.1).
+
+### 4.3 Gap — nothing asserts the *new* text is present
+
+Validation 3 greps for the *old* strings and expects zero. Nothing confirms the new prefix landed in all three places. Cheap addition: grep the new prefix and expect exactly three hits (one message, two asserts). This catches a message/assert prefix mismatch at grep time rather than at `cargo test` time, and catches the case where someone updates the asserts to a prefix the message does not actually contain in the same wrapped-string form. Note the message is a wrapped Rust string literal with a `\` continuation, so the chosen pinned prefix must not straddle the line break — `"--passthrough matches R1 or R2"` is safe against the drafted wrapping, but any re-wrap during implementation must preserve that.
+
+### 4.4 Gap — Validation 2 is an eyeball, not a check
+
+"Read the rendered message for byte-equal and case-variant inputs" is a human review step with no artefact. It will pass by construction. If §1.4 is adopted, it becomes a real test at no cost: `test_passthrough_rejects_pointing_at_r1` asserts the message names R1, `…_at_r2` asserts R2. That converts the one genuinely under-tested aspect of the new message — that it discriminates which input matched — into a regression pin, and it is the only new test worth writing in this change.
+
+### 4.5 No silent-wrong-result surface exists
+
+Worth stating plainly for the risk register: this change cannot make the program produce wrong output. It cannot alter which runs are refused, cannot alter trimming, and its worst realistic failure is an unhelpful or untrue sentence on stderr. That is why the *wording review* is the substance of the validation here, and it is also why §1.1 and §1.5 are graded as high as they are — the message text is the entire deliverable, so a false or misdirecting sentence is not cosmetic, it is the bug.
+
+---
+
+## 5. Alternatives
+
+All within the maintainer's decision (fold retained, no key change).
+
+### 5.1 Minimal — strip the claim, add nothing
+
+`"--passthrough matches R1 or R2 under case-insensitive comparison: {}"`. Satisfies #389's letter with the smallest possible diff and no new prose to get wrong. Loses all remediation, so a user who hits it byte-equal gets a correct statement and no guidance. Acceptable fallback if the preference is the tiniest diff; weaker than 5.3 for the same review cost.
+
+### 5.2 As drafted
+
+Truthful for both subcases, one remediation sentence aimed at the rarer one. Trade-off analysed in §1.5 — the drafted form's cost is that its only advice is wrong-footed for the likely user.
+
+### 5.3 RECOMMENDED — two-tier message, branch on which subcase matched
+
+The code can distinguish the subcases with a byte comparison it already has the operands for: `pt == &self.input[i]` (or `path_identity_key` equality, if `./` spellings should count as byte-equal) versus keys-equal-but-paths-not. Same key, same rejection, same order — the branch chooses only the sentence:
+
+- **byte-equal:** name the matched read and say the passthrough must be a third file, e.g. the index read.
+- **case-only:** state the comparison is case-folded for APFS/NTFS safety, name both spellings, and give the rename remediation.
+
+This resolves §1.4 and §1.5 together, gives each subcase advice that is correct *for that subcase*, and remains entirely inside "wording only" — no behavioural change whatsoever, since both arms `bail!`. It costs one `if` on the error path and makes Validation 2 testable per §4.4. The extra cost over 5.2 is a few lines of diff in a change that is already being reviewed by two reviewers; the benefit is that the message stops giving the common case advice that routes around the guard.
+
+### 5.4 Optional adjunct — delete the redundant `len == 2` guard
+
+`src/cli.rs:938`'s `if self.input.len() == 2` is provably always true given 1.ii (`src/cli.rs:896-902`). Removing it and de-indenting the body is behaviour-preserving and makes §1.3's note unnecessary. Against: it widens a strings-only diff into a control-flow diff, and defensive redundancy next to a data-loss guard is a defensible thing to keep. My recommendation is to **keep the guard and keep the one-clause comment** (§1.2's two-liner does both) — but if the maintainer prefers the guard gone, this is the moment, because the comment justifying it is being rewritten anyway.
+
+### 5.5 Considered and rejected — probe filesystem case sensitivity at runtime
+
+Would let the message be platform-accurate ("these are two files here, so this is refused conservatively" vs "these are one file"). Rejected: it requires filesystem access, and #385 already rejected syscall/symlink semantics for these keys by design (A2). It would also make the message non-deterministic across platforms, breaking the very unit tests this plan is updating. Recorded for completeness; do not pursue.
+
+---
+
+## 6. Action items
+
+### Critical
+
+1. **Fix the `norm_path()` premise before implementing.** `norm_path` is live at `src/io.rs:48`, is a component of `collision_key`, and the existing test comment describing it as "a single `to_ascii_lowercase()` call" is *true*. Correct the plan's Context bullet and Implementation step 3, and replace the sentence by re-anchoring it on `io::tests::identity_key_is_case_sensitive_but_collision_key_is_not` (`src/io.rs:1181`) rather than by substituting the function name — the literal substitution ships a false comment. (§1.1)
+
+### Important
+
+2. **Cut the new comment to two lines**, fact-stated, per the repo's comment rule; move the dual-consume derivation to the commit message. Drop the ambiguous "elsewhere". (§1.2)
+3. **Retain the `len == 2 per 1.ii` clause** so the redundant guard at `src/cli.rs:938` stays explained — or take §5.4 and remove the guard. (§1.3, §5.4)
+4. **Name which input matched** in the message; the code already knows, and the sibling output-collision message sets the precedent (PR #219, `src/io.rs:120-126`). (§1.4)
+5. **Fix the remediation for the byte-equal subcase** — "pass a third file (e.g. the index read)", not "rename one". As drafted, the advice lets the likely user walk around the guard instead of fixing the mistake. Adopting §5.3 resolves this and item 4 together. (§1.5, §5.3)
+6. **Extend scope to the two other mis-framing comments**: `src/cli.rs:885-889` (calls 1.ix "issue #216 protection"; #216 is the output-collision issue, 1.ix guards input dual-consume) and `src/io.rs:38-47` (`norm_path` doc claims direct use by `Cli::validate`, and uses the "aliasing" identity verb). One line each; without them #389 is two-thirds done. (§1.6)
+7. **Restate "no behaviour change" precisely** as "no change to which runs are accepted or rejected; the message text changes", in both the plan and the CHANGELOG entry. (§2.3)
+
+### Optional
+
+8. **Add a positive grep to Validation** — new prefix present exactly three times (message + two asserts); ensure the pinned prefix does not straddle the string literal's `\` line break. (§4.3)
+9. **Turn Validation 2 into assertions** — have `…_at_r1` / `…_at_r2` pin that the message names the correct read. Only worthwhile if item 4 is adopted, and then it is the one test worth adding. (§4.4)
+10. **Match the house qualifier idiom** — `(case-insensitive, for APFS/NTFS safety)`, as used at `src/io.rs:110` and `src/io.rs:121` and grepped by `.github/workflows/ci.yml:638`, rather than the drafted "compared case-insensitively, for APFS/NTFS safety". One vocabulary for one concept. (§1.4)
+11. **Avoid `: {}.`** — a path immediately followed by a period is ambiguous to copy-paste. House style interpolates paths mid-sentence followed by a comma or a word (`src/io.rs:112`). (§5.2)
+12. **Consider making `norm_path` private.** It is `pub` with no callers outside `collision_key` and its own tests; demoting it (or inlining it) would remove the naming confusion that produced item 1 in the first place. Out of this plan's scope — worth a follow-up issue rather than scope creep here. (§1.6)
+13. **Draft the CHANGELOG entry in house style** — bolded lead sentence plus issue link, matching the neighbouring entries in Unreleased → `#### Changes` (`CHANGELOG.md:129`). The `--output-dir` entry at `CHANGELOG.md:145-146` is the closest precedent for a message-only change. (§1.7)
+
+### Non-issues (verified, do not re-flag)
+
+- A1 holds: only `src/cli.rs:944-945` and `src/cli.rs:1880`/`1887` carry the text; `tests/integration_passthrough.rs` pins 1.i only; no CI grep touches this message. `ci.yml:638`'s grep targets the output-collision message and cannot be tripped.
+- Check ordering, the 1.viii-before-1.ix consequence, and both platform subcases are as the plan describes.
+- Efficiency is genuinely nil.
+- "Cross-case `validate()` testing needs a case-insensitive filesystem" is correct — but the fold property is already pinned at the key level, so there is no coverage gap (§4.2).

--- a/plans/08082026_passthrough-alias-wording/PLAN_REVIEW_B.md
+++ b/plans/08082026_passthrough-alias-wording/PLAN_REVIEW_B.md
@@ -1,0 +1,276 @@
+# Plan Review B — `--passthrough` alias check wording (#389)
+
+**Reviewer:** B (independent, fresh context)
+**Plan under review:** `plans/08082026_passthrough-alias-wording/PLAN.md`
+**Repo:** `/Users/fkrueger/Github/TrimGalore`, branch `dev` @ `03d793f` (verified as HEAD)
+**Date:** 2026-08-08
+**Scope note:** The maintainer's decision — keep the case-folded `collision_key`, change wording only — is treated as settled. This review evaluates the plan *given* that decision.
+
+**Verdict (short):** the decision is sound and I verified its premise independently. The plan's factual groundwork is almost entirely accurate, but it has three defects that matter: its automated validation does not actually protect the thing #389 asked for; it misses the one *other* place in `src/` that still carries both the objected-to framing and a now-false attribution; and step 3, followed literally, replaces a stale identifier with a **false** statement.
+
+---
+
+## 1. Logic review
+
+### 1.1 Claims I verified as correct
+
+Every line reference in the plan checks out against the working tree:
+
+| Plan claim | Actual | OK |
+|---|---|---|
+| check 1.ix at `src/cli.rs:933-949` | comment opens 933, block closes 949 | yes |
+| comment to replace at `933-937` | 5 lines, "…catches case-only INPUT aliases…" | yes |
+| message at `943-947` | `bail!` spanning 943-947 | yes |
+| tests at `cli.rs:1871-1888` | `test_passthrough_rejects_pointing_at_r1` 1871-1881, `_r2` 1883-1888 | yes |
+| shared test comment at `1872-1877` | 6 lines, names `norm_path()` | yes |
+| base `03d793f` | `git log -1` → `03d793f` | yes |
+| 1.ix runs after 1.viii existence check | `check_restartable_input(pt, …)` at 932 | yes |
+| `tests/integration_passthrough.rs` does not pin this text | its only stderr pin is `"--passthrough requires --paired"` (1.i) | yes |
+| CI does not exercise `--passthrough` message text | `grep -n passthrough .github/workflows/*.yml` → **zero hits** | yes |
+| no docs/README pin | no `alias`/`cannot point at` hit for passthrough in `docs/` or `README.md` | yes |
+
+The `case-insensitive match` grep hit at `.github/workflows/ci.yml:635` is a **false alarm for this plan** — it is a historical comment about the *output-collision* message (PR #219 reworded it), and the live CI grep is on `"case-insensitive, for APFS/NTFS safety"` against an output-collision log, not a passthrough run. No CI pin exists on 1.ix. The plan's Integration section is right.
+
+### 1.2 The decision's premise holds — verified independently
+
+The plan asserts that dropping the fold would reintroduce silent dual-consume. I checked whether anything *else* would catch it, because if the output pre-flight already did, the rationale would collapse:
+
+- passthrough output is `<stem>_passthrough.fq(.gz)` (`src/io.rs:321-340`), and it *is* pushed into the pre-flight candidate list (`src/main.rs:763-764`).
+- but `io::preflight_output_collisions` (`src/io.rs:96-130`) only compares **output-vs-input** and **output-vs-output**. With `--passthrough R1.fq.gz` (or `r1.fq.gz` on APFS), the planned outputs are `R1_val_1`, `R1_val_2`, `R1_passthrough` — none of which alias an input or each other.
+
+So nothing downstream catches input-vs-input aliasing. **1.ix is the sole guard**, and keeping the fold is the correct call. Good — the plan's rationale is not just asserted, it survives checking.
+
+### 1.3 C3 — step 3, followed literally, writes a *false* comment
+
+This is the sharpest defect. Plan line 15 says the test comment "references **`norm_path()`**, a stale pre-D13 name for what is now `collision_key`."
+
+**That premise is wrong.** `norm_path` is not a stale name — it still exists, still `pub`, at `src/io.rs:48-50`, and is still exactly one `to_ascii_lowercase()`:
+
+```rust
+pub fn norm_path(p: &Path) -> String {
+    p.to_string_lossy().to_ascii_lowercase()
+}
+```
+
+`collision_key` *calls* it: `norm_path(&lexical_normalise(p))` (`io.rs:85`).
+
+The real defect in the test comment is different, and the difference is load-bearing. The comment currently argues:
+
+> `norm_path()` is a single `to_ascii_lowercase()` call which is trivially correct
+
+That sentence is **true of `norm_path`** but the check no longer calls `norm_path` — it calls `collision_key`. Step 3 instructs "replace the stale `norm_path()` reference with `collision_key`". Do that mechanically and the committed comment reads "`collision_key()` is a single `to_ascii_lowercase()` call which is trivially correct" — which is **false**: `collision_key` also absolutises via `std::path::absolute` and folds `..` against the component stack (`lexical_normalise`, `io.rs:55-73`). Step 3 would replace a stale-but-true statement with a current-but-false one, in a change whose entire purpose is removing a false statement from this exact block.
+
+Fix: rewrite the clause, don't swap the identifier. The byte-equal-is-a-subset argument still holds and can be stated without claiming what the function does — e.g. "byte-equal paths yield equal keys under any normalisation, so this covers the folded path too; the fold itself is pinned by `io::tests::test_norm_path_case_folds`." That last pointer is worth having, because the fold genuinely *is* tested there (`io.rs:767-784`) — which also answers the comment's "CI can't test cross-case" worry properly.
+
+### 1.4 C2 — the goal is not met: `src/io.rs:38-47` survives untouched
+
+The plan's Goal is "make the check's words match its semantics", and its A1 grep concluded the old framing lives in exactly four lines of `cli.rs`. It does not. `norm_path`'s own doc comment says:
+
+```rust
+/// Case-folded (ASCII lowercase) string view of a path for collision detection
+/// on case-insensitive filesystems (APFS/NTFS). Used by:
+///   * `Cli::validate()` to catch `--passthrough` aliasing R1 or R2 (e.g.
+///     `--passthrough r1.fq.gz` while R1 is `R1.fq.gz`).
+```
+
+Two problems in one bullet:
+
+1. It carries **the same "aliasing" framing #389 objects to** — and here it is on a `pub fn`'s rustdoc, i.e. more durable than an inline comment.
+2. It is **factually stale as an attribution**: `Cli::validate` does not call `norm_path`. `grep -rn norm_path --include='*.rs'` shows exactly three non-test call sites — its definition (48), `collision_key` (85), and the test (768-783). Post-#385, `validate` reaches the fold only *through* `collision_key`, which the second bullet already describes.
+
+Leaving this in means the fix is cosmetic: the objected-to sentence still ships, one file over. A secondary, milder instance sits at `io.rs:769-771` ("the output-collision pre-flight + `--passthrough` validation both use") — that one is transitively true and can stay, though it reads oddly once bullet 1 above is corrected.
+
+Root cause: **A1's grep was phrase-narrow.** It searched two exact strings from `cli.rs`; the same idea spelled "aliasing R1 or R2" was invisible to it. See I5.
+
+### 1.5 The "no behaviour change" claim
+
+Holds in the sense that matters: no key, no comparison, no ordering, no control flow changes; the rejection surface is bit-identical. Two honest caveats worth putting in the plan rather than leaving implicit:
+
+- **stderr text is user-visible behaviour.** Anyone's wrapper script grepping `"cannot point at R1 or R2"` breaks. That is the intended effect, not a bug, but it is why the CHANGELOG entry is not optional. The plan already has the CHANGELOG step, so this is a wording nit on the claim, not a gap.
+- If I2's "name both paths" refinement is adopted, the diff stops being string-only (see §5).
+
+### 1.6 Edge cases
+
+The plan says "none new" and that is right. One pre-existing ordering artifact becomes slightly more visible and is worth a sentence: R1/R2 existence is checked at `cli.rs:987-989`, **after** the passthrough block, so on a case-sensitive filesystem with a genuinely-missing `R1.fq` and `--passthrough r1.fq`, the user sees the new "rename one so the paths differ" advice rather than "Input file not found". Pre-existing, low harm, not worth reordering — but "no new edge cases" is more precisely "no new edge cases; one pre-existing ordering artifact that the new remediation sentence makes marginally more confusing".
+
+---
+
+## 2. Assumptions
+
+### Stated
+
+- **A1 — "No test outside `cli.rs:1871-1888` pins the old text."** True for *test* pins (I re-ran the grep over `src/`, `tests/`, `docs/`, `.github/`, `README.md`, `CHANGELOG.md`: only `cli.rs:944-945`, `1880`, `1887`). But A1 was used to conclude the *comment* scope too, and there it fails — see C2. Narrow the claim to "no test pins" and add a separate scope grep for the framing.
+- **A2 — "D13 taxonomy stays as-is."** Valid and consistent with the recorded decision. Nothing in the plan touches either key.
+
+### Implicit assumptions the plan does not surface
+
+- **The message is only ever read by humans.** Nothing machine-parses TrimGalore stderr in-repo (verified), but the assumption should be stated, because it is what licenses a free-form rewrite.
+- **`plans/` is out of scope for the "zero stale hits" grep.** The plan does not say this, and it must — see I4.
+- **The rejection is desirable in the common case.** The plan reasons hard about the rare case-sensitive-FS shape and barely about the overwhelmingly likely one (user fat-fingered R1 as the passthrough file). That asymmetry leaks into the proposed message — see I3.
+- **A 4-line comment is acceptable here.** The project's own convention says otherwise — see I1.
+
+### Ambiguity
+
+- "CHANGELOG.md — Unreleased/changed" does not name an existing heading. `Unreleased` currently has **four** subsections: `#### Bug fixes` (line 6), `#### Changes` (129), `#### Fixes` (272), `#### Infrastructure (contributor-facing)` (458). With both "Bug fixes" and "Fixes" available, an implementer can easily file a no-behaviour-change edit as a bug fix. Name `#### Changes` explicitly.
+
+---
+
+## 3. Efficiency analysis
+
+Nothing to analyse — no allocation, loop, or I/O change; `collision_key` is called the same two times on the same paths. The plan's one-line dismissal is proportionate.
+
+Two non-performance mechanical hazards in the same territory, since this is where "nothing to measure" tempts an unreviewed diff:
+
+- **Backslash-continuation whitespace.** The existing message uses `\` line continuations, which eat the next line's leading whitespace, so the trailing space must sit *before* the backslash. A three-line prose message is three chances to produce `case-insensitivelyfor` — and with the pin as currently specified (prefix only), **no test would catch it**. This is a second, independent reason to adopt C1.
+- **`cargo fmt` and long string literals.** `fmt` will not rewrap a string literal, so the author owns the line breaks; keep them under 100 columns to match the surrounding block or clippy's line-length-adjacent lints in `-D warnings` mode become the discovery mechanism.
+
+---
+
+## 4. Validation sufficiency
+
+The plan's four validations catch a partial test-pin update, formatting, and clippy. They do **not** protect the deliverable. Two gaps:
+
+### C1 (Critical) — the proposed pin does not protect the #389 fix
+
+Validation 1 relies on the two unit tests, and step 3 pins them to `contains("--passthrough matches R1 or R2")`. That prefix says nothing about honesty. A future "tidy up the error messages" commit could ship:
+
+```
+--passthrough matches R1 or R2: sample_R1.fq.gz aliases an input file
+```
+
+…and both tests stay green. The exact defect #389 was filed about would be reintroduced with a green suite. For a change whose entire deliverable *is* the wording, the wording has to be the contract.
+
+Pin the honest part, positively and negatively:
+
+```rust
+assert!(err.contains("--passthrough"), "got: {err}");
+assert!(
+    err.contains("case-insensitiv"),          // the comparison is stated, not assumed
+    "1.ix must say the comparison is case-insensitive (#389); got: {err}"
+);
+assert!(
+    !err.contains("aliases an input"),        // no unconditional identity claim
+    "1.ix must not assert identity (#389); got: {err}"
+);
+```
+
+The negative assertion is the one that actually holds the line, and the `#389` in the failure message tells the next person why the test exists. Add it to both tests, or factor the three asserts into a small helper the two tests share.
+
+### Gap 2 (Important) — no validation covers the scope question
+
+Validation 3 greps for the two *old* strings. Nothing greps for the *framing*, which is why C2 slipped through. Add:
+
+```bash
+grep -rn "aliasing R1 or R2\|aliases an input\|cannot point at R1" \
+  src/ tests/ docs/ .github/ README.md CHANGELOG.md
+```
+
+### I4 (Important) — Validation 3's expected result is wrong as written
+
+"grep for `"cannot point at R1"` and `"aliases an input"` post-change → zero hits" is unachievable and, worse, actively misleading. Unscoped, those two phrases hit **this plan itself** (4 lines), `plans/06062026_passthrough-mode/PLAN.md:114`, and about eight more files under `plans/08062026_se-output-collision-preflight/` and `plans/08072026_paired-report-preflight/`. An implementer chasing "zero hits" would either report a false failure or start editing historical plan artifacts — which the global workflow rules put off-limits. Scope the grep to `src/ tests/ docs/ .github/ README.md CHANGELOG.md` and state the expectation as "zero hits outside `plans/`".
+
+### What is adequately covered
+
+- The fold itself is already pinned by `io::tests::test_norm_path_case_folds` (`io.rs:767-784`), including the `R1.fq.gz`/`r1.fq.gz` equality. The plan does not mention this, but it means the "cross-case can't be tested on CI" caveat in the test comment is narrower than it sounds — the *key* is tested, only the end-to-end filesystem behaviour is not. Worth citing in the rewritten comment (see C3).
+- Validation 2 is a human read, which is the right instrument for prose. Keep it, but make it a checklist of the two subcases rather than a vibe check: (a) byte-equal — does the message still tell the user what to do? (b) case-variant on ext4 — is the rename advice reachable and correct?
+
+---
+
+## 5. Alternatives (within the settled decision)
+
+### 5.1 Name both paths, not just the passthrough one — I2
+
+The proposed message interpolates only `pt.display()`, then says:
+
+> If **these** are genuinely two different files on a case-sensitive filesystem, rename one…
+
+"these" and "one" have no antecedent — only one path was printed. The user must guess whether R1 or R2 matched, which is precisely the information needed to act. The repo already set the opposite precedent for the sibling message: PR #219 reworked the output-collision error specifically to name **both** colliding paths, and `ci.yml:634-637` records that as a deliberate improvement.
+
+Minimal restructure that yields the matched path:
+
+```rust
+let pt_key = crate::io::collision_key(pt);
+if let Some(matched) = self
+    .input
+    .iter()
+    .find(|p| crate::io::collision_key(p) == pt_key)
+{
+    anyhow::bail!(
+        "--passthrough must not be one of the R1/R2 inputs; {} and {} compare equal \
+         case-insensitively (for APFS/NTFS safety). If they are genuinely two different \
+         files on a case-sensitive filesystem, rename one so the paths differ by more \
+         than letter case.",
+        pt.display(),
+        matched.display()
+    );
+}
+```
+
+Rejection surface is unchanged (`1.ii` guarantees `input.len() == 2`, so iterating equals testing `[0]`/`[1]`), and the redundant `if self.input.len() == 2` wrapper falls away with it.
+
+**Trade-off, stated plainly:** this converts a string-only diff into a small logic diff, which raises the review bar on a change Felix has already flagged as single-reviewer-weight. If keeping the diff string-only is worth more than naming the match, then fix the dangling pronoun instead of the plumbing:
+
+> …rename either the passthrough file or the matching input so the paths differ by more than letter case.
+
+Both are acceptable; I'd take the first, because "which input did I collide with" is the user's actual next question.
+
+### 5.2 Keep the imperative for the common case — I3
+
+"`--passthrough` **cannot point at** R1 or R2" was doing real work: it told the 99% user (who mistakenly passed R1 as the passthrough file) what to change. The proposed "`--passthrough` **matches** R1 or R2" is a statement of fact followed by advice that only applies to the pathological case. The message gets more honest and less useful at the same time.
+
+"must not be one of the R1/R2 inputs" (as in 5.1) keeps the normative content, keeps the common-case remediation implicit-but-clear, and still makes no identity claim — the identity question is deferred to the conditional second sentence, which is exactly the structure #389 asked for.
+
+### 5.3 Shorten the comment to project convention — I1
+
+The proposed replacement is four lines carrying a reasoning chain ("…rather than risking silent dual-consume elsewhere" — and "elsewhere" is vague). The repo's own convention is explicit: default to one line, two maximum, state the fact not the evidence, and put the derivation in the commit message. The full dual-consume argument belongs in the commit body and in #389, both of which will outlive the comment.
+
+```rust
+// 1.ix — deliberately case-folded, not an identity check (#389): on APFS/NTFS a
+// case-variant passthrough is R1/R2 and would be read twice.
+```
+
+Two lines, states the fact, keeps the issue pointer. Everything else the plan wants to say is already written down in the plan and the issue.
+
+### 5.4 Trim the duplicate rationale at `cli.rs:885-889` — O1
+
+The `--passthrough` envelope preamble already says:
+
+> case-folded collision check (1.ix) uses `crate::io::collision_key` to share the same APFS/NTFS-aware normalisation as the output-collision pre-flight in `main.rs` (issue #216 protection).
+
+Not false, but "issue #216 protection" is an *output* concern attached to an *input* check — the same conflation #389 is about — and after this change the file carries two rationales for 1.ix, nine lines apart, framed differently. Drop the 1.ix clause from the preamble (the new inline comment covers it) or reduce it to a pointer.
+
+### 5.5 Considered and rejected
+
+- **A third key (`input_alias_key`) or platform-conditional check.** Out of bounds per A2 and already rejected in #385; adds a taxonomy entry to buy a pathological case.
+- **Downgrade 1.ix to a warning on case-only matches.** Superficially attractive (case-sensitive FS proceeds, APFS user gets told) but it cannot distinguish the two without a syscall, and a warning on APFS means shipping the silent dual-consume with a note. Correctly not on the table.
+
+---
+
+## 6. Action items
+
+### Critical
+
+- **C1 — pin the honesty, not just the prefix.** Add a positive assertion on the case-insensitivity qualifier and a **negative** assertion `!err.contains("aliases an input")` to both `test_passthrough_rejects_pointing_at_r1`/`_r2`, with `#389` in the failure message. Without this the plan's deliverable is unprotected and a future message tidy-up can reintroduce the exact defect with a green suite. (§4)
+- **C2 — fix `src/io.rs:38-47`.** The `norm_path` rustdoc's first "Used by" bullet both repeats the objected-to "aliasing R1 or R2" framing and is factually wrong (`Cli::validate` calls `collision_key`, not `norm_path`). Drop or re-attribute that bullet; without it the plan's stated Goal is not met. Add the file to the Implementation outline. (§1.4)
+- **C3 — rewrite the test comment's clause; do not just swap the identifier.** `norm_path` is *not* a stale name (it lives at `io.rs:48`, still one `to_ascii_lowercase()`), so plan line 15's premise is wrong, and following step 3 literally produces the **false** statement "`collision_key()` is a single `to_ascii_lowercase()` call" — `collision_key` also absolutises and folds `..`. Restate the byte-equal-subset argument without describing the function's internals, and point at `io::tests::test_norm_path_case_folds` for the fold. (§1.3)
+
+### Important
+
+- **I1 — cut the new comment to ≤2 lines** per the project's comment convention; move the dual-consume derivation to the commit message and #389. Concrete rewrite in §5.3.
+- **I2 — name both paths in the message** so "these"/"one" have an antecedent and the user learns which input matched; follows the PR #219 precedent for the sibling output-collision error. Restructure in §5.1, with a string-only fallback if the diff must stay string-only.
+- **I3 — keep the normative clause** ("must not be one of the R1/R2 inputs") so the common-case user still learns what to change; the current draft offers remediation only for the rare case. (§5.2)
+- **I4 — fix Validation 3's expectation.** Scope the grep to `src/ tests/ docs/ .github/ README.md CHANGELOG.md`; unscoped it hits this plan plus about nine files under `plans/`, so "zero hits" is unachievable and invites editing historical artifacts. (§4)
+- **I5 — widen the scope grep** beyond two exact phrases to catch the framing (`aliasing R1 or R2`), and correct A1 to claim only "no *test* pins outside `cli.rs`". This is the root cause of C2. (§2)
+
+### Optional
+
+- **O1 — trim the duplicate 1.ix rationale** at `cli.rs:885-889`, or its "(issue #216 protection)" tag, so the file carries one framing rather than two. (§5.4)
+- **O2 — name the CHANGELOG subsection explicitly** (`#### Changes`, line 129); `Unreleased` has both `Bug fixes` and `Fixes`, and a no-behaviour-change edit should not land under either.
+- **O3 — watch the `\` continuation whitespace** in the multi-line format string; a missing space before a backslash silently joins two words and, with the prefix-only pin, no test catches it. Largely mitigated by C1.
+- **O4 — consider a distinct qualifier phrasing.** "(compared case-insensitively, for APFS/NTFS safety)" is near-identical to the CI-pinned output-collision string `"case-insensitive, for APFS/NTFS safety"` (`ci.yml:637`). No conflict today (different invocations, different logs), but a future grep-tightening could cross-match.
+- **O5 — soften the "no new edge cases" claim** to acknowledge the pre-existing ordering artifact: R1/R2 existence is validated after 1.ix (`cli.rs:987-989`), so on a case-sensitive filesystem with a missing R1 the rename advice can appear in place of "Input file not found". (§1.6)
+- **O6 — record in the plan that the fold is already unit-tested** (`io.rs:767-784`), which narrows the test comment's "CI can't test cross-case" caveat to end-to-end filesystem behaviour only.
+
+### On review weight
+
+The plan asks whether single-reviewer weight suffices. On the evidence: the diff is small, but its two-string surface concealed three Critical items — an unprotected deliverable, a missed file that defeats the stated goal, and an instruction that writes a false comment if followed literally. Small diff, not small review. If I2's restructure is adopted, the diff also stops being string-only.

--- a/plans/08082026_passthrough-alias-wording/PROGRESS.md
+++ b/plans/08082026_passthrough-alias-wording/PROGRESS.md
@@ -1,0 +1,21 @@
+# Progress: `--passthrough` alias check wording (#389)
+
+**Last updated:** 2026-08-08
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | PLAN.md r2 — review findings folded in (two-tier message, scope widened to io.rs/preamble, hardened pins, new portable case-variant test); awaiting Felix's sign-off |
+| Plan Review | ✅ Complete | PLAN_REVIEW_A.md, PLAN_REVIEW_B.md — both verdicts REVISE; 3 agreed criticals incl. a false premise in the plan (norm_path is not stale) |
+| Impl Plan | ✅ Complete | Folded into PLAN.md r2 implementation outline (no separate IMPL.md, per pipeline convention) |
+| Implementation | ✅ Complete | 1f43363 + review batch 478e1d0 |
+| Code Review | ✅ Complete | CODE_REVIEW_A.md (APPROVE, 3 Low), CODE_REVIEW_B.md (APPROVE, 4 Low) — batch applied in 478e1d0 |
+| Coverage | ✅ Complete | COVERAGE.md: COMPLETE (14 DONE, 2 documented deviations); post-audit note for 478e1d0 |
+
+## History
+
+- 2026-08-08: Implementation + Code Review + Coverage → ✅ Complete (review batch 478e1d0)
+- 2026-08-08: Plan revised to r2 (all dual-review findings incorporated; re-presented)
+- 2026-08-08: Plan Review → ✅ Complete (dual reviewers; both REVISE — plan revision needed before implementation)
+- 2026-08-08: Plan → ✅ Complete (decision resolved via AskUserQuestion: keep fold, fix wording; PLAN.md written)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -931,20 +931,26 @@ impl Cli {
             // 1.ix — case-folded on purpose, not an identity check (#389): a case-variant
             // passthrough IS R1/R2 on APFS/NTFS and would be consumed twice. len == 2 per 1.ii.
             if self.input.len() == 2 {
+                let pt_id = crate::io::path_identity_key(pt);
                 let pt_key = crate::io::collision_key(pt);
-                if let Some(matched) = self
+                // Identity first: a byte-equal input gets the identity diagnosis even
+                // if the other input is a case-variant of it (identity ⊆ collision).
+                if let Some(same) = self
+                    .input
+                    .iter()
+                    .find(|p| crate::io::path_identity_key(p) == pt_id)
+                {
+                    anyhow::bail!(
+                        "--passthrough must be a third file (e.g. the index read), not \
+                         one of the R1/R2 inputs: {} is input {}",
+                        pt.display(),
+                        same.display()
+                    );
+                } else if let Some(matched) = self
                     .input
                     .iter()
                     .find(|p| crate::io::collision_key(p) == pt_key)
                 {
-                    if crate::io::path_identity_key(matched) == crate::io::path_identity_key(pt) {
-                        anyhow::bail!(
-                            "--passthrough must be a third file (e.g. the index read), not \
-                             one of the R1/R2 inputs: {} is input {}",
-                            pt.display(),
-                            matched.display()
-                        );
-                    }
                     anyhow::bail!(
                         "--passthrough matches input {} case-insensitively (for APFS/NTFS \
                          safety): {}. On a case-insensitive filesystem these are the same \
@@ -1883,8 +1889,8 @@ mod tests {
             "1.ix identity-branch prefix missing (#389); got: {err}"
         );
         assert!(
-            err.contains(matched),
-            "matched input {matched} not named (#389); got: {err}"
+            err.contains(&format!("is input {matched}")),
+            "matched input {matched} not named in the matched slot (#389); got: {err}"
         );
         assert!(
             !err.contains("aliases an input"),
@@ -1894,9 +1900,8 @@ mod tests {
 
     #[test]
     fn test_passthrough_rejects_pointing_at_r1() {
-        // Byte-equal is a strict subset of case-folded equality (the fold is pinned
-        // by io::tests::test_norm_path_case_folds); the case-variant branch has its
-        // own lexical test below.
+        // Byte-equal ⊂ case-folded (fold pinned by io::tests::test_norm_path_case_folds);
+        // the case-variant branch has its own lexical test below.
         let cli = Cli::parse_from(["trim_galore", "--paired", "--passthrough", R1, R1, R2]);
         let err = cli.validate().unwrap_err().to_string();
         assert_passthrough_identity_rejection(&err, R1);
@@ -1910,10 +1915,26 @@ mod tests {
     }
 
     #[test]
+    fn test_passthrough_rejects_dot_slash_spelling_of_input() {
+        // pt and the matched input differ textually here, so the "is input {…}"
+        // assertion discriminates the matched slot rather than echoing pt (#389).
+        let pt = format!("./{R1}");
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--paired",
+            "--passthrough",
+            pt.as_str(),
+            R1,
+            R2,
+        ]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert_passthrough_identity_rejection(&err, R1);
+    }
+
+    #[test]
     fn test_passthrough_rejects_case_variant_of_input() {
-        // The check is lexical, so a case-variant of an UNWRITTEN input path hits
-        // the case-only branch identically on ext4 and APFS: 1.viii needs only the
-        // passthrough file to exist; input existence is validated later (#389).
+        // Lexical check: a case-variant of an UNWRITTEN input hits the case-only branch
+        // on ext4 and APFS alike — only the passthrough must exist at 1.viii (#389).
         let dir = std::env::temp_dir().join(format!("tg_pt_case_{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let pt = dir.join("r1.fq");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -883,10 +883,8 @@ impl Cli {
         }
 
         // --passthrough: 9-item compatibility envelope. Layout mirrors --clumpify
-        // above. Each rejection has a precise user-facing message; case-folded
-        // collision check (1.ix) uses crate::io::collision_key to share the same
-        // APFS/NTFS-aware normalisation as the output-collision pre-flight in
-        // main.rs (issue #216 protection).
+        // above. Each rejection has a precise user-facing message; 1.ix is the
+        // input dual-consume guard (#389) — see its own comment for the key choice.
         if let Some(ref pt) = self.passthrough {
             // 1.i — paired-end required
             if !self.paired {
@@ -930,19 +928,29 @@ impl Cli {
             // 1.viii — file must exist, and must be re-readable (#379): the
             // passthrough stream is opened once to sanity-check and again to read.
             check_restartable_input(pt, "--passthrough file not found")?;
-            // 1.ix — case-folded collision with R1/R2 (issue #216-style APFS/NTFS guard).
-            // self.input.len() == 2 here per 1.ii. The plan's main.rs::run pre-flight
-            // catches case-only output collisions; this catches case-only INPUT aliases
-            // where --passthrough silently dual-consumes one input on a case-insensitive
-            // filesystem.
+            // 1.ix — case-folded on purpose, not an identity check (#389): a case-variant
+            // passthrough IS R1/R2 on APFS/NTFS and would be consumed twice. len == 2 per 1.ii.
             if self.input.len() == 2 {
-                let pt_norm = crate::io::collision_key(pt);
-                if pt_norm == crate::io::collision_key(&self.input[0])
-                    || pt_norm == crate::io::collision_key(&self.input[1])
+                let pt_key = crate::io::collision_key(pt);
+                if let Some(matched) = self
+                    .input
+                    .iter()
+                    .find(|p| crate::io::collision_key(p) == pt_key)
                 {
+                    if crate::io::path_identity_key(matched) == crate::io::path_identity_key(pt) {
+                        anyhow::bail!(
+                            "--passthrough must be a third file (e.g. the index read), not \
+                             one of the R1/R2 inputs: {} is input {}",
+                            pt.display(),
+                            matched.display()
+                        );
+                    }
                     anyhow::bail!(
-                        "--passthrough cannot point at R1 or R2 (case-insensitive match \
-                         on APFS/NTFS): {} aliases an input file",
+                        "--passthrough matches input {} case-insensitively (for APFS/NTFS \
+                         safety): {}. On a case-insensitive filesystem these are the same \
+                         file and the stream would be consumed twice; if they are genuinely \
+                         two files, rename one so the paths differ by more than letter case.",
+                        matched.display(),
                         pt.display()
                     );
                 }
@@ -1867,24 +1875,68 @@ mod tests {
         assert!(err.contains("--passthrough file not found"), "got: {err}");
     }
 
+    /// Shared 1.ix assertions (#389): normative prefix, matched input named,
+    /// and no unconditional identity claim.
+    fn assert_passthrough_identity_rejection(err: &str, matched: &str) {
+        assert!(
+            err.contains("--passthrough must be a third file"),
+            "1.ix identity-branch prefix missing (#389); got: {err}"
+        );
+        assert!(
+            err.contains(matched),
+            "matched input {matched} not named (#389); got: {err}"
+        );
+        assert!(
+            !err.contains("aliases an input"),
+            "1.ix must not assert identity (#389); got: {err}"
+        );
+    }
+
     #[test]
     fn test_passthrough_rejects_pointing_at_r1() {
-        // 1.ix collision check: the byte-equal case is the strict subset of
-        // case-folded equality, so this also covers the case-folded path —
-        // norm_path() is a single `to_ascii_lowercase()` call which is
-        // trivially correct (and exercised by io::tests in its own right).
-        // True cross-case testing would need a case-insensitive filesystem
-        // which CI doesn't guarantee.
+        // Byte-equal is a strict subset of case-folded equality (the fold is pinned
+        // by io::tests::test_norm_path_case_folds); the case-variant branch has its
+        // own lexical test below.
         let cli = Cli::parse_from(["trim_galore", "--paired", "--passthrough", R1, R1, R2]);
         let err = cli.validate().unwrap_err().to_string();
-        assert!(err.contains("cannot point at R1 or R2"), "got: {err}");
+        assert_passthrough_identity_rejection(&err, R1);
     }
 
     #[test]
     fn test_passthrough_rejects_pointing_at_r2() {
         let cli = Cli::parse_from(["trim_galore", "--paired", "--passthrough", R2, R1, R2]);
         let err = cli.validate().unwrap_err().to_string();
-        assert!(err.contains("cannot point at R1 or R2"), "got: {err}");
+        assert_passthrough_identity_rejection(&err, R2);
+    }
+
+    #[test]
+    fn test_passthrough_rejects_case_variant_of_input() {
+        // The check is lexical, so a case-variant of an UNWRITTEN input path hits
+        // the case-only branch identically on ext4 and APFS: 1.viii needs only the
+        // passthrough file to exist; input existence is validated later (#389).
+        let dir = std::env::temp_dir().join(format!("tg_pt_case_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let pt = dir.join("r1.fq");
+        std::fs::write(&pt, "@r\nACGT\n+\nIIII\n").unwrap();
+        let r1 = dir.join("R1.fq");
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--paired",
+            "--passthrough",
+            pt.to_str().unwrap(),
+            r1.to_str().unwrap(),
+            R2,
+        ]);
+        let err = cli.validate().unwrap_err().to_string();
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            err.contains("case-insensitively"),
+            "1.ix must state the case-insensitive comparison (#389); got: {err}"
+        );
+        assert!(
+            !err.contains("aliases an input"),
+            "1.ix must not assert identity (#389); got: {err}"
+        );
     }
 
     // ── --output-format (PLAN v2.1 §3.4a) ─────────────────────────────────

--- a/src/io.rs
+++ b/src/io.rs
@@ -35,12 +35,9 @@ pub fn is_gzipped(path: &Path) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("gz"))
 }
 
-/// Case-folded (ASCII lowercase) string view of a path for collision detection
-/// on case-insensitive filesystems (APFS/NTFS). Used by:
-///   * `Cli::validate()` to catch `--passthrough` aliasing R1 or R2 (e.g.
-///     `--passthrough r1.fq.gz` while R1 is `R1.fq.gz`).
-///   * `collision_key`, which absolutises first and is what every
-///     output-collision pre-flight in `main.rs` now hashes (issues #216, #383).
+/// Case-folded (ASCII lowercase) string view of a path — the folding component
+/// of `collision_key`, which absolutises first and is what every collision
+/// check hashes (issues #216, #383, #389).
 ///
 /// Pragmatic trade-off: on opt-in case-sensitive APFS volumes this may
 /// false-positive, but the penalty is a loud early error rather than

--- a/src/io.rs
+++ b/src/io.rs
@@ -37,7 +37,7 @@ pub fn is_gzipped(path: &Path) -> bool {
 
 /// Case-folded (ASCII lowercase) string view of a path — the folding component
 /// of `collision_key`, which absolutises first and is what every collision
-/// check hashes (issues #216, #383, #389).
+/// check uses (issues #216, #383, #389).
 ///
 /// Pragmatic trade-off: on opt-in case-sensitive APFS volumes this may
 /// false-positive, but the penalty is a loud early error rather than
@@ -71,7 +71,7 @@ fn lexical_normalise(p: &Path) -> PathBuf {
 
 /// Is this the same file? Case-**sensitive**, because on a case-sensitive filesystem
 /// `X` and `x` are two files and calling them one would reject valid input. Used for
-/// input identity in `Cli::validate` (issue #383).
+/// input identity in `Cli::validate` (issues #383, #389).
 pub fn path_identity_key(p: &Path) -> String {
     lexical_normalise(p).to_string_lossy().into_owned()
 }


### PR DESCRIPTION
The `--passthrough`-matches-R1/R2 check keeps its case-folded key (deliberately: on APFS/NTFS a case-variant passthrough IS the input and would be consumed twice, and this check is the sole guard for that) but stops claiming identity unconditionally. The message is now two-tier: pointing at an input directly says the passthrough must be a third file (e.g. the index read) and names the matched input; a case-variant match states the comparison is case-insensitive and suggests a rename. Accept/reject behaviour is unchanged — both branches bail identically. Companion fixes: `norm_path`'s rustdoc no longer claims direct use by `Cli::validate` or uses the "aliasing" framing; the envelope preamble drops the "#216 protection" label. Tests pin the honesty (negative assertion on the old identity claim) and a new lexical case-variant test covers the case-only branch identically on ext4 and APFS.

Plan + dual plan-review + implementation notes: `plans/08082026_passthrough-alias-wording/` (artifacts follow in a second commit after code review + coverage audit complete).

Closes #389 (manual close needed — dev is not the default branch).
