### PR TITLE
fix(main): clumping reports join the clump-only collision pre-flights (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 #### Bug fixes
 
+- **`--clump_only --paired` no longer silently overwrites one mate's clumping
+  report with the other's**
+  ([#391](https://github.com/FelixKrueger/TrimGalore/issues/391)). Primaries
+  carry `_clumped_1`/`_clumped_2`, but reports are named from the input
+  filename alone, so `-o out A/reads.fq B/reads.fq` wrote ONE report at exit 0.
+  Clumping-report paths now join the collision pre-flight on every clump arm
+  (gated on `--no_report_file`, matching the writers), which also stops a
+  clumping report from silently overwriting an *input* named like one — on the
+  paired arm and the single-end/uBAM arms alike. The single-interleaved-BAM
+  shape gets the same candidate line as defensive symmetry only; with one input
+  its report can never alias it.
+
 - **Whether input is gzipped is now decided by reading the file, not by its
   name.** This corrects two opposite failures:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
   clumping report from silently overwriting an *input* named like one — on the
   paired arm and the single-end/uBAM arms alike. The single-interleaved-BAM
   shape gets the same candidate line as defensive symmetry only; with one input
-  its report can never alias it.
+  its report can never alias it. As with #388, two inputs whose filenames differ
+  only in case are now refused into a shared output directory even on a
+  case-sensitive filesystem, where both reports could in fact coexist.
 
 - **Whether input is gzipped is now decided by reading the file, not by its
   name.** This corrects two opposite failures:

--- a/docs/src/content/docs/modes/clump-only.md
+++ b/docs/src/content/docs/modes/clump-only.md
@@ -106,7 +106,7 @@ Accepted but inert: `-q` / `--quality`, `--stringency`, `-e` / `--error`. These 
 
 ## Reorder report
 
-The reorder report at `<stem>_clumping_report.txt` is narrower than the standard trimming report by design — no adapter counts, no quality statistics, no filter counters, and no JSON companion.
+The reorder report at `<input-name>_clumping_report.txt` is narrower than the standard trimming report by design — no adapter counts, no quality statistics, no filter counters, and no JSON companion.
 
 ```
 Trim Galore version: 2.x.x
@@ -119,7 +119,7 @@ Compression ratio: <x.yy>x                    # omitted unless BOTH sides are co
 Preserved tags: TAG1,TAG2,…                   # uBAM only; omitted if empty
 ```
 
-The `Compression ratio` line is emitted only when both input and output are compressed (any of gzip / BGZF). Under `--dont_gzip` or when input was plain FASTQ, the ratio would be misleading and is omitted. The report filename uses `_clumping_report` rather than `_trimming_report` specifically so downstream nf-core/MultiQC pipelines that scan `*_trimming_report.*` don't misclassify it as a trim result. Multi-pair PE runs produce one report per pair, matching v1 SE's one-report-per-input convention.
+The `Compression ratio` line is emitted only when both input and output are compressed (any of gzip / BGZF). Under `--dont_gzip` or when input was plain FASTQ, the ratio would be misleading and is omitted. The report filename uses `_clumping_report` rather than `_trimming_report` specifically so downstream nf-core/MultiQC pipelines that scan `*_trimming_report.*` don't misclassify it as a trim result. Paired FASTQ runs write one report per mate; the uBAM shapes write one per pair (keyed on the pair's first input), matching v1 SE's one-report-per-input convention.
 
 ## Relationship to `--clumpify`
 

--- a/plans/08082026_clump-paired-report-preflight/CODE_REVIEW_A.md
+++ b/plans/08082026_clump-paired-report-preflight/CODE_REVIEW_A.md
@@ -1,0 +1,309 @@
+# Code Review A — #391: clumping reports join the `--clump_only` collision pre-flights
+
+**Reviewer:** A (independent; Reviewer B reviews the same diff separately)
+**Branch:** `fix/391-clump-report-preflight` @ `2704b52` (base `dev` @ `7ea2741`)
+**Plan:** `plans/08082026_clump-paired-report-preflight/PLAN.md` (r2 + Implementation notes)
+**Diff:** `src/main.rs`, `src/io.rs`, `tests/integration_output_collision.rs`, `CHANGELOG.md` (+464 / −65)
+
+## Summary
+
+**Verdict: approve.** No Critical or High findings. The change does what the plan says, in the
+place the plan says, and the load-bearing claims hold under independent re-derivation: every
+candidate set keys on exactly the inputs its writer keys on, the `--no_report_file` gate is
+identical in polarity and position at all five arms, and the widened namer cannot alter a written
+path. `--clock`/`--implicon` are behaviourally unchanged, not merely "probably unchanged" — a
+2-element `Vec` extended into `planned` produces the identical candidate list, in the identical
+order, that the two `push`es produced.
+
+Three Medium findings, all additive rather than corrective: one CHANGELOG sentence missing (a real
+new over-rejection class that #388's entry documented for its own change) and two test shapes that
+#388's sibling test set has and this one does not. Eight Low items, most of them one-line
+trivial fixes.
+
+### Verification performed
+
+| Check | Result |
+| --- | --- |
+| `cargo fmt --all -- --check` | clean |
+| `cargo clippy --all-targets -- -D warnings` | clean (debug profile; CI's `--release` was verified by the implementer) |
+| `cargo test` (full) | **557 passed, 0 failed** — matches the claimed count exactly |
+| `cargo test --test integration_output_collision clump` | 9/9 pass |
+| Live binary: #391 repro | rejected, message pins the report path |
+| Live binary: same filename in two dirs, no `-o` | exit 0, correct file layout (see M3) |
+| Live binary: fold-equal filenames, `-o` | rejected (see M1/M2) |
+| `tempdir` tag uniqueness across the file | all 45 tags unique |
+
+---
+
+## Logic — re-derived and confirmed
+
+Each item below was checked against the tree, not taken from the plan.
+
+**1. Five candidate sets ↔ four writer gates.** Each arm passes exactly the report-keyed inputs
+its writer uses:
+
+| Arm (`src/main.rs`) | Candidate inputs | Writer | Writer's key |
+| --- | --- | --- | --- |
+| paired FASTQ namer (:558) | `&[r1, r2]` | `clump_only.rs:534-536` | `input_r1` **and** `input_r2` |
+| SE FASTQ (:590) | `&cli.input` | `clump_only.rs:366` | `input`, per input |
+| Shape B, N=1 uBAM (:633) | `&cli.input` | `clump_only.rs:1083` | `inputs[0]` |
+| Shape A, per pair (:672) | `slice::from_ref(&chunk[0])` | `clump_only.rs:1083` | `inputs[0]` |
+| SE BAM (:727) | `&cli.input` | `clump_only.rs:837` | `input`, per input |
+
+Shape B's `&cli.input` is length-1 by its branch guard (`cli.input.len() == 1`), so it is exactly
+`inputs[0]` — the whole-slice spelling is safe, not an accident. Shape A's
+`slice::from_ref(&chunk[0])` is the one place a `chunk[1]` slip could hide, and
+`clump_paired_bam_rejects_report_that_aliases_an_input` discriminates precisely that (keyed wrong,
+pair 1 plans `y.fq_clumping_report.txt`, nothing collides, run proceeds).
+
+**2. Gate parity.** `clump_report_candidates` returns `Vec::new()` iff `no_report_file`; all four
+writers skip iff `!no_report_file` is false. Every call site passes the same `cli.no_report_file`
+expression it passes the corresponding writer (`main.rs:559/577`, `591/607`, `634/649`, `673/706`,
+`728/744`). Position is right at all five: candidates are appended *before* the
+`preflight_output_collisions` call, which itself precedes every reader open.
+
+**3. The widened namer cannot change a written byte.** `planned` in `run_specialty_paired`
+(`main.rs:2543-2547`) is consumed only by `preflight_output_collisions`; the writers re-derive
+their own paths from `naming::*`. Confirmed by reading the function end to end, not by trusting the
+plan's three-way verification.
+
+**4. `--clock` / `--implicon` unchanged.** `vec![a, b]` extended == `push(a); push(b)` — same
+paths, same order, so even the *first-offender* path named in an error message is unchanged.
+`clock_collision_gets_the_cwd_hint_not_the_false_advice` (`:642`) passes.
+
+**5. `run_specialty_paired`'s doc-comment mode list is now complete.** Exactly three callers exist
+(`:483` clock, `:498` implicon, `:547` clump paired); `--hardtrim5/3` use their own loops, so the
+list "(`--clock`, `--implicon`, `--clump_only --paired`)" is exhaustive rather than merely longer.
+
+**6. No fifth writer.** `grep clumping_report_name src/` returns only the `io.rs` definition, the
+four `clump_only.rs` writer sites, two `clump_only.rs` tests, the two `io.rs` property tests, and
+`main.rs:128` (the new helper). The trim-path `--clumpify` writes no clumping report.
+
+**7. Hint constant has no string-continuation whitespace defect.** Every continuation line in
+`main.rs` ends with a space before the `\` (verified by regex `[^ ]\\$` over the whole file —
+zero hits). The rendered text was confirmed by running the repro:
+
+> `Output path collision (case-insensitive, for APFS/NTFS safety): …/out/reads.fq_clumping_report.txt and …/out/reads.fq_clumping_report.txt would be written to the same file. Outputs and reports are named from the input filename alone, so inputs sharing a filename can collide when --output_dir (or a shared input directory) sends them to one place — rename one input, or pass --no_report_file if only the reports collide.`
+
+The wording matches the plan's approved text verbatim (backticks dropped, correct for stderr). The
+old doc comment on the constant was actually *wrong* — it described `CWD_OUTPUT_HINT`'s role — so
+the rewrite fixes a stale comment as well as stale prose. Both pre-existing use sites (`:838` trim
+paired FASTQ, `:1942` trim→uBAM) were re-read: their surrounding comments reference `#388` and the
+`_val_` discriminator, not the hint's wording, so nothing went stale there.
+
+**8. No new false-rejection class from report-vs-primary.** Report names always end
+`_clumping_report.txt`; clump primaries end `_clumped.fq`, `_clumped.fq.gz`, or `_clumped.bam`. The
+two families can never be equal, so the only new candidate-pair dimension is report-vs-report and
+report-vs-input, both of which are genuine overwrites. The `--no_report_file` acceptance siblings
+plus `clump_paired_accepts_distinct_filenames`'s exact-set assertion pin this from the other side.
+
+**9. Property-test direction is sound.** The new 3×3 cross-product (primaries
+`single_end_output_name` / `clumped_output_name` / `clumped_bam_output_name` vs secondaries
+`report_name` / `json_report_name` / `clumping_report_name`) asserts nine instances of one true
+implication: all three primaries key on the *stem*, all three secondaries on the *full filename*,
+and both resolve directory identically (`output_dir` else the input's own parent). Distinct stems
+imply distinct filenames, so "primaries differ ⇒ secondaries differ" holds in every cell.
+
+---
+
+## Efficiency
+
+Nothing beyond the plan's O(paths) claim. Candidate growth is 2P → ≤4P on the paired FASTQ arm and
++1 per input/pair elsewhere; `preflight_output_collisions` remains two hash lookups per candidate
+with `HashMap::with_capacity(planned.len())`. Allocation delta is one `Vec` per helper call plus one
+per pair on the paired arm — on a code path about to read gigabytes. `slice::from_ref` in the Shape
+A loop avoids a per-chunk temporary array. Making the helper return an iterator would remove one
+`Vec` per call at the cost of complicating the gate; not worth it. **No findings.**
+
+---
+
+## Errors
+
+No bugs found. Two non-issues checked and closed:
+
+- `clump_report_candidates` returns `Vec` rather than `Result` — correct, since unlike
+  `planned_secondary_outputs` (which reads the demux barcode file) it performs no I/O.
+- `clumping_report_name`'s `file_name().unwrap_or_default()` yields an empty name for a path
+  ending in `..`; pre-existing, and such a path fails as an unreadable input earlier.
+
+The closure at `main.rs:553` newly captures `&cli` (for `cli.no_report_file`) alongside
+`run_specialty_paired(&cli, …)`'s own immutable borrow. Both immutable, and the `run_pair` closure
+already captured `cli`, so no new borrow surface. Compiles and passes.
+
+---
+
+## Findings and recommendations
+
+### M1 — CHANGELOG omits the new case-only over-rejection (Medium)
+
+Verified live on this build:
+
+```
+--clump_only --paired -o out a/Reads.fq b/reads.fq
+→ Error: … out/Reads.fq_clumping_report.txt and out/reads.fq_clumping_report.txt
+  would be written to the same file.
+```
+
+Both primaries (`Reads_clumped_1.fq` / `reads_clumped_2.fq`) differ even folded, so this run
+succeeded before the patch and on a case-sensitive filesystem both reports genuinely could
+coexist. It is the same loud-error-over-silent-loss trade #216 established — and #388's CHANGELOG
+entry spells it out explicitly for its own change ("two genuinely distinct inputs whose filenames
+differ only in case are refused even on a case-sensitive filesystem, where both reports could in
+fact coexist"). #391's entry does not mention it, so a user hitting the refusal on ext4 has no
+release note to point at.
+
+**Recommendation:** add one sentence to the #391 bullet mirroring #388's, e.g. *"As with #388, two
+inputs whose filenames differ only in case are now refused into a shared output directory even on a
+case-sensitive filesystem, where both reports could coexist."*
+
+### M2 — no fold-equal integration test on the clump arms (Medium)
+
+`paired_rejects_fold_equal_filenames_into_shared_output_dir`
+(`tests/integration_output_collision.rs:886`) is #388's dedicated fold-dimension test — six lines.
+The clump set has no counterpart: `clump_paired_rejects_cross_pair_report_collision` uses
+*exactly*-equal filenames (`a/x.fq a/y.fq b/y.fq b/x.fq`). The plan's Behavior 2b promised
+"cross-pair **fold-equal** report names under `-o`" but the test it specced in step 8 is the
+exact-equal shape, so the gap is inherited from the plan rather than introduced here. The
+`io.rs` property test covers the fold dimension at the *namer* level; nothing exercises an actual
+fold-equal clump-report rejection end to end.
+
+**Recommendation:** add the six-line twin of `:886` (rejection asserted, so filesystem-independent);
+M1's message shows both distinct filenames, so it can pin both. This is also the only clump test
+that would exercise the `collision_key` fold path through the whole binary.
+
+### M3 — no over-rejection guard for `output_dir = None` (Medium)
+
+#388 has `paired_report_candidates_do_not_over_reject` (`:970`), whose third case exists precisely
+to pin that report candidates honour `output_dir = None`. The clump set has no equivalent, and the
+consequence is concrete: a helper that resolved report directories into `-o`-or-cwd instead of each
+input's own parent would pass **all nine** new tests. Walking them —
+`clump_paired_rejects_shared_mate_report_without_output_dir` and
+`clump_se_rejects_report_that_aliases_an_input` both still reject under that mutation (paths
+normalise to the same keys), the two `--no_report_file` cases plan no reports at all, and the rest
+pass `-o`.
+
+Verified the missing shape currently behaves correctly:
+
+```
+--clump_only --paired A/reads.fq B/reads.fq        (no -o)  → exit 0
+A/: reads.fq  reads_clumped_1.fq  reads_clumped_2.fq  reads.fq_clumping_report.txt
+B/: reads.fq  reads.fq_clumping_report.txt
+```
+
+Mitigating: `clumping_report_name`'s `None` rule is unit-pinned at `io.rs:958-959`, and the helper
+delegates to it rather than re-deriving, so the mutation is not reachable without editing `io.rs`.
+That is what keeps this Medium rather than High.
+
+**Recommendation:** add `clump_report_candidates_do_not_over_reject` in the shape of `:970` —
+same filename in two directories, no `-o`, assert exit 0 and both per-input reports beside their
+own inputs. It closes the file's own stated convention ("every rejection case … paired with an
+acceptance case on the same dispatch path") and doubles as executable documentation of the
+primaries-follow-R1 / reports-follow-each-mate asymmetry the plan lists as a follow-up.
+
+### L1 — `assert_dir_holds_only` no longer says which directory failed (Low, trivial fix)
+
+The generalised message (`tests/…:86-89`) dropped "a rejected run must write nothing" without
+gaining the directory name, and this diff is the first caller to invoke it three times in one test
+(`clump_paired_rejects_shared_mate_report_without_output_dir` checks `p/`, `d/`, `q/`). On failure
+you get two unlabelled file lists.
+
+**Trivial fix:** `"{} must hold exactly the expected files", dir.display()`.
+
+### L2 — three-line inline comment against the project's two-line max (Low, trivial fix)
+
+`main.rs:630-632`. Suggested two-line form: `// #391 — defensive symmetry: with one input the
+report can never alias it; / // the arm keeps its siblings' shape.` The other new inline comments
+(`:550-551`, `:589`, `:670-671`, `:726`) are within budget. The 4-line `///` doc on
+`clump_report_candidates` matches `planned_secondary_outputs`' 8-line doc directly above it, so it
+reads as house style rather than excess.
+
+### L3 — `io.rs:1239-1241` undersells and slightly misdescribes its own fixture (Low, trivial fix)
+
+"primaries fold-collide (skipped pair)" reads as though the new `d/SAME.fastq.gz` input proves
+nothing. Its actual role is stronger and worth recording: it *couples the skip predicate to the
+assertion metric*. Under the old `a == b` skip, `d/SAME` vs `d/same` with `-o` would not be skipped
+(the two `PathBuf`s differ), and the new `collision_key`-based secondary assertion would then
+**fail**. The fixture is what makes the `collision_key` skip load-bearing rather than cosmetic.
+
+**Trivial fix:** `// Fold-equal twin of d/same: the skip must use collision_key, not PathBuf
+equality (#391).`
+
+### L4 — `io.rs:1311-1313` doc invites a misreading (Low)
+
+The doc now says "`_clumped_N` inverts it the same way, #391" three lines above an assertion that
+`clumped_paired_bam_output_name` does **not** invert (it collapses three spellings onto one
+primary). Both statements are true of different namers: the inverting one is
+`clumped_paired_output_names` (FASTQ, `_clumped_1`/`_clumped_2`), which is deliberately covered by
+*neither* property test because the property is false there — that is the whole of #391. Worth one
+clause naming which namer inverts, so the next reader does not think the added `clumped_pe_bam`
+block contradicts the doc.
+
+### L5 — the helper's "unit-testable" justification is unrealised (Low, informational)
+
+`clump_report_candidates` takes a bare leading `bool` (rather than `&Cli`, as
+`planned_secondary_outputs` does) partly so it can be unit-tested in isolation. `src/main.rs` has
+no `#[cfg(test)]` module and is the bin crate, so the helper is unreachable from both unit and
+integration tests; the signature choice buys nothing today. Behaviour is fully covered by the nine
+integration tests, and the shape matches its neighbour, so no change is needed — flagged only so
+the claim is not relied on later. Moving it into the library (beside `naming`) would make it
+testable and put it next to the namer it wraps; that is a refactor, not a fix.
+
+### L6 — two idioms now coexist for one job (Low)
+
+`main.rs` builds clump report candidates through a helper but trim report candidates inline at
+`:825-832` and `:1931-1937` (both from #388). A `trim_report_candidates` twin would unify them and
+remove the second inline copy. Follow-up material — doing it here would widen a bug-fix diff into
+the trim paths.
+
+### L7 — `docs/…/modes/clump-only.md` is wrong in exactly this area (Low, separate issue)
+
+Both pre-existing, neither introduced here, and #388 set the precedent of not touching docs — but
+they misdescribe the mechanism #391 is about:
+
+- `:109` calls the report `<stem>_clumping_report.txt`. It is `<input-name>_clumping_report.txt`,
+  as `:45` of the same page correctly says. Stem-vs-full-name is the exact confusion that produced
+  #391.
+- `:122` says "Multi-pair PE runs produce one report per pair" unscoped. True on the uBAM arm
+  (`clump_only.rs:1083`), false on the paired FASTQ arm, which writes one report per *mate*
+  (`clump_only.rs:534-536`) — as `clump_paired_accepts_distinct_filenames` now asserts.
+
+### L8 — CHANGELOG placement (Low, editorial)
+
+#391's bullet is first in `#### Bug fixes`, #388's is last, 116 lines apart, though they are one
+defect family and #391's prose recapitulates #388's mechanism. The section is not in merge order
+(#388 merged most recently), so there is no rule being broken — but the release notes would read
+better with the two adjacent. Felix's call.
+
+---
+
+## Pre-existing residual, re-confirmed (no action)
+
+The report-vs-report message prints the same path twice ("`…/out/reads.fq_clumping_report.txt` and
+`…/out/reads.fq_clumping_report.txt`"), because `preflight_output_collisions` has no input
+provenance. Confirmed live. Already recorded as a plan follow-up (B-A3); the hint's
+`--no_report_file` clause is what makes the message actionable in the meantime.
+
+---
+
+## Test-convention audit
+
+Conforms to the file's established conventions:
+
+- Unique `tempdir` tags — all 45 in the file are distinct, and `remove_dir_all` targets exact
+  paths, so the prefix-sharing pairs (`clump_rep` / `clump_rep_norep`, `clump_se_alias` /
+  `clump_se_alias_ok`) cannot wipe each other.
+- Rejection/acceptance pairing on the same dispatch path: paired FASTQ (4 rejections + 2
+  acceptances), SE FASTQ (1 + 1), Shape A uBAM (1 + 0 — acceptance covered by the pre-existing
+  multi-pair BAM tests). The two gaps are M2 and M3.
+- Attributable read prefixes throughout (`CR1`, `CN1`, `D1`, `X1`, `MX`, `B1`, `SRC`, `REPORTY`,
+  `PX`, `PR`), and acceptance cases assert content via `count_reads_from` rather than mere
+  existence.
+- Test names mirror the #388 family (`clump_paired_rejects_cross_pair_report_collision` beside
+  `paired_rejects_cross_pair_report_collision`), which makes the two sets readable together.
+- Doc comments explain *why each test would fail without the fix*, matching the module's tone.
+  `clump_paired_bam_rejects_report_that_aliases_an_input`'s comment naming the exact surviving
+  mutation is the strongest of the nine.
+
+`assert_dir_holds_only`'s repurposing for acceptance-side exact-set assertions (documented as a
+deviation) is the right call — it is the assertion that pins "candidate list == written set", the
+invariant whose absence caused both #388 and #391.

--- a/plans/08082026_clump-paired-report-preflight/CODE_REVIEW_B.md
+++ b/plans/08082026_clump-paired-report-preflight/CODE_REVIEW_B.md
@@ -1,0 +1,311 @@
+# Code Review B — #391 clumping reports join the `--clump_only` collision pre-flights
+
+**Branch:** `fix/391-clump-report-preflight` @ `2704b52` (base `dev` @ `7ea2741`)
+**Plan:** `plans/08082026_clump-paired-report-preflight/PLAN.md` (r2 + Implementation notes)
+**Reviewer:** B (independent; Reviewer A reviews the same diff separately)
+**Files reviewed:** `src/main.rs`, `src/io.rs`, `tests/integration_output_collision.rs`, `CHANGELOG.md`
+**Files edited by this review:** none (recommend-only, per instructions)
+
+## Summary
+
+**Verdict: approve.** No correctness defect found. Every one of the five clump arms passes exactly
+the report-keyed inputs its writer uses; the `no_report_file` gate is identical in polarity to all
+four writers; the widened namer provably cannot change a written path; `--clock`/`--implicon` plan
+byte-identical candidate lists to before. The reworded hint constant assembles correctly (verified
+by extracting the literal from the built binary — no lost or doubled spaces at the five
+continuations, em-dash intact).
+
+Findings are all non-blocking: one **pre-existing docs statement that this PR proves false**
+(Medium), four small test/property-test coverage gaps (Low), and four comment/style nits (Low).
+
+### Independent verification performed
+
+| Check | Result |
+|---|---|
+| `cargo test` (full) | 557 passed, 0 failed (matches the implementation note) |
+| `cargo test --test integration_output_collision` | 43 passed (9 new + 34 pre-existing) |
+| `cargo test --test integration_clump_only --test integration_clump_only_ubam` | 12 + 15 passed |
+| `cargo fmt --all -- --check` | clean |
+| `cargo clippy --all-targets -- -D warnings` | clean |
+| Hint literal, extracted from `target/debug/trim_galore` | correct spacing, em-dash preserved |
+| Assembled rejection message, run against live fixtures | correct (see Logic §5) |
+| **Over-rejection probe** (not in the test suite) | legitimate no-`-o` same-filename paired run still exits 0 and writes both reports (see Logic §6) |
+
+Not verified by me: the expected-fail control against the unpatched tree. The tree is shared with
+other agents and I was told not to switch branches. I confirmed the *mechanism* by inspection
+instead — pre-patch the paired closure returned only the two primaries, so the two identical report
+paths were never hashed, and on the SE/Shape A alias shapes the report path was never compared
+against the input list. The claim is sound; I am relying on the caller's run for the empirical half.
+
+---
+
+## Logic
+
+### 1. Candidate inputs match the writers' keys — all five arms
+
+Re-derived from the writers, not from the plan:
+
+| Arm | Writer + key | Candidate call | Match |
+|---|---|---|---|
+| SE FASTQ | `clump_only.rs:365-366`, `clumping_report_name(input, …)` per input | `main.rs:590`, `&cli.input` | ✅ |
+| Paired FASTQ | `clump_only.rs:534-536`, both `input_r1` and `input_r2` in one gate | `main.rs:558`, `&[r1, r2]` | ✅ |
+| SE BAM | `clump_only.rs:836-837`, per input | `main.rs:727`, `&cli.input` | ✅ |
+| Paired BAM Shape A | `clump_only.rs:1082-1084`, ONE report keyed `inputs[0]` where `inputs` = `chunk` (`main.rs:696`) | `main.rs:672`, `std::slice::from_ref(&chunk[0])` | ✅ |
+| Paired BAM Shape B | same writer, `inputs[0]` where `inputs` = `&cli.input` len 1 (`main.rs:640`) | `main.rs:633`, `&cli.input` | ✅ |
+
+`grep clumping_report_name src/` confirms no fifth writer (the only other hits are two `clump_only.rs`
+test bodies and the helper itself). `--clumpify` on the trim path writes no clumping report — the
+only mention outside `clump_only.rs`/`io.rs` is a doc string in `cli.rs:186`.
+
+### 2. Gate parity — identical polarity and position
+
+All four writers gate on `if !no_report_file` and on nothing else: no zero-record short-circuit, no
+"only when stats non-empty" condition, no early `return` between the primary write and the report
+write that would skip it. The helper's `if no_report_file { return Vec::new(); }` is the exact
+complement. Position differs harmlessly: the writers write reports *after* the primary and only on
+success, so the pre-flight is conservative (it can plan a report a failing run never writes) — the
+same conservatism #388 already shipped on the trim path.
+
+### 3. The widened namer cannot change a written path
+
+`run_specialty_paired` consumes `pair_outputs`' return value at exactly one place — `planned.extend(…)`
+at `main.rs:2545` — and `planned` feeds only `preflight_output_collisions` at `:2547`. `run_pair` is a
+separate closure that re-derives its own paths inside `clump_only::*`. Verified by reading the whole
+function (`main.rs:2531-2571`); there is no second consumer.
+
+### 4. `--clock` / `--implicon` unchanged
+
+`(a, b)` → `vec![a, b]` preserves both element order and content, and the old driver pushed `o1` then
+`o2` in that same order. The planned list is therefore byte-identical, and their hint argument
+(`CWD_OUTPUT_HINT`) is untouched. `clock_collision_gets_the_cwd_hint_not_the_false_advice` still
+passes, including its negative assertion that the generic advice does not appear.
+
+### 5. Hint: correct string, and a free improvement
+
+Extracted from the binary:
+
+> Outputs and reports are named from the input filename alone, so inputs sharing a filename can
+> collide when --output_dir (or a shared input directory) sends them to one place — rename one input,
+> or pass --no_report_file if only the reports collide.
+
+Each of the five continuation lines ends with a space before the `\`, so no words are joined. The
+statement is true at all three use sites (`main.rs:552`, `:838`, `:1942`); the clause it replaced
+("collide **regardless of source directory**") was false at all three, since reports follow each
+mate's own parent on the FASTQ arms.
+
+Unremarked side effect worth knowing: on the clump-paired arm a *primary*-vs-primary collision
+previously rendered `GENERIC_ADVICE` ("different source directories or `--output_dir`"), which is
+false advice for a user who already passed `-o` and already has different source directories. Those
+messages improve too. Nothing pins `GENERIC_ADVICE` (`grep` finds only the two negative assertions in
+the hardtrim/clock tests and the `io.rs` unit test, all green), so this is safe.
+
+Pre-existing wart, unchanged and correctly deferred to the plan's follow-up list: a report-vs-report
+collision prints the *same path twice*, e.g.
+
+```
+Error: Output path collision (…): /…/out/reads.fq_clumping_report.txt and
+/…/out/reads.fq_clumping_report.txt would be written to the same file. Outputs and reports are …
+```
+
+The reworded hint ("inputs sharing a filename") does soften it — the user can at least infer what to
+rename, which the old text could not express.
+
+### 6. Over-rejection: probed, and clean
+
+The direction reviews usually miss. Two checks:
+
+- **Cross-class impossible by construction.** A primary always ends `_clumped.fq`, `_clumped.fq.gz`
+  or `_clumped.bam`; a report always ends `_clumping_report.txt`, and `.txt` is not stripped by
+  `strip_fastq_extensions`. So a report candidate can never fold-equal a primary candidate, and the
+  new entries cannot manufacture a collision between two things that are both written.
+- **The legitimate same-filename shape still runs.** I ran the debug binary on
+  `--clump_only --paired a/reads.fq b/reads.fq` with **no** `-o`: exit 0, primaries
+  `a/reads_clumped_1.fq` + `a/reads_clumped_2.fq`, and **two** reports, one in each mate's own
+  directory. That is the shape the directory asymmetry makes legal, and the fix leaves it legal.
+  It is also the one behaviour this PR does not pin — see Recommendation R2.
+
+### 7. Edge cases re-checked upstream of the change
+
+- Odd input counts: rejected in `validate_paired_input` (`cli.rs:527`), so `chunk[1]` is always safe.
+- `--clump_only --paired` N=1 FASTQ: rejected at `main.rs:539` before the driver.
+- Behaviour 2c really does reach the pre-flight: `validate_paired_input` rejects only within-pair
+  R1==R2 (`cli.rs:537`) and *exact* duplicate pairs (`cli.rs:549`), and the general duplicate scan is
+  `!self.paired`-gated (`cli.rs:633`). A file reused as the mate of two different pairs passes — which
+  is exactly what `clump_paired_rejects_shared_mate_report_without_output_dir` exercises.
+- `--basename` with 2 paired inputs is allowed (`cli.rs:651` only rejects `> 2`), so the `--basename`
+  variant of the repro is a valid invocation.
+- `--no_report_file` is unconditionally accepted (`cli.rs:232`, no validate interaction), so the
+  hint's remedy is valid at all three hint sites including the uBAM-out one.
+
+---
+
+## Efficiency
+
+Matches the plan's O(paths) claim; nothing to flag. The paired closure's `vec![o1, o2]` + `extend`
+may realloc once from capacity 2 to 4 per pair — on a code path about to read gigabytes. The
+pre-flight remains two hash lookups per candidate. `impl AsRef<Path>` monomorphises to two instances
+(`&Path`, `PathBuf`).
+
+One cosmetic redundancy in the property test: `clumped_bam_output_name` ignores `gzip`, so its primary
+set is rebuilt identically for `gzip=true` and `gzip=false` — 8 iterations where 4 would do. Unit-test
+noise only, not worth changing.
+
+---
+
+## Errors
+
+No bugs found. Specifics checked and clear: no `unwrap`/index added on a fallible path; the helper
+cannot panic (empty slice yields an empty Vec); `from_ref(&chunk[0])` is bounds-safe because
+`chunks(2)` guarantees a non-empty chunk; no new I/O ordering (the pre-flight still precedes every
+reader open on all five arms).
+
+---
+
+## Structure and tests
+
+### Tests match the file's conventions
+
+All nine follow the established shape: unique `tempdir` tags (verified — all 45 tags in the file are
+distinct, and the near-prefix pairs `clump_rep`/`clump_rep_norep` and
+`clump_se_alias`/`clump_se_alias_ok` are sibling directories, so the `remove_dir_all`-at-start hazard
+B-V5b warned about does not apply), attributable read prefixes (`CR1`/`CN1`/`PX`/…), rejection cases
+paired with acceptance cases, acceptance cases asserting content rather than existence, and
+`assert_dir_holds_only` for the no-`-o` cases where `assert_rejected_cleanly`'s empty-directory form
+cannot apply. `clump_paired_rejects_shared_mate_report_without_output_dir` open-codes the
+`!ok` + `DUP_MSG` asserts instead of using the helper, matching
+`hardtrim5_rejects_same_basename_across_dirs_without_output_dir`.
+
+The Shape A test does discriminate what it claims: keyed on `chunk[1]`, pair 1 would plan
+`y.fq_clumping_report.txt`, which collides with nothing, and the run would proceed.
+
+### `assert_dir_holds_only` message change
+
+Correct and necessary — the helper now serves acceptance-side exact-set assertions, so
+"a rejected run must write nothing" would have been a false diagnostic. `assert_rejected_cleanly`
+keeps its own version of that wording for the empty-directory case, so nothing is lost.
+
+### Items to consider (none blocking)
+
+**I1 [Medium] — `docs/…/modes/clump-only.md:122` states something this PR proves false.**
+"Multi-pair PE runs produce one report per pair, matching v1 SE's one-report-per-input convention."
+True for the uBAM shapes (`clump_only.rs:1082`, one report keyed `inputs[0]`), **false for paired
+FASTQ**, which writes one report *per mate* (`clump_only.rs:534-548` — and my live run produced both
+`a/reads.fq_clumping_report.txt` and `b/reads.fq_clumping_report.txt`). The sentence sits in the
+generic "Reorder report" section with no shape qualifier. Pre-existing, so out of the diff's strict
+scope — but the per-mate paired-FASTQ report topology is the entire subject of #391, and a reader
+reaching for the docs to understand the new rejection lands on the one sentence that contradicts it.
+Cheapest fix, one line: *"Paired FASTQ runs write one report per mate; the uBAM shapes write one per
+pair, matching v1 SE's one-report-per-input convention."* Precedent exists (no prose docs were added
+for #383/#385/#388's rejections, so **not** adding rejection docs here is consistent — this is about
+the false sentence only).
+
+**I2 [Low] — property-test coverage: `clumped_paired_bam_output_name` missing from `primary_sets`.**
+`io.rs:1251-1264` covers `single_end_output_name`, `clumped_output_name`, `clumped_bam_output_name`,
+but not the Shape A primary namer — and that test carries the direction that licenses "hash primaries
+alone" (distinct primaries ⇒ distinct secondaries). The sibling test at `:1368` does cover it, but
+only in the coarser-than direction. The gap is latent rather than live, because
+`clumped_paired_bam_output_name` currently ignores its `_input_r2` parameter and is therefore
+identical in shape to `clumped_bam_output_name`; if anyone ever makes it *use* R2 (a combined stem,
+say), Shape A's A3 licence would silently lapse. One line closes it.
+
+**I3 [Low] — stale doc comment on the test that changed most.**
+`io.rs:1211-1227` still reads "Single-end naming only: paired `_val_N` primaries break this (#388)"
+and says nothing about now covering the clump namers or about the switch from `PathBuf` equality to
+`collision_key`. The *sibling* test's doc got its #391 note (`:1310-1315`); this one did not. Strictly
+speaking "single-end naming only" is still true of the namers tested, so this is an omission rather
+than an error.
+
+**I4 [Low] — `clump_paired_rejects_cross_pair_report_collision` is not attributable.**
+It asserts `DUP_MSG` only. The plan's reason for skipping a filename pin was candidate order deciding
+*which* report gets flagged — but the class suffix is order-independent: whichever report collides,
+`_clumping_report.txt` appears. Adding `assert!(stderr.contains("_clumping_report.txt"))` buys
+attribution without reintroducing the fragility. Trivial fix.
+
+**I5 [Low] — no acceptance sibling on the Shape A dispatch path.**
+The module doc (`tests/integration_output_collision.rs:11-14`) states the file's invariant: "Every
+rejection case here is paired with an acceptance case on the same dispatch path and output format."
+`clump_paired_bam_rejects_report_that_aliases_an_input` has none. The path *is* covered elsewhere —
+`integration_clump_only_ubam.rs::multi_pair_pe_bam_produces_one_output_per_pair` runs two pairs with
+reports on — so this is a consistency gap in the file's own contract, not a coverage hole. Either add
+the `--no_report_file` sibling or note the cross-file coverage.
+
+**I6 [Low] — comments exceeding the two-line maximum.**
+`main.rs:630-632` (Shape B defensive-symmetry note) and `io.rs:1248-1250` (the `#391` note above
+`primary_sets`) are three lines each; both condense to two without losing the fact. Trivial fix.
+
+**I7 [Low, optional] — `clump_report_candidates`' doc third sentence is CHANGELOG material.**
+"The pre-flight is only as complete as its candidate list: #391 was the paired arm planning primaries
+alone while the writer also wrote per-mate reports." — history, recoverable from `git log -L`. That
+said, `planned_secondary_outputs` directly above it carries an eight-line doc of exactly this kind, so
+keeping it is the *locally consistent* choice. Flagging for the record only; my recommendation is to
+leave it.
+
+**I8 [Low] — stale line reference in a comment this diff re-indented.**
+`io.rs:1270` says `cli.rs:620`; the multi-input `--basename` guard is at `cli.rs:624`. Pre-existing
+text, but the diff moved it, so it is fair drive-by scope. Trivial fix.
+
+**I9 [Low, informational] — the plan's "unit-testable" rationale for the helper is not realised.**
+`src/main.rs` has no `#[cfg(test)]` module (verified: `cargo test` reports 0 tests for the `main.rs`
+target), so `clump_report_candidates` is only exercised through the integration tests. That is
+consistent with its neighbours `planned_secondary_outputs` and `planned_hardtrim_outputs`, so I would
+**not** move it into the library just for testability — recording it so the plan's phrasing isn't
+mistaken for coverage that exists.
+
+**I10 [Low, informational] — a justification was dropped at the clump-paired call site.**
+The replaced comment explained why the hint was `None` ("`clumped_paired_output_names` uses
+`input.parent()`, not the CWD" — i.e. `CWD_OUTPUT_HINT` would be false here). A future reader of
+`main.rs:550-552` can no longer see why the *other* hint constant is wrong for this arm. The two
+constants' doc comments carry part of it (`:55-56`, `:64`). Optional half-line.
+
+### Duplication note (no action recommended)
+
+There are now three spellings of "collect the report paths a run plans":
+`planned_secondary_outputs` (SE trim, returns `Result`, also handles demux), the two inline
+`if !cli.no_report_file { for input in [&chunk[0], &chunk[1]] { … } }` blocks at `main.rs:827` and
+`:1931` (paired trim FASTQ and uBAM, from #388), and now `clump_report_candidates`. Unifying them
+would touch #388's shipped paths for no behavioural gain; the right time is whenever those two inline
+blocks next need editing.
+
+---
+
+## Out-of-scope observations (surface, don't fix here)
+
+- **`--clump_only`'s `--help` text is stale.** `cli.rs:195` lists `--output-format ubam` among the
+  flags "rejected" under `--clump_only`, and `cli.rs:206` says "v1 is FASTQ in / FASTQ out only. uBAM
+  in/out is a natural follow-up." Both predate the shipped uBAM arms this PR just extended. User-facing
+  text; worth its own issue.
+- **FastQC side-outputs remain outside every candidate list.** Under `--clump_only --fastqc`, an input
+  named `s_clumped_fastqc.zip` can still be overwritten. Pre-existing and already acknowledged as a
+  known residual in `io.rs:1222-1227`; unchanged by this diff.
+
+---
+
+## Recommendations, by priority
+
+**Critical / High:** none.
+
+**Medium**
+
+- **R1 (I1)** — fix `docs/…/modes/clump-only.md:122`'s "one report per pair" sentence, which this
+  change proves false for paired FASTQ. One line, in this PR or as a filed follow-up. *Trivial fix.*
+
+**Low**
+
+- **R2 (Logic §6)** — add the over-rejection acceptance test the family's own model provides
+  (`paired_report_candidates_do_not_over_reject` at `tests/integration_output_collision.rs:1006`):
+  same-filename mates, **no** `-o`, expect exit 0 with both primaries in R1's directory and one report
+  in *each* mate's directory. I verified this behaviour by hand; nothing in CI pins it, and the
+  per-mate report-directory rule is currently pinned only from the rejection side. Highest-value item
+  in this list.
+- **R3 (I2)** — add `clumped_paired_bam_output_name` to `primary_sets` in
+  `distinct_primary_outputs_imply_distinct_secondary_outputs`. One line.
+- **R4 (I4)** — add the order-independent `_clumping_report.txt` substring assertion to
+  `clump_paired_rejects_cross_pair_report_collision`. *Trivial fix.*
+- **R5 (I3)** — refresh `io.rs:1211-1227`'s doc comment: clump namers now covered, comparison now via
+  `collision_key`. *Trivial fix.*
+- **R6 (I6, I8)** — condense `main.rs:630-632` and `io.rs:1248-1250` to two lines; correct
+  `cli.rs:620` → `cli.rs:624` at `io.rs:1270`. *Trivial fixes.*
+- **R7 (I5)** — either add the Shape A `--no_report_file` acceptance sibling or note the cross-file
+  coverage, so the module doc's stated invariant stays literally true.
+
+**Informational (no action):** I7, I9, I10, and both out-of-scope observations.

--- a/plans/08082026_clump-paired-report-preflight/COVERAGE.md
+++ b/plans/08082026_clump-paired-report-preflight/COVERAGE.md
@@ -1,0 +1,161 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs plan — no separate IMPL.md; ledger built from the plan's Implementation outline, Behavior, and Validation sections)
+**Plan(s):** `plans/08082026_clump-paired-report-preflight/PLAN.md` (r2, incl. Implementation notes)
+**Date:** 2026-08-08
+**Verdict:** INCOMPLETE — 1 item unresolved
+
+Branch `fix/391-clump-report-preflight` @ `2704b52`; base `dev` @ `7ea2741`; PR [#396](https://github.com/FelixKrueger/TrimGalore/pull/396) (OPEN).
+Diff scope: `CHANGELOG.md`, `src/io.rs`, `src/main.rs`, `tests/integration_output_collision.rs` — exactly the four files the plan names, and no others.
+
+## Summary
+
+- Total items: 29 (11 Implementation-outline steps + 7 Behavior items + 11 Validation rows)
+- DONE: 28
+- PARTIAL: 1
+- MISSING: 0
+- DEVIATED: 0 undocumented (2 deviations documented in the plan's Implementation notes; both verified present and both non-behavioural)
+
+The single unresolved item is one omitted **test assertion**, not a behavioural gap: `clump_se_rejects_report_that_aliases_an_input` does not assert the alias filename in stderr, which outline step 8 specifies. The pre-flight does emit it (verified by hand, below), so the assertion would pass if added.
+
+## Coverage ledger
+
+### Implementation outline (11 steps)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| O1 | `run_specialty_paired`: widen `NameFn` to `-> Vec<PathBuf>`, `planned.extend(pair_outputs(…))`, update doc comment (mode list + "every path the pair writes") | Outline 1 | DONE | `main.rs:2524-2556`. Doc comment now reads "(`--clock`, `--implicon`, `--clump_only --paired`)" and "`pair_outputs` must return EVERY path the pair will write — primaries plus gated secondaries (#391)". Loop body is a single `extend`. |
+| O2 | Add `clump_report_candidates` near `planned_secondary_outputs`, matching its doc-comment style | Outline 2 | DONE | `main.rs:114-130`, immediately after `planned_secondary_outputs` (ends `:112`). Signature matches Behavior 5 verbatim: `(no_report_file: bool, report_inputs: &[impl AsRef<Path>], output_dir: Option<&Path>) -> Vec<PathBuf>`. Doc comment carries the same "the pre-flight is only as complete as its candidate list" rationale as its neighbour. |
+| O3 | `--clock`/`--implicon` call sites wrap their two names in `vec![…]` | Outline 3 | DONE | `main.rs:485-491` (clock), `:500-506` (implicon). These are the only other `run_specialty_paired` callers (`grep` finds exactly three: `:483`, `:498`, `:547`). |
+| O4 | Clump paired-FASTQ arm: namer returns primaries + `clump_report_candidates(cli.no_report_file, &[r1, r2], output_dir)`; hint `None` → `Some(PAIRED_REPORT_HINT)`; replace the comment that justified `None` | Outline 4 | DONE | `main.rs:547-564`. Namer builds `vec![o1, o2]` then extends with the helper over `&[r1, r2]`. Old comment ("clumped_paired_output_names uses input.parent(), not the CWD") replaced by the #391 rationale. |
+| O5 | Task 2: four sibling arms extend via the helper with the per-arm inputs; Shape B framed as defensive symmetry in comment and CHANGELOG | Outline 5 | DONE | SE FASTQ `main.rs:589-594` (`&cli.input`); Shape B `:630-637` (`&cli.input`, len==1 guarded at `:618`) with the "defensive symmetry" comment; Shape A `:670-676` (`std::slice::from_ref(&chunk[0])`); SE BAM `:726-731` (`&cli.input`). Each matches its writer's key — see the writer audit below. |
+| O6 | Reword `PAIRED_REPORT_HINT` per Behavior 3; rewrite its doc comment (first constant only), naming the user sites | Outline 6 | DONE | `main.rs:55-62`. Copy is byte-identical to Behavior 3's specified text (confirmed against live stderr, below). Doc comment names all three users: "paired trim (FASTQ and uBAM out) and `--clump_only --paired` (#391)" — and `grep` confirms exactly three use sites (`:552`, `:838`, `:1942`). `CWD_OUTPUT_HINT`'s comment (`:64`) left untouched, as specified. No stale "regardless of source directory" text survives anywhere in `src/`, `tests/`, or `docs/`. |
+| O7 | io.rs property test(s) extended over the clump namers via `collision_key`; `_clumped_N`/#391 note added to the doc comment | Outline 7 | DONE | `distinct_primary_outputs_imply_distinct_secondary_outputs` (`io.rs:1229+`) now loops three primary namers (`single_end_output_name`, `clumped_output_name`, `clumped_bam_output_name`) with **all** comparisons on `collision_key`, plus a new case-variant input `d/SAME.fastq.gz`. `primary_output_key_is_coarser_than_secondary_keys` (`:1317`) adds all three clump primary namers incl. `clumped_paired_bam_output_name`. Doc comment `:1310-1315` gained "and `_clumped_N` inverts it the same way, #391". See the coverage-split note under Notes. |
+| O8 | Nine integration tests in `tests/integration_output_collision.rs`, unique `tempdir` tag each | Outline 8 | **PARTIAL** | All nine exist and pass; tags all unique (44 tags in the file, no tag is a prefix-path of another, so `remove_dir_all` cannot cross-wipe). **Gap:** test 7 (`clump_se_rejects_report_that_aliases_an_input`) omits the specified stderr assertion on the alias filename. Detail in Gaps. |
+| O9 | Expected-fail control on every rejection test vs the unpatched build; results recorded in the PR body | Outline 9 | DONE | Plan Implementation notes claim it (all six rejection tests exited 0 unpatched, the two alias cases destroying an input; three acceptance tests passed unpatched) — treated as the evidence per audit instructions. Independently confirmed the record reached PR #396's body verbatim. The six/three split matches the actual test set (6 rejection + 3 acceptance = 9). |
+| O10 | CHANGELOG under Unreleased → `#### Bug fixes`: reports join the clump pre-flights; credit the free report-vs-input closure; Shape B as defensive symmetry | Outline 10 | DONE | `CHANGELOG.md:8-18`, under the existing `#### Bug fixes` heading. All three required content points present, including "The single-interleaved-BAM shape gets the same candidate line as defensive symmetry only; with one input its report can never alias it." |
+| O11 | `cargo fmt --all -- --check`, `cargo clippy --all-targets --release -- -D warnings`, `cargo test` | Outline 11 | DONE | Run live this audit: fmt clean; clippy clean (release, `-D warnings`, no output); `cargo test` 557 passed / 0 failed across 14 binaries. Step 11's note re-verified: no test pins `GENERIC_ADVICE` or any hint text; the only hint fragment pinned by the new tests is `--no_report_file`. |
+
+### Behavior (7 items)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| B1 | Pre-flight surface: per pair, two primaries + (gated) two per-mate reports; list spans all pairs; sibling arms add per-input / `chunk[0]` / single-input candidates | Behavior 1 | DONE | One `planned` vec accumulated across `cli.input.chunks(2)`, pre-flight called once after the loop (`main.rs:2547-2552`). Cross-pair coverage empirically confirmed by test 4. |
+| B2 | Newly rejected shapes (a) issue repro, (b) cross-pair fold-equal under `-o`, (c) no-`-o` shared-mate, (d) report-vs-input | Behavior 2 | DONE | (a) test 1, (b) test 4, (c) test 5, (d) tests 7 (SE FASTQ) + 9 (Shape A). All five rejection paths verified passing; (c) reaching the pre-flight also confirms the plan's claim that `validate_paired_input` permits one file as the mate of two different pairs. |
+| B3 | Hint fixed at the shared constant, with the specified copy; clump arm switches `None` → `Some`; first doc comment rewritten (not swapped) | Behavior 3 | DONE | Verified in live stderr: the reworded hint renders exactly as the plan specifies, em-dash intact, with correct word gaps across the `\` line continuations. |
+| B4 | `--no_report_file` parity — report candidates exist iff the writer writes them, via one shared gate; repro succeeds under the flag | Behavior 4 | DONE | Single early-return gate in the helper (`main.rs:123-125`). All four writers gate on `!no_report_file` (`clump_only.rs:365`, `:534`, `:836`, `:1082`). Tests 2 and 8 are the acceptance controls. |
+| B5 | Shared helper with the specified signature, feeding five call sites with the per-arm report inputs | Behavior 5 | DONE | Five call sites verified against the four writers: paired FASTQ `&[r1, r2]` ↔ `clumping_report_name(input_r1/input_r2)`; SE FASTQ `&cli.input` ↔ `(input)`; SE BAM `&cli.input` ↔ `(input)`; Shape A `from_ref(&chunk[0])` ↔ `(inputs[0])`; Shape B `&cli.input` (len 1) ↔ `(inputs[0])`. `grep clumping_report_name src/` finds no fifth production writer (the other two hits are in `clump_only.rs`'s own `mod tests`). |
+| B6 | No naming changes — output paths, report paths, and report contents byte-identical on accepted runs | Behavior 6 | DONE | `clump_only.rs` (all writers) untouched by the diff; every `io.rs` hunk falls inside `mod tests` (starts `:569`, hunks at `:1236`/`:1308`/`:1348`), so no naming function changed. `main.rs` changes are confined to candidate lists, the hint constant, and the namer's return type. Empirically pinned by test 3's exact-set assertion and tests 2/3/8's content verification. |
+| B7 | Edge cases: odd counts and N=1 `--paired` still rejected earlier; `--basename` reports still key on input filenames; duplicate-mate reuse tested | Behavior 7 | DONE | The N=1 `--clump_only --paired` guard (`main.rs:539-545`) is untouched context in the diff. `--basename` variant is test 6; duplicate-mate reuse is test 5. |
+
+### Validation (11 rows)
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| V1 | Issue repro rejected, attributed to the report | Validation 1 | DONE | `clump_paired_rejects_shared_report_name` passes: `assert_rejected_cleanly` (non-zero exit + collision prefix + `DUP_MSG` + empty out dir) plus separate asserts on `reads.fq_clumping_report.txt` and `--no_report_file`. |
+| V2 | Gate parity | Validation 2 | DONE | `clump_paired_accepts_shared_report_name_with_no_report_file`: exit 0, both primaries content-verified at 40 reads with source-attributable IDs, `assert_dir_holds_only` proves zero report files. |
+| V3 | Candidate list == written set | Validation 3 | DONE | `clump_paired_accepts_distinct_filenames` asserts exactly the four expected filenames (two primaries + two reports) and content-verifies both primaries. |
+| V4 | Cross-pair surface under `-o` | Validation 4 | DONE | `clump_paired_rejects_cross_pair_report_collision`: rejection only, no filename pin — matching the plan's reasoning about candidate order. |
+| V5 | Case-free no-`-o` class, on ext4 AND APFS | Validation 5 | DONE | `clump_paired_rejects_shared_mate_report_without_output_dir` passes locally (APFS). Fixtures are all-lowercase and the collision is exact-string, so the case dimension is absent by construction and the result cannot differ by filesystem. The ext4 confirmation is CI's `Rust Tests (ubuntu-latest)`, **pending** at audit time (run 31254241237) — an external confirmation in flight, not an implementation gap. |
+| V6 | Report-vs-input, SE: rejection + `ALIAS_MSG` + inputs intact; acceptance sibling | Validation 6 | DONE | Both tests pass with everything this row's expectation names. (The assertion the plan asked for beyond this row lives in O8 — see Gaps.) |
+| V7 | `chunk[0]` keying, Shape A | Validation 7 | DONE | `clump_paired_bam_rejects_report_that_aliases_an_input` passes: rejection, `ALIAS_MSG`, all four inputs present with nothing extra written (`assert_dir_holds_only`), content-verified for the two a pre-patch run would have clobbered. The discriminator holds: keyed on `chunk[1]`, pair 1 would plan `y.fq_clumping_report.txt`, collide with nothing, and the run would proceed — so a mis-keyed helper call fails this test. |
+| V8 | Report path isolated from stems | Validation 8 | DONE | `clump_paired_rejects_shared_report_name_with_basename`: `--basename foo` makes the primaries `foo_clumped_1/2` — non-colliding by construction — and the run is still rejected, naming the report. |
+| V9 | A3 held by CI | Validation 9 | DONE | Both io.rs property tests pass (`cargo test --lib io::tests` — 54 passed; second test confirmed individually). Non-vacuity witness: the new `d/SAME.fastq.gz` input fold-collides with `d/same.fastq.gz`, so it is skipped only because the guard is now `collision_key`-based — under the previous `PathBuf` guard that pair would reach the assertion and fail it. The metric change is therefore load-bearing, not cosmetic. |
+| V10 | Fix actually fires (expected-fail control) | Validation 10 | DONE | Per audit instructions, the plan's Implementation notes are the evidence; they claim all six rejection tests exited 0 against the unpatched tree. Independently confirmed the same record appears in PR #396's body. |
+| V11 | No collateral | Validation 11 | DONE | Live: 557 tests green (0 failed), fmt clean, clippy `-D warnings` clean. The three existing tests the plan singled out all exist and are in the green set: `pe_byte_identity` (`tests/integration_clump_only.rs:142`), `multi_pair_pe_bam_produces_one_output_per_pair` (`tests/integration_clump_only_ubam.rs:477`), `pe_bam_collision_preflight_case_folded` (`:630`). |
+
+### Documented deviations (Implementation notes)
+
+Both are recorded in the plan and verified present; neither changes behaviour, so per the audit rules neither is a gap.
+
+| Deviation | Verified |
+|---|---|
+| `assert_dir_holds_only`'s failure message generalized to "directory must hold exactly the expected files", since it now also serves acceptance-side exact-set assertions | Yes — `tests/integration_output_collision.rs:86-89`, with the doc comment updated to describe both uses |
+| `distinct_primary_outputs_imply_distinct_secondary_outputs` restructured to loop three primary namers; the demux-stem sub-check stays scoped to the SE trim namer and is now guarded by `collision_key` inequality | Yes — `src/io.rs:1247-1301`; sub-check reads `let se_primaries = &primary_sets[0];` and guards on `collision_key(a) != collision_key(b) && a.parent() == b.parent()` |
+
+## Gaps (detail)
+
+### Item O8: `clump_se_rejects_report_that_aliases_an_input` omits the specified alias-filename assertion
+
+**Expected** (outline step 8, seventh bullet): "assert `ALIAS_MSG` **+ the alias filename** (the input branch names one path only), `count_reads_from`-verified intact inputs, `assert_dir_holds_only(&dir, &[both inputs])`."
+
+**Found** (`tests/integration_output_collision.rs:1206-1221`): the test asserts non-zero exit, `stderr.contains(ALIAS_MSG)`, `count_reads_from` on the alias file (40 reads, `REPORTY`), and `assert_dir_holds_only(&dir, &["s.fq", "s.fq_clumping_report.txt"])`. There is no assertion that stderr contains `s.fq_clumping_report.txt`.
+
+**Gap:** one assertion. The pre-flight's output-vs-input branch does print the path — verified by hand against the built binary:
+
+```
+Error: Output path collision (case-insensitive, for APFS/NTFS safety): this run would
+write output to …/se/s.fq_clumping_report.txt, which is also one of its inputs. …
+```
+
+So adding `assert!(stderr.contains("s.fq_clumping_report.txt"), …)` would pass as written. Without it, the test would still pass if the rejection came from some other alias in the run rather than the clumping-report candidate — which is precisely the attribution the plan wanted pinned, and which its sibling tests (1, 5, 6) do pin on their own messages.
+
+Two related observations, recorded for completeness rather than as gaps, since the plan's own Validation rows do not ask for them:
+
+- Content verification in tests 7 and 9 covers the inputs a pre-patch run destroyed (the alias files) rather than literally all inputs; the remaining inputs are covered for existence and no-extra-writes by `assert_dir_holds_only`. Outline step 8's wording ("intact inputs" / "all four inputs intact") is satisfied in substance.
+- Outline step 7 permits "and/or", and all three clump primary namers are covered across the two property tests — but the split is asymmetric: `clumped_output_name` and `clumped_bam_output_name` are checked in **both** tests, while `clumped_paired_bam_output_name` appears only in `primary_output_key_is_coarser_than_secondary_keys`. The paired-BAM namer is therefore checked in the "spellings collapse to one primary" direction but not in `distinct_primary_outputs_imply_distinct_secondary_outputs`' "distinct primaries ⇒ distinct reports, on `collision_key`" direction. Adding it there would be a one-line `map` (`|p| clumped_paired_bam_output_name(p, None, output_dir, basename)`), matching how test 2 already invokes it.
+
+## Test verification (Mode B)
+
+`cargo test --test integration_output_collision clump` — 9 passed, 0 failed, 34 filtered out.
+
+| Test name | File | Status |
+|-----------|------|--------|
+| `clump_paired_rejects_shared_report_name` | `tests/integration_output_collision.rs:1016` | PASS |
+| `clump_paired_accepts_shared_report_name_with_no_report_file` | `:1048` | PASS |
+| `clump_paired_accepts_distinct_filenames` | `:1077` | PASS |
+| `clump_paired_rejects_cross_pair_report_collision` | `:1112` | PASS |
+| `clump_paired_rejects_shared_mate_report_without_output_dir` | `:1141` | PASS |
+| `clump_paired_rejects_shared_report_name_with_basename` | `:1175` | PASS |
+| `clump_se_rejects_report_that_aliases_an_input` | `:1206` | PASS (assertion set short of spec — see Gaps) |
+| `clump_se_accepts_report_alias_with_no_report_file` | `:1225` | PASS |
+| `clump_paired_bam_rejects_report_that_aliases_an_input` | `:1260` | PASS |
+
+`cargo test --lib io::tests` — 54 passed, 0 failed.
+
+| Test name | File | Status |
+|-----------|------|--------|
+| `distinct_primary_outputs_imply_distinct_secondary_outputs` | `src/io.rs:1229` | PASS |
+| `primary_output_key_is_coarser_than_secondary_keys` | `src/io.rs:1317` | PASS (confirmed individually as well) |
+
+Whole-suite and gate checks, run live during this audit:
+
+| Check | Result |
+|---|---|
+| `cargo test` (all 14 test binaries) | 557 passed, 0 failed, 0 ignored |
+| `cargo fmt --all -- --check` | clean |
+| `cargo clippy --all-targets --release -- -D warnings` | clean |
+| PR #396 CI | Lint, Coverage, Docs, Reproducibility, Security audit pass; `Rust Tests (ubuntu-latest)` and `(macos-latest)` pending at audit time |
+
+## Verdict
+
+**INCOMPLETE — 1 item unresolved.**
+
+Everything the plan specifies is implemented and verified except one test assertion:
+
+1. **`tests/integration_output_collision.rs`, `clump_se_rejects_report_that_aliases_an_input`** — add the stderr assertion on the alias filename that outline step 8 specifies:
+
+   ```rust
+   assert!(
+       stderr.contains("s.fq_clumping_report.txt"),
+       "the aliased path must be the clumping report:\n{stderr}"
+   );
+   ```
+
+   The message already contains that path (verified against the built binary), so this is an added assertion with no production change. Either add it, or record the omission in the plan's Implementation notes as a deliberate deviation — the plan's other five rejection tests all pin their message this way, so the asymmetry is currently undocumented.
+
+Nothing else remains. No plan item is MISSING; the two deviations in the Implementation notes are both present in the code and both non-behavioural; the ext4 leg of Validation 5 is an in-flight CI job on a test whose construction is case-free, not an implementation gap.
+
+---
+
+## Post-audit resolution (2026-08-08, caller)
+
+The single unresolved item (O8: missing alias-filename assertion in
+`clump_se_rejects_report_that_aliases_an_input`) was implemented in commit
+`d99f23e` exactly as this report specified, and passes. The same commit applied
+the review batch Felix approved (fold-equal + over-rejection tests, cross-pair
+class assertion, `clumped_paired_bam_output_name` in the distinct-primaries
+property test — closing this report's second recorded observation — plus
+CHANGELOG/docs/comment precision items). Full suite after the batch: 559
+passed, 0 failed; fmt and clippy `-D warnings` clean. With the gap closed, the
+plan's ledger stands fully covered.

--- a/plans/08082026_clump-paired-report-preflight/PLAN.md
+++ b/plans/08082026_clump-paired-report-preflight/PLAN.md
@@ -1,0 +1,144 @@
+# Plan: `--clump_only --paired` clumping reports join the collision pre-flight (#391)
+
+**Issue:** [#391](https://github.com/FelixKrueger/TrimGalore/issues/391) — filed from #388's code review (both reviewers, independently; reproduced on the #388 branch).
+**Base:** `dev` @ `7ea2741`.
+
+## Revision history
+
+- **r2 (2026-08-08):** incorporates dual plan-review (PLAN_REVIEW_A.md "approve with changes", PLAN_REVIEW_B.md "no criticals") and two maintainer decisions: **fix the shared `PAIRED_REPORT_HINT` constant** (not a new clump-specific one) and **use a shared `clump_report_candidates` helper** (not five inline blocks). Corrects four r1 prose errors (Shape B exposure over-claim A§1.5; duplicate-inputs over-claim A§1.7; "swap the comments" instruction A§1.6; `--basename` mechanism B-A4). Adds: the A3 property test (A§4.2/B-V1, both reviews' highest-value item), the Shape A representative test (A-Critical-1/B-V3), the no-`-o` cross-pair same-mate test (A§4.3), the test-5 respec (A§4.4/B-V2), the exact-set upgrade of test 3 (B-V4), the `--basename` variant of test 1 (A§4.4), expected-fail controls on every rejection test (A§4.4), unique tempdir tags (B-V5b), and the corrected A4/A5 assumptions.
+- r1 (2026-08-08): initial plan; Task 2 scope confirmed IN by Felix.
+
+## Goal
+
+`--clump_only --paired -o out A/reads.fq B/reads.fq` exits 0 with **one** clumping report: primaries carry positional discriminators (`reads_clumped_1.fq` / `reads_clumped_2.fq`) so they never collide, but `clumping_report_name` keys on the bare input filename, so both mates plan `out/reads.fq_clumping_report.txt` and R2's report silently overwrites R1's. Make the per-mate clumping-report names part of the collision pre-flight — gated on `!no_report_file` to match the writer — so this fails loudly before any I/O. Task 1 thereby also closes report-vs-**input** on the paired arm for free (the pre-flight runs its input check on every candidate — A§1.8). Task 2 extends the same candidates to the sibling clump arms, whose real exposure is the report-vs-input direction (#385 defect-2 class).
+
+## Context
+
+- **Dispatch:** `main.rs:526-550` — the `--clump_only --paired` FASTQ arm calls `run_specialty_paired` with a namer returning only the two primaries.
+- **Driver:** `main.rs:2476-2518` — the namer feeds only the pre-flight (called once, at `main.rs:2490`); written paths are re-derived by the writers (`clump_only.rs:415-416`, `535-536`). Verified three ways by review A§1.2: widening the namer's return type cannot change a written byte. Doc comment's mode list (`main.rs:2470-2471`) still reads "(`--clock`, `--implicon`)" and must gain `--clump_only --paired`.
+- **Writers and gates (all four, verified A§1.3):** SE FASTQ `clump_only.rs:365` (keyed per input); paired FASTQ `:534` (both mates in one gate, keyed on `input_r1`/`input_r2`); SE BAM `:836` (per input); paired BAM Shapes A+B `:1082` (ONE report per pair, keyed on `inputs[0]` — `clump_only.rs:1083`). `grep clumping_report_name src/` confirms no fifth writer; `--clumpify` on the trim path writes no clumping report.
+- **Namer:** `io.rs:469-482` — full input filename + `_clumping_report.txt`, into `output_dir` or **that input's own** `parent()`. Ignores `--basename`.
+- **Directory asymmetry (review finding, load-bearing):** without `-o`, the paired arm's *primaries* both go to `input_r1.parent()` (`io.rs:407-409`) while each *report* follows its own mate's parent (`io.rs:478-481`). Consequences: the hint must not claim directory-independence (see Behavior 3), and a collision class exists with no `-o` at all (see Behavior 2c). Same asymmetry exists at #388's trim site — follow-up material, not fixed here.
+- **Pre-flight:** `io.rs:96-130`. Output-vs-output errors name both paths + hint; the output-vs-**input** branch names only the input path (`io.rs:109-115`) — constrains test assertions (r1's A5 was half-wrong).
+- **`--clock`/`--implicon`:** verified unaffected — `specialty.rs` has zero report/fastqc writes.
+- **uBAM arms and report-vs-report (A3):** re-derived independently by both reviewers and airtight — report and primary key off the *same* input with the *same* directory rule, and `strip_fastq_extensions` is fold-equivariant (`strip_suffix_ignore_ascii_case` + positional `file_stem`), so a report collision implies a primary collision the pre-flight already rejects. Premises now stated explicitly: `gzip` is global, derived from `cli.input[0]` (`main.rs:351`); multi-input `--basename` never reaches these arms — rejected at `cli.rs:624` (SE) / `cli.rs:651` (paired), which is the *actual* guard (r1 cited a nonexistent primary-collision mechanism).
+- **Shape B is not exposed at all** (r1 over-claimed): it requires `input.len() == 1`, and `--passthrough`/`--demux` are rejected under `--output-format ubam` (`cli.rs:588/602`), so `guarded_inputs` is exactly the one input and the report path is that filename plus a suffix — never fold-equal to it. Task 2's Shape B line is **defensive symmetry**, and the CHANGELOG/PR must say so, not claim a closed hole.
+- **Duplicate inputs (r1 over-claimed):** `validate_paired_input` rejects only within-pair R1==R2 and *exact* duplicate pairs; the general duplicate scan (`cli.rs:631`) is SE-only. **A file reused as a mate of two different pairs passes validate** — which enables the case-free collision in Behavior 2c.
+- **Test home:** `tests/integration_output_collision.rs` (question closed in r1's favour — B§5.5: its module doc narrates this defect family and its helpers/constants are exactly what these tests need). Shared constants `DUP_MSG`/`ALIAS_MSG`/`PREFIX` at `:89-91`; models: `assert_rejected_cleanly` `:95`, `assert_dir_holds_only` `:77`, `se_trim_rejects_output_that_aliases_a_report_input` `:674`.
+
+## Behavior
+
+1. **Pre-flight surface.** Candidates per paired-FASTQ pair: the two primaries plus — when `!cli.no_report_file` — the two per-mate clumping-report paths; the list spans all pairs. The four sibling arms add their report-keyed candidates the same way (per input for SE FASTQ/BAM; `chunk[0]` per pair for Shape A; the single input for Shape B).
+2. **Newly rejected shapes** (all exit 0 with silent loss today):
+   a. the issue's repro — same filename mates, `-o`, reports collide;
+   b. cross-pair fold-equal report names under `-o`;
+   c. **no `-o`, same file as the mate of two pairs** (A§4.3): reports collide in the shared mate's own parent while all four primaries stay distinct — case-free and filesystem-independent;
+   d. report-vs-input: an input named like a clumping report is no longer silently overwritten (paired arm via Task 1; SE FASTQ/BAM and Shape A via Task 2).
+3. **Hint (maintainer decision: fix the shared constant).** `PAIRED_REPORT_HINT`'s "collide **regardless of source directory**" is false wherever reports follow their inputs' parents (this arm and #388's site alike), and "named from the input filename alone" points at the primaries, which are fine. Reword the constant once, accurately for all its sites (trim paired FASTQ `main.rs:784`, trim→uBAM `main.rs:1888`, and now this arm):
+   > "Outputs and reports are named from the input filename alone, so inputs sharing a filename can collide when `--output_dir` (or a shared input directory) sends them to one place — rename one input, or pass `--no_report_file` if only the reports collide."
+   The clump arm's hint argument changes `None` → `Some(PAIRED_REPORT_HINT)`. **Doc-comment fix is a rewrite of the FIRST comment only** (`main.rs:55-56`) — r1's "swap them" would make it self-referential (A§1.6); the second comment is already correct. The rewritten comment names all users.
+4. **`--no_report_file` parity.** Report candidates exist iff the writer will write them — one shared gate in the helper (Behavior 5). The issue's repro succeeds under `--no_report_file`.
+5. **Shared helper (maintainer decision).** One seam both auditable against the writers and unit-testable:
+   ```rust
+   /// Clumping-report paths a clump-only run plans — one per report-keyed input,
+   /// nothing when --no_report_file (matching every writer's gate).
+   fn clump_report_candidates(
+       no_report_file: bool,
+       report_inputs: &[impl AsRef<Path>],
+       output_dir: Option<&Path>,
+   ) -> Vec<PathBuf>
+   ```
+   Call sites: paired FASTQ namer closure (`&[r1, r2]`), SE FASTQ (`&cli.input` — note this arm currently builds `planned` as an iterator chain, `main.rs:553-557`; extend after collecting), SE BAM (`&cli.input`), Shape A (`std::slice::from_ref(&chunk[0])` per chunk), Shape B (`&cli.input`). The "which inputs" parameter is where a `chunk[1]` mistake could hide — that is exactly what the Shape A test discriminates (Validation 7).
+6. **No naming changes.** Output paths, report paths, and report contents are byte-identical on every accepted run.
+7. **Edge cases.** Odd input counts and N=1 `--paired` are rejected earlier (existing checks, unchanged). `--basename`: reports still key on input filenames (A1), so the repro shape rejects identically — and with `--basename` the primaries *cannot* collide (`foo_clumped_1/2`), which makes the `--basename` variant the sharpest isolation of the report path (Validation 8). Duplicate-mate reuse is *not* rejected by validate (see Context) — Behavior 2c depends on that and tests it.
+
+## Signature
+
+`run_specialty_paired`'s namer widens from `(PathBuf, PathBuf)` to `Vec<PathBuf>` — "every path this pair writes". The tuple encoded the bug: it cannot express a third planned output (B§5.1). Parameter renamed `output_names` → `pair_outputs` (not r1's `planned_outputs`, one character from the local `planned` — A§1.8). Callers: clock/implicon wrap their two names in `vec![…]`; the clump arm appends `clump_report_candidates(…)`. Rejected alternatives unchanged from r1 (optional secondary closure; duplicate pre-flight in the arm), plus one added for the record (review request): **discriminating the report name instead of rejecting** — rejected because report filenames are a published contract (`*_clumping_report.txt` deliberately dodges MultiQC's `*_trimming_report.*` glob, `io.rs:463-468`) and #388 chose rejection for the identical class; two answers to one defect class is worse than either.
+
+## Implementation outline
+
+1. `main.rs::run_specialty_paired` — widen `NameFn` to `-> Vec<PathBuf>`; `planned.extend(pair_outputs(&chunk[0], &chunk[1]))`; update the doc comment (mode list + "every path the pair writes" contract).
+2. `main.rs` — add `clump_report_candidates` (Behavior 5) near `planned_secondary_outputs` (`main.rs:89`), whose doc-comment style it follows.
+3. `--clock`/`--implicon` call sites — wrap existing names in `vec![…]`.
+4. `--clump_only --paired` FASTQ arm — namer returns primaries + `clump_report_candidates(cli.no_report_file, &[r1, r2], output_dir)`; hint `None` → `Some(PAIRED_REPORT_HINT)`; update the line-530 comment (it justified `None` against `CWD_OUTPUT_HINT`).
+5. Task 2 — the four sibling arms extend their planned lists via the helper (inputs per Behavior 5). Shape B framed as defensive symmetry in comment and CHANGELOG.
+6. Hint constant — reword `PAIRED_REPORT_HINT` per Behavior 3; rewrite its doc comment (first constant only), naming the three-plus-one user sites.
+7. **io.rs property test (both reviews' top item)** — extend `distinct_primary_outputs_imply_distinct_secondary_outputs` (`io.rs:1229`) and/or `primary_output_key_is_coarser_than_secondary_keys` (`io.rs:1293`) so the clump namers (`clumped_output_name`, `clumped_bam_output_name`, `clumped_paired_bam_output_name` vs `clumping_report_name`) are covered, comparing via **`collision_key`** (the existing `PathBuf` inequality misses the fold dimension — A§4.2). Add `_clumped_N`/#391 alongside the "`_val_N` inverts this, #388" note in the doc comment at `io.rs:1287-1291`. This machine-checks A3, which licenses the uBAM report-vs-report non-fix AND proves Task 2 rejection-neutral (its entire behavioural delta is report-vs-input — B§1.4).
+8. Integration tests in `tests/integration_output_collision.rs` (unique `tempdir` tag per test — tags share `process::id()` and `remove_dir_all` first, so a shared tag lets one test wipe another mid-run and make test 2 pass vacuously — B-V5b):
+   - `clump_paired_rejects_shared_report_name` — the repro; `assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG)` **plus** separate asserts: stderr contains `reads.fq_clumping_report.txt` (pins the collision to the report) and contains `--no_report_file` (the durable hint fragment only — B-A2).
+   - `clump_paired_accepts_shared_report_name_with_no_report_file` — same fixtures + flag; success; both primaries content-verified; zero report files. The matched negative control.
+   - `clump_paired_accepts_distinct_filenames` — upgraded to `assert_dir_holds_only(&out, &[the four exact filenames])` (B-V4): pins "candidate list == written set", the invariant whose absence is this whole family's root cause.
+   - `clump_paired_rejects_cross_pair_report_collision` — pairs (`a/x.fq`,`a/y.fq`)+(`b/y.fq`,`b/x.fq`), `-o out`; assert rejection ONLY — candidate order makes the flagged filename pair 2's report, so no filename pin (A§4.4).
+   - **New** `clump_paired_rejects_shared_mate_report_without_output_dir` — pairs (`p/a.fq`,`d/x.fq`)+(`q/b.fq`,`d/x.fq`), no `-o` (Behavior 2c). Case-free, filesystem-independent; also pins the per-mate report-directory rule.
+   - **New** `--basename` variant of test 1 — `--basename foo` forces distinct primaries by construction; reports still collide; rejected.
+   - `clump_se_rejects_report_that_aliases_an_input` — **respec'd** (r1's shape couldn't run: `assert_rejected_cleanly` demands an empty dir and the alias must sit in the report's directory): no `-o`, one dir holding `s.fq` + `s.fq_clumping_report.txt` (both valid FASTQ — content-based detection accepts a `.txt` name, and validity keeps the rejection attributable to the pre-flight, not a parse error); assert `ALIAS_MSG` + the alias filename (the input branch names one path only), `count_reads_from`-verified intact inputs, `assert_dir_holds_only(&dir, &[both inputs])`. Model: `:674`. Plus a `--no_report_file` acceptance sibling.
+   - **New** `clump_paired_bam_rejects_report_that_aliases_an_input` (Shape A — A-Critical-1): inputs `a/x.fq a/y.fq a/x.fq_clumping_report.txt a/z.fq` (all valid FASTQ), `--clump_only --paired --output-format ubam`, no `-o`; pair 1's report == input 3 → rejected, `ALIAS_MSG`, all four inputs intact. **Discriminates `chunk[0]` vs `chunk[1]`**: keyed wrong, the planned report would be `a/y.fq_clumping_report.txt`, nothing collides, and the run proceeds.
+9. **Expected-fail controls on every rejection test** (A§4.4): run each against the unpatched build first; each must fail there (A verified all exit 0 pre-patch; the SE alias case *destroys an input* pre-patch). Record the pre-patch results in the PR body.
+10. `CHANGELOG.md` — Unreleased → `#### Bug fixes` (the heading's actual name): reports join the clump pre-flights (#391); credit Task 1's free report-vs-input closure; Shape B named as defensive symmetry.
+11. `cargo fmt --all -- --check`, `cargo clippy --all-targets --release -- -D warnings`, `cargo test`. (r1's Validation-7 grep is pre-answered by both reviewers: nothing pins `GENERIC_ADVICE`; the only hint pins are `CWD_OUTPUT_HINT`'s at `:625`/`:661`, untouched. The reworded `PAIRED_REPORT_HINT` has no test pins today.)
+
+## Efficiency
+
+Candidate list grows from 2P to ≤4P (paired FASTQ) and by ≤1 per input/pair elsewhere; the pre-flight stays two hash passes, O(paths). One `Vec` allocation per pair replaces a tuple, on a path about to read gigabytes. No new I/O; the pre-flight still precedes every reader open.
+
+## Integration
+
+- Writers untouched; report names/contents unchanged; byte-identity on accepted runs is the safety claim, which is why the "one shared derivation for namer and writer" refactor (B§5.2) is deliberately NOT taken — the exact-set assertion (step 8, test 3) buys most of that protection for one line.
+- `run_specialty_paired` is `main.rs`-internal; no test references its signature.
+- Perl-parity CI matrix does not cover `--clump_only`. Existing tests verified unaffected by both reviewers (incl. `pe_byte_identity`, `multi_pair_pe_bam_produces_one_output_per_pair`, `pe_bam_collision_preflight_case_folded` — the last still trips on a *primary*, which precedes its report in candidate order).
+
+## Assumptions
+
+- **A1:** `clumping_report_name` ignores `--basename` — verified (`io.rs:469-482`).
+- **A2:** clock/implicon plan nothing beyond two primaries — verified (zero report/fastqc writes in `specialty.rs`).
+- **A3:** uBAM/SE report-vs-report collisions imply primary collisions — re-derived by both reviewers; premises now explicit (fold-equivariant stripping; same-input same-dir keying; global `gzip` from `cli.input[0]`, `main.rs:351`; multi-input `--basename` rejected at `cli.rs:624/651`). Machine-checked by step 7 from this change on.
+- **A4 (sharpened):** FastQC side-outputs on the clump paths derive from the discriminated primaries (`clump_only.rs:551-554`) and so cannot collide where primaries don't — benign here, not merely "out of scope".
+- **A5 (corrected):** the pre-flight's output-vs-output error names both paths; the output-vs-**input** branch names only the input (`io.rs:109-115`). For report-vs-report between two mates the two displayed paths are the *same string* — pre-existing, unfixable without input provenance in the pre-flight; follow-up material (B-A3).
+- **A6 (new):** content-based format detection accepts FASTQ content under any filename (first-byte `@` probe) — the premise of both alias tests.
+- **A7 (new):** Shape A's report keys on `inputs[0]` (`clump_only.rs:1083`), never `inputs[1]` — pinned by the Shape A test.
+
+## Validation
+
+| # | What | How | Expected |
+|---|------|-----|----------|
+| 1 | Issue repro rejected, attributed to the report | test 1 (DUP_MSG + report filename + hint fragment) | exit ≠ 0, out dir empty |
+| 2 | Gate parity | test 2 (same fixtures, `--no_report_file`) | exit 0, primaries content-verified, zero reports |
+| 3 | Candidate list == written set | test 3 exact-set assertion | exit 0, exactly the four expected files |
+| 4 | Cross-pair surface (`-o`) | test 4 | exit ≠ 0 (no filename pin) |
+| 5 | Case-free no-`-o` class (Behavior 2c) | shared-mate test | exit ≠ 0 on ext4 AND APFS |
+| 6 | Report-vs-input, SE | respec'd alias test + acceptance sibling | exit ≠ 0, `ALIAS_MSG`, inputs intact / sibling exit 0 |
+| 7 | `chunk[0]` keying, Shape A | Shape A alias test | exit ≠ 0, `ALIAS_MSG`, four inputs intact |
+| 8 | Report path isolated from stems | `--basename` variant of test 1 | exit ≠ 0 with primaries provably non-colliding |
+| 9 | A3 held by CI | io.rs property test over clump namers via `collision_key` | passes; fails if any clump namer's report key ever becomes finer than its primary key |
+| 10 | Fix actually fires | expected-fail control on EVERY rejection test vs the unpatched build | each fails pre-patch; results recorded in PR body |
+| 11 | No collateral | full `cargo test` + clippy + fmt | green |
+
+## Questions or ambiguities
+
+- **[Resolved r2 — Felix]** Hint: fix the shared constant. Helper vs inline: shared helper. Test placement: `integration_output_collision.rs` (closed by both reviewers in r1's favour).
+- **[Open]** None blocking. Copy of the reworded hint is reviewable prose; its durable fragment (`--no_report_file`) is the only pinned part.
+
+## Follow-ups (out of scope, to file separately)
+
+- Report-vs-report collisions display the same path twice and cannot name which *input* to rename — input provenance in `preflight_output_collisions` (B-A3).
+- Report/primary directory asymmetry on the paired arms (reports follow each mate's parent; primaries follow R1's) — shared with #388's site (B§1.3).
+
+## Implementation notes (2026-08-08, branch `fix/391-clump-report-preflight` @ `2704b52`)
+
+Implemented as planned: `pair_outputs: … -> Vec<PathBuf>` widening, `clump_report_candidates(no_report_file, &[impl AsRef<Path>], output_dir)` helper feeding all five arms, `PAIRED_REPORT_HINT` reworded at the constant with its doc comment rewritten (first comment only), clump-paired hint `None` → `Some(PAIRED_REPORT_HINT)`, io.rs property tests extended over the clump namers via `collision_key` (+ case-variant input, + `_clumped_N`/#391 doc note), nine integration tests, CHANGELOG under `#### Bug fixes`. Full suite 557 green; fmt + clippy `-D warnings` clean.
+
+**Expected-fail control (validation 10):** all six rejection tests run against the unpatched tree first — all six exited 0 there (the SE and Shape A alias cases destroying an input in the process); the three acceptance tests passed unpatched. Post-fix 9/9 green.
+
+**Deviations (documented, none behavioural):**
+- `assert_dir_holds_only`'s failure message generalized ("directory must hold exactly the expected files") since it now also serves acceptance-side exact-set assertions (B-V4).
+- The `distinct_primary_outputs_imply_distinct_secondary_outputs` restructure loops over three primary namers; the demux-stem sub-check stays scoped to the SE trim namer (its semantics are SE-trim-specific) and is now guarded by `collision_key` inequality like the rest.
+
+**Iteration log:**
+- #1: initial implementation (`2704b52`); expected-fail control 6/6 pre-patch, 9/9 post.
+- #2 (`d99f23e`): review batch per dual code review + coverage audit — coverage's one gap (alias-filename assertion) closed; A-M1/M2/M3, B-R1/R3/R4/R5/R6/R7, A-L1/L3/L4 applied; suite 559 green. Review items deliberately NOT taken: A-L5/B-I9 (helper stays in main.rs beside its neighbours), A-L6/B-duplication (trim-path unification deferred to when those blocks next change), A-L8 (CHANGELOG bullet order — Felix's call), B-I7 (helper doc history sentence kept for local consistency), B-I10 (half-line on why CWD_OUTPUT_HINT is wrong here — covered by the constants' own docs).
+
+- **Logic:** every reviewer-cited anchor re-verified against the tree before adoption (io.rs test names/lines, integration helpers/constants, `cli.rs:588/602/624/651` guards). The helper's one hazard (wrong `report_inputs` at a call site) is pinned by Validation 7, which was designed to discriminate exactly that mistake.
+- **Corrections owned:** r1's four prose errors are corrected in place and called out in the revision history rather than silently rewritten.
+- **Edge cases:** Behavior 2c added the shape r1's `-o`-only analysis missed; `--basename` and duplicate-mate interactions now stated with their true mechanisms.
+- **Remaining risks:** the reworded hint is shared prose across three pre-existing sites — its accuracy there was reviewed (the old clause was equally false at #388's site), but implementation must re-read those two sites' surrounding comments when swapping the text.

--- a/plans/08082026_clump-paired-report-preflight/PLAN_REVIEW_A.md
+++ b/plans/08082026_clump-paired-report-preflight/PLAN_REVIEW_A.md
@@ -1,0 +1,223 @@
+# Plan Review A — `--clump_only --paired` clumping reports join the collision pre-flight (#391)
+
+**Reviewer:** A (independent)
+**Plan:** `plans/08082026_clump-paired-report-preflight/PLAN.md`
+**Repo:** `/Users/fkrueger/Github/TrimGalore`, branch `dev` @ `03d793f` (verified: `git rev-parse HEAD` = `03d793f76f9993b43abf506f1dc90d870f1db08d`)
+**Date:** 2026-08-08
+**Scope note:** Task 2 (reports join the four sibling clump arms' pre-flights) is a maintainer-confirmed IN-scope decision and is NOT relitigated here.
+
+**Verdict: approve with changes.** The diagnosis is correct, the mechanism is the right one, and every load-bearing claim I could check against the code holds — including the A3 derivation, which I re-derived independently rather than accepting. The gaps are all in the *validation* half of the plan, not the fix: one of Task 2's two claimed representative tests is never actually specified, the A3 derivation that licenses skipping three whole arms is never machine-checked despite the repo already owning the exact test scaffolding for it, and the plan's `-o`-only test set misses a filesystem-independent collision shape that its own analysis does not predict. Two factual over-claims (Shape B exposure; "duplicate inputs are rejected earlier") need correcting before they reach the PR body, and step 5's prescribed comment fix is literally wrong as written.
+
+---
+
+## 1. Logic review
+
+### 1.1 Claims verified against code (all correct)
+
+| Plan claim | Verified at | Result |
+|---|---|---|
+| Dispatch arm | `src/main.rs:526-550` | ✅ exact |
+| Driver + pre-flight loop | `src/main.rs:2476-2518`, namer called at `2490` only | ✅ exact |
+| Writer + gate | `src/clump_only.rs:532-549`, gate at `534` | ✅ exact |
+| Namer keys on full filename, no `--basename` | `src/io.rs:469-482` | ✅ exact |
+| Pre-flight semantics | `src/io.rs:96-130` | ✅ exact |
+| `--clock` / `--implicon` sites | `src/main.rs:462-476`, `477-501` | ✅ exact |
+| Four sibling clump arms | `main.rs:552-558`, `674-678`, `621-630`, `587-597` | ✅ exact |
+| BAM report keyed on `inputs[0]` | `src/clump_only.rs:1080-1087` | ✅ exact |
+| Hint constants | `src/main.rs:55-66` | ✅ (see §1.4) |
+| #388 pattern | `src/main.rs:770-778` (plan says 771; comment opens at 770) | ✅ trivial off-by-one |
+
+### 1.2 The namer really is pre-flight-only — no behavioural leak
+
+Confirmed three ways, so widening `NameFn`'s return to `Vec<PathBuf>` cannot change a single written byte:
+
+1. `output_names` is invoked exactly once in `run_specialty_paired`, at `main.rs:2490`, and its result is pushed into `planned` which flows only into `preflight_output_collisions` (`main.rs:2494`). It is never passed to `run_pair`.
+2. `clump_only_paired` re-derives its own paths at `clump_only.rs:415-416` (`naming::clumped_paired_output_names(...)`) and its report paths at `535-536`. Same for `clock`/`implicon`, which take `(output_dir, gzip)` and name internally.
+3. `run_specialty_paired` has exactly three call sites, all in `main.rs` (`463`, `478`, `527`), and no test references the signature (`tests/integration_clump_only_ubam.rs:409` mentions it only in a doc comment). So the change is genuinely `main.rs`-internal, as §Integration claims.
+
+The proposed closure compiles: `&cli`, `basename` (`cli.basename.as_deref()`, `main.rs:507`) and the namer's `cli.no_report_file` are all *immutable* borrows of `cli`, and the run closure already borrows `cli.cores`/`cli.compression`/`cli.fastqc`/`cli.no_report_file` today (`main.rs:541-546`). No borrow conflict.
+
+### 1.3 The `!no_report_file` gate matches the writers exactly
+
+All four writer gates are `if !no_report_file`, with no inner condition:
+
+- `clump_only.rs:365` — SE FASTQ, one report keyed on `input`
+- `clump_only.rs:534` — paired FASTQ, **both** mates inside one gate, keyed on `input_r1` / `input_r2`
+- `clump_only.rs:836` — SE BAM, one report keyed on `input`
+- `clump_only.rs:1082` — paired BAM (Shapes A and B), **one** report keyed on `inputs[0]`
+
+The plan's candidate additions mirror each of these one-for-one, including Shape B's `&cli.input[0]` ≡ `inputs[0]` when `inputs.len() == 1`. Gate parity is exact. `grep -rn clumping_report_name src/` confirms these are the *only* four write sites — in particular `--clumpify` on the trim path writes no clumping report, so the plan's enumeration of arms is complete and there is no fifth site hiding on the trim paths.
+
+### 1.4 A3 (uBAM arms cannot collide report-vs-report) — airtight, and I re-derived it
+
+The plan asked me not to inherit its argument, so I rebuilt it. The invariant needed is:
+
+> report-path collision ⟹ primary-path collision (which the existing pre-flight already rejects).
+
+It holds because for every one of the four arms, report and primary are functions of **the same input path**, with **the same directory rule**:
+
+| Arm | Report dir | Primary dir | Report key | Primary key |
+|---|---|---|---|---|
+| SE FASTQ | `-o` else `input.parent()` | `-o` else `input.parent()` (`io.rs:430-433`… `clumped_output_name`) | `file_name(input)` | `strip_fastq_extensions(input)` |
+| SE BAM | same | same (`io.rs:430-433`) | `file_name(input)` | `strip_fastq_extensions(input)` |
+| Paired BAM Shape A | `-o` else `chunk[0].parent()` | `-o` else `input_r1.parent()` (`io.rs:456-458`) | `file_name(chunk[0])` | `strip_fastq_extensions(chunk[0])` |
+| Paired BAM Shape B | N=1 — see §1.5 | | | |
+
+And `strip_fastq_extensions` is **fold-equivariant**: its gzip-family strip uses `strip_suffix_ignore_ascii_case`, its `.fastq`/`.fq` strip likewise, and its fallback `Path::file_stem()` splits at the last `.` — a position, not a character class — so ASCII case-folding commutes with all three. Therefore fold-equal filenames ⟹ fold-equal stems ⟹ (same dir, same suffix) fold-equal primaries. `gzip` is global (`main.rs:351`: `let gzip = !cli.dont_gzip && naming::is_gzipped(&cli.input[0]);`) so the SE-FASTQ suffix is uniform across inputs. Cross-shape collision (report vs primary) is impossible: `_clumping_report.txt` cannot equal `_clumped.fq{,.gz}` or `_clumped.bam`.
+
+The `--basename` and mixed-extension shapes the lead flagged are covered: with `--basename` every primary in a multi-input SE run collapses to one path (and `cli.rs:624-628` rejects multi-input SE + `--basename` *before* that anyway), and every multi-pair Shape A primary collapses to `foo_clumped.bam`. Mixed extensions (`x.fq` vs `x.fastq`) move the *primary* key coarser, not the report key — the wrong direction to create an uncaught report collision. **A3 stands.** But see §4.2: it stands as prose, and nothing in CI holds it there.
+
+### 1.5 ⚠️ Over-claim: paired-BAM **Shape B cannot be exposed at all**
+
+The plan states, in §Context and again in §Behavior 5, that "all four sibling clump arms **ARE** exposed to report-vs-INPUT overwrites". For Shape B that is false, and the code proves it:
+
+- Shape B is reached only when `cli.input.len() == 1` (`main.rs:581`).
+- `--passthrough` and `--demux` — the only other contributors to `guarded_inputs` (`main.rs:70-79`) — are hard-rejected under `--output-format ubam` (`cli.rs:588`, `cli.rs:602`).
+- So `guarded_inputs` is exactly `[cli.input[0]]`, and the report path is that same input's filename **plus a suffix** — strictly longer, hence never fold-equal to it.
+
+Shape B's *existing* one-candidate pre-flight (`main.rs:587-597`) is therefore already unreachable, and Task 2's addition there is purely defensive symmetry. Keeping the edit is fine (five sites, one shape, easier to review than four-plus-an-exception), but the plan, the CHANGELOG and the PR body must not claim it closes a hole. This matters because it is currently the stated *justification* for the edit and for skipping a Shape B test.
+
+### 1.6 ⚠️ Step 5's prescribed comment fix is wrong as written
+
+The plan says the two doc comments at `main.rs:55-62` "are swapped … Swap them." They are not symmetrically swapped. Only the first is wrong:
+
+```rust
+/// Replaces the generic advice for the modes that name output into the CWD
+/// (`--hardtrim5/3`, `--clock`, `--implicon`), where "use `--output_dir`" is false.
+const PAIRED_REPORT_HINT: &str = …          // ← wrong: describes the OTHER constant
+
+/// CWD-output modes' remediation; see `PAIRED_REPORT_HINT` for the paired sites.
+const CWD_OUTPUT_HINT: &str = …             // ← already correct for its constant
+```
+
+A literal swap yields `PAIRED_REPORT_HINT` documented as "*see `PAIRED_REPORT_HINT` for the paired sites*" — self-referential nonsense. **Rewrite the first comment; leave the second alone.** And note this change gives `PAIRED_REPORT_HINT` a *third* user, so the rewritten comment should name them: paired trim FASTQ (`main.rs:784`), paired trim → uBAM (`main.rs:1888`), and now `--clump_only --paired`.
+
+### 1.7 ⚠️ Behavior §6 over-claims what `validate` rejects
+
+The plan says "duplicate inputs are rejected earlier by existing checks (`cli.rs::validate`, `main.rs:519-525`)". `main.rs:519-525` is the N=1 guard, not a duplicate check, and `validate_paired_input` rejects only two things: R1 == R2 *within* a pair, and an *exact* duplicate pair (same R1 **and** same R2). The general duplicate-input scan at `cli.rs:631` is gated on `!self.paired`, so it never runs here. **A file reused as a mate of two different pairs passes validate.** That is not a nit — it is exactly the shape that produces the uncovered collision class in §4.3.
+
+### 1.8 Minor logic notes
+
+- **A5 is half-true.** "The pre-flight error names both colliding paths" holds for the output-vs-**output** branch (`io.rs:120-126`) but not the output-vs-**input** branch (`io.rs:109-115`), which names only `input.display()`. This constrains Task 2's test 5: it can assert the alias filename (because that filename *is* the input) but cannot assert two paths. Fix the assumption's wording so the implementer doesn't write an assertion that can't pass.
+- **Task 1 also closes report-vs-input for the paired FASTQ arm**, for free, because `preflight_output_collisions` runs the input check on every candidate. The plan attributes report-vs-input closure exclusively to Task 2, which undersells Task 1 in the CHANGELOG.
+- **A4 is benign on this arm, not merely "pre-existing".** `--fastqc` side-outputs derive from `out_r1_path`/`out_r2_path` (`clump_only.rs:551-554`), which carry the `_clumped_1`/`_clumped_2` discriminators — so they inherit distinctness and cannot collide here. Worth saying, since "out of scope" reads like an unquantified risk.
+- **`PAIRED_REPORT_HINT`'s "regardless of source directory" clause is loose on this arm.** Without `-o`, clump-paired reports go to *each mate's own* parent (`io.rs:478-481`) while both primaries go to `input_r1.parent()` (`io.rs:407-409`). So two same-named inputs in different directories do **not** collide on reports without `-o`. The actionable half of the hint ("rename one input, or pass `--no_report_file`") is still correct in every case where it prints, so this is cosmetic — but it is the same directory-rule asymmetry that produces §4.3's missing test, so it is worth understanding rather than waving through.
+- **Parameter naming:** renaming `output_names` → `planned_outputs` puts it one character from the local `planned` (`main.rs:2488`) in a six-line body. `pair_outputs` reads better.
+- **CHANGELOG:** the live section is `### Unreleased` → `#### Bug fixes` (`CHANGELOG.md:4,6`), not "fixed".
+
+## 2. Assumptions
+
+| # | Status | Note |
+|---|---|---|
+| A1 | ✅ verified | `clumping_report_name(input, output_dir)` — `io.rs:469`; no `basename` parameter exists to honour. |
+| A2 | ✅ verified | `grep -c report src/specialty.rs` = 0. `--clock`/`--implicon` plan nothing but their two primaries. |
+| A3 | ✅ verified, ❗untested | Re-derived independently (§1.4). Sound today; nothing in CI pins it. See §4.2. |
+| A4 | ✅ verified, stronger than stated | Benign on this arm specifically (§1.8). |
+| A5 | ⚠️ half-true | Output-vs-input branch names one path only (§1.8). |
+| Gate is load-bearing | ✅ agreed | Exactly right, and the writers confirm it (§1.3). |
+
+**Implicit assumptions the plan does not surface:**
+
+1. **`gzip` is global and derived from `cli.input[0]`.** A3 leans on this. True (`main.rs:351`), but it is an assumption about a variable defined 150 lines from the arm it protects. Worth naming.
+2. **`--output_dir` is the only thing that can put two mates' reports in one directory on this arm.** Not stated, and as §4.3 shows, not true — two pairs can share a mate's directory without `-o`.
+3. **Shape A's report keys on `chunk[0]`, never `chunk[1]`.** True (`clump_only.rs:1083`: `let report_input = &inputs[0];`), and the plan's step 4 gets it right — but nothing in the proposed test set would catch getting it wrong. See §4.1.
+4. **A `.txt`-named file with FASTQ content is accepted as FASTQ input.** Task 2's test 5 depends on this. It holds — `format::detect_input_format` peeks the first byte (`@` → plain FASTQ) and ignores the name — but it is the load-bearing premise of the test and should be written down.
+
+## 3. Efficiency analysis
+
+Nothing to flag. The candidate list grows from 2P to at most 4P paths for paired FASTQ and by ≤1 per input/pair elsewhere; `preflight_output_collisions` is two `HashMap` passes, so total cost stays O(paths) with the map pre-sized (`io.rs:104`). No new I/O — the pre-flight is pure path arithmetic and still runs before any reader opens (`main.rs:2494` precedes the `run_pair` loop).
+
+The one new cost is one `Vec<PathBuf>` allocation per pair where a tuple used to be returned, i.e. P small allocations for P pairs of a run that is about to read gigabytes. Irrelevant, and the alternative (an out-parameter `&mut Vec<PathBuf>`) would trade a measurable nothing for a worse signature. Keep the `Vec`.
+
+## 4. Validation sufficiency
+
+The four Task-1 tests are well designed — in particular tests 1 and 2 are a genuine matched pair (same fixtures, differing only in `--no_report_file`), and test 1's assertion on the *report* filename in stderr is what makes it prove the report path rather than a primary. I checked test 1's shape end to end: `a/reads.fq` + `b/reads.fq` with `-o out` gives primaries `out/reads_clumped_1.fq` / `out/reads_clumped_2.fq` (distinct), so the reports are the *only* collision. That is the right isolation. `assert_rejected_cleanly` will work for it because the inputs live in `a/` and `b/`, not in `out`.
+
+Four gaps, in descending severity.
+
+### 4.1 ❗ Task 2's paired-BAM Shape A change ships untested
+
+Step 6 says "One representative per shape family: SE FASTQ + paired-BAM Shape A", but the enumerated test list contains only `clump_se_rejects_report_that_aliases_an_input` and its `--no_report_file` sibling, and Validation row 5 lists only that test. **No Shape A test is actually specified.** The prose and the deliverables disagree.
+
+This is the gap that matters most, because Shape A is the one arm whose edit sits inside a `for chunk in cli.input.chunks(2)` loop and must key on `chunk[0]` rather than `chunk[1]`. Push `chunk[1]`'s report by mistake and you get a pre-flight that guards a path the run never writes while leaving the path it *does* write unguarded — a silent, permanent hole, and not one test in the proposed set fires. Specify it:
+
+```
+clump_paired_bam_rejects_report_that_aliases_an_input
+  inputs: a/x.fq  a/y.fq  a/x.fq_clumping_report.txt  a/z.fq   (all valid FASTQ)
+  args:   --clump_only --paired --output-format ubam            (no -o)
+  expect: rejected, ALIAS_MSG, all four inputs intact
+```
+Pair 1's report is `a/x.fq_clumping_report.txt` = input 3. Keying on `chunk[1]` instead would plan `a/y.fq_clumping_report.txt`, collide with nothing, and the run would proceed — so this test discriminates the exact mistake. Shape A accepts FASTQ input only (BAM pairs are rejected upstream by `reject_bam_format_mismatch_in_pair`), so plain FASTQ fixtures are correct here.
+
+### 4.2 ❗ A3 licenses skipping three arms and is never machine-checked
+
+A3 is the load-bearing argument that SE FASTQ, SE BAM and Shape B need no report-vs-report coverage. It is sound today (§1.4). But it is a naming invariant, and naming invariants in this repo have broken before — #382 widened `strip_fastq_extensions` and turned a naming inconsistency into data loss; #388 is *literally* the case where a primary key stopped being coarser than a report key. If a future change makes `clumped_bam_output_name` honour something `clumping_report_name` doesn't, A3 dies silently and no test in the plan notices.
+
+The repo already owns the scaffolding. `src/io.rs:1288-1320`, `primary_output_key_is_coarser_than_secondary_keys`, does exactly this job for SE trim naming — and its doc comment already says *"paired `_val_N` inverts this, #388"*, i.e. the author of that test understood precisely the invariant #391 is about. Extend it (or add a sibling) over the clump namers:
+
+- for each pair of inputs drawn from a table spanning `{.fq, .fastq, .fq.gz, .bgz, mixed case, same name/different dir}` × `{basename None/Some}` × `{gzip true/false}` × `{output_dir None/Some}`,
+- assert: `collision_key(clumping_report_name(a, o)) == collision_key(clumping_report_name(b, o))` **implies** `collision_key(primary(a)) == collision_key(primary(b))`, for `primary ∈ {clumped_output_name, clumped_bam_output_name, clumped_paired_bam_output_name}`.
+
+Note the existing test uses case-**sensitive** `assert_ne!` on `PathBuf`, which is weaker than the pre-flight's `collision_key`. Use `collision_key` so the fold dimension is actually exercised. This turns A3 from a paragraph a reviewer has to re-derive into a line CI holds — cheap, and it is the single highest-value addition to this plan.
+
+### 4.3 ❗ A collision class the plan's analysis does not predict, and no test covers
+
+Every proposed test passes `-o out`. That hides the directory-rule asymmetry from §1.8: reports use **each mate's own** `input.parent()`, primaries use **R1's** `input_r1.parent()` for both mates. Combined with §1.7 (a file may be the mate of two different pairs), there is a **case-free, filesystem-independent** collision that the fix catches and the plan never mentions:
+
+```
+pair 1: p/a.fq  d/x.fq
+pair 2: q/b.fq  d/x.fq        # same R2 in both pairs — validate permits this
+args:   --clump_only --paired  (no -o)
+
+primaries: p/a_clumped_1.fq  p/x_clumped_2.fq  q/b_clumped_1.fq  q/x_clumped_2.fq   → all distinct
+reports:   p/a.fq_…  d/x.fq_…  q/b.fq_…  d/x.fq_…                                   → COLLIDE
+```
+
+Today: exit 0, one report silently lost. With the fix: rejected. This is strictly better than the plan's test 4 as a "candidate list spans pairs" proof, because it needs no `-o` (so it also pins the report directory rule) and no case-folding (so it behaves identically on APFS and ext4 — test 4's cousin `paired_rejects_fold_equal_filenames_into_shared_output_dir` needed a filesystem caveat for exactly this reason). Add it alongside test 4, not instead of it.
+
+While you are here: correct Behavior §6's claim about duplicate inputs (§1.7), since this test is a live counterexample to it.
+
+### 4.4 Smaller validation items
+
+- **Extend validation 6 (the expected-fail control) to all three rejection tests**, not just test 1. I checked each pre-patch: test 1 exits 0 (reports collide, no primary does), test 4 exits 0 (all four primaries distinct), test 5 exits 0 *and destroys an input*. All three genuinely fail pre-patch, so the control is cheap and it is the plan's own stated defence against fixture-selection blindness. Applying it to one of three tests is where that defence historically leaks.
+- **Add a `--basename` variant of test 1.** A1 asserts `--basename` runs are "exposed identically" and fixed by the same candidates; nothing tests it. Three extra lines: `--basename foo` makes the primaries `out/foo_clumped_1.fq` / `out/foo_clumped_2.fq` — *guaranteed* distinct by construction — while the reports still collide. That is a harder isolation of the report path than test 1 achieves, since a reader no longer has to reason about stems at all.
+- **Point test 5 at the existing model.** `assert_rejected_cleanly` cannot be used (it demands an empty directory, and test 5's inputs live in the directory being checked). The pattern to copy is `se_trim_rejects_output_that_aliases_a_report_input` (`tests/integration_output_collision.rs:674-691`): assert `ALIAS_MSG`, then `count_reads_from(&alias_file, "REPORTY") == 40` for content-verified intactness. Keeping the alias file valid FASTQ is essential and the plan already says so — without it, a future regression that removed the pre-flight would still fail the run (on a parse error) and the test would pass for the wrong reason.
+- **Test 4 must not assert a filename.** Candidate order is `[p1_primary, p1_primary, p1_rep_r1, p1_rep_r2, p2_primary, …]`, so the first duplicate found is pair 2's R1 report — `y.fq_clumping_report.txt`, not `x.fq`. The plan correctly asserts only "rejected"; flagging so an implementer doesn't "improve" it into a flaky assertion.
+- **No existing test regresses.** I checked the ones that could: `pe_byte_identity` (`tests/integration_clump_only.rs:141-171`) uses distinct `_R1`/`_R2` filenames; `multi_pair_pe_bam_produces_one_output_per_pair` (`integration_clump_only_ubam.rs:477-518`) copies `B_R{1,2}.fastq.gz` *into* its `-o` dir, but neither new report candidate equals an input, so no over-rejection; `pe_bam_collision_preflight_case_folded` (`:630`) still trips on pair 2's *primary* (which precedes its report in the candidate order), so its `contains("collision")` assertion holds. **And the hint change is safe:** the only tests pinning hint text are `integration_output_collision.rs:625` and `:661`, both on `--hardtrim5`/`--clock` (`CWD_OUTPUT_HINT`), and the two negative assertions on `"different source directories"` are on those same tests. Nothing pins `GENERIC_ADVICE` on any clump path. Validation 7's grep is a good instinct but it will come back clean.
+
+## 5. Alternatives
+
+**Keep the chosen shape.** Widening `NameFn` to `-> Vec<PathBuf>` is the right call and the plan's rationale is sound. It also matches how the trim arm already does this job — `main.rs:747` builds a local `candidates: Vec<PathBuf>` and extends `planned` — so after the change the two paired pre-flights read the same way. The rejected alternative (a second pre-flight inside the clump arm) is correctly rejected: it would run the check twice with two different hints and duplicate the chunking.
+
+Two alternatives worth a decision rather than silence:
+
+**(a) A shared `clump_report_candidates` helper instead of five inline blocks.** Task 1 + Task 2 plant the same `if !cli.no_report_file { push(clumping_report_name(…)) }` shape at five sites. `main.rs` already established the opposite convention for this exact job: `planned_secondary_outputs` (`main.rs:89-110`) and `planned_hardtrim_outputs` (`main.rs:113-130`) are named helpers precisely so the candidate-list↔writer parity is auditable in one place — and `planned_secondary_outputs`' doc comment spells out why. A `fn clump_report_candidates(cli: &Cli, inputs: &[PathBuf], output_dir: Option<&Path>) -> Vec<PathBuf>` would collapse all five (SE FASTQ passes `&cli.input`, SE BAM the same, Shape A passes `&chunk[..1]`, Shape B `&cli.input`, paired FASTQ `&[r1, r2]`). Trade-off: five two-line blocks are individually trivial to review, and the helper adds an indirection whose "which inputs" parameter is itself a place to get `chunk[0]` vs `chunk[1]` wrong. My recommendation: **take the helper**, because the writers it must stay in step with are already scattered across four functions in `clump_only.rs`, and one call site per arm is easier to diff against them than five hand-rolled copies — but it is a genuine judgement call and either answer is defensible.
+
+**(b) Derive `clumping_report_name` from the primary output path.** `demux::demux_base_name` already takes this approach (deriving from the primary, not the input), which is why demux's secondaries inherit primary distinctness structurally. Applied here it would make report collisions *impossible* wherever primaries differ, retiring #391, #388's clump twin, and A3 in one stroke. **Reject it**, and the reason is worth recording: it changes report filenames, which are a published contract — `io.rs:463-468` documents that `*_clumping_report.txt` is deliberately shaped so nf-core/rnaseq's MultiQC `*_trimming_report.*` glob does not pick it up, and `--clumpify`'s per-input report convention depends on the current spelling. Not worth it for a pre-flight fix.
+
+## 6. Action items
+
+### Critical
+
+1. **Specify the paired-BAM Shape A test.** Step 6's prose claims it as a representative; the deliverable list omits it, so Task 2's most error-prone edit would ship with zero coverage. Concrete shape in §4.1 — it discriminates the `chunk[0]` vs `chunk[1]` mistake, which nothing else in the plan does.
+
+### Important
+
+2. **Add the `collision_key`-based property test for A3** (§4.2), extending or siring a sibling to `src/io.rs:1288`'s `primary_output_key_is_coarser_than_secondary_keys`. A3 is what licenses skipping three arms; right now it lives only in the plan. Use `collision_key`, not `PathBuf` equality, so the fold dimension is real. Highest value-per-line item in this review.
+3. **Correct the Shape B exposure claim** in §Context and §Behavior 5 (§1.5): Shape B is `N=1` with `--passthrough`/`--demux` rejected, so its report can never alias an input and its pre-flight is already unreachable. Keep the edit as defensive symmetry if you prefer, but say that — the current wording will otherwise land in the CHANGELOG and PR body as a fixed hole that never existed.
+4. **Fix step 5's instruction** (§1.6): rewrite `PAIRED_REPORT_HINT`'s doc comment; do not swap the two. A swap makes it self-referential. The rewrite should list all three users, including the new `--clump_only --paired` site.
+5. **Add the no-`-o` cross-pair test from §4.3.** Case-free, filesystem-independent, and it covers a collision class the plan's `-o`-only analysis does not predict — namely that reports use per-mate `input.parent()` while primaries use R1's.
+6. **Extend validation 6's expected-fail control to tests 4 and 5** (§4.4). All three demonstrably exit 0 pre-patch, so the control costs one extra run each and is the plan's own named defence against fixture-selection blindness.
+7. **Correct Behavior §6** on duplicate inputs (§1.7): only within-pair `R1 == R2` and *exact* duplicate pairs are rejected; a file reused across two different pairs passes `validate`, and item 5's test relies on that.
+8. **Fix A5** (§1.8): the output-vs-input branch names only the input path. State it, so test 5's assertions are written against what the code actually prints.
+
+### Optional
+
+9. Add the `--basename` variant of test 1 (§4.4) — three lines, and it isolates the report path more sharply than test 1 does.
+10. Decide alternative (a): one `clump_report_candidates` helper vs five inline blocks (§5). I lean helper; either is defensible, but the plan should choose deliberately rather than default into five copies.
+11. Note in §Behavior/CHANGELOG that Task 1 also closes report-vs-input for the paired FASTQ arm for free (§1.8) — a real part of the fix that currently goes unadvertised.
+12. Sharpen A4: FastQC side-outputs on this arm inherit the `_clumped_{1,2}` discriminators and so cannot collide (§1.8). "Out of scope" reads like an open risk; it isn't one here.
+13. Record the two unstated premises: `gzip` is global from `cli.input[0]` (`main.rs:351`), and content-based format detection accepts FASTQ content in a `.txt`-named file (which is what makes test 5 possible).
+14. Rename the widened parameter `pair_outputs` rather than `planned_outputs` — one character from the local `planned` (§1.8).
+15. CHANGELOG heading is `#### Bug fixes` under `### Unreleased`, not "fixed" (`CHANGELOG.md:4,6`).
+16. Plan says `main.rs:771-778` for the #388 pattern; the comment opens at 770.

--- a/plans/08082026_clump-paired-report-preflight/PLAN_REVIEW_B.md
+++ b/plans/08082026_clump-paired-report-preflight/PLAN_REVIEW_B.md
@@ -1,0 +1,281 @@
+# Plan Review B — `--clump_only --paired` clumping reports join the collision pre-flight (#391)
+
+**Reviewer:** B (independent; fresh context)
+**Plan:** `plans/08082026_clump-paired-report-preflight/PLAN.md`
+**Base verified at:** `dev` @ `03d793f` (`fix(cli): reject --hardtrim5 with --hardtrim3 (#386) (#393)`) — matches the plan's stated base.
+**Date:** 2026-08-08
+
+**Verdict up front:** the diagnosis is correct, the fix shape is correct, and every code citation in the plan checks out against the tree. I found **no Critical defects** — nothing that would make the patch wrong or the issue stay open. What I did find is a cluster of **Important** issues concentrated in two places: (a) the user-facing hint text the plan adopts is partly false for this arm, and (b) the validation section over-promises relative to what it enumerates, and one of its tests cannot be written with the helper the plan names. Plus a high-value, low-cost validation upgrade the plan misses.
+
+---
+
+## 0. Claim-by-claim verification
+
+Every line/behaviour claim in the plan was checked against the tree. Result: **all verified, one sub-argument factually wrong (harmless conclusion).**
+
+| Plan claim | Verdict |
+|---|---|
+| Dispatch at `main.rs:526-550`, namer returns only the two primaries | ✅ exact |
+| `run_specialty_paired` at `main.rs:2476-2518`; `NameFn: FnMut(&Path,&Path) -> (PathBuf,PathBuf)` | ✅ exact (bound at 2484) |
+| Namer used **only** in the pre-flight (2489-2493); real paths re-derived in `clump_only.rs:415-416` | ✅ verified — see §2.1 |
+| Writer `clump_only.rs:532-549`, gated `!no_report_file`, keys `clumping_report_name(input_rN, output_dir)` | ✅ exact (gate at 534, names at 535-536) |
+| `clumping_report_name` (`io.rs:469-482`) ignores `--basename` | ✅ signature is `(input, output_dir)`; body uses `file_name()` verbatim |
+| `preflight_output_collisions` (`io.rs:96-130`): input check first, then dup check; names both paths; hint replaces `GENERIC_ADVICE` | ✅ exact |
+| `--clock`/`--implicon` write nothing but two primaries | ✅ `grep -n "report\|fastqc" src/specialty.rs` → **zero matches** |
+| uBAM paired report keyed on `inputs[0]` (`clump_only.rs:1080-1087`) | ✅ exact |
+| Task 2 sites: SE FASTQ 552-558, SE BAM 674-678, Shape A 621-630, Shape B 587-597 | ✅ all four exact |
+| `PAIRED_REPORT_HINT` / `CWD_OUTPUT_HINT` doc comments are mismatched (`main.rs:55-66`) | ✅ confirmed — the "modes that name output into the CWD (`--hardtrim5/3`, `--clock`, `--implicon`)" prose sits on `PAIRED_REPORT_HINT` |
+| A3's premise "extension stripping is case-insensitive since #390" | ✅ `strip_fastq_extensions` (`io.rs:540`) uses `strip_suffix_ignore_ascii_case` for both suffix groups; the `.bam` fallback is `Path::file_stem`, which splits positionally — so the function is **fold-equivariant**, which is what A3 actually needs |
+| A3's sub-argument "with `--basename`, multi-pair primaries collide immediately" | ❌ **wrong mechanism** — see A-4 |
+
+Two additional facts I established that the plan does not state, both favourable:
+
+- **No existing test breaks.** `grep` for `GENERIC_ADVICE`'s text ("distinct output paths") across `tests/` → zero hits. The only hint-text assertions in the suite are `stderr.contains("current working directory")` at `tests/integration_output_collision.rs:625` and `:661`, which pin `CWD_OUTPUT_HINT` on the hardtrim/clock paths and are untouched. Validation 7's grep is prudent but will come up empty — the plan can say so.
+- **The only binary-driven `--clump_only --paired` test today is `tests/integration_clump_only.rs:141 pe_byte_identity`**, and it uses `BS-seq_10K_R1/R2.fastq.gz` — distinct filenames, so distinct reports. Not newly rejected. `tests/integration_output_collision.rs` contains **zero** `clump` matches today, so the plan is adding the first collision coverage for this mode, not extending existing coverage.
+
+---
+
+## 1. Logic review
+
+### 1.1 The diagnosis is right, and the fix is complete for the issue as filed
+
+Reports collide iff two candidates share a `collision_key`, i.e. same directory + fold-equal filename. `clumping_report_name` is injective in `file_name()`, and `clumped_paired_output_names` appends `_clumped_1` / `_clumped_2` — so the primary key is *finer* than the report key on this arm, which is exactly the inversion #388 documented for `_val_N`. Adding the two gated report paths to the candidate list closes it.
+
+I checked the two reachable collision shapes and both are covered by the plan's candidate list:
+
+1. **With `--output_dir`** (the issue's repro): `-o out a/reads.fq b/reads.fq` → both reports land on `out/reads.fq_clumping_report.txt`. Rejected. ✅
+2. **Without `--output_dir`, via a case-only alias**: `a/x.fq a/X.fq`. `path_identity_key` is case-**sensitive** (`io.rs:78`), so `Cli::validate`'s same-file and duplicate-pair checks let this through; reports become `a/x.fq_clumping_report.txt` and `a/X.fq_clumping_report.txt` → fold-equal → rejected. Primaries (`x_clumped_1.fq` / `X_clumped_2.fq`) stay distinct, so nothing else catches it. ✅ The plan does not name this shape; it is covered by construction, but see V-4.
+
+### 1.2 The `!no_report_file` gate placement matches the writer exactly
+
+`main.rs:546` passes `cli.no_report_file` into `clump_only_paired`, which gates at `clump_only.rs:534`. The plan's closure gates on `!cli.no_report_file` — the same value, the same polarity, guarding the same two `clumping_report_name` calls with the same arguments. **Exact parity, including the directory asymmetry** noted in §1.3. No drift.
+
+### 1.3 An asymmetry worth recording (not a defect in the plan)
+
+On the paired FASTQ arm the report and primary do **not** share a directory rule when `-o` is absent: `clumped_paired_output_names` puts *both* primaries in `input_r1.parent()` (`io.rs:407-409`), while `clumping_report_name(input_r2, None)` puts R2's report in `input_r2.parent()`. So `trim_galore --clump_only --paired A/r1.fq B/r2.fq` writes both outputs into `A/` but R2's report into `B/`.
+
+The plan's fix mirrors the writer exactly, so this causes no bug — but it matters twice:
+
+- it is why A3's "same directory rule" argument is scoped to the SE/uBAM arms only (correct as written);
+- it is why the hint text the plan adopts is inaccurate (see A-1).
+
+The identical asymmetry exists on the #388 trim-paired path (`paired_end_output_names` also resolves to `input_r1.parent()`), so this is a shared, pre-existing quirk and a reasonable follow-up issue, not a blocker.
+
+### 1.4 A3 is sound — and Task 2 is provably rejection-neutral because of it
+
+A3's chain holds: report collision ⟹ fold-equal `file_name()` ⟹ (fold-equivariance of `strip_fastq_extensions`, verified) fold-equal stem ⟹ fold-equal primary in the same directory ⟹ already rejected. I probed the shapes the brief asked about:
+
+- **Mixed extensions** (`x.fq` vs `x.FQ`, `x.fq` vs `x.fq.gz`): fold-equal filenames force identical extensions up to case, so this reduces to the case-alias shape and is covered. The *reverse* direction (`x.fq` + `x.fastq` → same stem, different reports) produces a primary collision without a report collision — irrelevant, already rejected.
+- **Shape B**: `cli.input.len() == 1`, therefore exactly one report and one primary. Report-vs-report is structurally impossible. ✅
+- **Shape A**: one report per pair keyed on `chunk[0]`, primary keyed on the same `chunk[0]` into the same directory. Multi-pair collisions coincide. ✅
+- **Report-vs-primary**: a report path always ends `_clumping_report.txt`; every clump primary ends `_clumped.fq`, `_clumped.fq.gz`, `_clumped_N.fq(.gz)` or `_clumped.bam`. Disjoint suffixes, so this cross-kind collision cannot occur on any arm. ✅
+- **`--basename`**: unreachable as a multi-input shape — see A-4.
+
+A consequence the plan should state explicitly, because it is the strongest argument for Task 2's safety: **by A3, Task 2 adds zero new output-vs-output rejections.** Every report path it appends can only collide with another report path when a primary already collides (rejected today), and can never collide with a primary. So Task 2's *entire* behavioural delta is the report-vs-input direction it is designed to close. That makes it about as low-risk as a pre-flight widening can be — and it also means A3 is load-bearing for Task 2's blast-radius claim, not just for the decision to skip report-vs-report on the uBAM arms. Which is why I want A3 machine-checked (V-1).
+
+### 1.5 Widening `NameFn` to `Vec<PathBuf>` really is pre-flight-only
+
+Confirmed on all three call sites:
+
+- `run_specialty_paired` calls `output_names` at `main.rs:2490` and nowhere else; the value is pushed into `planned`, consumed by `preflight_output_collisions`, and dropped.
+- `clump_only_paired` re-derives via `naming::clumped_paired_output_names` at `clump_only.rs:415-416`.
+- `specialty::clock` / `specialty::implicon` receive `(r1, r2, gzip, output_dir, cores, compression)` — no paths passed in, so they re-derive too.
+
+So there is **no behavioural leak**: the widened return type cannot change a single written path. The plan's claim is airtight.
+
+On compilation: the proposed closure captures `cli` immutably while `&cli` is also passed as argument 1 of the same call. That already happens today (the run closure reads `cli.cores`, `cli.fastqc`, `cli.no_report_file`), so it compiles. `naming` is already imported at these sites.
+
+### 1.6 Coverage of the dispatch surface is complete
+
+I enumerated every `--clump_only` dispatch branch (`main.rs:502-697`): paired FASTQ, SE FASTQ, Shape B, Shape A, SE BAM — five arms, matching the plan's five (one Task 1 + four Task 2). They map onto exactly four report-writing sites (`clump_only.rs:366`, `535/536`, `837`, `1084`); Shapes A and B share `1084`. Nothing is missed.
+
+I also checked for a **sixth** exposure the plan might have inherited: `--clumpify` on the trim path. `grep -rn clumping_report_name src/` returns hits only in `io.rs` and `clump_only.rs`, so `--clumpify` writes no clumping report and the trim path's pre-flight (`planned_secondary_outputs`, `main.rs:89-110`) is already complete for its own secondaries after #388. **No fifth site.** The comment at `clump_only.rs:532` ("mirrors `--clumpify`'s per-input report convention") refers to the convention, not to a second writer.
+
+### 1.7 The cross-pair test's arithmetic checks out
+
+Pairs `(a/x.fq, a/y.fq)` and `(b/y.fq, b/x.fq)` with `-o out` give primaries `x_clumped_1`, `y_clumped_2`, `y_clumped_1`, `x_clumped_2` — four distinct names — while reports collide on both `x.fq_…` and `y.fq_…`, and collide **only across pairs** (within each pair the two filenames differ). So the test isolates exactly the property it claims. `validate`'s duplicate-pair check compares `(r1,r2)` key pairs and does not fire. ✅ Good test design.
+
+---
+
+## 2. Assumptions
+
+### A-1 (Important) — `PAIRED_REPORT_HINT` contains a clause that is false on this arm
+
+The plan changes the hint from `None` to `Some(PAIRED_REPORT_HINT)`. I agree the change is *needed* — `GENERIC_ADVICE` is actively unhelpful for the issue's repro, since it suggests "different source directories or `--output_dir`" when the inputs are already in different directories and `--output_dir` is what *caused* the collision. But the constant's text says:
+
+> "Paired outputs and reports are named from the input filename alone, so two inputs sharing a filename collide **regardless of source directory** — rename one input, or pass `--no_report_file` if only the reports collide."
+
+Two problems on the clump-paired arm:
+
+1. **"regardless of source directory" is false without `-o`.** Per §1.3, dropping `--output_dir` genuinely *does* separate the two reports (they follow their own inputs' parents). The hint tells the user the one remedy that works is unavailable.
+2. **"Paired outputs … are named from the input filename alone"** is the opposite of the defect: the *outputs* carry `_clumped_1`/`_clumped_2` and are fine; only the *reports* lack a discriminator. A user reading this will look for a primary collision.
+
+The remedy clauses ("rename one input", "`--no_report_file`") are both correct here, including under `--basename` (which affects primaries only). So the damage is confined to the explanatory half.
+
+Recommendation: introduce a third constant rather than reuse `PAIRED_REPORT_HINT`, e.g.
+
+> "Clumping reports are named from the input filename alone (no `_clumped_N` discriminator), so two inputs sharing a filename collide on reports once `--output_dir` collects them in one place — rename one input, drop `--output_dir`, or pass `--no_report_file`."
+
+If the maintainer prefers one constant for both paired sites (defensible — it keeps the message surface small), then fix the wording at the constant, since the "regardless of source directory" clause is equally false at #388's trim-paired site for the same reason. Either way this should be a deliberate decision recorded in the plan, not an inherited string.
+
+### A-2 (Important) — the hint change is untested in both directions
+
+No proposed validation asserts the hint appears. Given A-1, that cuts both ways: without an assertion a future edit can silently revert the hint; with an assertion on the wrong text you lock in the inaccuracy. Recommendation: settle A-1 first, then assert only the durable, actionable fragment (`--no_report_file`) in test 1 — not the whole sentence.
+
+### A-3 (verified, but state the consequence) — A5 is true, and the message is unhelpfully symmetric
+
+`preflight_output_collisions` names both paths — but for a report-vs-report collision `existing` and `p` are *the same string*, so stderr reads:
+
+> `out/reads.fq_clumping_report.txt and out/reads.fq_clumping_report.txt would be written to the same file.`
+
+Combined with a hint that says "rename one input", the user is told to rename an input the message never identifies. This is pre-existing (identical at the #388 site) and fixing it means threading input provenance into the pre-flight (`&[(PathBuf, &Path)]`), which is out of scope for a bug-fix PR. It does not break the plan's test assertion — `reads.fq_clumping_report.txt` is present and is attributable only to a report namer. Worth a follow-up issue and a one-line acknowledgement in the plan's Assumptions, so the next reader does not mistake it for a defect introduced here.
+
+### A-4 (Important) — A3's `--basename` branch cites a mechanism that does not exist
+
+The plan writes: "With `--basename`, multi-pair primaries collide immediately (all `foo_clumped.bam`)." That shape never reaches the pre-flight: `cli.rs:651` rejects `--basename` with more than one paired pair, and `cli.rs:624` rejects it with more than one SE input. So `--basename` is only ever seen with a single input (SE) or a single pair, in which case there is exactly one report and one primary and no collision of any kind is possible.
+
+The conclusion (no silent report loss under `--basename`) survives intact; only the reason is wrong. But A3 is the plan's justification for a *deliberate non-fix* on four arms, so a reviewer inheriting a wrong mechanism is precisely how this rots. Replace the sentence with the actual guard citation.
+
+### A-5 (Optional) — A4 is broader than it needs to be
+
+A4 states FastQC side-outputs stay outside every pre-flight. True, and correctly out of scope — but on the clump paths the residual is *narrower* than the general case: `clump_only.rs:551-554` derives FastQC's inputs from `out_r1_path` / `out_r2_path`, which carry the `_clumped_N` discriminators, so a FastQC output cannot collide where the primaries do not. Sharpening A4 to say so removes a phantom risk from the next reader's list.
+
+### A-6 (Optional) — the `no_report_file` gate rationale is right and worth keeping
+
+The plan's "Fixed vs configurable" note ("a candidate list that includes reports the run won't write would reject legal `--no_report_file` runs") is exactly the correct framing and is the reason test 2 is a genuine control rather than a formality. No change needed; flagging it as a strength.
+
+---
+
+## 3. Efficiency analysis
+
+Nothing to challenge. Concretely:
+
+- Candidate list grows by ≤ 2 per pair (Task 1) and ≤ 1 per input/pair (Task 2). `preflight_output_collisions` is two `HashMap` builds over that list, so total work stays `O(planned + inputs)` with `String` keys of path length. For realistic invocations (tens of files) this is microseconds against a run that reads gigabytes.
+- The `Vec<PathBuf>` return replaces a 2-tuple with one heap allocation per pair. Allocations equal to the pair count, on a path that already does per-pair `File::create` and gigabyte-scale I/O. Immeasurable.
+- `guarded_inputs(cli)` clones `cli.input` on every call — pre-existing, unchanged, and once per dispatch.
+- No new I/O, no new syscalls, no change on any accepted run.
+
+One micro-note if the implementer cares: `planned.extend(planned_outputs(...))` will reallocate as it grows; `Vec::with_capacity(cli.input.len() * 3)` would avoid a couple of reallocs. Not worth the line.
+
+---
+
+## 4. Validation sufficiency
+
+The proposed suite is well-designed in structure — rejection/acceptance pairs on the same dispatch path, a shared-fixture negative control, and an expected-fail-pre-patch step. Four specific gaps, one of them a plan-versus-plan inconsistency.
+
+### V-1 (Important) — A3 is prose-only, and there is an existing test that should carry it
+
+`src/io.rs:1229 distinct_primary_outputs_imply_distinct_secondary_outputs` already asserts, over a matrix of `basename × gzip × output_dir`, that distinct primaries imply distinct secondaries — and it **already includes `clumping_report_name`** in its namer list. But its primaries come from `single_end_output_name` only. Adding `clumped_output_name` and `clumped_bam_output_name` to that primary set (a few lines, no new fixtures, no new test) converts A3 from an argument in a plan file into a CI-enforced invariant. Given §1.4 — A3 is what makes both the uBAM non-fix *and* Task 2's rejection-neutrality true — this is the highest-value item in my review.
+
+While there: `src/io.rs:1287-1291`'s doc comment says "the primary key is strictly coarser than the report key (in single-end naming — paired `_val_N` inverts this, #388)". `_clumped_N` inverts it the same way; add #391 so the next reader finds the second instance.
+
+### V-2 (Important) — test 5 cannot be written with `assert_rejected_cleanly`, and the plan does not say what shape it takes
+
+`assert_rejected_cleanly` (`tests/integration_output_collision.rs:95`) requires the passed directory to be **empty** after the run. For a report-vs-input collision the aliasing input must sit in the directory the report would be written to — i.e. inside `-o out`, or (cleaner) both inputs in one directory with no `-o` at all. Either way that directory contains the inputs, so `assert_rejected_cleanly` fails on its `leftovers.is_empty()` assertion.
+
+The workable shape is the no-`-o` one, which the file already has a helper for:
+
+- fixtures `dir/s.fq` (valid FASTQ) and `dir/s.fq_clumping_report.txt` (also valid FASTQ content, so the rejection cannot come from a format error);
+- `s.fq`'s report resolves to `dir/s.fq_clumping_report.txt` == input 2 → `ALIAS_MSG`;
+- primaries are `dir/s_clumped.fq` and `dir/s.fq_clumping_report_clumped.fq` — distinct, so nothing else fires;
+- assert with `assert_dir_holds_only(&dir, &["s.fq", "s.fq_clumping_report.txt"])`, which is strictly stronger than "both inputs intact" because it also proves no primary was created.
+
+Note `input[0]` must be valid FASTQ regardless: `sanity_check_any(&cli.input[0])` runs at main entry before dispatch. Also confirmed there is **no input-extension whitelist** in `Cli::validate`, so a `.txt`-named input is accepted and the fixture is viable.
+
+### V-3 (Important) — the plan promises two Task 2 representatives and enumerates one
+
+Step 6's last bullet says "One representative per shape family: SE FASTQ + paired-BAM Shape A", but only `clump_se_rejects_report_that_aliases_an_input` is named, and validation row 5 lists only that one. Either write the Shape A test or drop the claim. If written, it is cheap: Shape A takes two FASTQ inputs plus `--output-format ubam` (the existing `se_trim_ubam_rejects_shared_stem` at `:284` establishes that in-test plain FASTQ works fine on uBAM-output arms), and the aliasing input is a file named `<r1-filename>_clumping_report.txt` in the report's directory. My preference is to write it: Shape A is the only Task 2 arm whose report keys on `inputs[0]` rather than "each input", so it is the one whose candidate-list line differs in shape from the others.
+
+### V-4 (Important) — strengthen the acceptance test to bind namer to writer
+
+Test 3 asserts "primaries + both reports present". Upgrade it to `assert_dir_holds_only(&out, &[<the four exact filenames>])`. The helper already exists at `:77`. This costs one line and converts a weak existence check into the invariant whose *absence* is the root cause of this entire bug family: **the pre-flight's candidate list equals the set of files the run writes.** #388 and #391 are both instances of the namer and the writer disagreeing; an exact-set assertion is the only test shape that catches a future third instance. I would rate this the second-highest-value item after V-1.
+
+(It also happens to be the cheapest available answer to Alternative 5.2 below, which is the structurally correct but expensive fix.)
+
+### V-5 (Optional) — two smaller items
+
+- **Test 1 needs two assertions, not one.** `assert_rejected_cleanly` takes a single `expect`. Pass `DUP_MSG` (so the collision *kind* is pinned, via the existing constant) and add a separate `assert!(stderr.contains("reads.fq_clumping_report.txt"))` for the report attribution. The plan currently implies one assertion covering both.
+- **Unique `tempdir` tags.** `tempdir(tag)` (`:31`) keys on `std::process::id()`, which is identical for every test in the binary, and it `remove_dir_all`s first. Two tests sharing a tag will destroy each other's fixtures under `cargo test`'s thread-parallel execution. Five new tests need five unused tags. The nastier failure mode is not the obvious one: test 2's "no report files exist" assertion could pass **vacuously** if a same-tag test wiped the directory mid-run — and test 2 is the plan's whole defence against fixture-selection blindness. Worth a line in step 6.
+
+### V-6 (Optional) — the paired arm's report-vs-input direction has no test
+
+Task 1's widened list closes report-vs-input on the paired FASTQ arm too, and that is the more destructive direction (it overwrites a file the run was told to read). Reachable: `--paired dir/x.fq dir/x.fq_clumping_report.txt` with no `-o` → R1's report lands on input 2 while primaries stay distinct. Contrived, but it is one more test of the same shape as V-2's and it covers a different candidate-list construction. At minimum, note in the validation table that it is covered by construction so a coverage audit does not read it as a gap.
+
+### V-7 — could any proposed test pass for the wrong reason?
+
+I checked each against the repo's fixture-selection-blindness history and they hold up well:
+
+- **Test 1**: `assert_rejected_cleanly` pins the `PREFIX` ("Output path collision…"), so a rejection from `validate`, from format detection, or from a sanity check fails the test. `path_identity_key` is case-sensitive and the two inputs differ in their parent, so neither the same-file nor the duplicate-pair check fires. The string `reads.fq_clumping_report.txt` is producible only by `clumping_report_name`. **Sound.**
+- **Test 2**: the true negative control — identical fixtures, one flag, and the *only* thing that flag removes from the candidate list is the two report paths. **Sound, and the plan is right to lean on it.**
+- **Test 3**: passes today, pre-patch (nothing collides), so it is not a fix-detector — it is an over-rejection detector, which is its stated job. Weak only in its assertions; V-4 fixes that.
+- **Test 4**: verified in §1.7 — collisions occur only across pairs, so the cross-pair property is genuinely isolated.
+- **Test 5**: sound *if* built per V-2; as sketched with `assert_rejected_cleanly` it will not run at all.
+- **Validation 6** (run test 1 against the unpatched build) is the right guard and should be reported in the PR body, not just performed.
+
+One thing no proposed test covers: `gzip` is derived from `is_gzipped(&cli.input[0])` (`main.rs:351`), so all-plain-FASTQ fixtures give `_clumped_1.fq` (no `.gz`) — which matches the filenames the plan asserts. Consistent; just confirming the plan's expected filenames are right.
+
+---
+
+## 5. Alternatives
+
+### 5.1 `Vec<PathBuf>` namer vs. an optional secondary closure — plan's choice is right
+
+Agreed, and for a reason the plan does not give: the tuple return type *encodes the bug*. "Return the two primaries" is a shape that cannot express a mode with three planned outputs, so every future secondary would need another parameter. `Vec<PathBuf>` with the doc contract "every path this pair writes" makes the pre-flight's completeness a property of the type rather than of the caller's diligence. Keep it, and keep the parameter rename (`output_names` → `planned_outputs`) — the name is doing real work. Also extend the function's doc comment's mode list: it currently says "(`--clock`, `--implicon`)" at `main.rs:2470-2471` and has silently gained `--clump_only --paired`.
+
+### 5.2 Share one derivation between pre-flight and writer (structurally correct, expensive)
+
+The residual weakness after this patch: `clumping_report_name` is still called independently in two places under two independently written `!no_report_file` gates. That is the same duplication that produced #391, just with the two copies now agreeing. The durable fix is one derivation — either pass the report paths into `clump_only_paired`, or have both sides call a shared `clump_paired_planned_outputs(...)`.
+
+I do **not** recommend doing this in a bug-fix PR: it touches the writer, and byte-identity of accepted runs is the plan's strongest safety claim. V-4's exact-set assertion buys most of the protection for one line, and is the right trade here. Worth recording as the reason the duplication was accepted.
+
+### 5.3 Task 2: five inline pushes vs. one `planned_clump_secondary_outputs` helper (worth considering)
+
+Task 2 as written adds the same `if !cli.no_report_file { push(clumping_report_name(…)) }` at four sites, and Task 1 adds a fifth copy in a closure. The trim path already solved this shape once: `planned_secondary_outputs` (`main.rs:89-110`) centralises "the secondaries an SE trim run writes", and its doc comment even explains the A2/A3-style reasoning. A `fn planned_clump_report_outputs(cli, inputs, output_dir) -> Vec<PathBuf>` would give five call sites one line each, one gate, and — usefully — a unit-testable seam for A3-style properties without driving the binary.
+
+Trade-off: the four arms key their reports differently (each input for SE; `inputs[0]` per chunk for the BAM paired shapes), so the helper needs either a small enum or two functions, which erodes some of the win. Given the maintainer confirmed Task 2 is in scope and the plan calls the additions "four trivially-reviewable lines", inline is defensible. But the repo's own history (#383 → #385 → #388 → #391, four rounds of "another dispatch path had no pre-flight") argues that the reviewable unit should be "one list every clump arm shares" rather than "four lists that currently agree". I'd raise it with the maintainer as a genuine fork rather than assume inline.
+
+### 5.4 Rejected alternative worth naming explicitly: discriminate the report name instead of rejecting
+
+Give clumping reports a positional discriminator (`reads_clumped_1.fq_clumping_report.txt`, or key the report off the *output* path rather than the input) and the collision disappears — both reports get written, no run fails. This is arguably what a user hitting the issue wants. Reasons to reject, which the plan should state since it is the first question a reviewer will ask:
+
+- it changes output filenames, which is the one thing this repo treats as near-invariant (MultiQC/nf-core glob on `*_clumping_report.txt`; the naming is deliberately distinct from `*_trimming_report.*` per `io.rs:463-468`);
+- it diverges from #388, which chose rejection for the structurally identical trim-report case three commits ago — two different answers to one defect class is worse than either answer;
+- rejection is strictly safer: it never silently produces a file whose name the user did not predict.
+
+The plan's "Rejected alternative" section only discusses a duplicate pre-flight inside the clump arm. Adding this one makes the design record complete.
+
+### 5.5 Test placement (the plan's open question) — keep it in `integration_output_collision.rs`
+
+Agreeing with the plan, with a reason: that file's module doc (`:1-18`) is written as the narrative of the pre-flight defect family, and its three shared constants (`DUP_MSG`, `ALIAS_MSG`, `PREFIX`) plus `assert_rejected_cleanly` / `assert_dir_holds_only` are exactly what these tests need. Splitting collision cases by mode would mean re-deriving those helpers in `integration_clump_only.rs`, whose stated job is byte-identity and determinism. Close the question in the plan's favour.
+
+---
+
+## 6. Action items
+
+### Critical
+
+None. The plan is implementable as written and closes the issue; every code citation verifies; the `Vec<PathBuf>` widening is provably pre-flight-only; the gate matches the writer exactly.
+
+### Important
+
+1. **A-1 — Fix the hint text before adopting it.** `PAIRED_REPORT_HINT`'s "regardless of source directory" is false on this arm (dropping `--output_dir` does separate the reports), and "Paired outputs … named from the input filename alone" points the user at the primaries, which are fine. Either add a clump-specific constant or fix the wording at `PAIRED_REPORT_HINT` — noting the same clause is equally false at #388's site. Record the choice in the plan.
+2. **V-1 — Make A3 machine-checked.** Extend `src/io.rs:1229`'s primary set with `clumped_output_name` and `clumped_bam_output_name`. A3 is what justifies *not* fixing report-vs-report on four arms **and** what makes Task 2 rejection-neutral (§1.4); it should not live only in a plan file. Also add `_clumped_N` / #391 to the doc comment at `io.rs:1287-1291`.
+3. **V-2 — Respecify test 5.** It cannot use `assert_rejected_cleanly` (the directory holds the inputs). Use the no-`-o` two-inputs-in-one-directory shape with `assert_dir_holds_only`, and keep the aliasing input valid FASTQ so the rejection is attributable to the pre-flight.
+4. **V-4 — Turn test 3 into an exact-set assertion.** `assert_dir_holds_only(&out, &[<4 filenames>])`. One line; it is the only test shape that catches the next namer-vs-writer divergence, which is the root cause of this whole family.
+5. **V-3 — Resolve the Task 2 representative count.** Write the paired-BAM Shape A test (it is the one arm keying on `inputs[0]` rather than per-input) or strike the claim from step 6.
+6. **A-4 — Correct A3's `--basename` sentence.** Multi-input `--basename` never reaches the pre-flight; it is rejected at `cli.rs:624` (SE) and `cli.rs:651` (paired). Conclusion unchanged, mechanism wrong.
+7. **A-2 — Decide the hint assertion deliberately.** After A-1, assert only the durable fragment (`--no_report_file`) in test 1, so the hint cannot silently revert and the inaccurate half is not pinned.
+8. **5.3 — Put the "four inline pushes vs. one shared helper" fork to the maintainer** rather than assuming inline. The trim path's `planned_secondary_outputs` is the established precedent, and this repo has now litigated missing-pre-flight four times.
+
+### Optional
+
+9. **V-5a** — test 1 needs two assertions (`DUP_MSG` via the helper, plus the report filename separately).
+10. **V-5b** — five unique `tempdir` tags; note the vacuous-pass risk for test 2 if tags collide.
+11. **V-6** — add (or explicitly mark as covered-by-construction) the paired-arm report-vs-input case.
+12. **A-3** — record that the report-vs-report message names the same path twice and cannot identify which input to rename; file a follow-up for input provenance in `preflight_output_collisions`.
+13. **A-5** — sharpen A4: on clump paths FastQC's outputs derive from the discriminated primaries, so the residual is narrower than the general case.
+14. **§1.3** — record the report/primary directory asymmetry on the paired arms (both primaries → `input_r1.parent()`, R2's report → `input_r2.parent()`) as a follow-up issue; it is pre-existing and shared with #388.
+15. **5.4** — add "discriminate the report name instead of rejecting" to the rejected-alternatives list with the MultiQC-glob and #388-consistency reasons.
+16. **Step 1** — the `run_specialty_paired` doc comment's mode list (`main.rs:2470-2471`) still says "(`--clock`, `--implicon`)"; add `--clump_only --paired`.
+17. **Step 4** — the SE FASTQ arm's candidate list is an iterator chain (`main.rs:553-557`); adding reports needs a `for` loop or `flat_map`, not a `push`. Spell out which, since the plan's own guidance warns about post-`cargo fmt` anchor drift during scripted patching.
+18. **Validation 7 is already answered:** no test in the suite pins `GENERIC_ADVICE`; the only hint assertions are the two `"current working directory"` checks at `tests/integration_output_collision.rs:625,661`, which cover `CWD_OUTPUT_HINT` on hardtrim/clock and are unaffected. The plan can state this as verified rather than as a step to perform.

--- a/plans/08082026_clump-paired-report-preflight/PROGRESS.md
+++ b/plans/08082026_clump-paired-report-preflight/PROGRESS.md
@@ -1,0 +1,21 @@
+# Progress: `--clump_only --paired` clumping reports join the collision pre-flight (#391)
+
+**Last updated:** 2026-08-08
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | PLAN.md r2 — review findings + Felix's two decisions folded in (shared-constant hint fix, clump_report_candidates helper, 4 prose corrections, 4 new tests incl. Shape A discriminator + A3 property test); awaiting his sign-off |
+| Plan Review | ✅ Complete | PLAN_REVIEW_A.md ("approve with changes"), PLAN_REVIEW_B.md ("no criticals") — fix confirmed sound; gaps in validation + several plan-text errors to correct; 2 forks for Felix (hint text, helper-vs-inline) |
+| Impl Plan | ✅ Complete | Folded into PLAN.md r2 implementation outline (no separate IMPL.md, per pipeline convention) |
+| Implementation | ✅ Complete | 2704b52 + review batch d99f23e; expected-fail control 6/6 |
+| Code Review | ✅ Complete | CODE_REVIEW_A.md (approve, 3 Medium additive), CODE_REVIEW_B.md (approve, 1 Medium docs) — batch applied in d99f23e |
+| Coverage | ✅ Complete | COVERAGE.md: INCOMPLETE (1 assertion) → resolved in d99f23e, addendum recorded |
+
+## History
+
+- 2026-08-08: Implementation + Code Review + Coverage → ✅ Complete (review batch d99f23e; coverage gap closed)
+- 2026-08-08: Plan revised to r2 (dual-review findings + Felix's hint/helper decisions incorporated; re-presented)
+- 2026-08-08: Plan Review → ✅ Complete (dual reviewers; fix sound, validation gaps + plan-text corrections needed; revision pending)
+- 2026-08-08: Plan → ✅ Complete (PLAN.md written; presented for manual review)

--- a/src/io.rs
+++ b/src/io.rs
@@ -1211,9 +1211,11 @@ mod tests {
     /// Assumption A2, in the direction that makes the pre-flight sufficient:
     /// where two inputs' PRIMARY output paths differ, every secondary output
     /// path must differ too — so a secondary can never collide unless a primary
-    /// already has, and hashing primaries alone is enough. Single-end naming
-    /// only: paired `_val_N` primaries break this (#388), which is why the
-    /// paired pre-flight carries report candidates explicitly.
+    /// already has, and hashing primaries alone is enough. Covers the SE trim
+    /// and clump primary namers, compared on `collision_key` (the pre-flight's
+    /// own metric). Paired `_val_N` / `_clumped_N` primaries break the
+    /// implication (#388, #391), which is why the paired pre-flights carry
+    /// report candidates explicitly.
     ///
     /// Checked across the flag matrix (`--basename` / `--dont_gzip` / `-o`, each
     /// on and off) because `--basename` and `-o` are exactly the flags that
@@ -1236,8 +1238,8 @@ mod tests {
             Path::new("e/gamma.fq.gz"),
             Path::new("d/same.fastq.gz"),
             Path::new("e/same.fastq.gz"),
-            // Case-variant of d/same: primaries fold-collide (skipped pair), which
-            // is the collision_key dimension PathBuf equality used to miss (#391).
+            // Fold-equal twin of d/same: the skip must use collision_key, not
+            // PathBuf equality, or the assertion below fails on this pair (#391).
             Path::new("d/SAME.fastq.gz"),
         ];
         let out = PathBuf::from("shared_out");
@@ -1245,9 +1247,8 @@ mod tests {
         for basename in [None, Some("fixed")] {
             for gzip in [true, false] {
                 for output_dir in [None, Some(out.as_path())] {
-                    // #391 — the same implication must hold for every clump primary
-                    // namer, and on the pre-flight's own metric (collision_key), so
-                    // the fold dimension is exercised rather than PathBuf equality.
+                    // #391 — same implication for every clump primary namer, on the
+                    // pre-flight's own metric (collision_key) so the fold is real.
                     let primary_sets: Vec<Vec<PathBuf>> = vec![
                         inputs
                             .iter()
@@ -1261,13 +1262,17 @@ mod tests {
                             .iter()
                             .map(|p| clumped_bam_output_name(p, output_dir, basename))
                             .collect(),
+                        inputs
+                            .iter()
+                            .map(|p| clumped_paired_bam_output_name(p, None, output_dir, basename))
+                            .collect(),
                     ];
                     for primaries in &primary_sets {
                         for (i, a) in primaries.iter().enumerate() {
                             for (j, b) in primaries.iter().enumerate().take(i) {
                                 if collision_key(a) == collision_key(b) {
                                     // --basename collapses every input onto one primary; the
-                                    // pre-flight rejects that, and cli.rs:620 rejects it earlier
+                                    // pre-flight rejects that, and cli.rs:624 rejects it earlier
                                     // still for multi-input SE. Nothing to prove here.
                                     continue;
                                 }
@@ -1309,8 +1314,9 @@ mod tests {
 
     /// Complement to the above: the primary key is strictly *coarser* than the
     /// report key (in single-end naming — paired `_val_N` inverts this, #388,
-    /// and `_clumped_N` inverts it the same way, #391), which is why checking
-    /// SE primaries covers reports rather than merely coinciding with them.
+    /// as does `clumped_paired_output_names`' `_clumped_N`, #391; the clump
+    /// primaries asserted below all collapse), which is why checking SE
+    /// primaries covers reports rather than merely coinciding with them.
     /// Three spellings of one sample share a primary while keeping three
     /// distinct report names.
     #[test]

--- a/src/io.rs
+++ b/src/io.rs
@@ -1236,40 +1236,63 @@ mod tests {
             Path::new("e/gamma.fq.gz"),
             Path::new("d/same.fastq.gz"),
             Path::new("e/same.fastq.gz"),
+            // Case-variant of d/same: primaries fold-collide (skipped pair), which
+            // is the collision_key dimension PathBuf equality used to miss (#391).
+            Path::new("d/SAME.fastq.gz"),
         ];
         let out = PathBuf::from("shared_out");
 
         for basename in [None, Some("fixed")] {
             for gzip in [true, false] {
                 for output_dir in [None, Some(out.as_path())] {
-                    let primaries: Vec<PathBuf> = inputs
-                        .iter()
-                        .map(|p| single_end_output_name(p, output_dir, basename, gzip))
-                        .collect();
+                    // #391 — the same implication must hold for every clump primary
+                    // namer, and on the pre-flight's own metric (collision_key), so
+                    // the fold dimension is exercised rather than PathBuf equality.
+                    let primary_sets: Vec<Vec<PathBuf>> = vec![
+                        inputs
+                            .iter()
+                            .map(|p| single_end_output_name(p, output_dir, basename, gzip))
+                            .collect(),
+                        inputs
+                            .iter()
+                            .map(|p| clumped_output_name(p, output_dir, basename, gzip))
+                            .collect(),
+                        inputs
+                            .iter()
+                            .map(|p| clumped_bam_output_name(p, output_dir, basename))
+                            .collect(),
+                    ];
+                    for primaries in &primary_sets {
+                        for (i, a) in primaries.iter().enumerate() {
+                            for (j, b) in primaries.iter().enumerate().take(i) {
+                                if collision_key(a) == collision_key(b) {
+                                    // --basename collapses every input onto one primary; the
+                                    // pre-flight rejects that, and cli.rs:620 rejects it earlier
+                                    // still for multi-input SE. Nothing to prove here.
+                                    continue;
+                                }
+                                // Primaries differ, so every secondary must differ too.
+                                for namer in [report_name, json_report_name, clumping_report_name] {
+                                    assert_ne!(
+                                        collision_key(&namer(inputs[i], output_dir)),
+                                        collision_key(&namer(inputs[j], output_dir)),
+                                        "secondary collided while primaries {a:?} / {b:?} differ \
+                                         (basename={basename:?} gzip={gzip} out={output_dir:?})"
+                                    );
+                                }
+                            }
+                        }
+                    }
 
-                    for (i, a) in primaries.iter().enumerate() {
-                        for (j, b) in primaries.iter().enumerate().take(i) {
-                            if a == b {
-                                // --basename collapses every input onto one primary; the
-                                // pre-flight rejects that, and cli.rs:620 rejects it earlier
-                                // still for multi-input SE. Nothing to prove here.
-                                continue;
-                            }
-                            // Primaries differ, so every secondary must differ too.
-                            for namer in [report_name, json_report_name, clumping_report_name] {
-                                assert_ne!(
-                                    namer(inputs[i], output_dir),
-                                    namer(inputs[j], output_dir),
-                                    "secondary collided while primaries {a:?} / {b:?} differ \
-                                     (basename={basename:?} gzip={gzip} out={output_dir:?})"
-                                );
-                            }
-                            // The demux stem, via the same function `demultiplex` uses.
-                            // Only meaningful when the two primaries share a directory:
-                            // demux resolves its output dir to `-o` else the primary's
-                            // parent, so differing parents already separate the paths and
-                            // the stem is allowed to repeat.
-                            if a.parent() == b.parent() {
+                    // The demux stem, via the same function `demultiplex` uses — a
+                    // property of the SE trim primary only. Only meaningful when the
+                    // two primaries share a directory: demux resolves its output dir
+                    // to `-o` else the primary's parent, so differing parents already
+                    // separate the paths and the stem is allowed to repeat.
+                    let se_primaries = &primary_sets[0];
+                    for (i, a) in se_primaries.iter().enumerate() {
+                        for b in se_primaries.iter().take(i) {
+                            if collision_key(a) != collision_key(b) && a.parent() == b.parent() {
                                 assert_ne!(
                                     crate::demux::demux_base_name(a),
                                     crate::demux::demux_base_name(b),
@@ -1285,10 +1308,11 @@ mod tests {
     }
 
     /// Complement to the above: the primary key is strictly *coarser* than the
-    /// report key (in single-end naming — paired `_val_N` inverts this, #388),
-    /// which is why checking SE primaries covers reports rather than merely
-    /// coinciding with them. Three spellings of one sample share a
-    /// primary while keeping three distinct report names.
+    /// report key (in single-end naming — paired `_val_N` inverts this, #388,
+    /// and `_clumped_N` inverts it the same way, #391), which is why checking
+    /// SE primaries covers reports rather than merely coinciding with them.
+    /// Three spellings of one sample share a primary while keeping three
+    /// distinct report names.
     #[test]
     fn primary_output_key_is_coarser_than_secondary_keys() {
         let variants = [
@@ -1324,5 +1348,30 @@ mod tests {
             .map(|p| single_end_bam_output_name(p, None, None))
             .collect();
         assert!(bam.windows(2).all(|w| w[0] == w[1]), "got {bam:?}");
+
+        // #391 — and for every clump primary namer: the three spellings share
+        // one primary each, so a clump report can only collide where the
+        // primary already has.
+        let clumped: Vec<PathBuf> = variants
+            .iter()
+            .map(|p| clumped_output_name(p, None, None, true))
+            .collect();
+        assert!(clumped.windows(2).all(|w| w[0] == w[1]), "got {clumped:?}");
+        let clumped_bam: Vec<PathBuf> = variants
+            .iter()
+            .map(|p| clumped_bam_output_name(p, None, None))
+            .collect();
+        assert!(
+            clumped_bam.windows(2).all(|w| w[0] == w[1]),
+            "got {clumped_bam:?}"
+        );
+        let clumped_pe_bam: Vec<PathBuf> = variants
+            .iter()
+            .map(|p| clumped_paired_bam_output_name(p, None, None, None))
+            .collect();
+        assert!(
+            clumped_pe_bam.windows(2).all(|w| w[0] == w[1]),
+            "got {clumped_pe_bam:?}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,12 +52,14 @@ type AdapterList = Vec<(String, String)>;
 type SetupResult = Result<(String, AdapterList, AdapterList, trimmer::TrimConfig)>;
 type ResolvedAdapter = Result<(String, AdapterList, AdapterList, Option<(usize, usize)>)>;
 
-/// Replaces the generic advice for the modes that name output into the CWD
-/// (`--hardtrim5/3`, `--clock`, `--implicon`), where "use `--output_dir`" is false.
-const PAIRED_REPORT_HINT: &str = "Paired outputs and reports are named from the input \
-                                  filename alone, so two inputs sharing a filename collide \
-                                  regardless of source directory — rename one input, or pass \
-                                  --no_report_file if only the reports collide.";
+/// Hint for the sites whose report names carry no positional discriminator:
+/// paired trim (FASTQ and uBAM out) and `--clump_only --paired` (#391).
+const PAIRED_REPORT_HINT: &str = "Outputs and reports are named from the input \
+                                  filename alone, so inputs sharing a filename can \
+                                  collide when --output_dir (or a shared input \
+                                  directory) sends them to one place — rename one \
+                                  input, or pass --no_report_file if only the \
+                                  reports collide.";
 
 /// CWD-output modes' remediation; see `PAIRED_REPORT_HINT` for the paired sites.
 const CWD_OUTPUT_HINT: &str = "This mode writes output to the current working directory, \
@@ -107,6 +109,24 @@ fn planned_secondary_outputs(
         }
     }
     Ok(v)
+}
+
+/// Clumping-report paths a `--clump_only` run plans — one per report-keyed input,
+/// nothing under `--no_report_file` (matching every writer's gate in clump_only.rs).
+/// The pre-flight is only as complete as its candidate list: #391 was the paired
+/// arm planning primaries alone while the writer also wrote per-mate reports.
+fn clump_report_candidates(
+    no_report_file: bool,
+    report_inputs: &[impl AsRef<Path>],
+    output_dir: Option<&Path>,
+) -> Vec<std::path::PathBuf> {
+    if no_report_file {
+        return Vec::new();
+    }
+    report_inputs
+        .iter()
+        .map(|input| naming::clumping_report_name(input.as_ref(), output_dir))
+        .collect()
 }
 
 /// Prospective hardtrim output paths for every input, per resolved output format.
@@ -465,10 +485,10 @@ fn main() -> Result<()> {
             "Clock",
             Some(CWD_OUTPUT_HINT),
             |r1, r2| {
-                (
+                vec![
                     specialty::clock_output_name(r1, "R1", output_dir, gzip),
                     specialty::clock_output_name(r2, "R2", output_dir, gzip),
-                )
+                ]
             },
             |r1, r2| specialty::clock(r1, r2, gzip, output_dir, cli.cores, cli.compression),
         )?;
@@ -480,10 +500,10 @@ fn main() -> Result<()> {
             "IMPLICON",
             Some(CWD_OUTPUT_HINT),
             |r1, r2| {
-                (
+                vec![
                     specialty::implicon_output_name(r1, umi_len, "R1", output_dir, gzip),
                     specialty::implicon_output_name(r2, umi_len, "R2", output_dir, gzip),
-                )
+                ]
             },
             |r1, r2| {
                 specialty::implicon(
@@ -527,9 +547,20 @@ fn main() -> Result<()> {
                     run_specialty_paired(
                         &cli,
                         "--clump_only",
-                        None, // clumped_paired_output_names uses input.parent(), not the CWD
+                        // #391 — reports carry no _clumped_N discriminator; the hint's
+                        // --no_report_file remedy is the escape hatch when only they collide.
+                        Some(PAIRED_REPORT_HINT),
                         |r1, r2| {
-                            naming::clumped_paired_output_names(r1, r2, output_dir, basename, gzip)
+                            let (o1, o2) = naming::clumped_paired_output_names(
+                                r1, r2, output_dir, basename, gzip,
+                            );
+                            let mut v = vec![o1, o2];
+                            v.extend(clump_report_candidates(
+                                cli.no_report_file,
+                                &[r1, r2],
+                                output_dir,
+                            ));
+                            v
                         },
                         |r1, r2| {
                             clump_only::clump_only_paired(
@@ -550,11 +581,17 @@ fn main() -> Result<()> {
                     )?;
                 } else {
                     // SE FASTQ pre-flight (issues #216, #383).
-                    let planned: Vec<std::path::PathBuf> = cli
+                    let mut planned: Vec<std::path::PathBuf> = cli
                         .input
                         .iter()
                         .map(|input| naming::clumped_output_name(input, output_dir, basename, gzip))
                         .collect();
+                    // #391 — reports join so the input check covers them too.
+                    planned.extend(clump_report_candidates(
+                        cli.no_report_file,
+                        &cli.input,
+                        output_dir,
+                    ));
                     naming::preflight_output_collisions(&planned, &guarded_inputs(&cli), None)?;
                     for input in &cli.input {
                         clump_only::clump_only_single(
@@ -584,17 +621,21 @@ fn main() -> Result<()> {
                         // its condition is a strict subset of the `--paired`
                         // N=1 non-BAM guard in main() — and was retired with
                         // #363. Retained note so the absence is intentional.
-                        let planned = naming::clumped_paired_bam_output_name(
+                        let mut planned = vec![naming::clumped_paired_bam_output_name(
                             &cli.input[0],
                             None,
                             output_dir,
                             basename,
-                        );
-                        naming::preflight_output_collisions(
-                            &[planned],
-                            &guarded_inputs(&cli),
-                            None,
-                        )?;
+                        )];
+                        // #391 — defensive symmetry: with N=1 the report (input filename
+                        // plus a suffix) can never alias the input, but the arm keeps the
+                        // same shape as its siblings.
+                        planned.extend(clump_report_candidates(
+                            cli.no_report_file,
+                            &cli.input,
+                            output_dir,
+                        ));
+                        naming::preflight_output_collisions(&planned, &guarded_inputs(&cli), None)?;
                         clump_only::clump_only_paired_to_bam_one_pair(
                             &cli.input,
                             output_dir,
@@ -625,6 +666,13 @@ fn main() -> Result<()> {
                                 Some(&chunk[1]),
                                 output_dir,
                                 basename,
+                            ));
+                            // #391 — ONE report per pair, keyed on the pair's first input
+                            // (clump_only.rs writes clumping_report_name(inputs[0], …)).
+                            planned.extend(clump_report_candidates(
+                                cli.no_report_file,
+                                std::slice::from_ref(&chunk[0]),
+                                output_dir,
                             ));
                         }
                         naming::preflight_output_collisions(&planned, &guarded_inputs(&cli), None)?;
@@ -675,6 +723,12 @@ fn main() -> Result<()> {
                     for input in &cli.input {
                         planned.push(naming::clumped_bam_output_name(input, output_dir, basename));
                     }
+                    // #391 — reports join so the input check covers them too.
+                    planned.extend(clump_report_candidates(
+                        cli.no_report_file,
+                        &cli.input,
+                        output_dir,
+                    ));
                     naming::preflight_output_collisions(&planned, &guarded_inputs(&cli), None)?;
                     for input in &cli.input {
                         clump_only::clump_only_single_to_bam(
@@ -2468,28 +2522,27 @@ fn pct(part: usize, total: usize) -> f64 {
 }
 
 /// Multi-pair driver for the run-and-exit specialty modes (`--clock`,
-/// `--implicon`). Iterates over `cli.input.chunks(2)`, prints a per-pair
-/// header for multi-pair invocations, and runs the supplied per-pair
-/// function. Mirrors `--paired`'s output-collision pre-flight (case-
-/// insensitive on full path) so two pairs that would write to the same
-/// output file fail loudly before any I/O.
+/// `--implicon`, `--clump_only --paired`). Iterates over `cli.input.chunks(2)`,
+/// prints a per-pair header for multi-pair invocations, and runs the supplied
+/// per-pair function. Mirrors `--paired`'s output-collision pre-flight (case-
+/// insensitive on full path); `pair_outputs` must return EVERY path the pair
+/// will write — primaries plus gated secondaries (#391) — so two pairs that
+/// would write to the same file fail loudly before any I/O.
 fn run_specialty_paired<NameFn, RunFn>(
     cli: &Cli,
     mode_label: &str,
     hint: Option<&str>,
-    mut output_names: NameFn,
+    mut pair_outputs: NameFn,
     mut run_pair: RunFn,
 ) -> Result<()>
 where
-    NameFn: FnMut(&Path, &Path) -> (std::path::PathBuf, std::path::PathBuf),
+    NameFn: FnMut(&Path, &Path) -> Vec<std::path::PathBuf>,
     RunFn: FnMut(&Path, &Path) -> Result<()>,
 {
     // Pre-flight across pairs before any I/O; see io::collision_key for the key.
     let mut planned: Vec<std::path::PathBuf> = Vec::new();
     for chunk in cli.input.chunks(2) {
-        let (o1, o2) = output_names(&chunk[0], &chunk[1]);
-        planned.push(o1);
-        planned.push(o2);
+        planned.extend(pair_outputs(&chunk[0], &chunk[1]));
     }
     naming::preflight_output_collisions(&planned, &guarded_inputs(cli), hint)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -627,9 +627,8 @@ fn main() -> Result<()> {
                             output_dir,
                             basename,
                         )];
-                        // #391 — defensive symmetry: with N=1 the report (input filename
-                        // plus a suffix) can never alias the input, but the arm keeps the
-                        // same shape as its siblings.
+                        // #391 — defensive symmetry: with one input the report (filename
+                        // plus a suffix) can never alias it; the arm keeps its siblings' shape.
                         planned.extend(clump_report_candidates(
                             cli.no_report_file,
                             &cli.input,

--- a/tests/integration_output_collision.rs
+++ b/tests/integration_output_collision.rs
@@ -71,9 +71,9 @@ fn count_reads_from(path: &Path, prefix: &str) -> usize {
         .count()
 }
 
-/// After a rejected run, `dir` must contain exactly `expected` — nothing written.
-/// Used where output would land beside the inputs (no `--output_dir`), so the
-/// "directory is empty" form does not apply.
+/// `dir` must contain exactly `expected`. For rejected runs (nothing written
+/// beside the inputs — the no-`--output_dir` twin of "directory is empty") and
+/// for accepted runs where the written set must equal the planned set (#391).
 fn assert_dir_holds_only(dir: &Path, expected: &[&str]) {
     let mut found: Vec<String> = std::fs::read_dir(dir)
         .unwrap()
@@ -83,7 +83,10 @@ fn assert_dir_holds_only(dir: &Path, expected: &[&str]) {
     found.sort();
     let mut want: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
     want.sort();
-    assert_eq!(found, want, "a rejected run must write nothing");
+    assert_eq!(
+        found, want,
+        "directory must hold exactly the expected files"
+    );
 }
 
 const DUP_MSG: &str = "would be written to the same file";
@@ -1002,4 +1005,286 @@ fn paired_report_candidates_do_not_over_reject() {
     );
     assert!(dir3.join("A/reads.fq_trimming_report.txt").is_file());
     assert!(dir3.join("B/reads.fq_trimming_report.txt").is_file());
+}
+
+// ── --clump_only: clumping reports join the pre-flight (#391) ─────────────
+
+/// The #391 repro: same filename mates, `-o` collecting both reports onto one
+/// path. Primaries carry `_clumped_1`/`_clumped_2` and never collide; the
+/// reports are the only collision, and the message must say so.
+#[test]
+fn clump_paired_rejects_shared_report_name() {
+    let dir = tempdir("clump_rep");
+    write_fastq(&dir.join("a/reads.fq"), "CR1");
+    write_fastq(&dir.join("b/reads.fq"), "CR2");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--paired",
+            "-o",
+            "out",
+            "a/reads.fq",
+            "b/reads.fq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+    assert!(
+        stderr.contains("reads.fq_clumping_report.txt"),
+        "the colliding path must be the clumping report:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--no_report_file"),
+        "hint must offer the report-only remedy:\n{stderr}"
+    );
+}
+
+/// Same fixtures, `--no_report_file`: the only paths the flag removes from the
+/// candidate list are the two reports, so success here proves the rejection
+/// above came from the reports — and that the gate matches the writer.
+#[test]
+fn clump_paired_accepts_shared_report_name_with_no_report_file() {
+    let dir = tempdir("clump_rep_norep");
+    write_fastq(&dir.join("a/reads.fq"), "CN1");
+    write_fastq(&dir.join("b/reads.fq"), "CN2");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--paired",
+            "--no_report_file",
+            "-o",
+            "out",
+            "a/reads.fq",
+            "b/reads.fq",
+        ],
+    );
+    assert!(ok, "expected success:\n{stderr}");
+    assert_eq!(count_reads_from(&out.join("reads_clumped_1.fq"), "CN1"), 40);
+    assert_eq!(count_reads_from(&out.join("reads_clumped_2.fq"), "CN2"), 40);
+    assert_dir_holds_only(&out, &["reads_clumped_1.fq", "reads_clumped_2.fq"]);
+}
+
+/// Acceptance guard: distinct filenames → primaries + reports all written, and
+/// nothing else. The exact-set assertion pins that the pre-flight's candidate
+/// list and the writer's file set agree — the invariant whose absence is this
+/// bug family's root cause (#388, #391).
+#[test]
+fn clump_paired_accepts_distinct_filenames() {
+    let dir = tempdir("clump_ok");
+    write_fastq(&dir.join("a/r1.fq"), "D1");
+    write_fastq(&dir.join("b/r2.fq"), "D2");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--paired",
+            "-o",
+            "out",
+            "a/r1.fq",
+            "b/r2.fq",
+        ],
+    );
+    assert!(ok, "expected success:\n{stderr}");
+    assert_eq!(count_reads_from(&out.join("r1_clumped_1.fq"), "D1"), 40);
+    assert_eq!(count_reads_from(&out.join("r2_clumped_2.fq"), "D2"), 40);
+    assert_dir_holds_only(
+        &out,
+        &[
+            "r1_clumped_1.fq",
+            "r2_clumped_2.fq",
+            "r1.fq_clumping_report.txt",
+            "r2.fq_clumping_report.txt",
+        ],
+    );
+}
+
+/// Cross-pair: all four primaries distinct (the positional suffixes cross),
+/// reports collide across pairs. Pins that the candidate list spans pairs.
+/// No filename assertion: candidate order decides which report is flagged.
+#[test]
+fn clump_paired_rejects_cross_pair_report_collision() {
+    let dir = tempdir("clump_xpair");
+    write_fastq(&dir.join("a/x.fq"), "X1");
+    write_fastq(&dir.join("a/y.fq"), "Y1");
+    write_fastq(&dir.join("b/y.fq"), "Y2");
+    write_fastq(&dir.join("b/x.fq"), "X2");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--paired",
+            "-o",
+            "out",
+            "a/x.fq",
+            "a/y.fq",
+            "b/y.fq",
+            "b/x.fq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+}
+
+/// Case-free and no `-o`: one file as the mate of two pairs (validate permits
+/// this — only exact duplicate pairs are rejected). Reports collide in the
+/// shared mate's own directory while all four primaries stay distinct, so the
+/// rejection behaves identically on APFS and ext4.
+#[test]
+fn clump_paired_rejects_shared_mate_report_without_output_dir() {
+    let dir = tempdir("clump_mate");
+    write_fastq(&dir.join("p/a.fq"), "M1");
+    write_fastq(&dir.join("d/x.fq"), "MX");
+    write_fastq(&dir.join("q/b.fq"), "M2");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--paired",
+            "p/a.fq",
+            "d/x.fq",
+            "q/b.fq",
+            "d/x.fq",
+        ],
+    );
+    assert!(!ok, "expected rejection:\n{stderr}");
+    assert!(
+        stderr.contains(DUP_MSG),
+        "expected duplicate wording:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("x.fq_clumping_report.txt"),
+        "the colliding path must be the shared mate's report:\n{stderr}"
+    );
+    assert_dir_holds_only(&dir.join("p"), &["a.fq"]);
+    assert_dir_holds_only(&dir.join("d"), &["x.fq"]);
+    assert_dir_holds_only(&dir.join("q"), &["b.fq"]);
+}
+
+/// `--basename foo` forces `foo_clumped_1`/`foo_clumped_2` primaries — distinct
+/// by construction — so this isolates the report path without any reasoning
+/// about stems. Reports ignore `--basename` and still collide.
+#[test]
+fn clump_paired_rejects_shared_report_name_with_basename() {
+    let dir = tempdir("clump_base");
+    write_fastq(&dir.join("a/reads.fq"), "B1");
+    write_fastq(&dir.join("b/reads.fq"), "B2");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--paired",
+            "--basename",
+            "foo",
+            "-o",
+            "out",
+            "a/reads.fq",
+            "b/reads.fq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+    assert!(
+        stderr.contains("reads.fq_clumping_report.txt"),
+        "with --basename the reports are the only possible collision:\n{stderr}"
+    );
+}
+
+/// #385 defect-2 class on the SE clump arm: an input named like another input's
+/// clumping report was silently overwritten (this run exited 0 and destroyed
+/// input 2 before #391). Both files are valid FASTQ so the rejection is
+/// attributable to the pre-flight, not a parse error.
+#[test]
+fn clump_se_rejects_report_that_aliases_an_input() {
+    let dir = tempdir("clump_se_alias");
+    write_fastq(&dir.join("s.fq"), "SRC");
+    write_fastq(&dir.join("s.fq_clumping_report.txt"), "REPORTY");
+    let (ok, stderr) = run_in(&dir, &["--clump_only", "s.fq", "s.fq_clumping_report.txt"]);
+    assert!(!ok, "expected rejection:\n{stderr}");
+    assert!(
+        stderr.contains(ALIAS_MSG),
+        "expected alias wording:\n{stderr}"
+    );
+    assert_eq!(
+        count_reads_from(&dir.join("s.fq_clumping_report.txt"), "REPORTY"),
+        40
+    );
+    assert_dir_holds_only(&dir, &["s.fq", "s.fq_clumping_report.txt"]);
+}
+
+/// The same shape runs when reports are off — and writes exactly the primaries.
+#[test]
+fn clump_se_accepts_report_alias_with_no_report_file() {
+    let dir = tempdir("clump_se_alias_ok");
+    write_fastq(&dir.join("s.fq"), "SRC");
+    write_fastq(&dir.join("s.fq_clumping_report.txt"), "REPORTY");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--no_report_file",
+            "s.fq",
+            "s.fq_clumping_report.txt",
+        ],
+    );
+    assert!(ok, "expected success:\n{stderr}");
+    assert_eq!(count_reads_from(&dir.join("s_clumped.fq"), "SRC"), 40);
+    assert_eq!(
+        count_reads_from(&dir.join("s.fq_clumping_report_clumped.fq"), "REPORTY"),
+        40
+    );
+    assert_dir_holds_only(
+        &dir,
+        &[
+            "s.fq",
+            "s.fq_clumping_report.txt",
+            "s_clumped.fq",
+            "s.fq_clumping_report_clumped.fq",
+        ],
+    );
+}
+
+/// Task 2's paired-BAM Shape A arm plans ONE report per pair, keyed on the
+/// pair's FIRST input (clump_only.rs keys on inputs[0]). Keyed on chunk[1] by
+/// mistake, pair 1 would plan y.fq_clumping_report.txt, collide with nothing,
+/// and the run would proceed — this test discriminates exactly that.
+#[test]
+fn clump_paired_bam_rejects_report_that_aliases_an_input() {
+    let dir = tempdir("clump_bam_alias");
+    write_fastq(&dir.join("x.fq"), "PX");
+    write_fastq(&dir.join("y.fq"), "PY");
+    write_fastq(&dir.join("x.fq_clumping_report.txt"), "PR");
+    write_fastq(&dir.join("z.fq"), "PZ");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--paired",
+            "--output-format",
+            "ubam",
+            "x.fq",
+            "y.fq",
+            "x.fq_clumping_report.txt",
+            "z.fq",
+        ],
+    );
+    assert!(!ok, "expected rejection:\n{stderr}");
+    assert!(
+        stderr.contains(ALIAS_MSG),
+        "expected alias wording:\n{stderr}"
+    );
+    assert_eq!(count_reads_from(&dir.join("x.fq"), "PX"), 40);
+    assert_eq!(
+        count_reads_from(&dir.join("x.fq_clumping_report.txt"), "PR"),
+        40
+    );
+    assert_dir_holds_only(&dir, &["x.fq", "y.fq", "x.fq_clumping_report.txt", "z.fq"]);
 }

--- a/tests/integration_output_collision.rs
+++ b/tests/integration_output_collision.rs
@@ -84,8 +84,10 @@ fn assert_dir_holds_only(dir: &Path, expected: &[&str]) {
     let mut want: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
     want.sort();
     assert_eq!(
-        found, want,
-        "directory must hold exactly the expected files"
+        found,
+        want,
+        "{} must hold exactly the expected files",
+        dir.display()
     );
 }
 
@@ -1131,6 +1133,78 @@ fn clump_paired_rejects_cross_pair_report_collision() {
         ],
     );
     assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+    assert!(
+        stderr.contains("_clumping_report.txt"),
+        "whichever report is flagged first, the class is order-independent:\n{stderr}"
+    );
+}
+
+/// Fold-equal report names: the primaries differ even case-folded (positional
+/// suffixes), so the reports are the only collision, and only under the fold.
+/// The REJECTION is asserted, so the test is filesystem-independent.
+#[test]
+fn clump_paired_rejects_fold_equal_report_names() {
+    let dir = tempdir("clump_foldeq");
+    write_fastq(&dir.join("a/Reads.fq"), "FU");
+    write_fastq(&dir.join("b/reads.fq"), "FL");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--paired",
+            "-o",
+            "out",
+            "a/Reads.fq",
+            "b/reads.fq",
+        ],
+    );
+    assert_rejected_cleanly(&out, ok, &stderr, DUP_MSG);
+    assert!(
+        stderr.contains("_clumping_report.txt"),
+        "the fold-equal pair must be the reports:\n{stderr}"
+    );
+}
+
+/// Over-rejection guard: same filename in two dirs WITHOUT -o is legal — both
+/// primaries land in R1's directory, each report beside its own mate. Pins that
+/// the candidates honour output_dir = None; a builder that resolved reports
+/// into one directory would over-reject this.
+#[test]
+fn clump_report_candidates_do_not_over_reject() {
+    let dir = tempdir("clump_ok_no_odir");
+    write_fastq(&dir.join("A/reads.fq"), "Q1");
+    write_fastq(&dir.join("B/reads.fq"), "Q2");
+    let (ok, stderr) = run_in(
+        &dir,
+        &["--clump_only", "--paired", "A/reads.fq", "B/reads.fq"],
+    );
+    assert!(
+        ok,
+        "same filename in two dirs without -o must run:\n{stderr}"
+    );
+    assert_eq!(
+        count_reads_from(&dir.join("A/reads_clumped_1.fq"), "Q1"),
+        40
+    );
+    assert_eq!(
+        count_reads_from(&dir.join("A/reads_clumped_2.fq"), "Q2"),
+        40
+    );
+    assert_dir_holds_only(
+        &dir.join("A"),
+        &[
+            "reads.fq",
+            "reads_clumped_1.fq",
+            "reads_clumped_2.fq",
+            "reads.fq_clumping_report.txt",
+        ],
+    );
+    assert_dir_holds_only(
+        &dir.join("B"),
+        &["reads.fq", "reads.fq_clumping_report.txt"],
+    );
 }
 
 /// Case-free and no `-o`: one file as the mate of two pairs (validate permits
@@ -1213,6 +1287,10 @@ fn clump_se_rejects_report_that_aliases_an_input() {
         stderr.contains(ALIAS_MSG),
         "expected alias wording:\n{stderr}"
     );
+    assert!(
+        stderr.contains("s.fq_clumping_report.txt"),
+        "the aliased path must be the clumping report:\n{stderr}"
+    );
     assert_eq!(
         count_reads_from(&dir.join("s.fq_clumping_report.txt"), "REPORTY"),
         40
@@ -1256,6 +1334,8 @@ fn clump_se_accepts_report_alias_with_no_report_file() {
 /// pair's FIRST input (clump_only.rs keys on inputs[0]). Keyed on chunk[1] by
 /// mistake, pair 1 would plan y.fq_clumping_report.txt, collide with nothing,
 /// and the run would proceed — this test discriminates exactly that.
+/// Acceptance sibling for this dispatch path lives cross-file:
+/// integration_clump_only_ubam.rs::multi_pair_pe_bam_produces_one_output_per_pair.
 #[test]
 fn clump_paired_bam_rejects_report_that_aliases_an_input() {
     let dir = tempdir("clump_bam_alias");


### PR DESCRIPTION
`--clump_only --paired -o out A/reads.fq B/reads.fq` exited 0 with ONE clumping report: primaries carry `_clumped_1`/`_clumped_2` and never collide, but reports key on the bare input filename, so R2's report silently overwrote R1's — the #388 shape on the clump path. Clumping-report paths now join the collision pre-flight on every clump arm via a shared `clump_report_candidates` helper (gated on `--no_report_file`, matching the writers), which also stops a clumping report from destroying an *input* named like one (the SE and paired-uBAM Shape A arms both did that at exit 0). `run_specialty_paired`'s namer widens to `Vec<PathBuf>` ("every path this pair writes") — pre-flight-only, so no written byte changes on accepted runs. `PAIRED_REPORT_HINT` is reworded to stop claiming directory-independence that doesn't hold. The io.rs naming property tests now cover the clump namers via `collision_key`, holding the "report collides ⇒ primary already collided" invariant in CI.

Expected-fail control: all six new rejection tests were run against the unpatched tree first and all six exited 0 there (the two alias cases destroying an input in the process); the three acceptance controls passed unpatched. Post-fix: 9/9 green, 557 total.

Plan + dual plan-review + implementation notes: `plans/08082026_clump-paired-report-preflight/` (artifacts follow in a second commit after code review + coverage audit complete).

Closes #391 (manual close needed — dev is not the default branch).
