### PR TITLE
refactor(io): make norm_path private and re-home the fold trade-off (#399)

### DIFF
--- a/plans/08082026_normpath-visibility/CODE_REVIEW_A.md
+++ b/plans/08082026_normpath-visibility/CODE_REVIEW_A.md
@@ -1,0 +1,198 @@
+# Code Review A — #399 `norm_path` visibility + doc re-homing
+
+**Reviewer:** A (independent; Reviewer B reviews the same diff separately)
+**Branch:** `fix/399-normpath-private` @ `315557d` — base `dev` @ `ac08a97`
+**Diff:** `git diff ac08a97..315557d` — one file, `src/io.rs`, 3 hunks, +10/−12
+**Plan:** `plans/08082026_normpath-visibility/PLAN.md` (r2)
+**Verdict:** **APPROVE.** No Critical, no High. One Medium worth fixing before merge (a doc statement that is narrower than the truth), one Medium that belongs in a separate issue, five Lows.
+
+---
+
+## Summary
+
+The change does what it claims and nothing else. `io::norm_path` is now module-private, the substantive case-folding trade-off has moved onto `collision_key` where the decision is actually made, and `collision_key` gained an accurate pointer to the case-preserving `path_identity_key`. Behaviour is unchanged; I verified that by compiling and running, not by reading.
+
+Two things are worth the caller's attention.
+
+**First, the one real defect.** The relocated trade-off paragraph says the false positive happens "on opt-in case-sensitive APFS volumes". That scoping is too narrow: Linux ext4/xfs are case-sensitive *by default*, so ordinary Linux — the platform most Trim Galore runs on, and the platform CI runs on — is the primary home of this false positive, not a macOS opt-in edge case. The repo already knows this: the regression-test doc at `io.rs:1170-1174` uses the general framing and ends "which on Linux is false". The text was moved verbatim, so this is not a regression introduced here, but the move promotes it to the primary public location for the fact, and #399 exists to remove exactly this class of imprecision. One-line generalisation, trivial fix.
+
+**Second, a caveat about how I verified.** `cargo clippy --all-targets --release -- -D warnings` in the shared working tree returned exit 0 in **0.32 s** — a pure cache hit, not a compile. I did not accept that as evidence. I re-ran the check from scratch in an isolated `git archive` copy of `315557d` (tracked files only, so no untracked `examples/fastqc_only.rs`, matching what CI sees) with a private target dir, and additionally ran the positive control myself. Results below. The negative is trustworthy; it would not have been on the cached run alone.
+
+The plan's central question — "does privatizing delete the only public statement of the trade-off?" — is verifiably answered *no*: I built the rustdoc and confirmed `norm_path` has vanished from the rendered surface entirely while `collision_key`'s page now carries the paragraph.
+
+---
+
+## Verification log
+
+Everything here I ran or read myself.
+
+| # | Check | Result |
+|---|-------|--------|
+| 1 | `cargo fmt --all -- --check` | **clean** |
+| 2 | `cargo clippy --all-targets --release -- -D warnings` (shared tree) | exit 0 — but `Finished in 0.32s`, i.e. **cache hit, not a compile**. Not relied upon. |
+| 3 | **Cold-cache** `cargo clippy --all-targets -- -D warnings`, isolated `git archive 315557d` copy, private target dir, tracked files only | **exit 0, clean** — a genuine compile of exactly what CI compiles |
+| 4 | **Positive control:** external caller `trim_galore::io::norm_path` planted in `tests/` of the isolated copy | **`error[E0603]: function norm_path is private`, exit 101** — the harness demonstrably fails |
+| 5 | Probe removed → re-check | **exit 0** — back to green, so #4 was caused by the probe |
+| 6 | `cargo test` (full) **on the pinned isolated copy**, with `fn norm_path` (private) confirmed at `io.rs:39` in that tree | **561 passed, 0 failed** across 1 lib + 11 integration binaries + doc-tests, incl. `io::tests::test_norm_path_case_folds ... ok` |
+| 7 | `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` | fails on **12 pre-existing** diagnostics, **none from `io.rs`** — this diff adds zero |
+| 8 | Rendered docs: is `norm_path` gone? | **yes** — no `fn.norm_path.html`, zero grep hits across the entire generated doc tree |
+| 9 | Rendered docs: did the trade-off survive? | **yes** — `io/fn.collision_key.html` renders both the "different question" pointer and the trade-off paragraph |
+| 10 | CI rustdoc gate (`cargo doc` / `RUSTDOCFLAGS` / `rustdoc` / `--document-private-items` in `.github/workflows/`) | **absent** (grep exit 1) — confirms the plan |
+| 11 | Every production caller of `collision_key` read for the "loud early error" claim | `io.rs:104-110` bails; `cli.rs:949-962` bails. **No caller where a false positive could silently lose data.** |
+| 12 | Repo-wide `git grep norm_path -- ':!plans/'` | only `src/io.rs` + one `//` comment naming the *test* |
+
+Two notes on how this evidence was obtained, both of which changed what I was willing to claim.
+
+**The shared working tree moved off the reviewed commit mid-review.** By the time I finished, `/Users/fkrueger/Github/TrimGalore` was on `fix/400-clump-help-text` @ `0676fdf`, and `315557d` is **not** an ancestor of it. `git diff 315557d HEAD -- src/io.rs` is +12/−10 — the exact inverse of #399's −10/+12 — i.e. that branch carries the *pre*-#399 `pub fn norm_path`. Consequences worth knowing:
+
+- Every load-bearing check above (#3, #4, #5, #6, #7, #8, #9) ran against a `git archive 315557d` copy, so it is commit-pinned and unaffected. I re-ran the full test suite on that pinned copy specifically to remove any doubt, after confirming `fn norm_path` is private in it.
+- `fix/400-clump-help-text` was cut from `dev` (`ac08a97`) and **does not contain #399**. That is fine for parallel work, but if both land the caller should merge them independently rather than assuming one carries the other. #400 also adds a CHANGELOG entry (+15 lines) where #399 deliberately adds none.
+- Any check another agent runs in the shared tree right now is not a statement about #399.
+
+**One of my own runs was a false negative I had to discard.** My first `cargo test` was piped through `tail -40`, which truncated the log to a single binary's summary and hid the fold test entirely — it looked like a 23-test suite. The 561-test figure comes only from runs with the complete log captured.
+
+---
+
+## Issues by area
+
+### 1. Logic / correctness — sound
+
+- **Demotion compiles, nothing reachable is broken.** Verified by #3/#4/#5 above, not by inference. `--all-targets` is genuinely the net: the positive control proves it catches an external caller that plain `cargo check` would miss.
+- **The fold is still pinned.** `io::tests::test_norm_path_case_folds` runs and passes, so the child module does reach the private fn (plan assumption A2 verified by execution). The assertions are unchanged; `collision_key` was correctly *not* substituted for `norm_path` in the test, because `collision_key` absolutises and would make the relative-path assertions cwd-dependent.
+- **The `path_identity_key` cross-reference is accurate.** It is genuinely case-preserving (`lexical_normalise` then `to_string_lossy`, no folding anywhere), and it is genuinely what input identity uses — `cli.rs:537`, `549-550`, `635`, `638`, `934`, `941`. The sentence is true as written.
+- **The relocated trade-off is now attached to the right function.** This is the substantive win. `norm_path` is `to_string_lossy().to_ascii_lowercase()` — "may false-positive" is not a property of lowercasing a string. It is a property of deciding output collisions on a folded key, which is what `collision_key` does. I checked the claim's second half against every production caller (#11): both comparison sites bail loudly, so "the penalty is a loud early error rather than silent data loss" holds universally for this key. There is no caller that feeds `collision_key` into a dedup or map where a false positive would silently discard work.
+
+#### M1 — the trade-off's scope is too narrow *(Medium; trivial fix)*
+
+`src/io.rs:77-79`:
+
+```rust
+/// Pragmatic trade-off: on opt-in case-sensitive APFS volumes this may
+/// false-positive, but the penalty is a loud early error rather than
+/// silent data loss.
+```
+
+"Opt-in case-sensitive APFS volumes" names only the macOS case. But:
+
+- Linux ext4/xfs/btrfs are case-sensitive **by default**. On Linux, `Sample_R1_trimmed.fq` and `sample_r1_trimmed.fq` are two genuinely distinct files, and this key folds them together, so the pre-flight refuses a run that would have been safe. That is the false positive, and it lives on the dominant platform — not on an opt-in volume.
+- The repo already documents it that way. `io.rs:1170-1174` (the `identity_key_is_case_sensitive_but_collision_key_is_not` doc): the #216 CI guard "feeds four genuinely distinct files (`Sample_R1` / `SAMPLE_R1`) on a case-sensitive filesystem and asserts the *output* pre-flight refuses them … which on Linux is false." So CI exercises this trade-off on Linux on every run.
+
+The rest of the file's "APFS/NTFS" framing is correct where it appears, because there it explains why folding is *necessary* (those filesystems are case-insensitive). The false-positive clause is the mirror image and needs the mirror-image scope. Suggested replacement, same length:
+
+```rust
+/// Pragmatic trade-off: on a case-sensitive filesystem (Linux ext4, opt-in APFS)
+/// two outputs differing only in case are distinct, and this rejects them — a loud
+/// early error in preference to silent data loss.
+```
+
+Not a regression from this diff (moved verbatim), but this diff is the moment it becomes the canonical public statement of the fact.
+
+#### L1 — "these two paths" for a one-path function *(Low; pre-existing, no action)*
+
+`io.rs:73` opens "Would these two paths be the same *output* file?" while the signature takes one `&Path` and returns a key; the two-path comparison is the caller's. Reads fine as a rhetorical framing and predates this diff.
+
+### 2. Errors / rustdoc — clean here, but the crate is not
+
+- **No bracketed intra-doc link exists anywhere in `io.rs`.** The only two `[…]` constructs are full markdown URLs to issue #381 (`io.rs:532`, `io.rs:583`). The plan's instruction to use plain backticks rather than intra-doc links was followed, so **the demotion cannot have created a private-link error** — and I confirmed that positively by building the docs: of 12 rustdoc diagnostics, **zero come from `io.rs`**.
+- **CI would not catch it either way** — no rustdoc job exists (#10), independently confirming the plan.
+
+#### M2 — the crate already has 12 rustdoc errors, including this exact hazard *(Medium; out of scope — file separately)*
+
+`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` fails today on `dev`, independent of this change:
+
+| Location | Diagnostic |
+|---|---|
+| `src/alignment.rs:11` | **public documentation for `alignment` links to private item `myers_proves_no_match`** |
+| `src/cli.rs:401,405,409,413,417,421` | unresolved link to `Deprecated` (×6) |
+| `src/clump_only.rs:874` | unresolved link to `i` (×2) |
+| `src/report.rs:33` | unresolved link to `match_len` |
+| `src/cli.rs:370,375` | unclosed HTML tag `N` (from `.<N>bp_5prime.fq`) |
+
+The `alignment.rs:11` entry is the realized instance of precisely the hazard the plan reasoned about hypothetically — a public doc pointing at a private item. Since `release.yml` publishes to crates.io and `Cargo.toml` has no `publish = false`, docs.rs renders all of this. It is not this PR's job to fix, but it is the natural companion to the lib.rs-surface follow-up the plan already filed, and it means a future `[norm_path]` link would join the list silently. Worth an issue.
+
+#### L2 — the `path_identity_key` reference is not clickable *(Low; recommend leaving as-is)*
+
+Rendered output shows `path_identity_key` as plain code, not a link. An intra-doc link would be safe here (the target is `pub`, so no private-link risk) and rustdoc would catch a typo in it. But the file uses backticks uniformly, and consistency is the better argument. Keep the backticks — noting only that the plan's stated reason ("no CI job would catch a broken link") is the weaker justification of the two available.
+
+### 3. Structure / style — compliant
+
+- **The 2-line test comment is within convention.** CLAUDE.md sets one line as default, two as maximum. It states the fact, carries no measurements and no reasoning chain. Compliant.
+- **`///` blocks are a different register from `//` comments in this file, and correctly treated as such.** `is_gzipped` carries 21 doc lines, `ensure_output_dir` 17. Against that, `collision_key` at 7 lines (was 2) and `norm_path` at 1 (was 7) are both in keeping. The one-line rule governs code comments, and the diff respects it there.
+- **Widths fine.** New lines run 83–88 chars against a pre-existing file maximum of 90; `cargo fmt --check` is clean.
+
+#### L3 — moved paragraph kept its old wrap *(Low; trivial fix)*
+
+`io.rs:77-79` wraps at ~70 chars while lines 73-75 immediately above wrap at 83-88, giving the block a ragged right edge halfway down. Reflowing the paragraph to match (2 lines instead of 3) would tidy it. Folds naturally into the M1 rewrite.
+
+#### L4 — "never directly" sits above five direct calls *(Low; trivial fix)*
+
+`io.rs:765-766` says callers "reach it through that key, never directly", and the next five lines call `norm_path` directly — the test itself is the exception. True of production callers, so `production callers` would remove the wrinkle.
+
+#### L5 — mild garden-path in the test comment *(Low; optional)*
+
+"The fold `collision_key` is built on (…)" elides the relative pronoun, so with the backticks drawing the eye it can momentarily parse as `collision_key` being the subject of "is built on". "The fold that `collision_key` is built on" costs one word.
+
+#### Did anything become less clear by moving?
+
+One thing, mildly. The old test comment named *where the fold matters* ("the output-collision pre-flight + `--passthrough` validation both use"); the new one names only the immediate consumer. A reader of the test now learns the plumbing but not the stakes. Two things offset it: the old claim was true only indirectly (both reach the fold via `collision_key`), which is the imprecision #399 exists to remove; and the stakes now live on `collision_key`, which is the better home. **Net clarity: improved.** No other regression — the in-source reader who previously found the trade-off at the fold now finds it 35 lines later at the decision point, which is where they need it.
+
+### 4. Dangling references — none
+
+- **No `pub` item's doc mentions `norm_path`.** Checked every doc block in `io.rs` and grepped `src/` — nothing points a public reader at the now-private symbol for the trade-off or for anything else. This was the specific risk of moving the paragraph out, and it is clean.
+- **`cli.rs:1903` is live, not dangling.** It reads "fold pinned by `io::tests::test_norm_path_case_folds`" — it names the *test*, which still exists under exactly that name (it appears in the passing test list), and it is a `//` comment, not a doc comment. Correctly left alone.
+- **Nothing outside `src/` refers to the symbol.** `git grep norm_path -- ':!plans/'` returns `src/` only: no `docs/`, no `build.rs`, no `Cargo.toml`, no README. The untracked `examples/fastqc_only.rs` does not reference it either (and my isolated verification excluded it, so the green result speaks about the tracked tree).
+- **Rendered docs corroborate.** Zero occurrences of `norm_path` anywhere in the generated doc tree, and `fn.norm_path.html` is gone from the `io` module listing, which now exposes 19 public functions.
+
+### 5. Efficiency — nil, as expected
+
+Visibility is a compile-time annotation with no codegen consequence; the sole call site is unchanged and was already a direct intra-module call. If anything the change is marginally *helpful* — the symbol is no longer externally reachable, so it is a cleaner inlining candidate — but the function is one `to_ascii_lowercase` and the effect is immaterial. Nothing to report.
+
+---
+
+## Plan conformance
+
+All seven implementation steps are satisfied.
+
+| Step | Status |
+|---|---|
+| 1. `pub fn` → `fn` | done |
+| 2. Move trade-off paragraph to `collision_key` | done, verbatim |
+| 3. Reduce `norm_path` doc to one line, no "(private)" framing | done — the plan's suggested wording used verbatim |
+| 4. Note that input identity uses the case-preserving key; plain backticks | done, no `[…]` links introduced |
+| 5. Optional drive-by on the test comment | done, with a deviation worth naming (below) |
+| 6. Verification commands | all run; clippy re-run cold because the shared-tree result was cached |
+| 7. No CHANGELOG entry | honoured — diff touches `src/io.rs` only |
+
+**Deviation on step 5, benign.** The plan asked the test comment to stop implying `norm_path` is used directly *and* noted it omits that `--passthrough` uses both keys for different questions. The implementation dropped the `--passthrough` mention rather than qualifying it, and the "two keys, two questions" fact landed in `collision_key`'s doc under step 4 instead. That is the better placement — a test comment is not where a reader looks for the key-semantics distinction — so I would not change it back. Noted only because a coverage audit comparing plan text to diff will spot the missing `--passthrough` clause in the test comment and should know it moved rather than vanished.
+
+**Commit message.** It documents the `pub(crate)`-considered-and-rejected reasoning the plan required, and its factual claims check out independently: "561 tests green" matches my run exactly, and I reproduced the E0603 positive control from scratch. Detail sits in the commit message rather than the source, per CLAUDE.md.
+
+**Semver (Low, already covered).** Removing a `pub fn` from `trim-galore` 2.3.0 is technically a breaking API change; `lib.rs` still exposes 17 bare `pub mod` with no `pub use` curation and no `//!` disclaimer. Plan A3 states this accurately rather than denying it, and the durable fix is already filed as a follow-up. No action for this PR.
+
+---
+
+## Recommendations by priority
+
+**Critical** — none.
+
+**High** — none.
+
+**Medium**
+
+1. **M1 — generalise the trade-off's scope** (`io.rs:77-79`). Replace "on opt-in case-sensitive APFS volumes" with a phrasing that includes Linux ext4, which is where this false positive actually lives and where CI exercises it. Rewrite supplied above; folds L3's reflow in at the same time. *Trivial fix.* This is the only item I would ask for before merge.
+2. **M2 — file an issue for the 12 pre-existing rustdoc errors**, `src/alignment.rs:11` first (a public doc linking to a private item — the realized form of the hazard this plan reasoned about). Natural companion to the lib.rs-surface follow-up. *Out of scope for this PR.*
+
+**Low**
+
+3. **L4** — "callers" → "production callers" in the test comment (`io.rs:765`). *Trivial fix.*
+4. **L3** — reflow the moved paragraph to match its neighbours' ~85-char wrap. *Trivial fix; subsumed by M1.*
+5. **L5** — "The fold that `collision_key` is built on" to remove the garden-path. *Trivial fix; optional.*
+6. **L2** — leave `path_identity_key` as backticks (consistency with the whole file beats clickability). *No action.*
+7. **L1** — `collision_key`'s "these two paths" opener; pre-existing. *No action.*
+
+**Process notes for the caller.**
+
+- **The shared tree is no longer on this commit.** It is on `fix/400-clump-help-text` @ `0676fdf`, whose `src/io.rs` is the pre-#399 version. Any gate that runs in the shared tree from here on is not testing #399. Re-checks must pin the commit (`git archive 315557d` into a scratch dir, private `CARGO_TARGET_DIR`) — which is how every load-bearing result in this review was produced.
+- **`fix/400` does not contain #399.** Merge the two independently; neither branch carries the other.
+- **A sub-second clippy "success" in the shared tree is a cache hit, not evidence.** The trustworthy form is a cold target dir on a tracked-files-only copy, which also excludes the untracked `examples/fastqc_only.rs` that CI does not have.
+- **Don't pipe verification output through `tail`.** It cost me one false negative here: a truncated `cargo test` log looked like a 23-test suite and hid the very test the plan asks to confirm.

--- a/plans/08082026_normpath-visibility/CODE_REVIEW_B.md
+++ b/plans/08082026_normpath-visibility/CODE_REVIEW_B.md
@@ -1,0 +1,337 @@
+# Code Review B — #399 `norm_path` visibility demotion + doc re-homing
+
+**Reviewer:** B (independent; A reviewing in parallel)
+**Branch:** `fix/399-normpath-private` @ `315557d` — base `dev` @ `ac08a97`
+**Diff:** `git diff ac08a97..315557d` — one file (`src/io.rs`), 3 hunks, +10/−12
+**Plan:** `plans/08082026_normpath-visibility/PLAN.md` (r2)
+
+## Verdict
+
+**Approve.** No Critical, no High. The demotion is correct, complete, and verified by
+real compiles including a positive control that proves the safety net fires. The doc
+re-homing is a genuine improvement, not a shuffle: the trade-off paragraph now sits on
+the item that actually makes the trade-off, on the page rendered docs readers land on,
+and two existing pointers in `main.rs` that already said "see `io::collision_key`" now
+resolve to it. One **Medium** on the accuracy of the relocated prose (pre-existing
+wording, but promoted to a public API page by this change, so this is the cheap moment
+to fix it) and three **Low** prose nits.
+
+---
+
+## ⚠️ Tree hazard discovered mid-review — affects anyone re-running these numbers
+
+**The shared working tree moved during this review.** It is now on branch
+`fix/400-clump-help-text` @ `0676fdf`, which does **not** contain #399 —
+`src/io.rs` in the working directory is the **pre-change** version (`pub fn norm_path`
+with the 7-line doc, at line 45).
+
+Consequences worth flagging to the caller:
+
+- Any verification run against the *working tree* after that switch measures the wrong
+  branch. A "green" result there says nothing about #399.
+- **This is silent.** `cargo test`/`clippy` pass on both versions and the test count is
+  identical (561 either way — the change adds and removes no tests), so a reviewer who
+  ran the suite after the switch would see exactly the numbers they expected and draw a
+  conclusion about the wrong source. **Reviewer A's numbers are worth checking for this
+  same exposure.**
+- I therefore re-ran the whole suite against a copy pinned with
+  `git archive 315557d`, which is immune to the shared tree. All numbers in the
+  Verification section below are from the pinned copy unless stated otherwise.
+
+I did not switch branches or touch the tree, per instructions.
+
+---
+
+## Verification performed
+
+Pinned copy: `git archive 315557d -- src tests test_files Cargo.toml Cargo.lock build.rs`
+extracted to `<scratchpad>/probe399b`; confirmed `src/io.rs:39` reads `fn norm_path`
+(private) before running anything.
+
+| # | Check | Result |
+|---|-------|--------|
+| 1 | `cargo fmt --all -- --check` (pinned) | **exit 0**, no diff |
+| 2 | `cargo clippy --all-targets -- -D warnings` (pinned) | **exit 0**, zero warning/error lines |
+| 3 | Full `cargo test --release` (pinned) — CI's exact invocation | **exit 0, 561 passed / 0 failed.** Matches the commit message's "561 tests green" claim exactly. |
+| 4 | `cargo test test_norm_path_case_folds` | **pass** — `io::tests::test_norm_path_case_folds ... ok`. Plan assumption A2 (child module reaches a private parent item) verified by *running* it, not by citing the language rule. |
+| 5 | **Positive control — external caller** | Planted `tests/probe_e0603.rs` calling `trim_galore::io::norm_path` in the pinned copy. `cargo check` → **exit 0, zero E0603** (compiles lib+bin only, never sees `tests/`). `cargo check --all-targets` → **exit 101**, ``error[E0603]: function `norm_path` is private``. Probe removed → `--all-targets` back to **exit 0, 0 warnings**. The harness demonstrably both passes and fails. |
+| 6 | **Is the net actually in CI?** | Yes — `ci.yml:157` runs `cargo clippy --all-targets --release -- -D warnings`, and `ci.yml:76` runs `cargo test --release`. The `--all-targets` that control 5 proves is *required* is the flag CI uses. |
+| 7 | `--all-targets` scope | `cargo metadata`: 1 lib, 1 bin, 11 integration tests, 1 example. So a missed external caller anywhere in `tests/` is caught. |
+| 8 | `cargo doc --no-deps` (real tree, pre-switch) | **exit 0.** `target/doc/trim_galore/io/` contains `fn.collision_key.html` and `fn.path_identity_key.html` but **no `fn.norm_path.html`** — which is itself proof this run saw the private version. |
+| 9 | Caller search | `norm_path` appears **only** in `src/io.rs` (definition, the one call in `collision_key`, and the test) plus `src/cli.rs:1903`, which is a `//` line comment naming the *test* — unaffected. Searched `src/ tests/ examples/ benches/ build.rs Cargo.toml Docs/`; also confirmed `lib.rs` is 17 bare `pub mod` with **no `pub use`**, and checked the `use crate::io as naming` aliases in `specialty.rs`/`clump_only.rs` (no `naming::norm_path` anywhere). |
+| 10 | Diff scope | `git diff --stat` = `src/io.rs` only. No stray files, no CHANGELOG entry — consistent with plan step 7. |
+| 11 | Commit message | Accurate on every factual claim I checked, including the `pub(crate)`-rejected rationale the plan asked for and the E0603/`cargo check` asymmetry. |
+
+### A flake I hit, chased down, and cleared — recorded so nobody re-derives it
+
+My **first** pinned run was `cargo test` in **debug**, and it came back
+**559 passed / 2 failed**:
+
+```
+test ubam_out_se_fastqc_produces_report ... FAILED
+test ubam_out_pe_fastqc_produces_exactly_one_report ... FAILED
+integration_ubam_out.rs:561: FastQC zip missing — --fastqc silently skipped on the uBAM-output path
+```
+
+**This is not caused by #399, and I did not take it on trust in either direction.** What
+I established:
+
+1. The failing assertion is `io.rs`-independent — it is `--fastqc` on the uBAM-output
+   path. The assertion immediately *before* it (output BAM exists) **passed**, and the
+   process exited zero, so trimming worked and only the FastQC artifact was absent.
+2. Reproduced manually with the probe's own debug binary → **the zip and html were
+   produced correctly.** So the binary is fine.
+3. Same pinned source, **release**, same test target → **23/23 pass**.
+4. Same pinned source, **debug, `--test-threads=1`** → **23/23 pass**.
+5. Same pinned source, **debug, parallel, repeat run** → **23/23 pass**.
+6. Full **`cargo test --release`** (CI's invocation) → **561/0**.
+
+Four subsequent test runs green on identical source, plus a successful manual
+reproduction attempt ⇒ a non-deterministic failure in my sandboxed probe under first-run
+load, not a source defect. There is no mechanism by which a visibility keyword on a
+path-lowercasing helper reaches FastQC zip creation.
+
+**Residual observation, pre-existing and out of scope for #399** (flagged only because I
+have the data): these two tests appear non-deterministic under `cargo test` in **debug**
+with default parallelism. CI is unaffected — `ci.yml:76` runs `cargo test --release`. But
+CLAUDE.md tells contributors to run plain `cargo test`, so a contributor could see these
+two fail spuriously and go hunting. Worth its own issue if it recurs; **not** something
+#399 should absorb, and I could not reproduce it a second time to characterise it
+properly.
+
+---
+
+## Area 1 — Logic / correctness
+
+**Clean.** Findings:
+
+- **The demotion compiles and nothing reachable breaks.** Verified by a real
+  `clippy --all-targets` on pinned source, plus the E0603 positive control proving that
+  result is meaningful rather than vacuous.
+- **The fold is still pinned.** `test_norm_path_case_folds` survives, calls the private
+  fn from the child `mod tests`, and still asserts all five properties (lowercase
+  identity, uppercase fold, mixed fold, absolute-path fold, alias equality).
+- **No `dead_code` exposure.** `norm_path` retains a production caller
+  (`collision_key`, `io.rs:81`), so privatization cannot orphan it. Clippy confirms.
+- **The `path_identity_key` cross-reference is accurate.** `collision_key`'s new
+  sentence says input identity "uses the case-preserving `path_identity_key`". Verified:
+  `path_identity_key` is called at `cli.rs:537` (duplicate R1/R2 within a pair),
+  `cli.rs:549-550` (duplicate pair detection), `cli.rs:635-638` (duplicate input), and
+  `cli.rs:934/941` (passthrough input matching) — all input-identity questions, none of
+  them output naming. The claim is true as written.
+- **The trade-off paragraph is more accurate on `collision_key` than it was on
+  `norm_path`.** Agreed with the plan's reasoning, and it survives scrutiny: a function
+  returning `String` cannot "false-positive", but `collision_key`'s doc block is framed
+  as a *predicate* ("Would these two paths be the same *output* file?"), and under that
+  framing "may false-positive" means "may answer yes when the answer is no" — which is
+  exactly right. On `norm_path` (a bare `to_ascii_lowercase`) the sentence was a
+  category error.
+- **One nuance the plan did not claim but which supports the move:** `main.rs:790` and
+  `main.rs:2541` both carry the comment *"Pre-flight across pairs before any I/O; see
+  `io::collision_key` for the key."* Before this change a reader following that pointer
+  arrived at a two-line doc with no trade-off in it. Now the pointer lands on the
+  trade-off. The move repairs two pre-existing pointers rather than creating any.
+
+## Area 2 — Errors, rustdoc, and whether CI would catch anything
+
+**No new rustdoc breakage, and I can show why plus show that nothing would have caught
+it if there were.**
+
+- **No bracketed intra-doc link references `norm_path` anywhere.** `src/io.rs` contains
+  **zero** bracketed intra-doc links in the entire file — it uses plain backticks
+  throughout. So privatization cannot have created a `private_intra_doc_links` warning.
+  `cargo doc --no-deps` exits 0 and emits nothing about `io`.
+- **The hazard class is real in this crate, and it is completely ungated.** `cargo doc`
+  already emits 12 warnings on `dev`, **including exactly the failure mode in question**:
+
+  ```
+  warning: public documentation for `alignment` links to private item `myers_proves_no_match`
+           = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
+  ```
+
+  That warning is sitting in the tree unnoticed. It confirms both plan claims at once:
+  the hazard is live, and nothing catches it —
+  `grep -rniE "cargo doc|rustdoc|RUSTDOCFLAGS|document-private"` over `.github/` returns
+  **nothing**. `ci.yml:160`'s "Docs build (Astro)" is the documentation *website*. So
+  this change is safe because of a style choice, not because of a gate.
+- **The rest of the crate does use bracketed links** (`fastq.rs`, `trimmer.rs`,
+  `specialty.rs`, `adapter.rs`, `bam.rs`, `alignment.rs`, `fastqc.rs`, `report.rs`,
+  `main.rs`). So the plain-backtick choice matches `io.rs` locally while diverging from
+  the crate. See Low-2.
+- **Doc-tests:** no doc example anywhere references the symbol, so the `--all-targets`
+  blind spot the plan flagged (A5) stays theoretical. Full `cargo test` green anyway.
+- **Semver:** removing a `pub fn` from a crate published at 2.3.0 is strictly a breaking
+  API removal. The plan owns this (A3) and the risk is negligible — the library surface
+  is uncurated (17 bare `pub mod`, no `pub use`, no `publish = false`), and
+  `release.yml:442` publishes with `--no-verify`. No `cargo-semver-checks` in CI, so
+  nothing will object. No action for this PR; the plan's filed follow-up (a `//!` note
+  declaring the surface an implementation detail) is the right durable fix.
+
+## Area 3 — Structure / style
+
+**Comment budget: the change is net-negative in comment lines** (`norm_path` −6,
+`collision_key` +5, test −1). Worth stating plainly because CLAUDE.md's convention
+exists to stop comment growth, and this diff shrinks it while relocating.
+
+On the convention itself ("one line default, two max, state the fact not the
+evidence"): `collision_key`'s doc block is now 6 lines, which a literal reading would
+flag. I do **not** think that is the right reading here. That rule governs inline `//`
+comments in code bodies; `io.rs`'s established convention for `///` API blocks is
+substantially longer — `is_gzipped`, the function **immediately above** `norm_path`,
+carries a 21-line doc block (`io.rs:12-32`), and several test items carry 8–12-line
+blocks. The change also moves an existing paragraph rather than authoring new prose.
+Consistent with the file.
+
+The two rewritten comments:
+
+- `norm_path`'s reduced one-liner is **compliant and clear**, and correctly omits the
+  "(private)" framing the plan dropped — the `fn` keyword on the next line says it.
+- The test comment is now 2 lines (down from 3), within budget. But see Low-1 and Low-3.
+
+**Did anything become less clear?** One thing, and it is the only place I would say yes:
+the old `norm_path` doc contained *"`collision_key`, **which absolutises first**"*. That
+clause is gone. It was load-bearing for a specific reader — the one who asks "why is
+there a separate test for the fold instead of just testing `collision_key`?" The answer
+(the plan's own surviving rationale, B §1.4: `collision_key` absolutises, so re-expressing
+the fold test through it would make the relative-path assertions cwd-dependent) is no
+longer stated anywhere near either the fold or its test. It is recoverable —
+`lexical_normalise`'s doc four lines below says "absolutised" — so this is Low, not
+High. Noted under Low-3.
+
+## Area 4 — Dangling references
+
+**None.** Checked exhaustively:
+
+- `grep "Pragmatic trade-off"`, `grep "silent data loss"`, `grep "loud early error"`,
+  `grep -i "opt-in case"` over `src/` each return **exactly one hit**, all at the new
+  location (`io.rs:77-79`). The paragraph was moved, not copied — no second stale copy
+  survives. (I chased this specifically: an earlier review round
+  described this paragraph as "duplicated verbatim", so a leftover copy was a live
+  possibility. There isn't one.)
+- No comment anywhere points a reader at `norm_path` for the trade-off.
+- `cli.rs:1903` names `io::tests::test_norm_path_case_folds` — the test still exists
+  under that exact name, so the pointer is intact.
+- `io.rs:1210`'s test doc says outputs are "compared on `collision_key` (the pre-flight's
+  own metric)" — still true.
+- **Issue-reference coverage survives the move.** `#389` was dropped from `norm_path`'s
+  doc, but it lives on at `io.rs:74` on `path_identity_key` — which is the *correct*
+  home, since #389 was an input-identity confusion. `#216`/`#383` remain on
+  `collision_key`. Nothing was orphaned.
+
+## Area 5 — Efficiency
+
+**Nil, as expected.** Visibility is an annotation with no codegen consequence; the sole
+call site was already intra-crate. If anything privatization marginally *helps* codegen
+(no external linkage to preserve on a one-line function), which is unmeasurable and not
+a reason for the change.
+
+---
+
+## Recommendations by priority
+
+### Critical — none
+### High — none
+
+### Medium
+
+**M-1. The relocated trade-off names the rarest instance of its own condition, and now
+does so on a public page.**
+
+`io.rs:77` reads *"on opt-in case-sensitive APFS volumes this may false-positive"*. The
+condition for a false positive is **any case-sensitive filesystem** — which includes
+**every Linux run**, i.e. most TrimGalore invocations and all of CI. Naming only "opt-in
+case-sensitive APFS volumes" makes a routine, deliberately-accepted behaviour sound like
+an exotic edge case.
+
+This is not speculation — the repo's own test says so. `io.rs:1170-1174`:
+
+> REGRESSION: re-keying `Cli::validate`'s input-identity checks on the case-folded key
+> made the #216 CI guard fail — it feeds four genuinely distinct files (`Sample_R1` /
+> `SAMPLE_R1`) **on a case-sensitive filesystem** and asserts the *output* pre-flight
+> refuses them.
+
+So CI exercises this false positive on Linux on every run, by design, as the safe
+default. The wording is **pre-existing and unchanged by this diff** — but this change is
+what promotes it from a private helper's doc to `fn.collision_key.html`, a rendered
+public API page, which makes now the cheapest possible moment to correct it.
+
+*Trivial fix* — one word of scope:
+
+```rust
+/// Pragmatic trade-off: on case-sensitive filesystems (Linux, or opt-in
+/// case-sensitive APFS) this may false-positive, but the penalty is a loud
+/// early error rather than silent data loss.
+```
+
+Same line count. I did not apply it — it is prose the author may want to word
+differently, and the plan explicitly left doc copy reviewable.
+
+### Low
+
+**L-1. The test comment's first sentence is a fragment and reads awkwardly.** *(trivial
+fix)*
+
+```rust
+// The fold `collision_key` is built on (callers reach it through that key,
+// never directly). Plain lowercase is identity; upper/mixed folds down.
+```
+
+"The fold `collision_key` is built on" is a noun phrase with a trailing preposition and
+no main verb. The old version was grammatical ("norm_path is the case-folded
+normalisation that …"). Terser is good; this crossed into needing a second read.
+Suggestion, same 2 lines:
+
+```rust
+// The fold that `collision_key` is built on; production callers only ever
+// reach it through that key. Lowercase is identity; upper/mixed fold down.
+```
+
+**L-2. Consider making the `path_identity_key` reference a real link.** *(optional —
+author's call, genuine trade-off both ways)*
+
+`collision_key`'s new sentence exists to send a reader to `path_identity_key`. Both
+items are `pub` and rustdoc renders both pages (I verified `fn.path_identity_key.html`
+exists), so ``[`path_identity_key`]`` would resolve to a working hyperlink — exactly
+where the plan wants public readers to be able to go. The plan's stated reason for plain
+backticks (nothing in CI would catch a broken or private link) is a sound default, but
+does not apply to this particular link, whose target I confirmed is public and rendered.
+
+Counter-argument, which is why this is Low and not a recommendation: `io.rs` has zero
+bracketed links today, so this would be the first, and 8 other modules using the style
+does not oblige this one. Leaving it is defensible; I'd lean to leaving it for local
+consistency.
+
+**L-3. The dropped "which absolutises first" clause is the one real clarity loss.**
+*(optional)*
+
+See Area 3. If it matters to the author, the cheapest home is the test comment, since
+the fact's main use is explaining why the test targets the fold directly rather than
+going through `collision_key`. Not worth a line on its own if L-1 is taken instead.
+
+**L-4. "callers reach it through that key, never directly" is contradicted one line
+later.** *(trivial fix; subsumed by L-1)*
+
+The very next statement in the same test calls `norm_path` directly. "Callers" plainly
+means production callers, and L-1's rewording ("production callers") resolves it.
+
+---
+
+## Comparison notes for the caller
+
+Things I would specifically check against Reviewer A's report:
+
+1. **Whether A's verification ran against the switched tree.** See the tree-hazard
+   section — this failure is silent and produces the expected numbers.
+2. **Whether A also concluded the trade-off sentence is accurately homed on
+   `collision_key`.** I think it is, on the predicate-framing argument; a reviewer could
+   reasonably argue it belongs on `preflight_output_collisions`, where the bail actually
+   happens. I considered and rejected that: `collision_key` also serves `cli.rs:935`'s
+   passthrough check, so the key's doc covers both consumers while the pre-flight's would
+   cover one.
+3. **M-1 (scope of the false-positive condition)** — this is the only substantive
+   finding I have, and it is easy to miss because the wording is unchanged by the diff.
+4. **Whether A saw the two `integration_ubam_out` `--fastqc` failures.** If A ran
+   `cargo test` in debug they may have, and they are alarming at first glance
+   ("--fastqc silently skipped"). They are a flake, not #399 — see the section above for
+   the five runs that clear it. If A reported them as a defect, that is a false positive;
+   if A ran only `--release`, they will not have seen them at all.

--- a/plans/08082026_normpath-visibility/COVERAGE.md
+++ b/plans/08082026_normpath-visibility/COVERAGE.md
@@ -1,0 +1,79 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs plan — no separate `IMPL.md`; ledger built from the plan's Implementation outline, Behavior, Assumptions A1–A5, Validation table + caveat, and the one code-affecting item in Questions/Resolved)
+**Plan(s):** `plans/08082026_normpath-visibility/PLAN.md` (r2)
+**Date:** 2026-08-08
+**Verdict:** COMPLETE
+
+Branch audited: `fix/399-normpath-private` @ `315557d` (base `dev` @ `ac08a97`).
+Diff: `src/io.rs` only — 10 insertions, 12 deletions, single commit
+`315557d refactor(io): make norm_path private and re-home the fold trade-off (#399)`.
+
+## Summary
+
+- Total items: 19
+- DONE: 19 (one of them, outline step 5, was marked optional and was done anyway)
+- PARTIAL: 0
+- MISSING: 0
+- DEVIATED: 0
+
+## Coverage ledger
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | `pub fn norm_path` → `fn norm_path` | Outline 1 | DONE | `src/io.rs:39` is `fn norm_path(p: &Path) -> String`. Line moved from `:45` to `:39` because the doc block above it shrank (step 3). Body byte-identical. |
+| 2 | Move the trade-off paragraph from `norm_path` onto `collision_key` | Outline 2 | DONE | Removed from `norm_path`; present verbatim (3 lines) at `src/io.rs:77-79` inside `collision_key`'s block. |
+| 3 | Reduce `norm_path`'s doc to one line; no "(private)" framing | Outline 3 | DONE | `src/io.rs:38` — ``/// Case-folded (ASCII lowercase) view of a path; the folding half of `collision_key`.`` — the plan's own suggested wording, one line, no visibility narration. |
+| 4 | Add the one-line note that input identity uses the case-**preserving** `path_identity_key`; plain backticks, no `[…]` intra-doc links | Outline 4 | DONE | `src/io.rs:74-75`, appended to `collision_key`'s first paragraph: "Input identity asks a different question and uses the case-preserving `path_identity_key`." Plain backticks; no bracketed link anywhere in the file. Placement resolves the plan's ambiguous "while in the block" — it landed on `collision_key`, which is the only reading consistent with step 3's one-line cap on `norm_path`. |
+| 5 | Optional drive-by: fix the test comment's imprecision | Outline 5 (**explicitly optional**) | DONE | `src/io.rs:765-766` rewritten to "The fold `collision_key` is built on (callers reach it through that key, never directly)." The false "pre-flight + `--passthrough` both use `norm_path`" claim is gone. The plan's second sub-point (that `--passthrough` also uses the case-sensitive key) is resolved by deleting the `--passthrough` reference rather than by expanding the comment; that contrast now lives on `collision_key`'s doc (item 4) and in the pre-existing test `identity_key_is_case_sensitive_but_collision_key_is_not` (`src/io.rs:1176`). No claim in the comment is now imprecise. |
+| 6 | Run the four verification commands | Outline 6 | DONE | All four run, all green — see Test verification. |
+| 7 | No CHANGELOG entry | Outline 7 (deliberate decision) | DONE | `git diff --name-only ac08a97..315557d` → `src/io.rs` only. The plan's corrected rationale checks out: `#### Infrastructure (contributor-facing)` does exist (`CHANGELOG.md:481` and `:1148`), and `grep -E 'collision_key\|norm_path\|path_identity_key' CHANGELOG.md` over 1586 lines returns **zero** hits, so the changelog has never named these helpers. |
+| 8 | No behavioural change: same fold, same caller, same tests, same rendered output | Behavior | DONE | Diff is one visibility keyword plus doc/comment lines. `norm_path`'s body (`p.to_string_lossy().to_ascii_lowercase()`) and `collision_key`'s body (`norm_path(&lexical_normalise(p))`) are untouched; all five assertions in `test_norm_path_case_folds` unchanged; 561 tests green. |
+| 9 | **A1** — zero callers outside `io.rs`, aliases included | Assumptions | DONE | `git grep norm_path` over the tracked tree: `io.rs:39` (def), `io.rs:81` (sole production caller, inside `collision_key`), `io.rs:764-777` (the test), and `cli.rs:1903` — a `//` comment naming the *test*, unaffected. Repeating the grep over **all** files including untracked ones (excluding `plans/`, `target/`, `.git/`) adds nothing. `naming::norm_path`: zero hits, while both alias sites still exist (`src/specialty.rs:12`, `src/clump_only.rs:52`). |
+| 10 | **A2** — `mod tests` reaches the private item | Assumptions | DONE | Verified by execution, not by citing the rule: `io::tests::test_norm_path_case_folds ... ok` (1 passed). |
+| 11 | **A3** — published library surface is uncurated and treated as an implementation detail; the removal is technically semver-breaking and accepted | Assumptions | DONE | `src/lib.rs` has 17 `pub mod` and **no** `pub use`; `Cargo.toml` has no `publish = false` and no `[lib]` section — so the plan's accurate framing (rather than r1's denial) holds. No code obligation in this plan. The durable follow-up was in fact filed separately: issue **#402** "lib.rs publishes 17 uncurated pub modules — declare the library surface unstable". |
+| 12 | **A4** — no behavioural coupling to the fold's *name* | Assumptions | DONE | `--passthrough` validation (`src/cli.rs:934-952`) uses `path_identity_key` **and** `collision_key`; the pre-flight (`src/io.rs:98`, `:103`) uses `collision_key`; `src/main.rs:790` and `:2541` reference `collision_key` in comments. No caller names `norm_path`. |
+| 13 | **A5** — no doc-tests reference the symbol | Assumptions | DONE | The only doc fence in `src/` is the ```` ```text ```` block at `src/specialty.rs:235-240`, and the full suite reports `Doc-tests trim_galore … running 0 tests` — the crate has no doc-tests at all, so none can reference the symbol. |
+| 14 | **V1** — no missed caller, via `cargo clippy --all-targets --release -- -D warnings` | Validation | DONE | Exit 0, zero `warning:`/`error:` lines. Harness independently verified capable of seeing an external caller (below). |
+| 15 | **V2** — fold still pinned, via `cargo test test_norm_path_case_folds` | Validation | DONE | Exit 0; `1 passed`. |
+| 16 | **V3** — no collateral: full `cargo test` + `cargo fmt --all -- --check` | Validation | DONE | 561 passed / 0 failed across 14 result lines; `cargo fmt --all -- --check` exit 0 (so step 3's shortened doc line did not disturb rustfmt). |
+| 17 | **V4** — trade-off note landed where readers arrive | Validation | DONE | `collision_key`'s block (`src/io.rs:73-79`) now states the *what* (output collision, case-folded, #216/#383), the contrast with input identity, and the false-positive cost; `norm_path` is one line. |
+| 18 | **Caveat** — untracked `examples/fastqc_only.rs` means a local `--all-targets` run compiles a file CI lacks | Validation caveat | DONE | Confirmed the example is untracked and *is* compiled locally (it appears as `kind:["example"] name:"fastqc_only"` in the clippy target enumeration). It does not reference `norm_path` (the all-files grep in item 9 covers it). Because the extra target is purely additive and the lib/bin/`tests/` set is identical, the local green run is a **superset** of CI's, so the tracked-tree conclusion holds. |
+| 19 | Commit message notes `pub(crate)` was considered and rejected | Questions/Resolved (r2) | DONE | `315557d` body ¶3: "pub(crate) was considered and rejected: specialty.rs and clump_only.rs both alias crate::io as naming, so pub(crate) would keep norm_path reachable as naming::norm_path from exactly the modules whose readers the change is meant to protect." — B's argument, as the plan settled it. |
+
+## Gaps (detail)
+
+None. No item is PARTIAL, MISSING, or DEVIATED.
+
+Two items are worth reading before signing off, not as gaps but as judgement calls the auditor made explicit:
+
+### Item 4 — where the `path_identity_key` note landed
+
+**Expected:** outline step 4 says "While in the block, add the one-line note…". "The block" is not named.
+**Found:** the note is on `collision_key` (`src/io.rs:74-75`), not on `norm_path`.
+**Assessment:** DONE, not DEVIATED. Putting it on `norm_path` would have made that doc two lines and contradicted step 3's explicit one-line cap; and the note's substance (two keys, two questions) is a property of the key-comparison, which is `collision_key`. The reading chosen is the only self-consistent one.
+
+### Item 5 — how the test comment's second imprecision was fixed
+
+**Expected:** step 5 flags two faults in the old comment — (a) it credits `norm_path` with what the pre-flight and `--passthrough` validation do, true only indirectly; (b) it omits that the `--passthrough` check also uses the case-sensitive key for a different question.
+**Found:** the new comment fixes (a) directly and dissolves (b) by dropping the `--passthrough` reference entirely, rather than by adding the case-sensitive-key sentence there.
+**Assessment:** DONE. Step 5's stated purpose is removing imprecision, and no imprecise claim survives; the omitted contrast is now stated on `collision_key`'s doc (item 4), where the plan wanted it. This was also the optional step.
+
+## Test verification
+
+| Check | Command | Result |
+|---|---|---|
+| Clippy, all targets, deny warnings | `cargo clippy --all-targets --release -- -D warnings` | **PASS** — exit 0, no `warning:`/`error:` lines |
+| Fold pinned (private-fn reachability) | `cargo test test_norm_path_case_folds` | **PASS** — `io::tests::test_norm_path_case_folds ... ok`, 1 passed, 409 filtered out |
+| Full suite | `cargo test` | **PASS** — 561 passed, 0 failed, 0 ignored, across lib (410), bin (0), and 11 integration binaries; `Doc-tests trim_galore` 0 tests |
+| Formatting | `cargo fmt --all -- --check` | **PASS** — exit 0 |
+
+**Harness verified capable of failing (not assumed).** The plan's V1 rests on `--all-targets` compiling `tests/`, which is the only place an out-of-module caller of a `pub` item could hide. Rather than take that on faith, the clippy invocation was re-run with `--message-format=json` and its target list enumerated: it covers `lib trim_galore`, `bin trim_galore`, the `custom-build` script, the untracked `example fastqc_only`, and **all 11 test targets** (`integration_adapter2`, `integration_clump_only`, `integration_clump_only_ubam`, `integration_gzip_non_gz_extension`, `integration_no_args_help`, `integration_non_restartable_input`, `integration_output_collision`, `integration_paired_format_guard`, `integration_passthrough`, `integration_ubam`, `integration_ubam_out`). So an `E0603` from a planted external caller would be seen by exactly this command. The commit message additionally records that the implementer ran that positive control on this branch (planted caller → `E0603` under `--all-targets`, invisible to plain `cargo check`).
+
+## Verdict
+
+**COMPLETE — 19/19 items DONE, 0 unresolved.**
+
+Every step of the Implementation outline is present in `315557d`, including the optional step 5; step 7's "no CHANGELOG entry" is a satisfied decision rather than an omission (the diff touches `src/io.rs` alone). The Behavior contract holds — the only executable change in the diff is the removal of the `pub` keyword. All five assumptions were re-verified against the code rather than carried over from the plan's prose, and all four validation rows were executed green in this working tree, with the validation caveat about the untracked example resolved in the change's favour (local target set is a superset of CI's; the example does not touch the symbol).
+
+Nothing remains for the implementer.

--- a/plans/08082026_normpath-visibility/PLAN.md
+++ b/plans/08082026_normpath-visibility/PLAN.md
@@ -1,0 +1,84 @@
+# Plan: demote `io::norm_path` to private, and re-home the trade-off note (#399)
+
+**Issue:** [#399](https://github.com/FelixKrueger/TrimGalore/issues/399) — filed from #389's review round.
+**Base:** `dev` @ `ce13761`.
+
+## Revision history
+
+- **r2 (2026-08-08):** incorporates dual plan review (PLAN_REVIEW_A.md, PLAN_REVIEW_B.md — both *approve, no Criticals*). Both reviewers independently compiled the demotion in isolated copies of the crate with positive controls, and both raised the same four corrections: r1's validation credited the wrong command, its dead-code parenthetical was backwards, its CHANGELOG rationale misdescribed repo convention, and its reason for keeping the named function was the weaker of the two available. Scope gains **one doc hunk** (Important in both reviews): move the case-folding trade-off note to `collision_key`. Behaviour still unchanged.
+- r1 (2026-08-08): initial plan — visibility keyword + a "(private)" doc tweak.
+
+## Goal
+
+`io::norm_path` is `pub` with no callers outside `src/io.rs`. The public name is what enabled #389's planning error (it was mistaken for a stale alias of `collision_key`). Demote it to module-private, and — because privatization removes it from rendered docs — move the substantive case-folding trade-off note onto `collision_key`, where it belongs on substance and where public readers will land.
+
+## Context
+
+- `io.rs:45-47` — the function. Sole production caller `io.rs:82` (`collision_key`); test at `io.rs:765-780`. `cli.rs:1903` is a `//` comment naming the *test*, unaffected.
+- **Callerless-outside-`io.rs` verified four ways across both reviews**, including the surfaces a naive grep misses: `src/lib.rs` has 17 bare `pub mod` and **no `pub use`**; `benches/`/`examples/` don't exist in the tracked tree; `build.rs`, `Cargo.toml`, `docs/`, and untracked non-`plans/` files are clean. **B's sharpest catch:** `specialty.rs:12` and `clump_only.rs:52` both `use crate::io as naming`, so a caller there would read `naming::norm_path` — and historical plan text *does* describe `naming::norm_path` call sites, making this a live possibility rather than a hypothetical. Grepping the bare symbol covers the alias; grepping the qualified path would not have.
+- **Both reviewers compiled it for real** (isolated `git archive` copies; this tree untouched): `cargo check/clippy --all-targets` clean, 0 warnings, all 11 integration tests genuinely compiled (`.rmeta` present).
+- **The safety net is `E0603`, not `dead_code`, and only on `--all-targets`.** B ran the positive control: with an external caller planted in `tests/`, `cargo check` exits **0** (it compiles lib + bin only) while `cargo check --all-targets` exits **101** with `error[E0603]: function norm_path is private`; removing the probe returned it to green, so the harness demonstrably both passes and fails.
+- **No rustdoc gate exists in CI** (both verified): `ci.yml:160` "Docs build (Astro)" is the documentation *website*; no `cargo doc`, `RUSTDOCFLAGS`, or `--document-private-items` in any workflow. So the private-intra-doc-link hazard is both absent (no bracketed `[…]` references to the symbol anywhere — the file uses plain backticks throughout) and ungated.
+- **Doc-comment layout today:** `norm_path` (`:38-44`) carries the substantive *"Pragmatic trade-off: on opt-in case-sensitive APFS volumes this may false-positive, but the penalty is a loud early error rather than silent data loss"*; `path_identity_key` (`:72-77`) explains its case-sensitive rationale; `collision_key` (`:79-83`) is two lines and carries **none** of the trade-off.
+- **The crate publishes a library surface.** `release.yml:421-441` has a crates.io publish job, `Cargo.toml` has no `publish = false` and no `[lib]` restriction, so docs.rs renders `trim_galore::io::*` and removing a `pub fn` from a 2.x crate is technically a semver-breaking API removal (A §A3). r1 asserted the surface "is not a public API contract"; that stance is reasonable — nothing sane depends on TrimGalore as a library, and this is precisely the confusion #399 targets — but the plan should state it accurately rather than deny the surface exists. Durable fix filed separately (see Follow-ups).
+
+## Behavior
+
+No behavioural change: same fold, same caller, same tests, same rendered output. What changes: one visibility keyword, and which doc block carries the trade-off paragraph.
+
+## Implementation outline
+
+1. `io.rs:45` — `pub fn norm_path` → `fn norm_path`.
+2. **Move the trade-off paragraph** from `norm_path` (`:42-44`) onto `collision_key` (`:79-83`). Rationale (both reviewers, independently): `norm_path` is a pure `to_string_lossy().to_ascii_lowercase()` — "may false-positive" is not a property of lowercasing a string, it is a property of *deciding output collisions on a folded key*, which happens in `collision_key`. Privatization would otherwise delete the only statement of the trade-off from the rendered public docs, and an in-source reader arriving at `collision_key` must currently scroll *up* past `lexical_normalise` and `path_identity_key` to find it.
+3. **Reduce `norm_path`'s doc to one line** — e.g. `/// Case-folded (ASCII lowercase) view of a path; the folding half of `collision_key`.` **Do not** add "(private)" framing (r1's step 1, dropped per B §1.7): the `fn` keyword three lines below states the visibility, and docs that narrate their own visibility go stale the next time visibility changes.
+4. While in the block, add the one-line note that input identity deliberately uses the case-**preserving** `path_identity_key` — the two keys answer different questions (A Important-2). **Plain backticks, not `[…]` intra-doc links** (no CI job would catch a broken or private link).
+5. Optional drive-by, three lines from an edit already being made: the *test's* comment at `io.rs:766-768` says `norm_path` is what "the output-collision pre-flight + `--passthrough` validation both use" — true only indirectly (both go via `collision_key`), and it omits that the `--passthrough` check also uses the case-sensitive key for a different question (`cli.rs:934-952` uses both). Same class of imprecision #399 exists to remove.
+6. **Verification:** `cargo clippy --all-targets --release -- -D warnings`, `cargo test test_norm_path_case_folds`, full `cargo test`, `cargo fmt --all -- --check` (step 3 shortens a doc line and could disturb rustfmt's wrapping).
+7. **No CHANGELOG entry** — decision unchanged from r1, rationale corrected. The repo *does* have a slot for non-user-visible work (`CHANGELOG.md:481`, `#### Infrastructure (contributor-facing)`, with CI-job and `justfile` entries), so r1's "the repo only records behaviour/message changes" was false. The real reasons: this sits below that section's granularity floor (its entries are things a contributor trips over), and **`grep` for `collision_key|norm_path|path_identity_key` across 1300+ CHANGELOG lines returns zero hits** — the changelog has never named these helpers across the entire #216/#383/#384/#388/#389/#391 arc, so it should not start for a visibility keyword. Supporting: `7ea2741` (docs-only, #387) merged with no entry.
+
+## Efficiency / Integration
+
+Nil / none. Visibility is an annotation with no codegen consequence; the sole call is already intra-crate.
+
+## Assumptions
+
+- **A1:** zero callers outside `io.rs` — verified by exhaustive grep (including the `naming::` aliases), by real compiles, and by a positive control proving the greps could see markdown.
+- **A2:** `mod tests` reaches private items — verified by *running* `test_norm_path_case_folds` on a private-fn copy, not by citing the language rule.
+- **A3:** the published library surface is uncurated and treated as an implementation detail of the binary; this change is technically a semver-breaking API removal that no plausible consumer notices. Stated rather than denied (A §A3).
+- **A4:** no behavioural coupling to the fold's *name* — `--passthrough` validation and the pre-flight both reach the fold via `collision_key`; neither names `norm_path`.
+- **A5:** no doc-tests reference the symbol. Structurally impossible to matter here (the crate's only doc fence is a ```` ```text ```` block at `specialty.rs:235-240`), but worth recording *why* it matters: `--all-targets` excludes doc-tests, so a doc example using `norm_path` would slip past clippy and surface only under `cargo test` (B §2).
+
+## Validation
+
+| # | What | How | Expected |
+|---|------|-----|----------|
+| 1 | No missed caller | `cargo clippy --all-targets --release -- -D warnings` — **this** is the net, not `cargo build`: `check`/`build` compile lib + bin only and miss an external caller in `tests/` entirely (B §3.1, proven by positive control) | clean; an external caller would be `E0603` |
+| 2 | Fold still pinned | `cargo test test_norm_path_case_folds` | passes (child module reaches the private fn) |
+| 3 | No collateral | full `cargo test` + `cargo fmt --all -- --check` | green |
+| 4 | Trade-off note landed where readers arrive | read `collision_key`'s block after the move | states both *what* and the false-positive cost; `norm_path` reduced to one line |
+
+**Caveat for the implementer** (A V-gap 2): this working tree has an **untracked** `examples/fastqc_only.rs`, so a local `--all-targets` run compiles a file CI does not have. It doesn't reference `norm_path`, but a green local run is not automatically a statement about the tracked tree.
+
+## Questions or ambiguities
+
+- **[Resolved r2 — reviewer contradiction, settled without escalation]** A offered `pub(crate) fn` as an equally-valid variant ("removes it from the published surface exactly as `fn` does, permits a future second in-crate caller"); B called it *strictly worse here* because it keeps the symbol reachable from `specialty.rs`/`clump_only.rs` via their existing `crate::io as naming` aliases — preserving most of the confusion surface #399 exists to remove, for no benefit, since no cross-module caller exists or is wanted. **B's argument wins, and it is consistent with A's own reasoning** that the in-file/in-crate reader is the audience who made the #389 error. Plan keeps plain `fn`; the commit message should note `pub(crate)` was considered and rejected, since it is the obvious reviewer question.
+- **[Open, non-critical]** Exact doc copy is reviewable prose.
+
+## Follow-ups (out of scope, filed separately)
+
+- All 17 modules in `lib.rs` are `pub` with no `pub use` curation, so every internal helper is published API and every future demotion re-raises A3. A single `//!` note declaring the library surface an implementation detail with no semver guarantee would pre-authorise this change and its successors (A Optional-2).
+
+## Implementation notes (2026-08-08, branch `fix/399-normpath-private`)
+
+- `315557d` — demotion + doc re-homing as planned (all 7 outline steps, incl. the optional step-5 test-comment fix).
+- `1a2a384` — review batch. Both code reviewers APPROVED with no Criticals and independently raised the same Medium: the relocated trade-off said "opt-in case-sensitive APFS volumes", naming the rarest instance of its own condition, when Linux ext4/xfs are case-sensitive by default and every CI run exercises the rejection there (`io.rs:1170-1174` already said "which on Linux is false"). Widened. Also took both reviewers' L1/L4: the test comment claimed callers never reach the fold directly, five lines above five direct calls — now scoped to production callers, and it recovers B's "`collision_key` absolutises first" fact, which is what explains why the fold is tested directly.
+- **Reviewer contradiction resolved:** A suggested making the `path_identity_key` reference a real intra-doc link (its target is public, so no private-link risk); B leaned to plain backticks for local consistency (`io.rs` has zero bracketed links). Kept backticks — B's consistency argument, and A explicitly called its own point the weaker of the two.
+- **Not taken:** A's M2 and both reviewers' rustdoc observations → filed as #405 (12 pre-existing `cargo doc` errors, incl. `alignment.rs:11` — a public doc linking to a private item, the realized form of the hazard this plan reasoned about hypothetically, and completely ungated since no workflow runs `cargo doc`).
+- **Coverage: COMPLETE** (19/19, zero gaps).
+- **Verification note:** I ran the `E0603` positive control on the branch itself, not only in the reviewers' isolated copies — `cargo check` passes with an external caller planted in `tests/` while `--all-targets` exits 101, confirming the plan's corrected claim about which command is the guard.
+
+## Self-Review (r2)
+
+- **What r1 got wrong, owned:** three of its justifications were false or weak — `dead_code` cannot fire (its own parenthetical said why), `cargo build` is not the guard (it never compiles `tests/`, which is exactly where a hidden consumer of a `pub` item would live), and the repo does changelog non-user-visible work under a dedicated heading. r1's reason for keeping the named function ("the trade-off note lives well on the named fn") is now *inverted* by r2: the note moves precisely because it does **not** belong there. The surviving reason to keep the named seam is B §1.4's: `collision_key` absolutises, so re-expressing the fold test through it would make its relative-path assertions cwd-dependent.
+- **What the reviews added beyond corrections:** the doc re-homing, which converts a behaviour-neutral hide into "put each fact where its reader is" — and which is the difference between #399 *resolving* the re-audit's doc finding and merely concealing it. The misuse half of that finding is genuinely resolved and strengthened (from "a doc a reader might skim" to `E0603`); the informational half is resolved only if the note moves.
+- **Remaining risks:** none structural. A visibility change has no silent-wrong-result mode; the single failure mode is a compile error the validation demonstrably catches.

--- a/plans/08082026_normpath-visibility/PLAN_REVIEW_A.md
+++ b/plans/08082026_normpath-visibility/PLAN_REVIEW_A.md
@@ -1,0 +1,220 @@
+# Plan Review A — demote `io::norm_path` to private (#399)
+
+**Reviewer:** A (independent; Reviewer B reviewed the same plan separately)
+**Plan:** `plans/08082026_normpath-visibility/PLAN.md`
+**Base verified:** `dev` @ `ce13761` (matches the plan's stated base)
+**Verdict:** Approve with two doc-content changes folded in (Important). No Critical findings.
+
+---
+
+## What I verified (rather than trusted)
+
+Every factual claim in the plan was checked. The change was also **compiled for real** on an
+isolated copy of the crate in the scratchpad — the shared working tree was not touched.
+
+| Claim | Method | Result |
+|---|---|---|
+| Zero callers outside `src/io.rs` | Repo-wide grep incl. all file types, `tests/`, `examples/`, `build.rs`, `Cargo.toml`, `docs/`, `*.md` | **Confirmed.** Only `src/io.rs:45` (def), `:82` (`collision_key`), `:765-780` (test). Plus one *comment* at `src/cli.rs:1903` citing the test by name — unaffected. |
+| Grep could actually have found `.md`/docs hits | Positive control: same grep shape for `collision_key` | **Confirmed** — returns `SESSION_HANDOFF.md` and many `plans/*.md`, so markdown was genuinely in scope. The `norm_path` negative is trustworthy. |
+| No re-export widens the surface | Read `src/lib.rs` | **Confirmed.** 17 bare `pub mod` lines, **no `pub use`**. So `norm_path` is reachable today only as `trim_galore::io::norm_path`, and nothing uses that path. |
+| Making it private compiles | `cargo clippy --all-targets -- -D warnings` on a scratchpad copy with `pub fn` → `fn` | **Clean, exit 0** (honest exit code — first run was pipe-masked by `tail`, re-run without the pipe). Covers lib + bin + all 11 integration tests + the example. |
+| The compile-error net is real | Positive control: added an external `trim_galore::io::norm_path` caller in `tests/` | **Fires:** `error[E0603]: function `norm_path` is private`, exit 101. Removed afterwards. |
+| A2 — `mod tests` reaches a private item | `cargo test --lib test_norm_path_case_folds` on the private-fn copy | **Passes** (`test io::tests::test_norm_path_case_folds ... ok`; 409 other lib tests filtered out). |
+| No rustdoc intra-doc-link hazard | Grep for bracketed `[norm_path]` forms; audited CI | **None exist.** The file uses plain backticks throughout, never intra-doc links. Also: **CI has no rustdoc job at all** — `docs-build` is the *Astro* docs site (`.github/workflows/ci.yml:160`), and no workflow runs `cargo doc` or sets `RUSTDOCFLAGS`. So the hazard is both absent and ungated. |
+
+**Bottom line on §1 of the brief: yes, it compiles, and nothing beyond a compile error can break.**
+The rustdoc private-intra-doc-link hazard is real in principle but does not apply — see Important-2
+for the one way the implementer could *introduce* it.
+
+---
+
+## Logic review
+
+The plan is internally consistent and the mechanism is sound. Three corrections:
+
+**L1 — Validation 1's stated rationale is self-contradicting (wording, not substance).**
+The plan writes: *"`cargo build` (a dead-code warning would prove a missed caller assumption —
+none expected, `collision_key` uses it)"*. A `dead_code` warning **cannot** fire here, for exactly
+the reason given in its own parenthesis: `collision_key` at `io.rs:82` is a non-test caller. The
+check is right; the reason is wrong. The actual safety net is **`E0603` (privacy violation)** for an
+external caller, which I confirmed fires. Fix the sentence so the next reader does not inherit a
+false model of what the validation proves.
+
+**L2 — The plan's CHANGELOG justification is factually wrong about repo convention.**
+The plan skips the CHANGELOG as *"consistent with the repo treating only behaviour/message changes
+as entries"*. That is not this repo's convention. The **Unreleased** section (CHANGELOG.md lines
+4–500) already carries `#### Infrastructure (contributor-facing)` at line 481 — CI-job and
+`justfile` changes with no runtime effect — and history has `#### Tests`, `#### Documentation`, and
+even a literal `#### Infrastructure (contributor-facing, no runtime effect)` (line 1242). So the
+repo *does* record non-user-visible changes under a dedicated heading.
+
+Whether *this* change earns an entry is a separate judgement, and I think **skipping is still
+defensible** — the existing Infrastructure entries are things a contributor trips over (a CI job,
+a broken recipe), and a one-keyword visibility demotion is below that bar. But see Optional-1: the
+crates.io angle is the one argument that could tip it.
+
+**L3 — The change resolves the confusion for API readers, but only *hides* it for the audience
+that actually made the #389 error.** This is the substantive finding, and it answers the brief's
+§3 directly. Current doc blocks:
+
+- `norm_path` (io.rs:38-44) — carries the case-folding **trade-off note** and says it is *"what
+  every collision check uses"*. Mentions `collision_key`. **Does not mention `path_identity_key`.**
+- `path_identity_key` (io.rs:72-74) — *"Case-**sensitive**, because … `X` and `x` are two files"*.
+- `collision_key` (io.rs:79-80) — *"Case-**folded**, because outputs differing only in case alias
+  each other on APFS/NTFS"*. **Carries no trade-off note.**
+
+The re-audit's concern was that `norm_path`'s block never mentions the case-preserving sibling.
+Demoting it to private genuinely resolves that **for anyone reading the public API** (docs.rs or
+`cargo doc`): they now land on `path_identity_key` and `collision_key`, which sit six lines apart
+and explicitly contrast case-sensitive vs case-folded with the reason for each. That is a good
+adjacent pairing and a real improvement.
+
+It does **not** resolve it for the in-file reader — which is precisely who made the #389 mistake.
+`norm_path` remains at line 45, remains the *first* fold-related item in the file, remains
+documented, and still says nothing about `path_identity_key` while claiming to be what "every
+collision check uses" — an invitation to generalise to "every path comparison", which is the #389
+error itself. **The keyword is not the fix for that; the doc content is.** Treating #399 as closing
+the re-audit's doc concern is therefore only half-right. See Important-1 and Important-2.
+
+---
+
+## Assumptions
+
+- **A1 (zero external callers) — verified true**, by exhaustive grep *and* by a real compile.
+  Stronger than the plan claims: it holds across `src/`, `tests/`, `examples/`, `build.rs` and all
+  markdown/docs.
+- **A2 (`mod tests` reaches private items) — verified true** by actually running the test.
+- **A3 (unstated) — "the published crate's library surface is not a contract."** The plan's Context
+  bullet 3 asserts *"The crate is a binary product; `lib.rs` exists for unit-test reach, not as a
+  public API contract, so no external-consumer concern."* The **stance** is reasonable; the
+  **premise is asserted without acknowledging that the crate is published to crates.io**:
+  `release.yml:421-441` has a "Publish to crates.io" job, `Cargo.toml` has no `publish = false`,
+  no `[lib]` restriction, and full registry metadata (keywords, categories, readme). So the
+  implicit lib target ships, docs.rs renders `trim_galore::io::*`, and removing a `pub fn` from a
+  2.x crate is a technically semver-breaking API removal.
+
+  I am **not** arguing against the change — nothing sane depends on TrimGalore as a library, and
+  this is exactly the confusion the issue wants gone. I am arguing the plan should *say so
+  accurately* rather than deny that a published surface exists. See Optional-2 for the durable fix.
+- **A4 (unstated) — no behavioural coupling to the fold's name.** True: `--passthrough` validation
+  (`cli.rs:934-952`) and the pre-flight (`io.rs:99,104`) both reach the fold through
+  `collision_key`; neither names `norm_path`. Confirmed by grep.
+
+---
+
+## Efficiency
+
+Nil, correctly. No call sites move, no allocation or complexity change; `fn` vs `pub fn` is a
+visibility annotation with no codegen consequence (and the function was never a cross-crate
+inlining candidate, since nothing outside the crate called it). Nothing to add.
+
+---
+
+## Validation sufficiency
+
+**Sufficient for the highest-risk failure mode**, and I proved that rather than assuming it.
+
+- The single risk is a hidden external caller. `cargo clippy --all-targets` compiles lib, bin,
+  every `tests/*.rs`, and the example — the complete set of compiled callers. An external caller
+  produces `E0603`, which I demonstrated fires. There is no silent-wrong-result mode available to a
+  visibility change, so there is nothing for a behavioural test to catch that the compiler misses.
+- Validations 2 and 3 (`cargo test`) are cheap and appropriate; I ran validation 2 on the private
+  variant and it passes.
+
+Two gaps, both minor:
+
+- **V-gap 1 — nothing exercises rustdoc.** Since CI has no `cargo doc` job, a
+  `private_intra_doc_links` warning would never be caught. Irrelevant as the plan stands (no such
+  links exist), but it becomes relevant the moment the implementer adds a cross-reference per
+  Important-2 — so add the constraint: **use plain backticks, matching this file's existing style,
+  not `[…]` intra-doc links.** Optionally run `cargo doc --no-deps` once, locally.
+- **V-gap 2 — local `--all-targets` and CI's target set differ.** This working tree has an
+  **untracked** `examples/fastqc_only.rs`, so a local `--all-targets` run compiles a file CI does
+  not have. It does not reference `norm_path`, so it changes nothing here — but a green local run
+  is not automatically a statement about the tracked tree.
+
+---
+
+## Alternatives
+
+| Option | Assessment |
+|---|---|
+| **A. `fn` (plan's choice)** | **Recommended.** True minimum, zero behavioural surface, keeps the named seam. |
+| **B. Inline into `collision_key`** (the issue's alternative) | Correctly rejected, and the plan's reason understates its own case. `collision_key` absolutises, so `collision_key(Path::new("foo.fq.gz"))` returns a CWD-dependent absolute path — the existing exact-string assertions (`== "foo.fq.gz"`, `== "/some/dir/sample_r1.fq.gz"`) could not survive the rewrite, only weaker fold-equality pairs. Worth noting the *behavioural* pairing is already pinned independently by `identity_key_is_case_sensitive_but_collision_key_is_not` (io.rs:1178), so inlining would lose the fold *primitive's* unit test, not the fold's contract. Still: more churn, no benefit. |
+| **C. `pub(crate) fn`** | Not mentioned by the plan; worth one line. It removes the item from the published/docs.rs surface *exactly as `fn` does*, while permitting a future second in-crate caller without re-widening. Adds nothing today (no other module wants the raw fold), so `fn` is right — but this is the natural fallback if a second in-crate caller ever appears, and it satisfies #399 equally. |
+| **D. Keep `pub`, fix only the docs** | Rejects the issue's premise, so no. But note the asymmetry it exposes: per L3, **the doc edit carries most of the durable value and the keyword carries the API-surface value.** Shipping the keyword alone delivers the lesser half. |
+
+I agree with the plan's choice of A. My disagreement is narrow: the plan says the trade-off note
+*"lives well on the named fn"*, and I think that is wrong on the merits — see Important-1.
+
+---
+
+## Action items
+
+### Critical
+None.
+
+### Important
+
+**Important-1 — Move the case-folding trade-off note from `norm_path` to `collision_key`.**
+Not merely because visibility changes who reads it, but because **`collision_key` is where it
+belongs on substance**: `norm_path` is a pure string fold that decides nothing, so it cannot
+false-positive anything. The false-positive risk and the "loud early error rather than silent data
+loss" justification are properties of *the collision decision*. Two independent reasons to move it:
+
+1. Post-demotion it vanishes from the published API docs (docs.rs renders `collision_key`, which
+   currently states only *what* and *why folded*, never the *cost*).
+2. Even for in-file readers the note is 35+ lines above `collision_key`, with `lexical_normalise`
+   in between, so someone landing at line 81 does not see it today either.
+
+Leave `norm_path` with a one-line "what it does". This turns the change from behaviour-neutral into
+a net documentation improvement, at no extra risk.
+
+**Important-2 — Add the missing `path_identity_key` cross-reference; do not rely on the keyword to
+resolve the re-audit's concern.** Per L3, privacy hides `norm_path` from API readers but leaves the
+in-file reader with the same under-specified block that enabled #389. The plan's outline currently
+adds only *"(private)"* framing, which addresses none of this. `norm_path`'s block should note that
+the fold is the **output-collision** key and that input identity deliberately uses the
+case-**preserving** `path_identity_key` — the two answer different questions. Keep it to one line
+per the repo's comment convention, and **use plain backticks, not `[…]` intra-doc links** (V-gap 1:
+no CI job would catch a broken/private link).
+
+Also worth the implementer's glance while in the area: the *test's* comment at io.rs:766-768 says
+`norm_path` is *"the case-folded normalisation that the output-collision pre-flight + `--passthrough`
+validation both use."* True only indirectly — neither calls `norm_path`, both go via `collision_key`
+— and it omits that the `--passthrough` check *also* uses the case-sensitive key for a different
+question (`cli.rs:934-952` uses both). Same class of imprecision #399 exists to remove. Optional to
+fix, three lines from an edit the plan is already making.
+
+**Important-3 — Correct the two wrong justifications (L1, L2) in the plan text before
+implementing.** Both are one-sentence fixes, and both currently teach a false model: that
+`dead_code` is the safety net (it cannot fire), and that this repo does not changelog
+non-user-visible work (it has a dedicated section for it). Neither changes the diff.
+
+### Optional
+
+**Optional-1 — Reconsider the CHANGELOG once, on the correct grounds.** The real argument for an
+entry is not "internal change" but "**removes an item from the published crate's API**" (A3). If
+Felix wants the crates.io surface tracked, a one-liner under the existing
+`#### Infrastructure (contributor-facing)` heading is the right home. My own read: skip it — below
+the bar set by the neighbouring entries — but skip it for that reason, not the plan's.
+
+**Optional-2 — The durable fix for this whole class: declare the library surface unstable.** All 17
+modules in `lib.rs` are `pub` with no `pub use` curation, so every internal helper in the crate is
+published API and every future demotion re-raises A3. A single `//!` note in `src/lib.rs` — the
+library surface is an implementation detail of the binary and carries no semver guarantee — would
+pre-authorise this change and all its successors. Out of scope for #399; worth its own issue.
+
+**Optional-3 — Note the untracked-`examples/` caveat** (V-gap 2) if the implementer reports a green
+local `--all-targets` run as evidence about the tracked tree.
+
+---
+
+## Self-assessment of this review
+
+The load-bearing negative ("no callers outside `src/io.rs`") was confirmed three ways: exhaustive
+grep, a positive control proving the grep could see markdown, and a real compile with a positive
+control proving the compiler rejects an external caller. The plan's mechanism is correct and safe;
+my findings are about the plan's *reasoning* (two wrong justifications) and about an opportunity it
+declines (the doc content, which is where the #389 confusion actually lives). Nothing here should
+delay implementation.

--- a/plans/08082026_normpath-visibility/PLAN_REVIEW_B.md
+++ b/plans/08082026_normpath-visibility/PLAN_REVIEW_B.md
@@ -1,0 +1,341 @@
+# Plan Review B — demote `io::norm_path` to private (#399)
+
+**Plan:** `plans/08082026_normpath-visibility/PLAN.md`
+**Base verified:** `dev` @ `ce13761` (matches the plan's stated base; `git status --porcelain src/ CHANGELOG.md Cargo.toml` clean).
+**Reviewer:** B (independent; no shared state with Reviewer A).
+
+**Verdict up front:** the change is safe and correct, and I verified it compiles rather than
+taking the plan's word for it. Two of the plan's supporting *reasons* are wrong on the facts
+(the validation net is not `cargo build`, and a dead-code warning is impossible here), and one
+substantive omission is worth fixing inside this change: the case-folding trade-off note is
+about `collision_key`'s behaviour, not `norm_path`'s, and privatization deletes it from the
+rendered public docs. Details below.
+
+---
+
+## 1. Logic review
+
+### 1.1 Is `norm_path` genuinely callerless outside `src/io.rs`? — Yes, verified four ways
+
+The plan's grep claim holds. I checked the places a naive `io::norm_path` grep misses:
+
+| Surface | Result |
+|---|---|
+| `git grep norm_path -- src tests benches examples build.rs Cargo.toml docs '*.md'` | only `src/io.rs` (def `:45`, sole call `:82`, test `:765-780`) + one `//` comment at `src/cli.rs:1903` |
+| Untracked files too (`grep -rn`, excluding `plans/`, `target/`, `optimus_prime/`, `target_repro_b/`) | same set — nothing new |
+| `src/lib.rs` | 17 bare `pub mod` lines, **no `pub use` re-exports**, no prelude. So `io::norm_path` *is* public surface today (`trim_galore::io::norm_path` resolves), but nothing consumes it. |
+| `benches/`, `examples/` | do not exist |
+
+Two details that matter and that a `io::norm_path`-shaped grep would have missed:
+
+- `src/specialty.rs:12` and `src/clump_only.rs:52` both do `use crate::io as naming;`, so a caller
+  there would read `naming::norm_path`. Historical plan text does describe `naming::norm_path`
+  call sites, so this was a live possibility, not a hypothetical. Neither file contains the
+  identifier — grepping the bare symbol (as I did) covers the alias; grepping the qualified path
+  would not have.
+- `src/cli.rs:1903` is a `//` comment (not `///`) naming the **test**
+  `io::tests::test_norm_path_case_folds`, not the function. The test keeps its name, so this is
+  unaffected. The plan says this too and is right.
+
+### 1.2 Does it compile? — Yes, empirically
+
+I did not rely on reasoning. I extracted `git archive HEAD` into a scratch copy (the shared tree
+was not touched), applied `pub fn norm_path` → `fn norm_path` there, and ran
+`cargo check --all-targets --locked`:
+
+```
+Finished `dev` profile [unoptimized + debuginfo] target(s)   # exit 0, 0 warnings
+```
+
+All 11 integration tests were genuinely compiled, not skipped — `.rmeta` artifacts exist for
+`integration_adapter2` … `integration_ubam` in the scratch target dir. (My first log looked
+suspiciously short at 40 lines; that was my own `| tail -40`, not a truncated build.)
+
+**A2 is proven, not assumed:** `src/io.rs:565-567` is `#[cfg(test)] mod tests { use super::*; … }`,
+and the green `--all-targets` run compiles that module, so the private fn is reachable from the
+tests exactly as the plan says.
+
+### 1.3 Rustdoc intra-doc links — not a hazard here, and not gated by CI either
+
+Two independent reasons this cannot bite:
+
+1. **No intra-doc links to `norm_path` exist anywhere.** The only cross-file mention is the `//`
+   comment above. Plain backticks are not links — rustdoc resolves only bracketed forms
+   (`[`norm_path`]`), and there are none. The `private_intra_doc_links` lint direction is also
+   inverted from the worry: `norm_path`'s own doc references `collision_key`, i.e. a private item
+   pointing at a public one, which is always fine.
+2. **There is no rustdoc job in CI.** `ci.yml:160` "Docs build (Astro)" is the documentation
+   *website* (`working-directory: docs`, `npm ci && npm run build`), and `docs.yml` deploys that
+   same Astro site. No `cargo doc`, no `RUSTDOCFLAGS`, no `--document-private-items` anywhere in
+   `.github/workflows/`. So no rustdoc warning can gate this PR.
+
+Nothing beyond a compile error can break. The one *non-breaking* consequence is real and is my
+Important finding — see §1.5.
+
+### 1.4 `fn` (private) vs inlining into `collision_key` — `fn` is right, but for a different reason than the plan gives
+
+I agree with the resolution. I do not agree with the argument.
+
+**The plan's argument is the weaker one available.** It says inlining "dissolves the named seam
+`test_norm_path_case_folds` pins". But the fold is *already* pinned at the public boundary, twice:
+
+- `src/io.rs:1177-1191` `identity_key_is_case_sensitive_but_collision_key_is_not()` — asserts
+  `collision_key` folds while `path_identity_key` does not, and carries a REGRESSION note about
+  the #216 CI guard.
+- `src/io.rs:1194-1206` `both_keys_normalise_spelling()` — pins spelling normalisation on both keys.
+
+So losing `test_norm_path_case_folds` would not leave the fold unpinned, and "the seam the test
+pins" overstates what that test uniquely protects.
+
+**The argument that does survive scrutiny** (worth putting in the plan or the commit message
+instead): `collision_key` **absolutises before folding**, so re-expressing the fold test in terms
+of `collision_key` makes its relative-path assertions cwd-dependent. Today's test asserts
+`norm_path(Path::new("foo.fq.gz")) == "foo.fq.gz"`; through `collision_key` that becomes
+`"<lowercased cwd>/foo.fq.gz"`. Two of the test's four assertions use relative paths and would
+not translate cleanly. A named pure-fold function is what lets the fold be asserted as a property
+without dragging the working directory into the test. That is a real reason to keep the seam, and
+it is cheaper than inlining regardless.
+
+### 1.5 The trade-off note is mis-homed, and privatization makes that consequential — **Important**
+
+Current doc layout in `src/io.rs`:
+
+- `norm_path` (`:38-44`) carries the substantive paragraph: *"Pragmatic trade-off: on opt-in
+  case-sensitive APFS volumes this may false-positive, but the penalty is a loud early error
+  rather than silent data loss."*
+- `path_identity_key` (`:72-77`) explains its case-**sensitive** rationale well.
+- `collision_key` (`:79-83`) is two lines and carries **none** of the trade-off.
+
+The note is mis-homed *already*, before this change. `norm_path` is a pure
+`to_string_lossy().to_ascii_lowercase()`; "may false-positive" is not a property of lowercasing a
+string. It is a property of *deciding output collisions on a folded key* — which happens in
+`collision_key` and `preflight_output_collisions`, not in `norm_path`.
+
+Privatization turns that latent mis-homing into a concrete loss:
+
+- **rustdoc omits private items by default**, so after this change the only statement of the
+  trade-off vanishes from the generated docs entirely. Every remaining *public* path-key doc is
+  silent on it.
+- An in-source reader who arrives at `collision_key:81` must scroll *up* past `path_identity_key`
+  and `lexical_normalise` to find the reasoning behind the key they are reading.
+
+**Recommendation:** move the trade-off paragraph onto `collision_key` as part of this change, and
+reduce `norm_path`'s doc to one line. Two hunks instead of one, still zero behaviour change. This
+converts the change from "hide the confusing thing" into "put each fact where its reader is",
+which is a materially better answer to #399's own framing. Note this also retires the plan's
+stated reason for keeping the named fn ("the doc comment's trade-off note lives well on the named
+fn") — replace it with the cwd argument in §1.4.
+
+### 1.6 Does #399 resolve the re-audit's "`norm_path`'s doc omits `path_identity_key`" finding, or hide it?
+
+Split the finding in two; the answer differs per half.
+
+- **The misuse half — genuinely resolved.** The reason to cross-reference `path_identity_key` from
+  `norm_path` was to stop a caller reaching for the folded helper when they wanted the
+  case-preserving key. That is exactly the mistake #389 had to correct, and after privatization no
+  code outside `io.rs` *can* make it. The guarantee moves from "a doc a reader might skim" to
+  "the compiler rejects it" (`error[E0603]`, demonstrated in §3.1). That is strictly stronger than
+  the cross-reference would have been.
+- **The informational half — only resolved if the note moves.** A reader of the public API still
+  needs to learn that two keys exist with deliberately different case semantics. Most of that is
+  already served: `collision_key` says "Case-**folded**", `path_identity_key` says
+  "Case-**sensitive**, because …", the two are adjacent, and a test names the contrast. What is
+  *not* served after privatization is the trade-off sentence.
+
+**So:** treating #399 as the fix for the re-audit's finding is right about the misuse surface and
+right about the doc gap **only if §1.5 is adopted**. If the trade-off note stays on a private fn,
+#399 hides that finding rather than resolving it. That is the crux of this review.
+
+### 1.7 The "(private)" doc framing — mild objection (Optional)
+
+Plan step 1 proposes the first doc line "gains '(private)' framing". I would not. The `fn`
+keyword three lines below already states the visibility, and docs that narrate their own
+visibility go stale the next time visibility changes. `CLAUDE.md`'s comment convention ("state the
+fact, not the evidence", default to one line) argues for *shortening* this doc block, not adding a
+parenthetical to it. Combined with §1.5 the natural result is a single line:
+`/// Case-folded (ASCII lowercase) view of a path; the folding half of `collision_key`.`
+
+---
+
+## 2. Assumptions
+
+| Plan assumption | Status |
+|---|---|
+| **A1** — zero callers outside `io.rs`, grep-verified on `src/`, `tests/` | **Confirmed**, and widened: also `benches/`/`examples/` (absent), `build.rs`, `Cargo.toml`, `docs/`, all untracked non-`plans/` files, and the `use crate::io as naming` aliases in `specialty.rs`/`clump_only.rs`. |
+| **A2** — `mod tests` reaches private items | **Confirmed** by compile, not just by language rule (`io.rs:565` is `#[cfg(test)] mod tests` with `use super::*`). |
+
+Unstated assumptions the plan relies on, all of which I checked and all of which hold:
+
+- **No rustdoc gate in CI.** True (§1.3). Had `cargo doc -D warnings` existed, the plan's
+  validation table would have had a gap.
+- **No doc-tests reference the symbol.** True, and structurally impossible to matter here: the
+  crate's only doc code fence is a ```` ```text ```` block at `src/specialty.rs:235-240`, so there
+  are no compiled doc examples at all. Worth knowing *why* this matters: `--all-targets` excludes
+  doc-tests, so a doc example using `norm_path` would slip past clippy and surface only under
+  `cargo test`. Non-issue on this base.
+- **The coverage CI job has no threshold.** True — `ci.yml:271-310` runs `cargo llvm-cov` and
+  uploads LCOV with no fail-under gate, so a line-attribution shift cannot fail CI.
+- **The crate has no `#![deny(...)]`/`#![warn(missing_docs)]` lint attributes** that could react to
+  a visibility change. Confirmed: `src/lib.rs` and `src/main.rs` carry no inner attributes at all.
+
+The plan's line-number citations are all accurate on this base (`:45-47` def, `:82` caller,
+`:765-780` test).
+
+---
+
+## 3. Validation sufficiency
+
+The proposed command set is sufficient. The plan's *explanation* of why it is sufficient is wrong
+in two places, and one of them could cause a future reader to weaken the check.
+
+### 3.1 `cargo build` is NOT the safety net — clippy `--all-targets` is (**Important**)
+
+Validation row 1 reads "`cargo build` + clippy `-D warnings` → clean (an external caller would be
+a compile error)". The first half is false. `cargo build`/`cargo check` compile lib + bin only,
+**not** `tests/`. I ran the positive control rather than reasoning about it — added a new
+`tests/zz_probe.rs` calling `trim_galore::io::norm_path` against the private variant:
+
+```
+A) cargo check --locked                → EXIT 0   ("Finished dev profile")   ← MISSES it
+B) cargo check --all-targets --locked  → EXIT 101
+   error[E0603]: function `norm_path` is private
+     --> tests/zz_probe.rs:6:33
+```
+
+Removing the probe returned `--all-targets` to green (exit 0), so the harness demonstrably can
+both pass and fail — the §1.2 green result is trustworthy.
+
+Practically the plan is fine, because it *does* run `cargo clippy --all-targets` and `cargo test`,
+either of which catches this. The fix is to the wording, so nobody later trims the run to
+`cargo build` believing that is the guard. Since `tests/` is precisely where a hidden consumer of
+a `pub` library item would live, this is the one row where the stated reasoning inverts the risk.
+
+### 3.2 The dead-code claim is backwards (**Important**, wording only)
+
+Plan step 2: "a dead-code warning would prove a missed caller assumption — none expected,
+`collision_key` uses it". `dead_code` fires when **nothing** uses an item — the opposite of a
+missed caller — and it cannot fire here at all, because `collision_key` calls it. The clean run
+confirms: **0 warnings**. The lint that speaks in the failure mode is `E0603`, a hard error, and
+only on targets that actually get compiled. Recommend deleting the parenthetical rather than
+rewording it.
+
+### 3.3 Rows 2 and 3
+
+Both fine. `cargo test test_norm_path_case_folds` is unaffected by visibility (child module), and
+full `cargo test` is the belt-and-braces catch for the doc-test blind spot in §3.1 that does not
+apply here anyway. `cargo fmt --all -- --check` is listed and is worth keeping — the edit shortens
+a line and could in principle disturb rustfmt's doc-comment wrapping if §1.5's doc rewrite is
+adopted.
+
+### 3.4 Nothing material is missing
+
+I looked for a gap and did not find one. The whole risk surface of a `pub` → private demotion is
+"does every compilation unit that could reference it still compile", and `clippy --all-targets` +
+`cargo test` cover every unit this crate has. No runtime behaviour exists to test.
+
+---
+
+## 4. Efficiency
+
+Nil, as the plan says, and correctly dismissed. `norm_path` stays a separate function called once
+per path; privatization marginally widens the optimizer's freedom (a non-exported function is
+easier to inline away) but the call is already within one crate and one translation unit, so the
+effect is immaterial and not worth mentioning in the commit message.
+
+---
+
+## 5. CHANGELOG: skip is right, the stated reason is not
+
+The plan's conclusion (no entry) is correct. Its justification — "consistent with the repo treating
+only behaviour/message changes as entries" — is not accurate, and the real precedent is stronger:
+
+- **A slot for non-user-visible changes exists.** `CHANGELOG.md:481` — the Unreleased section
+  already has `#### Infrastructure (contributor-facing)`, with two entries (the new `docs-build`
+  CI job; the `justfile` docs recipes that ran `cd Docs`). v2.1.0-beta.2 had
+  `#### Infrastructure (contributor-facing, no runtime effect)` (CI gates, Dependabot config). So
+  "only behaviour/message changes" is false as stated.
+- **But this change is below that section's granularity floor.** Those entries are things a
+  contributor trips over — a new PR gate, a recipe broken on Linux, Dependabot routing. A
+  visibility keyword on an internal helper is not.
+- **The decisive precedent:** `grep -n "collision_key\|norm_path\|path_identity_key" CHANGELOG.md`
+  returns **zero hits** across 1300+ lines that document the entire #216 / #383 / #384 / #388 /
+  #389 / #391 collision-key arc — all of which touched these very functions. This changelog has
+  never named these helpers, so it certainly should not start for a `pub` removal.
+- Supporting: `7ea2741` (docs-only, #387) merged with no CHANGELOG entry, so not every PR gets one.
+
+**Recommendation:** keep the decision, fix the reason to something like *"below the Infrastructure
+section's granularity floor; the CHANGELOG has never named these helpers, across the whole
+collision-key arc."* An accurate precedent is worth more than a convenient one here, because the
+inaccurate version could be cited later to skip an entry that *does* belong.
+
+---
+
+## 6. Alternatives
+
+| Alternative | Assessment |
+|---|---|
+| **`fn` (plan's choice)** | Correct. Sole caller is in the same module, so module-private is the tightest visibility that works. |
+| **`pub(crate) fn`** | Strictly worse *here*. It would keep the symbol reachable from `specialty.rs`/`clump_only.rs` (which already alias `crate::io as naming`) — i.e. it preserves most of the confusion surface #399 exists to remove, while buying nothing, since no cross-module caller exists or is wanted. Reject explicitly if it comes up in review. |
+| **Inline into `collision_key`** | The issue's alternative. Viable but worse — see §1.4; the cwd-dependence argument, not the plan's seam argument, is what kills it. Also loses a cheap property test for no gain. |
+| **`#[inline]` + private** | Pointless noise; LLVM handles a one-liner in-crate. |
+| **Private + move the trade-off doc to `collision_key`** | **My recommendation** (§1.5). Same behaviour, same risk, one extra hunk, and it is the version that actually resolves the re-audit finding rather than hiding it. |
+| **Do nothing / close #399** | Not recommended, but worth naming the honest cost: the change buys clarity, not correctness. Given #389's planning error traced directly to the misleading `pub`, and given the compiler now enforces the misuse guard (§1.6), the clarity is worth one keyword. |
+
+---
+
+## 7. Action items
+
+### Critical
+None. The change compiles, behaviour is unchanged, and the plan's proposed commands do catch the
+only failure mode.
+
+### Important
+
+1. **Move the case-folding trade-off paragraph from `norm_path` to `collision_key`** (`src/io.rs`
+   `:42-44` → `:79-83`), and shorten `norm_path`'s doc to one line. Without this, privatization
+   deletes the trade-off from the rendered public docs and #399 hides the re-audit's doc finding
+   instead of resolving it (§1.5, §1.6). Small, zero-behaviour, and it is the difference between a
+   good change and a merely harmless one.
+2. **Fix validation row 1: the net is `clippy --all-targets` / `cargo test`, not `cargo build`.**
+   Empirically `cargo check` (same target set as `cargo build`) passes with an external caller in
+   `tests/` present; only `--all-targets` raises `E0603` (§3.1). Keep both commands — just stop
+   crediting the wrong one, so the step is not trimmed later.
+3. **Delete the dead-code parenthetical in step 2.** `dead_code` signals *no* caller, cannot fire
+   while `collision_key` calls the fn, and the clean run emits 0 warnings (§3.2).
+4. **Correct the CHANGELOG rationale** (keep the decision). The repo *does* have an
+   `Infrastructure (contributor-facing)` slot in the current Unreleased section; the real reason to
+   skip is granularity plus the zero-hit history for these three symbol names (§5).
+
+### Optional
+
+5. **Replace the plan's "seam" justification with the cwd-dependence argument** (§1.4). The current
+   one is refuted by `identity_key_is_case_sensitive_but_collision_key_is_not` and
+   `both_keys_normalise_spelling`, which already pin the fold publicly; the surviving argument is
+   that `collision_key` absolutises, so a fold test written through it becomes cwd-dependent.
+6. **Drop the "(private)" doc framing** (§1.7). The `fn` keyword states it; self-narrating
+   visibility goes stale and cuts against `CLAUDE.md`'s one-line comment convention.
+7. **Say `pub(crate)` was considered and rejected** in the commit message — it is the obvious
+   reviewer question and the answer (it keeps the `naming::` alias surface open for nothing) is
+   worth one clause.
+8. **Optionally note in the plan that no rustdoc gate exists** (§1.3). It is the assumption that
+   would have made this change riskier than it looks, and recording that it was checked saves the
+   next person the same audit.
+
+---
+
+## Appendix — how the claims here were verified
+
+- `git grep` + `grep -rn` over `src/ tests/ build.rs Cargo.toml docs/` and all untracked
+  non-`plans/` files; separate check of the `use crate::io as naming` aliases.
+- `src/lib.rs` read in full (17 `pub mod`, no re-exports).
+- `.github/workflows/{ci,docs,release}.yml` grepped for `cargo doc` / `rustdoc` / `RUSTDOCFLAGS` /
+  `document-private` — no hits; `ci.yml:160` job confirmed to be Astro.
+- **Isolated compile** (`git archive HEAD` → scratchpad, `pub fn` → `fn`, fresh
+  `CARGO_TARGET_DIR`): `cargo check --all-targets --locked` exit 0, 0 warnings; `.rmeta` present
+  for all 11 integration tests.
+- **Positive control**: probe caller in `tests/` → `cargo check` exit 0, `cargo check
+  --all-targets` exit 101 `E0603`; probe removed → exit 0 again.
+- `CHANGELOG.md` heading map + `grep` for the three helper names (zero hits); last 25 commits
+  classified by whether they touched `CHANGELOG.md`.
+- The shared working tree was **not** modified — every experiment ran in
+  `…/scratchpad/npcheck1`.

--- a/plans/08082026_normpath-visibility/PROGRESS.md
+++ b/plans/08082026_normpath-visibility/PROGRESS.md
@@ -1,0 +1,21 @@
+# Progress: demote `io::norm_path` to private (#399)
+
+**Last updated:** 2026-08-08
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | PLAN.md **r2** — dual review folded in; scope gains one doc hunk (trade-off note moves to collision_key). 4 plan-text corrections owned |
+| Plan Review | ✅ Complete | PLAN_REVIEW_A.md + PLAN_REVIEW_B.md — both approve, no Criticals; both compiled the change in isolated copies with positive controls |
+| Impl Plan | ✅ Complete | Folded into PLAN.md r2 outline (no separate IMPL.md, per pipeline convention) |
+| Implementation | ✅ Complete | 315557d + review batch 1a2a384; E0603 positive control run on-branch |
+| Code Review | ✅ Complete | CODE_REVIEW_A.md + _B.md — both APPROVE, no Criticals; agreed Medium (trade-off scope) applied in 1a2a384 |
+| Coverage | ✅ Complete | COVERAGE.md: COMPLETE, 19/19 DONE, zero gaps |
+
+## History
+
+- 2026-08-08: Implementation + Code Review + Coverage → ✅ Complete
+- 2026-08-08: Plan revised to r2 (dual-review findings incorporated; pub(crate) contradiction resolved in-plan)
+- 2026-08-08: Plan Review → ✅ Complete (dual reviewers; approve with doc-content changes)
+- 2026-08-08: Plan → ✅ Complete (PLAN.md written)

--- a/src/io.rs
+++ b/src/io.rs
@@ -74,9 +74,9 @@ pub fn path_identity_key(p: &Path) -> String {
 /// differing only in case alias each other on APFS/NTFS (issues #216, #383). Input
 /// identity asks a different question and uses the case-preserving `path_identity_key`.
 ///
-/// Pragmatic trade-off: on opt-in case-sensitive APFS volumes this may
-/// false-positive, but the penalty is a loud early error rather than
-/// silent data loss.
+/// Pragmatic trade-off: on a case-sensitive filesystem (Linux, or opt-in
+/// case-sensitive APFS) two outputs differing only in case are distinct, and this
+/// rejects them — a loud early error in preference to silent data loss.
 pub fn collision_key(p: &Path) -> String {
     norm_path(&lexical_normalise(p))
 }
@@ -762,8 +762,8 @@ mod tests {
 
     #[test]
     fn test_norm_path_case_folds() {
-        // The fold `collision_key` is built on (callers reach it through that key,
-        // never directly). Plain lowercase is identity; upper/mixed folds down.
+        // The fold that `collision_key` is built on; production callers only reach it
+        // through that key, which absolutises first — hence the direct test here.
         assert_eq!(norm_path(Path::new("foo.fq.gz")), "foo.fq.gz");
         assert_eq!(norm_path(Path::new("FOO.FQ.GZ")), "foo.fq.gz");
         assert_eq!(norm_path(Path::new("Foo.Fq.Gz")), "foo.fq.gz");

--- a/src/io.rs
+++ b/src/io.rs
@@ -35,14 +35,8 @@ pub fn is_gzipped(path: &Path) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("gz"))
 }
 
-/// Case-folded (ASCII lowercase) string view of a path — the folding component
-/// of `collision_key`, which absolutises first and is what every collision
-/// check uses (issues #216, #383, #389).
-///
-/// Pragmatic trade-off: on opt-in case-sensitive APFS volumes this may
-/// false-positive, but the penalty is a loud early error rather than
-/// silent data loss.
-pub fn norm_path(p: &Path) -> String {
+/// Case-folded (ASCII lowercase) view of a path; the folding half of `collision_key`.
+fn norm_path(p: &Path) -> String {
     p.to_string_lossy().to_ascii_lowercase()
 }
 
@@ -77,7 +71,12 @@ pub fn path_identity_key(p: &Path) -> String {
 }
 
 /// Would these two paths be the same *output* file? Case-**folded**, because outputs
-/// differing only in case alias each other on APFS/NTFS (issues #216, #383).
+/// differing only in case alias each other on APFS/NTFS (issues #216, #383). Input
+/// identity asks a different question and uses the case-preserving `path_identity_key`.
+///
+/// Pragmatic trade-off: on opt-in case-sensitive APFS volumes this may
+/// false-positive, but the penalty is a loud early error rather than
+/// silent data loss.
 pub fn collision_key(p: &Path) -> String {
     norm_path(&lexical_normalise(p))
 }
@@ -763,9 +762,8 @@ mod tests {
 
     #[test]
     fn test_norm_path_case_folds() {
-        // norm_path is the case-folded normalisation that the output-collision
-        // pre-flight + --passthrough validation both use. Plain lowercase is
-        // identity; uppercase / mixed case fold to lowercase.
+        // The fold `collision_key` is built on (callers reach it through that key,
+        // never directly). Plain lowercase is identity; upper/mixed folds down.
         assert_eq!(norm_path(Path::new("foo.fq.gz")), "foo.fq.gz");
         assert_eq!(norm_path(Path::new("FOO.FQ.GZ")), "foo.fq.gz");
         assert_eq!(norm_path(Path::new("Foo.Fq.Gz")), "foo.fq.gz");


### PR DESCRIPTION
`io::norm_path` was `pub` with no callers outside `io.rs` — and that public name is what let #389's planning mistake it for a stale alias of `collision_key`. It is now module-private, so the compiler enforces what a doc comment previously only suggested.

The case-folding trade-off note moves to `collision_key` in the same change. `norm_path` is a pure `to_ascii_lowercase` of a string, so "may false-positive" was never a property of it — false positives are a property of *deciding output collisions on a folded key*. Without the move, privatization would have deleted the only statement of that trade-off from the rendered docs. `collision_key` also gains the pointer to the case-preserving `path_identity_key`, which is exactly the distinction #389 got wrong.

`pub(crate)` was considered and rejected: `specialty.rs` and `clump_only.rs` both alias `crate::io as naming`, so it would keep the symbol reachable as `naming::norm_path` from precisely the modules whose readers this protects.

Verified with a positive control on this branch — an external caller planted in `tests/` raises `E0603` under `cargo check --all-targets`, while plain `cargo check` passes (it never compiles `tests/`), so the guard is the `--all-targets` run and not `cargo build`. 561 tests green; the fold stays pinned by `test_norm_path_case_folds`.

<details>
<summary>AI-assisted: plan, dual plan review, and what they corrected</summary>

Plan + reviews in `plans/08082026_normpath-visibility/` (committed separately). Both reviewers approved with no Criticals, each having compiled the demotion in an isolated copy with positive controls. They corrected three justifications in the original plan: `dead_code` cannot fire here (`collision_key` calls the function), `cargo build` is not the safety net, and the claim that this repo doesn't changelog internal work was false — it has an `Infrastructure (contributor-facing)` section. The entry is still skipped, on better grounds: the changelog has never named these three helpers across the entire #216/#383/#384/#388/#389/#391 arc.

Follow-up filed: #402 (declare `lib.rs`'s 17 uncurated `pub mod` surface an implementation detail, since the crate publishes to crates.io and every future demotion re-raises the semver question).
</details>

Closes #399 (manual close needed — dev is not the default branch).
