### PR TITLE
docs(cli): make --clump_only's help text format-aware (#400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,11 +151,18 @@
   paired run writes **one** interleaved `*_clumped.bam`, not two mate files, so
   anyone scripting against `_clumped_{1,2}.fq.gz` was misled. The whole block is
   now format-aware: per-format filenames, `--compression` and `--dont_gzip`
-  marked FASTQ-output-only, `--preserve-tags` named as the aux-tag opt-in, the
-  appended `@PG` record noted as the reason whole-file identity does not hold on
-  BAM output, and uBAM input documented as requiring `--output-format ubam`. The
+  marked FASTQ-output-only, `--preserve-tags` documented as requiring a uBAM
+  input, and uBAM input documented as requiring `--output-format ubam`. The
   `--output-format ubam` value description also gained the two rejections it was
-  missing (`--retain_unpaired`, `--dont_gzip`). No behaviour change.
+  missing (`--retain_unpaired`, `--dont_gzip`).
+
+  The fidelity claim is now scoped honestly, which is the correction most worth
+  reading: FASTQ in / FASTQ out is byte-identical, but **uBAM output is lossless
+  per record body and not byte-identical** — the space-separated header
+  description is dropped (so a standard Illumina `1:N:0:INDEX` field does not
+  survive), bases are uppercased, IUPAC codes become `N`, and aux tags survive
+  only when named in `--preserve-tags`. All four are long-standing writer
+  behaviours; only the documentation changes here. No behaviour change.
 
 - **The `--passthrough`-matches-R1/R2 message now says what it checks**
   ([#389](https://github.com/FelixKrueger/TrimGalore/issues/389)). The old text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,21 @@
 
 #### Changes
 
+- **`--clump_only`'s `--help` text no longer contradicts the shipped uBAM
+  support** ([#400](https://github.com/FelixKrueger/TrimGalore/issues/400)). The
+  block predated the uBAM arms and still listed `--output-format ubam` among the
+  *rejected* flags while closing with "v1 is FASTQ in / FASTQ out only" — so the
+  text actively deterred users from a feature that works. Most consequential: the
+  output-filename sentence was FASTQ-only, and under `--output-format ubam` a
+  paired run writes **one** interleaved `*_clumped.bam`, not two mate files, so
+  anyone scripting against `_clumped_{1,2}.fq.gz` was misled. The whole block is
+  now format-aware: per-format filenames, `--compression` and `--dont_gzip`
+  marked FASTQ-output-only, `--preserve-tags` named as the aux-tag opt-in, the
+  appended `@PG` record noted as the reason whole-file identity does not hold on
+  BAM output, and uBAM input documented as requiring `--output-format ubam`. The
+  `--output-format ubam` value description also gained the two rejections it was
+  missing (`--retain_unpaired`, `--dont_gzip`). No behaviour change.
+
 - **The `--passthrough`-matches-R1/R2 message now says what it checks**
   ([#389](https://github.com/FelixKrueger/TrimGalore/issues/389)). The old text
   claimed the passthrough file "aliases an input file" unconditionally — false on

--- a/docs/src/content/docs/modes/clump-only.md
+++ b/docs/src/content/docs/modes/clump-only.md
@@ -3,7 +3,7 @@ title: Clump-only (lossless reorder)
 description: Reorder FASTQ or uBAM records for gzip/BGZF-friendly compression without trimming (`--clump_only`).
 ---
 
-`--clump_only` is a run-and-exit mode that reorders FASTQ or unaligned BAM (uBAM) records by canonical 16-mer minimizer for compression-friendly grouping, **without any trimming, filtering, or adapter detection**. Every input record appears in the output byte-identically (header/name + sequence + quality + preserved aux tags for uBAM); only file-level order changes.
+`--clump_only` is a run-and-exit mode that reorders FASTQ or unaligned BAM (uBAM) records by canonical 16-mer minimizer for compression-friendly grouping, **without any trimming, filtering, or adapter detection**. Every input record appears in the output byte-identically on the FASTQ path (header + sequence + quality); only file-level order changes. uBAM output is lossless per record body rather than byte-identical — see [Record fidelity](#record-fidelity).
 
 Requested in [#353](https://github.com/FelixKrueger/TrimGalore/issues/353) as an archival and recompression path. It applies the same minimizer-based reordering as [`--clumpify`](/performance/clumpy/), which runs as a compression stage inside the trim pipeline, but operates as a standalone mode that leaves record contents unchanged.
 

--- a/docs/src/content/docs/modes/clump-only.md
+++ b/docs/src/content/docs/modes/clump-only.md
@@ -48,8 +48,8 @@ trim_galore --clump_only --output-format ubam --preserve-tags RG,BC,UB sample.ba
 
 The following fields are byte-identical between input and output:
 
-- Read ID (header line for FASTQ; name portion for BAM)
-- Sequence
+- Read ID (header line for FASTQ; name portion for BAM — a space-separated description such as `1:N:0:INDEX` is dropped on uBAM output)
+- Sequence (FASTQ output only; on uBAM output bases are uppercased and IUPAC codes are coerced to `N`)
 - Quality string
 - Aux tags (uBAM only, via `--preserve-tags`) — A/Z/i/f scalars round-trip losslessly. B (array) and H (hex) tags are rejected at BAM-read time by the underlying reader, the same constraint that applies to the trim uBAM path.
 

--- a/plans/08082026_clump-help-text/CODE_REVIEW_A.md
+++ b/plans/08082026_clump-help-text/CODE_REVIEW_A.md
@@ -1,0 +1,252 @@
+# Code Review A — #400 `--clump_only` help text
+
+**Reviewer:** A (independent; Reviewer B works in parallel with no shared state)
+**Target commit:** `0676fdf` — `docs(cli): make --clump_only's help text format-aware (#400)`
+**Base:** `dev` @ `ac08a97`
+**Files in diff:** `src/cli.rs` (variant doc + four-paragraph `clump_only` rustdoc), `CHANGELOG.md` (one entry)
+**Method:** every claim in the new copy re-derived from the code (`main.rs` five `--clump_only` dispatch arms, `cli.rs::Cli::validate` §3.4a + clump block, `io.rs` namers, `clump_only.rs` writers, `bam.rs` reader/writer), cross-read against `docs/src/content/docs/modes/clump-only.md`, then **empirically exercised** with the built binary (10 invocations, listed in §Evidence).
+
+---
+
+## Verdict
+
+**APPROVE WITH CHANGES.** The rewrite is a real improvement and lands all five falsified claims the plan set out to fix; I verified each one independently against the code and, for the filename claims, against actual output files. Nothing in the diff can affect runtime, and `fmt` / `clippy -D warnings` / `test` are green.
+
+Two accuracy problems survive into the shipped copy, both of the same class #400 exists to correct — an unqualified claim that is only true on one output format:
+
+1. **A1 (High)** — paragraph 1's byte-identity claim now covers uBAM output, where the BAM writer **silently uppercases lowercase bases** and **coerces IUPAC degenerate bases to N**. Demonstrated on a 3-record fixture: FASTQ→FASTQ preserves both, FASTQ→uBAM does not. The old copy escaped this only by (falsely) claiming FASTQ-only scope; the rewrite extends the claim into territory the code does not honour.
+2. **A2 (Medium)** — paragraph 1 read alone is the `-h` surface, and alone it implies uBAM-in → FASTQ-out is legal. That is the illegal 2×2 the plan explicitly caught in r1's draft; the constraint that rules it out now sits in paragraph 4, which `-h` does not render.
+
+Plus one flag mis-scoped (**A3**, `--preserve-tags` needs uBAM *input*, not just uBAM output — hard error otherwise, verified), one plan step under-delivered (**A4**, multi-pair), and small editorial items. The CHANGELOG entry is accurate, correctly sectioned, and in house register.
+
+---
+
+## Area 1 — Accuracy, claim by claim
+
+### Verified TRUE (no action)
+
+| Claim (new copy) | Verified against | Result |
+|---|---|---|
+| "reorder FASTQ or unaligned BAM (uBAM) records" | `format::open_sync_reader` at `clump_only.rs:764`; five dispatch arms `main.rs:529-748` | OK |
+| "compression-friendly grouping" (was "gzip-friendly compression") | BGZF on the BAM arms, gzip on FASTQ | OK, better than old |
+| SE FASTQ `*_clumped.fq(.gz)` | `io.rs:356-379` | OK |
+| PE FASTQ `*_clumped_{1,2}.fq(.gz)` | `io.rs:384-409` | OK |
+| SE uBAM `*_clumped.bam` | `io.rs:417-431`; **ran it** → `BS-seq_10K_R1_clumped.bam` | OK |
+| PE uBAM **ONE** interleaved `*_clumped.bam` per pair | `io.rs:442-458`; **ran it** → exactly one file; multi-pair N=4 → 2 files | OK (highest-value fix in the diff) |
+| `*_clumping_report.txt` emitted, distinct from `*_trimming_report.txt` | `io.rs:463+`; **ran it** on every arm | OK |
+| `--compression` **(FASTQ output only)** | never passed to the three BAM entry points (`main.rs:638-650`, `:695-707`, `:733-745`); recorded as level `0` at `clump_only.rs:780` | OK |
+| `--dont_gzip` **(FASTQ output only)** + rejected with `--output-format ubam` | `cli.rs:585-590`; **ran it** → exact message the copy describes | OK |
+| `--memory`, `--cores`, `--paired`, `--fastqc`, `--basename` compose | all threaded to both format arms; **ran `--fastqc` on the BAM arm** → `_clumped_fastqc.{html,zip}` produced | OK |
+| `--output-format ubam` moved out of the rejected list | no such bail in `cli.rs:751-892`; `cli.rs:875-878` states the opposite | OK (falsified claim #2 fixed) |
+| Rejected trimming/filtering list (`-a`, `--length`, `--rrbs`, `--polyA`, `--polyG`, `--trim-n`, `--clip_*`, `--nextseq`, `--rename`, `--discard_untrimmed`, `--consider_already_trimmed`, specialty modes, `--passthrough`, `--retain_unpaired`) | one bail each, `cli.rs:769-888` | OK, all 14 present |
+| `-q` / `--stringency` / `-e` silently ignored | `cli.rs:744-750` rationale; no bail | OK |
+| `@PG` appended on uBAM output → whole-file identity not preserved | `bam.rs:677-681` `add_program`; **ran `samtools view -H`** → `@PG ID:trim_galore VN:2.3.0 CL:…` present | OK (falsified claim #4 fixed) |
+| "uBAM input requires `--output-format ubam` (the FASTQ output path would drop aux tags)" | SE `clump_only.rs:265-272`, PE `format.rs:165-172`; **ran both** → message matches the copy near-verbatim | OK (falsified claim #5 fixed) |
+| Paired "a single interleaved uBAM" with `--output-format ubam` | **ran Shape B** on the interleaved BAM produced above → 10 000 pairs, one output | OK |
+| Variant doc's seven rejections | §3.4a is the **only** `OutputFormat::UBam` block in `cli.rs` (`cli.rs:580` is the single `matches!` site) and holds exactly seven bails: `--dont_gzip` `:585`, `--clumpify` `:591`, `--passthrough` `:596`, `--clock` `:599`, `--implicon` `:605`, `--demux` `:610`, `--retain_unpaired` `:618` | OK — **complete and correct**, matches the code 1:1 |
+
+Validation row 1 also passes: `grep -rn "natural follow-up\|FASTQ in / FASTQ out" src/ tests/` → zero hits.
+
+### A1 (High) — "byte-identically … sequence" is false on the uBAM-output path
+
+New paragraph 1:
+
+> Every input record appears in the output byte-identically — name, sequence, quality, plus any aux tags named in `--preserve-tags` on uBAM; only file-level order changes.
+
+`bam.rs::validate_and_normalize_seq_for_write` (`:800-826`) runs on the write side of **every** uBAM output arm:
+
+- `b.to_ascii_uppercase()` — lowercase input bases are **silently** uppercased, no warning;
+- `R Y M K S W B D H V` → `N`, with a once-per-run warning;
+- `=` and any non-IUPAC byte → hard error.
+
+The read side (`bam.rs:927-946`) applies the same IUPAC→N coercion, so **uBAM → uBAM is affected too** — which is the docs page's own headline archival use case (10X `CB`/`UB` BAMs; the warning text itself names "PacBio HiFi, ONT Dorado, and 10x cellranger uBAMs" as places IUPAC codes appear).
+
+Proved, not inferred. A 3-record fixture with one lowercase read and one `RYKM` read:
+
+```
+FASTQ -> FASTQ (control):  acgtACGT...  preserved    ACGTRYKM...  preserved
+FASTQ -> uBAM:             ACGTACGT...  UPPERCASED   ACGTNNNN...  COERCED
+```
+
+The old copy was not exposed to this, because it declared "v1 is FASTQ in / FASTQ out only" — and on the FASTQ arm the record is a byte copy, so the claim held exactly. By making the block format-aware **without** scoping the fidelity sentence, the rewrite converted a true statement into one that is false on the new path. That is precisely the defect class the issue was filed against, and it fails the plan's own pass criterion ("every claim is either true for both output formats or explicitly scoped to one").
+
+`docs/…/modes/clump-only.md` §Record fidelity is silent on this too, so the specification the plan leaned on does not cover it — a genuine gap, not a transcription slip.
+
+**Recommendation.** Not a trivial fix: it needs a maintainer call on wording and probably a companion docs edit. Minimal in-help form, appended to the fidelity sentence:
+
+> … only file-level order changes. On uBAM output the sequence is uppercased and IUPAC degenerate bases are coerced to `N` (BAM's 4-bit alphabet); FASTQ output is a byte copy.
+
+Two follow-ups worth filing regardless of the help wording:
+- the docs page's §Record fidelity list should carry the same caveat;
+- **the lowercase coercion is silent** while IUPAC warns. For a mode whose selling point is archival losslessness, silent case loss on the BAM path deserves at least the same one-time warning.
+
+### A2 (Medium) — paragraph 1 alone implies the illegal uBAM-in → FASTQ-out combination
+
+Confirmed from the built binary that `-h` renders **only** paragraph 1, as the plan predicted. Read on its own, paragraph 1 says the mode reorders "FASTQ or unaligned BAM (uBAM) records" and then gives the FASTQ filenames as the unmarked default with the BAM ones behind `--output-format ubam`. The natural inference is the full 2×2: uBAM in, FASTQ out, giving `*_clumped.fq.gz`.
+
+That combination is rejected on both arms. The plan's Context flagged exactly this inference as the reason r1's draft was unacceptable ("implied 2×2 and would have invited exactly the refused invocation") — the shipped copy fixes it in paragraph 4, the surface `-h` users never see. So the defect was not removed, it was relocated to the short-help surface.
+
+Mitigation in the field is decent: the rejection message is precise and self-remediating. But the point of separating `-h` from `--help` is that many users never run the long form.
+
+**Recommendation (trivial fix).** A few words in paragraph 1, e.g. in the filename sentence:
+
+> … or, under `--output-format ubam` (**required for uBAM input**), `*_clumped.bam` (SE) or ONE interleaved `*_clumped.bam` per pair (PE).
+
+### A3 (Medium) — `--preserve-tags` is scoped to uBAM *output*, but it needs uBAM *input*
+
+New paragraph 2 lists `` `--preserve-tags` (uBAM only) `` immediately after two entries scoped `(FASTQ output only)`. In that parallel construction "(uBAM only)" reads as "uBAM output only" — and that reading is wrong:
+
+```
+$ trim_galore --clump_only --output-format ubam --preserve-tags CB sample.fq.gz
+Error: --preserve-tags has no effect with all-FASTQ inputs; either remove the flag
+       or convert at least one input to uBAM via 'samtools import'
+```
+
+`main.rs:286-298` — with `--output-format ubam` set, `--preserve-tags` on all-FASTQ inputs is a **hard error**, and that guard sits at `main.rs:286`, ahead of the `--clump_only` dispatch at `:522`. So `--preserve-tags` requires at least one uBAM **input**; uBAM output alone is not enough.
+
+Paragraph 1's phrasing ("aux tags named in `--preserve-tags` on uBAM") is fine — it is the composes-list entry that mis-scopes.
+
+The docs page carries the same imprecision ("`--preserve-tags TAG1,TAG2,…` — uBAM only"), so this was inherited rather than invented — but this diff is the first time the flag appears in `--help` at all, so it ships the imprecision to a new audience.
+
+Compounding it, `--preserve-tags`' own clap doc (unchanged, rendered in `-h`) says "**Ignored for FASTQ input**" — flatly contradicting the hard error above. Out of this diff's scope, but the same defect class as #400 and worth a follow-up issue.
+
+**Recommendation (trivial fix).** `` `--preserve-tags` (uBAM input only) ``.
+
+### A4 (Low–Medium) — plan step 4 asked for multi-pair; the copy dropped it
+
+Paragraph 4 ships as "Paired mode takes two files, or — with `--output-format ubam` — a single interleaved uBAM." Plan step 4 specified "two files (Shape A, **multi-pair supported**) or one interleaved uBAM (Shape B)".
+
+Multi-pair is real and I ran it: `--clump_only --paired --output-format ubam R1 R2 R1' R2'` prints `=== Pair 1 of 2 ===` / `=== Pair 2 of 2 ===` and writes two `_clumped.bam` files (`main.rs:683-717`); the FASTQ arm gets the same shape from `run_specialty_paired`. "Takes two files" is true but reads as an upper bound, and the docs page states the multi-pair support explicitly.
+
+Second, smaller gap in the same sentence: it never says two separate uBAM files are refused. A user with `R1.bam R2.bam` gets a good error, but the help does not pre-empt it.
+
+**Recommendation (trivial fix).** "Paired mode takes two FASTQ files (or several pairs — an even count), or — with `--output-format ubam` — a single interleaved uBAM; two separate uBAM files are not accepted."
+
+### A5 (Low) — paragraph 3 still says "header", paragraph 1 now says "name"
+
+Paragraph 1 changed `(header, sequence, quality)` → `name, sequence, quality`; paragraph 3 kept "byte-identity applies to **header** + sequence + quality bytes".
+
+Both words matter, in opposite directions, and `bam.rs::parse_name_and_data` (`:707-722`) is why: on a FASTQ header `@NAME DESC`, the space-separated description is **discarded** on BAM output (`:717-718`, "Space: rest is descriptive FASTQ annotation — discard"). Confirmed in the dump — `@read1 some description here` came out as QNAME `read1`, description gone.
+
+So:
+- paragraph 1's "name" is the **more accurate** word for uBAM output, but under-promises on FASTQ output, where the entire header line including the description *is* preserved byte-identically (verified in the control run);
+- paragraph 3's retained "header" **over-promises** on uBAM output.
+
+The docs page already has the resolution, per format: "Read ID (header line for FASTQ; name portion for BAM)". As shipped, the two paragraphs disagree with each other and no reader can resolve that from the help alone.
+
+**Recommendation (trivial fix).** Make paragraph 3 match the docs formulation — "byte-identity applies to the read ID (the full header line on FASTQ output, the name portion on uBAM output), sequence, and quality bytes" — or at minimum use one word in both paragraphs.
+
+### A6 (Low) — paragraph 3's plus-line / CRLF sentences are unscoped FASTQ claims
+
+"The plus-line (line 3 of each record) is normalized to bare `+` on output; CRLF line endings are normalized to LF. Both normalizations are codebase-wide behaviours, inherited from the FASTQ reader/writer."
+
+Neither concept exists on the BAM path — BAM has no plus-line and no line endings. The statements are inapplicable rather than false, so the harm is nil, but under the plan's own pass criterion they are the last unscoped FASTQ-only claims in the block, one sentence away from the `@PG` sentence that *is* scoped. A five-word lead-in ("On FASTQ output, the plus-line…") closes it. Optional.
+
+### Adjacent bug found while verifying (out of scope — recommend a follow-up issue)
+
+The IUPAC warning fires with its **direction reversed** on the write side. Running FASTQ input → uBAM output:
+
+```
+WARNING: input uBAM contains IUPAC degenerate bases (R/Y/M/K/S/W/B/D/H/V);
+         coerced to N for FASTQ output.
+```
+
+The input was FASTQ and the output was BAM. `bam.rs` shares one `emit_iupac_warning_once()` between the read path (`:944`, where the wording is right) and the write path (`:823`, where it is exactly backwards). Not caused by this diff; same user-facing-accuracy family as #389/#400.
+
+---
+
+## Area 2 — Old vs new, side by side
+
+Nothing true was deleted. Paragraph by paragraph:
+
+| Old | New | Assessment |
+|---|---|---|
+| P1 "reorder FASTQ records … gzip-friendly compression" | "FASTQ or unaligned BAM (uBAM) … compression-friendly grouping" | improvement |
+| P1 "byte-identically (header, sequence, quality)" | "byte-identically — name, sequence, quality, plus any aux tags named in `--preserve-tags` on uBAM" | the aux-tag half is the fix for falsified claim #3 and is right; "name" trades one imprecision for another (**A5**); the sentence's scope is now wrong on sequence (**A1**) |
+| P1 "Output files use the … suffix" (FASTQ only) | per-format, incl. the ONE-interleaved-BAM PE shape | the diff's most valuable change |
+| P2 `--compression`, `--dont_gzip` unqualified | both "(FASTQ output only)" | correct |
+| P2 `--output-format ubam` in the **rejected** list | in the composes list; `--dont_gzip`+ubam kept visible as an explicit rejection | correct, and keeping the exclusion visible rather than silently dropping it is the right call |
+| P2 rejected trimming list | unchanged apart from removing `--output-format ubam` | all 14 entries still accurate |
+| P3 | + one `@PG` sentence | correct |
+| P4 "v1 is FASTQ in / FASTQ out only. uBAM in/out is a natural follow-up." | two sentences on input formats and paired shapes | false statement replaced by true ones; **A4** notes what the plan asked for and the copy omitted |
+| Variant doc: 5 rejections | 7 | complete, exactly matches §3.4a |
+
+**One newly introduced inaccuracy: A1.** **One newly introduced internal inconsistency: A5.** No other regressions.
+
+Variant-doc completeness footnote (Low, optional): two other uBAM-output rejections live in `main.rs`, not `validate()` — `--phred64` + BAM input (`:264`) and `--preserve-tags` + all-FASTQ input (`:293`). The doc's "rejected at validation" arguably scopes them out, and the plan deliberately limited the edit to §3.4a, so I would not block on it; the `--preserve-tags` one is the trap most worth a mention if the line is ever revisited.
+
+---
+
+## Area 3 — CHANGELOG
+
+**Correct as shipped.** No changes required.
+
+- **Section:** `#### Changes` under `### Unreleased` (`CHANGELOG.md:143`), which is right — no behaviour change, and it avoids the duplicated `#### Bug fixes` / `#### Fixes` hazard the plan flagged (tracked in #401). Placed at the head of the section, matching the newest-first ordering of its neighbours (#400 → #389 → #383).
+- **Register:** bold lead clause, parenthesised issue link, what-was-wrong-then-what-changed, closing "No behaviour change." Reads like its neighbours; no AI-slop phrasing; the `issues/` link form matches every sibling entry.
+- **Accuracy:** all eight factual assertions in the bullet check out against the diff and the code — the old text's rejected-list placement, the "v1 is FASTQ in / FASTQ out only" close, the one-interleaved-BAM PE shape, the two FASTQ-output-only qualifiers, `--preserve-tags` as the aux-tag opt-in, the `@PG` reason, uBAM-input-requires-the-flag, and the two added variant-doc rejections.
+- Leading with the filename correction as "most consequential" is the right emphasis and matches what I independently judged the highest-value fix.
+- Only observation: the entry does not mention the P1 fidelity-enumeration change (`header` → `name` + aux tags). If **A1** is addressed that sentence needs a clause anyway, so this resolves itself.
+
+---
+
+## Area 4 — Structure and render
+
+Rendered from the built binary at 80 and 100 columns.
+
+- **`-h` renders paragraph 1 only** — confirmed, exactly as the plan assumed. Paragraph 1 is format-aware, so the fix is visible on the surface r1 would have missed. Right call.
+- **`--help` renders all four** paragraphs, blank-line separated, correctly indented. Em-dashes render as literal em-dashes in all three places, matching house convention.
+- **Length.** Paragraph 1 grew from ~540 to 833 characters (≈10 wrapped lines at 80 cols). That is a lot for a "short" help entry — but this binary's `-h` already prints every flag's full first paragraph (`--compression` and `--memory` are comparable), so it is consistent with its surroundings rather than an outlier. Not a blocker.
+- **Does paragraph 1 carry what a short-help user needs?** Mostly yes — what the mode does, both input formats, the fidelity contract, per-format output filenames, the report name. It does **not** carry the uBAM-input constraint, which is **A2** and the one thing I would add. Everything else missing from `-h` (the `--dont_gzip`+ubam rejection, the paired shapes) produces a precise error at runtime, so the omission is tolerable.
+- **Ordering within paragraph 1.** The filename list — the highest-value item for anyone scripting — now sits at roughly character 470 of 833, behind the fidelity clause. Editorial only; worth a thought if the paragraph is reopened for **A1**/**A2**.
+- **Grammar nit (trivial fix).** "… or under `--output-format ubam` a single `*_clumped.bam` (SE) **and** ONE interleaved `*_clumped.bam` per pair (PE)" — the SE/PE alternation wants "or", not "and"; as written it can read as though both are produced. Also "a single" adds nothing for SE and slightly conflicts with SE multi-input runs, which write one BAM per input.
+- **Variant doc line.** `- ubam:  Unaligned BAM output. Always single-threaded; …` renders as one unwrapped ~180-character line when stdout is not a TTY (clap only wraps against a real terminal width); in a terminal it wraps normally. Adding two flag names made a long line longer, not a new problem. Fine.
+
+---
+
+## Area 5 — Efficiency
+
+Nil, as expected: the diff is doc comments and a changelog entry. No call sites, no runtime paths, no allocation or I/O effect. Nothing to review.
+
+---
+
+## Evidence
+
+Build and checks at `0676fdf`: `cargo build --release` clean; `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --release -- -D warnings` clean; `cargo test` exit 0.
+
+Invocations run (outputs to a scratch directory via `-o`):
+
+1. `--clump_only --output-format ubam` (SE FASTQ) → `BS-seq_10K_R1_clumped.bam`
+2. `--clump_only --paired --output-format ubam R1 R2` → **exactly one** `BS-seq_10K_R1_clumped.bam` + one report
+3. `--clump_only --paired --output-format ubam R1 R2 R1' R2'` → `Pair 1 of 2` / `Pair 2 of 2`, two BAMs (**A4**)
+4. `--clump_only --paired --output-format ubam interleaved.bam` (Shape B) → 10 000 pairs, one output
+5. `--clump_only --dont_gzip --output-format ubam` → rejected, message as documented
+6. `--clump_only --output-format ubam --preserve-tags CB` + FASTQ input → **hard error** (**A3**)
+7. `--clump_only sample.bam` (no `--output-format ubam`) → rejected, message as documented
+8. `--clump_only --paired --output-format ubam a.bam b.bam` → two-BAM rejection
+9. `--clump_only --output-format ubam --fastqc` → `_clumped_fastqc.{html,zip}`
+10. lowercase + IUPAC fixture, FASTQ→FASTQ vs FASTQ→uBAM, then `samtools view -h` → **A1** and **A5** proven
+
+---
+
+## Recommendations by priority
+
+**High**
+1. **A1** — scope the byte-identity sentence, or state the uBAM-output sequence normalisation (uppercasing + IUPAC→N). Needs a wording decision; also file the docs-page gap and consider warning on the silent lowercase coercion.
+
+**Medium**
+2. **A2** *(trivial fix)* — put the "uBAM input requires `--output-format ubam`" constraint into paragraph 1, so the `-h` surface stops implying the illegal 2×2.
+3. **A3** *(trivial fix)* — `--preserve-tags` → "(uBAM **input** only)".
+
+**Low**
+4. **A4** *(trivial fix)* — say multi-pair is supported, and that two separate uBAM files are not, in paragraph 4.
+5. **A5** *(trivial fix)* — reconcile paragraph 3's "header" with paragraph 1's "name"; the docs page's per-format formulation is the model.
+6. **A6** *(trivial fix, optional)* — scope paragraph 3's plus-line / CRLF sentences to FASTQ output.
+7. Grammar nit in paragraph 1's filename sentence: "and" → "or"; drop "a single" (Area 4).
+8. Follow-up issues, all outside this diff: the reversed IUPAC warning direction (`bam.rs:823`); `--preserve-tags`' own "Ignored for FASTQ input" line, which contradicts the hard error; `--output-format`'s "see `--help`" self-reference inside `--help`.
+
+**No changes required**
+- CHANGELOG entry.
+- Variant doc's seven rejections — complete and correct.
+- All output-filename claims, confirmed against real output files.
+
+No files in the worktree were edited, per instruction.

--- a/plans/08082026_clump-help-text/CODE_REVIEW_B.md
+++ b/plans/08082026_clump-help-text/CODE_REVIEW_B.md
@@ -1,0 +1,249 @@
+# Code Review B — #400: make `--clump_only`'s help text format-aware
+
+**Reviewer:** B (independent, fresh context)
+**Target:** commit `0676fdf` (`docs(cli): make --clump_only's help text format-aware (#400)`), base `ac08a97`
+**Files in diff:** `src/cli.rs` (clap rustdoc on `clump_only`, 4 paragraphs; `OutputFormat::UBam` variant doc), `CHANGELOG.md` (one bullet)
+**Plan:** `plans/08082026_clump-help-text/PLAN.md` (r2)
+**Governing virtue for this review:** completeness + accuracy of user-facing `--help` prose (per plan A3, the terse-code-comment rule does not apply here).
+
+## Verdict
+
+**APPROVE WITH CHANGES.** The rewrite fixes all five claims the plan set out to fix, and every new claim I checked against the code holds — the filename shapes, the `--compression`/`--dont_gzip` FASTQ-only scoping, the `@PG` sentence, and the "uBAM input requires `--output-format ubam`" rule are all verified true, several empirically. The variant doc's seven rejections are exactly the seven the `§3.4a` block enforces. Build gates are green and the plan's own validation rows 1 and 6 pass.
+
+Two things keep this from a clean APPROVE, and both are residual instances of the exact defect class #400 was filed to eliminate:
+
+1. **Paragraph 3 still carries an unqualified FASTQ-only claim** — "byte-identity applies to header + sequence + quality bytes". Under `--output-format ubam` the space-separated FASTQ description is **discarded**; I demonstrated it. This contradicts paragraph 1 of the same block (which correctly says "name") and contradicts the docs page that the plan designated as the specification.
+2. **The one cross-format legality rule is invisible on `-h`.** Paragraph 1 — the only paragraph `-h` renders — now advertises uBAM input with no hint that it requires `--output-format ubam`. That constraint lives in paragraph 4. The plan's own Context named this `-h`/`--help` asymmetry as r1's fatal flaw; the shipped copy reproduces it one level down.
+
+Both are one-clause edits. Nothing here is a correctness or runtime risk.
+
+---
+
+## Verification performed
+
+| Check | Method | Result |
+|---|---|---|
+| Build | `cargo build --release` | ok |
+| Format | `cargo fmt --all -- --check` | clean |
+| Lint | `cargo clippy --all-targets --release -- -D warnings` | clean |
+| Tests | `cargo test` | **561 passed, 0 failed** (410+15+12+15+11+1+8+45+11+2+8+23) |
+| Plan validation row 1 | `grep -rn "natural follow-up\|FASTQ in / FASTQ out" src/ tests/` | zero hits |
+| Plan validation row 2 | rebuilt, rendered `-h` and `--help` | `-h` = paragraph 1 only (confirmed); `--help` = all four |
+| Plan validation row 6a | `--clump_only --output-format ubam BS-seq_10K_R1.fastq.gz` | `BS-seq_10K_R1_clumped.bam` ✓ |
+| Plan validation row 6b | `--clump_only --paired --output-format ubam R1 R2` | **exactly one** `BS-seq_10K_R1_clumped.bam` ✓ |
+| Plan validation row 6c | `--clump_only --dont_gzip --output-format ubam …` | rejected with the documented message ✓ |
+| Header-fidelity probe (mine, not in the plan) | FASTQ with `@READ_001 some:description here` → uBAM; BAM parsed directly | QNAME = `READ_001` — **description dropped** |
+
+Code read for the accuracy audit: the five `--clump_only` dispatch arms (`src/main.rs:522-757`), the `§3.4a` `UBam` rejection block (`src/cli.rs:579-624`), the `if self.clump_only` block (`src/cli.rs:751-892`), `src/main.rs:286-295` (`--preserve-tags` §3.4b), the four clumped namers (`src/io.rs:356-464`), `src/clump_only.rs:250-272` and `:690-800`, `src/bam.rs:588-640` + `:707-723`, `src/format.rs:165-192`, and `docs/src/content/docs/modes/clump-only.md` end to end.
+
+---
+
+## Area 1 — Accuracy, claim by claim
+
+### Claims that hold (verified against code, not the plan)
+
+| New claim | Verified against | Verdict |
+|---|---|---|
+| "reorder FASTQ or unaligned BAM (uBAM) records" | 5 dispatch arms in `main.rs:522-757` | true |
+| aux tags round-trip only when named in `--preserve-tags` | `clump_only.rs:715-717` rustdoc; `preserve_tags` threaded to the 3 BAM entry points only (`main.rs:644`, `:701`, `:739`) | true |
+| SE FASTQ `*_clumped.fq(.gz)` | `io::clumped_output_name` (`io.rs:356-377`) | true |
+| PE FASTQ `*_clumped_{1,2}.fq(.gz)` | `io::clumped_paired_output_names` (`io.rs:384-409`) | true |
+| SE uBAM `*_clumped.bam` | `io::clumped_bam_output_name` (`io.rs:417-435`); empirically confirmed | true |
+| **ONE interleaved** `*_clumped.bam` per pair (PE uBAM) | `io::clumped_paired_bam_output_name` (`io.rs:442-458`, `_input_r2` unused) + `flush_bin_paired_to_bam` writing `R1, Some(1)` then `R2, Some(2)` (`clump_only.rs:702-710`); empirically confirmed | true — the highest-value correction in the diff |
+| `*_clumping_report.txt` emitted | `io::clumping_report_name`; both FASTQ and BAM arms | true (see NIT-9 for the two qualifiers it omits) |
+| `--compression` **(FASTQ output only)** | never passed to any BAM entry point; recorded as level `0` in `clump_only.rs:780` | true |
+| `--dont_gzip` **(FASTQ output only)** | `cli.rs:583-588` bail | true |
+| `--memory`, `--cores`, `--paired`, `--fastqc`, `--basename` compose | all five threaded to both FASTQ and BAM arms | true |
+| `--output-format ubam` composes (moved out of the rejected list) | no `output_format` rejection in the `clump_only` block; `cli.rs:872-875` comment confirms | true — this was the headline falsehood |
+| rejected list (`-a`, `--length`, `--rrbs`, `--polyA`, `--polyG`, `--trim-n`, `--clip_*`, `--nextseq`, `--rename`, `--discard_untrimmed`, `--consider_already_trimmed`, other specialty modes, `--passthrough`, `--retain_unpaired`) | each has a matching `anyhow::bail!` in `cli.rs:768-885` | true |
+| `--dont_gzip` + `--output-format ubam` rejected (BAM always BGZF) | `cli.rs:583-588`; empirically confirmed | true |
+| `-q` / `--stringency` / `-e` silently ignored | `cli.rs:746-750` comment; no bail | true (unchanged) |
+| `@PG` appended → whole-file identity not preserved, record bodies are | `clump_only.rs:720-723`; `bam::build_output_header`; empirically confirmed (`@HD VN:1.6` + one `@PG` with `CL:`) | true |
+| uBAM input **requires** `--output-format ubam` | `clump_only.rs:265-272` (SE) and `format.rs:165-177` via `PairedShape::ClumpOnlyFastqOut` (PE) — the help's parenthetical "(the FASTQ output path would drop aux tags)" matches both bail messages in substance | true |
+| Variant doc's seven rejections | `cli.rs:583-624`: `--dont_gzip`, `--clumpify`, `--passthrough`, `--clock`, `--implicon`, `--demux`, `--retain_unpaired` — exactly seven | complete and correct |
+
+### MEDIUM-1 — Paragraph 3's byte-identity sentence is still FASTQ-only and unqualified (and is now false on the uBAM path)
+
+Paragraph 3 was left almost intact:
+
+> Contract-scope note: byte-identity applies to **header** + sequence + quality bytes.
+
+On `--output-format ubam` this is false whenever a FASTQ header carries a space-separated description. `src/bam.rs:707-722`:
+
+```rust
+if sep == b'\t' {
+    // Tab: rest is the aux tag tail (from BamReader::next_record).
+    (name_str, Some(rest))
+} else {
+    // Space: rest is descriptive FASTQ annotation — discard.
+    (name_str, None)
+}
+```
+
+Demonstrated end to end. Input:
+
+```
+@READ_001 some:description here
+```
+
+Output BAM, header + records parsed directly from the BGZF stream:
+
+```
+@HD	VN:1.6
+@PG	ID:trim_galore	PN:trim_galore	VN:2.3.0	CL:… --clump_only --output-format ubam desc.fastq
+QNAME: 'READ_002'
+QNAME: 'READ_001'
+```
+
+`some:description here` is gone. This is not an exotic shape — it is the standard Illumina header, `@<instrument>:…:<pos> 1:N:0:<INDEX>`, so the read-number / filter / index field is what gets dropped. A user who reads paragraph 3 as written and archives FASTQ into uBAM under a heading that says byte-identical loses it silently.
+
+Three aggravating factors:
+
+- **It contradicts paragraph 1 of the same block**, which the rewrite changed to "name, sequence, quality". Paragraph 1 is right for BAM; paragraph 3 is right for FASTQ; the block now says both without reconciling them.
+- **It contradicts the designated specification.** `docs/src/content/docs/modes/clump-only.md:52` is precise: "Read ID (header line for FASTQ; name portion for BAM)". The plan's Context (and both plan reviewers) treated that page as accurate on every point at issue and as the source to write from. This sentence did not get written from it.
+- **It fails the plan's own pass criterion** for validation row 4: "every claim is either true for both output formats or explicitly scoped to one".
+
+**Trivial fix**, replacing the first sentence of paragraph 3:
+
+> Contract-scope note: byte-identity covers the read ID, sequence and quality bytes — on FASTQ output the whole header line; on uBAM output the name only, since a space-separated FASTQ description has no BAM field to land in.
+
+and, if paragraph 1 is to stay terse, "name" there can then read "read ID" and defer.
+
+### MINOR-3 — "Paired mode takes two files" invites a refused invocation
+
+Paragraph 4:
+
+> FASTQ and uBAM input are both supported, but uBAM input requires `--output-format ubam` … Paired mode takes two files, or — with `--output-format ubam` — a single interleaved uBAM.
+
+The preceding sentence has just told the reader uBAM input is supported; "takes two files" then reads format-agnostic. Two uBAM files under `--paired --output-format ubam` is rejected (`src/format.rs:181-192`, "`{mode} with two BAM files is not supported`"), and so is a mixed-format pair. The refusal is loud and its message is good, so the cost is a failed invocation rather than wrong output — but this is the same trap the plan flagged in r1's copy ("would have invited exactly the refused invocation"), just narrower.
+
+**Trivial fix:** "Paired mode takes two FASTQ files, or — with `--output-format ubam` — either two FASTQ files or one interleaved uBAM; two separate uBAMs are refused as ambiguous."
+
+### MINOR-4 — "`--preserve-tags` (uBAM only)" names the wrong side
+
+The precondition is uBAM **input**, not uBAM output. With `--output-format ubam` and all-FASTQ inputs, `--preserve-tags` is a **hard error**, not inert (`src/main.rs:286-295`):
+
+```rust
+anyhow::bail!(
+    "--preserve-tags has no effect with all-FASTQ inputs; either remove \
+     the flag or convert at least one input to uBAM via 'samtools import'"
+);
+```
+
+So `--clump_only --output-format ubam --preserve-tags CB sample.fq.gz` — a plausible reading of "composes with `--preserve-tags` (uBAM only)" — fails. **Trivial fix:** "(uBAM input only)".
+
+*Adjacent, out of scope:* `--preserve-tags`'s own help (`cli.rs:246-248`) says "Ignored for FASTQ input", which is false under `--output-format ubam` for the same reason. Same defect class as #400, different flag — worth its own issue rather than scope creep here.
+
+### MINOR-5 — Paragraph 1's "name" under-claims for FASTQ output
+
+Old text said "(header, sequence, quality)"; new says "name, sequence, quality". On the FASTQ→FASTQ path the entire header line, description included, is byte-identical, so "header" was the accurate word there and "name" quietly gives up a true guarantee. "name" is the accurate word for BAM. Neither covers both. Folds into MEDIUM-1's fix — name both formats once and let the other paragraph defer.
+
+### MINOR-6 — Paragraph 3's normalization sentences are unscoped FASTQ-writer behaviour
+
+"The plus-line (line 3 of each record) is normalized to bare `+` on output; CRLF line endings are normalized to LF." There is no line 3 and no line ending on the BAM path. Not misleading (a BAM user finds it irrelevant, not wrong), but unscoped against the plan's stated criterion. Optional: prefix "On FASTQ output, ".
+
+### Out-of-scope observation — `--cores`
+
+The plan's A4 resolved this and put it out of scope; I agree with the outcome and record only that the help is now less precise than its own docs page. `--cores` is threaded to all three BAM entry points and to `clump::resolve_layout`, so it affects bin layout and FastQC threads, but the reorder itself is single-threaded on every arm. `clump-only.md:83` says so explicitly ("accepted for interface parity — v1 is single-threaded internally"); the help lists `--cores` unqualified among things it "composes with". Equally (im)precise for both formats, so #400's remit does not reach it. Leaving it is correct for this PR.
+
+### Variant doc completeness
+
+Complete and correct for flag-vs-flag rejections. One further uBAM-output-only hard error is not represented: `--preserve-tags` with all-FASTQ inputs (`main.rs:286`). Omitting it is defensible — it is conditional rather than flag-vs-flag, and it fires after format detection rather than "at validation" as the sentence says — so I would **not** ask for a change. Recorded for completeness only.
+
+One cosmetic note: the seven are listed with `--dont_gzip` last, though it is the first to bail. Irrelevant to a reader.
+
+---
+
+## Area 2 — Old vs new, side by side
+
+**New inaccuracies introduced:** none that I could find. Every claim in the new copy is true; the defects above are a *retained* false claim (MEDIUM-1), a scoping gap (MINOR-3, MINOR-4, MINOR-6) and an under-claim (MINOR-5).
+
+**True statements dropped:**
+
+- "header" → "name" (MINOR-5) — the one real loss.
+- "gzip-friendly compression" → "compression-friendly grouping": a gain, not a loss; BGZF is not gzip in the user's mental model and the docs page uses the same neutral phrasing.
+- "Output files use the … suffix" → "Output is …": neutral.
+- `--output-format ubam` removed from the rejected list: correct, it is accepted.
+- "v1 is FASTQ in / FASTQ out only. uBAM in/out is a natural follow-up.": correctly deleted; grep confirms zero hits in `src/ tests/` and the two historical `CHANGELOG` / synced-docs records are untouched, as the plan required.
+
+**Plan-coverage gap (NIT-10):** plan step 4 asked the paired-shapes sentence to state "two files (Shape A, **multi-pair supported**) or one interleaved uBAM (Shape B)". The shipped sentence drops the multi-pair clause. Multi-pair *is* supported on the uBAM PE path (`main.rs:658-756` iterates `chunks(2)` with per-pair banners) and the docs page says so (`clump-only.md:80`). Whether this was deliberate compression or an oversight is worth a one-line confirmation from the implementer.
+
+---
+
+## Area 3 — CHANGELOG
+
+**Section: correct.** Lands under `### Unreleased` → `#### Changes` (line 143), not the `#### Bug fixes`/`#### Fixes` pair the plan flagged as a hazard (lines 6 and 310). Ordering within the section is newest-first (#400, #389, #383), consistent with its neighbours.
+
+**Register: correct.** Bold lead clause, issue link in the first sentence, concrete before/after, `No behaviour change.` closer — matches the #389 and #383 bullets directly below it. No banned AI-slop phrasing.
+
+**Accuracy: every claim verified true.** The `--output-format ubam`-in-the-rejected-list history, the "v1 is FASTQ in / FASTQ out only" quote, the one-interleaved-`*_clumped.bam` consequence, the `_clumped_{1,2}.fq.gz` scripting hazard, the FASTQ-output-only scoping of `--compression`/`--dont_gzip`, the `@PG` rationale, the requires-`--output-format ubam` rule, and the two added variant-doc rejections all check out against the diff and the code.
+
+Two observations, neither blocking:
+
+- **Length.** At 15 lines this is the longest bullet in `#### Changes` for the smallest change in it. The precedent the plan cited (`CHANGELOG.md:291-293`, "**Tidied the `--help` text** … No behaviour change") is three lines. The repo's recent entries do run long, so this is within house style — but the middle third ("The whole block is now format-aware: …" enumerating six items) duplicates what a reader gets from `--help` itself and could lose 4 lines without losing information.
+- **Omission.** The entry does not mention the byte-identity-enumeration correction (header → name + `--preserve-tags` aux tags). That is the subtlest change in the diff, it is the one MEDIUM-1 shows is still incomplete, and it is the one a user archiving into uBAM most needs to know changed. If MEDIUM-1 is fixed, this sentence should be added at the same time.
+
+---
+
+## Area 4 — Structure and `--help` readability
+
+**Paragraph 1 does *not* carry everything a short-help user needs — MEDIUM-2.**
+
+Confirmed empirically that `-h` renders paragraph 1 only; the rendered text stops at "…scanners unconfused)" and the next line is `--compression`. Paragraph 1 now opens:
+
+> Lossless reorder-only specialty mode: reorder **FASTQ or unaligned BAM (uBAM)** records …
+
+and mentions `--output-format ubam` only in the output-filename clause. The rule that uBAM *input* **requires** `--output-format ubam` is in paragraph 4, which `-h` never shows. So the `-h` reader is told BAM input works, is shown that `--output-format ubam` changes output filenames, and is given nothing that connects the two — `trim_galore --clump_only sample.bam` looks sanctioned and is refused.
+
+This is the same failure mode the plan diagnosed in r1 ("on the `-h` path the fix would have been invisible while paragraph 1 kept naming the wrong files"). The rewrite fixed the filenames on that surface but introduced a new `-h`-only gap in their place: the one legality rule that governs the input side.
+
+**Trivial fix**, appending to paragraph 1's existing `--output-format ubam` clause: "… ONE interleaved `*_clumped.bam` per pair (PE); uBAM input requires `--output-format ubam`." Nine words, on the surface that needs them.
+
+**Wrapping — MINOR-7, no change required.** `clap` is built without the `wrap_help` feature (`Cargo.toml:29`, `features = ["derive"]`), so clap performs **no** wrapping at all: each paragraph is emitted as one physical line and the terminal soft-wraps it mid-word. Measured on the built binary:
+
+| Line | Chars |
+|---|---|
+| paragraph 1 (`--clump_only`) | **728** (was ~545) |
+| paragraph 2 (`--clump_only`) | **709** (was ~620) |
+| next longest line in all of `--help` | 513 |
+
+So this flag now owns the two longest lines in the entire help output by ~40%, and `-h` shows a 728-character wall for a boolean flag. This is a pre-existing property of the CLI rather than a regression, and completeness was the agreed governing virtue (plan A3), so I am not asking for cuts. If the maintainer wants relief without losing content, moving the `*_clumping_report.txt` sentence from paragraph 1 to paragraph 2 removes ~180 characters from the `-h` surface — the report filename is not something a short-help reader needs before running the mode, whereas the input-legality rule from MEDIUM-2 is.
+
+**NIT-8 — `--dont_gzip` appears twice in paragraph 2**, once as composing "(FASTQ output only)" and once in the rejection clause. Deliberate per plan step 2, and both statements are accurate, but on a single unwrapped 709-character line the two verdicts land close together and read as a contradiction on first scan. Optional reshape: drop the parenthetical from the composes list and let the rejection clause carry the whole story ("…`--dont_gzip` is rejected together with `--output-format ubam` (BAM is always BGZF), so it applies to FASTQ output only").
+
+**NIT-9 — "A short `*_clumping_report.txt` is emitted"** is unconditional in prose but conditional in fact: `--no_report_file` suppresses it, PE FASTQ writes **two** (one per mate) while the uBAM shapes write **one per pair** (`clump-only.md:141`). Pre-existing wording, unchanged by this diff, and the glob form is not wrong. Mentioning `--no_report_file` in the composes list would close the loop cheaply.
+
+**Paragraph split otherwise reads well.** Four paragraphs, one job each: what it does and what it produces / what composes and what does not / what byte-identity does not cover / input-format legality. That is the right decomposition, and paragraph 4's promotion from a one-line "future work" note to a real input-format paragraph is a clear improvement.
+
+---
+
+## Area 5 — Efficiency
+
+Nil. Doc strings and a changelog bullet; no call sites, no runtime path, no output bytes. `cargo build --release` succeeds and the binary's behaviour is unchanged by construction.
+
+---
+
+## Recommendations by priority
+
+### Should fix before merge
+
+1. **MEDIUM-1** — scope paragraph 3's byte-identity sentence per format. It is currently false for `--output-format ubam` (FASTQ description dropped, empirically shown), it contradicts paragraph 1 of the same block, and it contradicts the docs page the plan designated as the specification. This is the last surviving instance of the defect class #400 was filed to remove. *Trivial fix.*
+2. **MEDIUM-2** — add the "uBAM input requires `--output-format ubam`" rule to **paragraph 1**, the only paragraph `-h` renders. Nine words. *Trivial fix.*
+
+### Should fix, low cost
+
+3. **MINOR-4** — "`--preserve-tags` (uBAM only)" → "(uBAM input only)". With `--output-format ubam` and all-FASTQ inputs it is a hard error, not inert. *Trivial fix.*
+4. **MINOR-3** — qualify "Paired mode takes two files" so two separate uBAMs are not implied to work. *Trivial fix.*
+5. **CHANGELOG** — if MEDIUM-1 is fixed, add the byte-identity-enumeration correction to the bullet; it is currently the one substantive change the entry does not mention.
+
+### Optional / maintainer's call
+
+6. **MINOR-5 + MINOR-6** — say "read ID" rather than "name" in paragraph 1, and prefix paragraph 3's plus-line/CRLF sentences with "On FASTQ output". Both fall out of MEDIUM-1's rewrite for free.
+7. **NIT-10** — confirm whether dropping plan step 4's "multi-pair supported" clause was deliberate.
+8. **NIT-8** — reshape paragraph 2 so `--dont_gzip` states its verdict once.
+9. **MINOR-7** — if `-h` bulk is a concern, move the `*_clumping_report.txt` sentence out of paragraph 1 (~180 chars off the short-help surface, nothing lost).
+10. **Separate issue** — `--preserve-tags`'s own help says "Ignored for FASTQ input", false under `--output-format ubam`. Same defect class, different flag; out of scope here.
+
+### Explicitly not recommended
+
+- A help-text regression test. Both plan reviewers argued against it independently, the repo has zero help-content assertions by design, and MEDIUM-1 is proof that the failure mode is doc-drift-after-feature, which no prose assertion catches. Agreed.

--- a/plans/08082026_clump-help-text/COVERAGE.md
+++ b/plans/08082026_clump-help-text/COVERAGE.md
@@ -1,0 +1,108 @@
+# Plan Coverage Report
+
+**Mode:** B (code vs plan). No separate `IMPL.md` — ledger built from the plan's **Implementation outline** (7 steps), **Behavior** (3 claims), **Assumptions** (A1–A4) and **Validation** table (6 rows), plus the explicitly "deliberately not added" help-text regression test, recorded as a decision rather than a gap.
+**Plan:** `/Users/fkrueger/Github/TrimGalore/plans/08082026_clump-help-text/PLAN.md` (r2)
+**Audited commit:** `0676fdf` "docs(cli): make --clump_only's help text format-aware (#400)", diffed against `ac08a97`
+**Date:** 2026-08-08
+**Verdict:** **INCOMPLETE — 2 items unresolved** (both PARTIAL, both trace to one clause in the final sentence of paragraph 4; no functional impact, prose completeness only)
+
+## Summary
+
+- Total audited items: 20
+- DONE: 18
+- PARTIAL: 2
+- MISSING: 0
+- DEVIATED: 0
+- Recorded decisions (not counted): 1
+
+Diff footprint is `CHANGELOG.md` (+15) and `src/cli.rs` (+28/−19) only — doc-comments and changelog prose, no executable lines. `git diff --stat ac08a97..0676fdf` confirms no other file was touched, so A2's "no companion docs edit" and the off-limits changelog/synced-docs records hold by construction.
+
+## Coverage ledger
+
+| # | Item | Source | Status | Notes |
+|---|------|--------|--------|-------|
+| 1 | Paragraph 1 (`cli.rs:181-191`) — `-h` surface made format-aware: opener names uBAM, byte-identity enumeration names aux tags as a `--preserve-tags` opt-in, filenames given per format incl. the PE-uBAM single-interleaved case, `*_clumping_report.txt` sentence retained | Outline 1 | DONE | All four sub-requirements present. Verified rendered on the `-h` path (line 62 of `-h`, single paragraph as predicted). `_clumping_report.txt` sentence kept; emission confirmed empirically. |
+| 2 | Paragraph 2 (`cli.rs:193-203`) — `--compression`/`--dont_gzip` qualified FASTQ-output-only; `--output-format ubam` moved from rejected to composes; `--preserve-tags` (uBAM only) added; `--dont_gzip` + ubam kept visible as an explicit rejection; trim/filter rejection list and the `-q`/`--stringency`/`-e` sentence unchanged | Outline 2 | DONE | All six sub-requirements present verbatim. `--output-format ubam` no longer in the rejected list; the `--dont_gzip` + ubam exclusion is stated, not dropped. |
+| 3 | Paragraph 3 (`cli.rs:205-210`) — one added sentence: `@PG` appended on uBAM output, whole-file identity not preserved, record bodies are | Outline 3 | DONE | Exactly one sentence added, matching `clump_only.rs:720-723` and docs §Record fidelity (61-63). |
+| 4 | Paragraph 4 (`cli.rs:212-215`) — stale sentence replaced; must say uBAM input **requires** `--output-format ubam`; **state the two paired shapes inline** — two files (Shape A, **multi-pair supported**) or one interleaved uBAM (Shape B); no docs-site pointer | Outline 4 | **PARTIAL** | Stale sentence gone ✓; "requires" wording ✓; both shapes stated inline ✓; no pointer ✓ (grep for `http`/`/modes/`/`docs.` inside the rendered block returns 0). **Missing:** the "multi-pair supported" detail the step names. Multi-pair *is* supported (`main.rs:546` routes `--clump_only --paired` through `run_specialty_paired`, which iterates `cli.input.chunks(2)`) and docs:73 states it, so this is an omitted true detail, not a correction. See Gap 1. |
+| 5 | `OutputFormat::UBam` variant doc (`cli.rs:17-19`) — add the two missing rejections (`--retain_unpaired`, `--dont_gzip`) | Outline 5 | DONE | Variant doc now lists all 7 rejections; matches the shipped §3.4a set exactly (`cli.rs:585` dont_gzip, `:591` clumpify, `:596` passthrough, `:599` clock, `:605` implicon, `:610` demux, `:618` retain_unpaired). Renders under "Possible values" in `--help` (line 128). |
+| 6 | CHANGELOG — one bullet under `### Unreleased` → `#### Changes`, naming the filename correction explicitly; avoid the `#### Bug fixes` / `#### Fixes` mis-landing hazard | Outline 6 | DONE | Bullet at `CHANGELOG.md:145`, inside `#### Changes` (`:143`) inside `### Unreleased` (`:4`) — the hazard sections are `:6` and `:310`, both avoided. Names the filename correction and the `_clumped_{1,2}.fq.gz` scripting risk explicitly; also records the variant-doc addition; closes "No behaviour change." |
+| 7 | `cargo fmt --all -- --check`, `cargo clippy --all-targets --release -- -D warnings`, `cargo test` | Outline 7 | DONE | All three green — see Test verification. |
+| 8 | `--help` and `-h` output change | Behavior | DONE | Both rebuilt-and-rendered. `-h` shows the rewritten paragraph 1; `--help` shows all four paragraphs. |
+| 9 | `--output-format` "Possible values" text gains two flag names | Behavior | DONE | `--retain_unpaired` and `--dont_gzip` appear in the rendered `ubam` value description. |
+| 10 | No runtime behaviour change, no flag semantics change | Behavior | DONE | Diff touches only `///` doc-comments and `CHANGELOG.md`. No executable statement, no `#[clap]` attribute, no validation logic changed. |
+| 11 | A1 — nothing pins the help text | Assumption | DONE (holds) | `tests/integration_no_args_help.rs:36` still pins only `"Usage: trim_galore"` and `"--adapter"`; neither string is in the edited block. No new help-content assertion anywhere in `tests/` or `src/`. The full suite passes unmodified. |
+| 12 | A2 — the docs page is the specification; no companion edit | Assumption | DONE (holds) | `docs/src/content/docs/modes/clump-only.md` is untouched by the diff. Read end to end for row 4; it remains accurate on every point at issue. |
+| 13 | A3 — help prose is exempt from the terse-comment convention; the block deliberately grows | Assumption | DONE (holds) | Block grew from 26 to 38 doc-comment lines; growth is intentional per the plan. |
+| 14 | A4 — leave `--cores` unqualified, out of scope | Assumption | DONE (holds) | `--cores` appears in the composes list with no format or threading qualifier, as directed. |
+| 15 | V1 — stale phrases gone from live text (`grep -rn "natural follow-up\|FASTQ in / FASTQ out" src/ tests/`) | Validation 1 | DONE | **Zero hits** (exit 1). The two off-limits historical records survive untouched: `CHANGELOG.md:294` and `docs/src/content/docs/reference/changelog.md:29`. `main.rs:524`'s accurate code comment left in place as directed. |
+| 16 | V2 — both help surfaces correct after a rebuild | Validation 2 | DONE | Rebuilt (`cargo build --release`, exit 0), then rendered both. Paragraph 1 is no longer FASTQ-only: on the `-h` path a user now sees the uBAM opener, the aux-tag scoping, and the per-format filenames incl. `ONE interleaved *_clumped.bam per pair`. `--help` additionally carries paragraphs 2-4 and the variant doc. |
+| 17 | V3 — build integrity (explicitly *not* evidence about the copy) | Validation 3 | DONE | fmt clean, clippy `-D warnings` clean, 561 tests pass across 13 binaries. |
+| 18 | V4 — whole-block accuracy vs the specification; pass criterion: **every claim is either true for both output formats or explicitly scoped to one** | Validation 4 | **PARTIAL** | 22 of 23 claims pass. One clause fails the criterion: "Paired mode takes two files" carries no format scoping, and under `--output-format ubam` two BAM files are a hard error. See Gap 2 (and the three observations below it, which pass). |
+| 19 | V5 — no newly-claimed composing flag is actually rejected | Validation 5 | DONE | Checked all 9 composing flags against the `if self.clump_only` block (`cli.rs:751-892`) and the shared §3.4a `UBam` block (`cli.rs:580-625`). No matching `anyhow::bail!` for `--compression`, `--memory`, `--paired`, `--fastqc`, `--basename`, `--output-format ubam`, `--preserve-tags`. `--dont_gzip`'s only bail is the ubam one the copy explicitly documents. `--cores`' only bail is the global `cores == 0` floor (`:706`), not a mode rejection. `--memory` is parsed for format only (`:890`). |
+| 20 | V6 — filename claims confirmed against reality | Validation 6 | DONE | All three invocations run from a temp dir with copied fixtures. See Test verification. |
+| — | Deliberately not added: a help-text regression test | Plan decision | N/A (decision) | Recorded as a documented decision, not a gap. Confirmed no such test was added: `tests/` gained no file and no help-content assertion. |
+
+## Gaps (detail)
+
+### Gap 1 — Outline step 4: the "multi-pair supported" detail is absent
+
+**Expected:** step 4 specifies the two paired shapes be stated inline as "two files (Shape A, **multi-pair supported**) or one interleaved uBAM (Shape B)". The docs page, which the plan designates as the specification, states it at line 73: "`--paired` — two-file paired input (Shape A, multi-pair `N=4, 6, …` supported) OR single interleaved uBAM (Shape B, N=1 + `--output-format ubam`)".
+
+**Found:** `cli.rs:214-215` — "Paired mode takes two files, or — with `--output-format ubam` — a single interleaved uBAM." Both shapes are named; the multi-pair capability is not.
+
+**Gap:** multi-pair input under `--clump_only --paired` is genuinely supported (`main.rs:546` → `run_specialty_paired`, which iterates `cli.input.chunks(2)`), so this is an omitted true capability rather than a deliberate correction of the plan. The plan's Revision history frames the four-paragraph rewrite as the deliverable and names this parenthetical explicitly, so its absence is a shortfall against the spec. Nothing in the shipped copy contradicts multi-pair support.
+
+### Gap 2 — Validation row 4: "Paired mode takes two files" is not format-scoped
+
+**Expected:** row 4's pass criterion — "every claim is either true for both output formats or explicitly scoped to one".
+
+**Found:** `cli.rs:214-215` — "Paired mode takes two files, or — with `--output-format ubam` — a single interleaved uBAM." The "takes two files" clause is unqualified. Under `--output-format ubam` it holds only when both files are FASTQ:
+
+- Two BAM files: hard error, `format.rs:182-191` — "`--clump_only --paired` with two BAM files is not supported. uBAM paired mode expects a single interleaved file" (docs:99).
+- N=1 FASTQ under `--paired --output-format ubam`: rejected (docs:100).
+- Mixed FASTQ/BAM in one pair: rejected, `format.rs:196-203` (docs:101).
+
+**Gap:** the sentence would let a user with two uBAM files read "uBAM input requires `--output-format ubam`" plus "Paired mode takes two files" and attempt `--clump_only --paired --output-format ubam R1.bam R2.bam`, which bails. This is the same failure shape the plan's own Self-Review flags against r1 ("implied a format combination the code refuses"), one step removed: the copy does not assert the refused shape works, but it does not scope the clause that suggests it. The runtime error is clear and offers a `samtools merge -n` remediation, so the consequence is a wasted invocation, not wrong output. Same source sentence as Gap 1.
+
+### Observations from row 4 that pass the criterion (recorded, not gaps)
+
+- **Paragraph 3's contract-scope enumeration** still reads "byte-identity applies to header + sequence + quality bytes" — FASTQ vocabulary, and it omits the aux tags paragraph 1 now names. Not falsified on either format (those three fields *are* byte-identical on both paths), and the plan scoped step 3 to adding one sentence, so this is per-spec.
+- **The A/Z/i/f aux-tag constraint** (docs:54) is not in the help. No help claim contradicts it: B (array) and H (hex) tags are rejected at BAM-read time, so "appears byte-identically" cannot be silently breached — the run fails instead.
+- **`--cores`'s "single-threaded internally"** (docs:76) is not in the help. Explicitly out of scope per A4; `--cores` is accepted on both format paths, so this is a depth qualification, not a format-scoping defect.
+- **`--basename`** is listed as composing without noting it bails on multiple inputs/pairs (`cli.rs:633`, `:660`). Pre-existing and format-independent; the docs page (79) is equally unqualified. Outside this plan's scope.
+
+## Test verification
+
+| Check | Command / file | Status |
+|---|---|---|
+| V1 — stale phrases in live text | `grep -rn "natural follow-up\|FASTQ in / FASTQ out" src/ tests/` | PASS (zero hits) |
+| V1 — off-limits records preserved | `CHANGELOG.md:294`, `docs/.../reference/changelog.md:29` | PASS (both present, untouched) |
+| V2 — `-h` renders paragraph 1 only, format-aware | `./target/release/trim_galore -h` | PASS |
+| V2 — `--help` renders all four paragraphs + variant doc | `./target/release/trim_galore --help` | PASS |
+| V3 — formatting | `cargo fmt --all -- --check` | PASS (exit 0) |
+| V3 — lints | `cargo clippy --all-targets --release -- -D warnings` | PASS (exit 0) |
+| V3 — test suite | `cargo test` | PASS — 561 tests, 0 failed (lib 410; `integration_clump_only` 12; `integration_clump_only_ubam` 15; `integration_ubam_out` 23; `integration_output_collision` 45; `integration_adapter2` 15; `integration_gzip_non_gz_extension` 11; `integration_paired_format_guard` 11; `integration_non_restartable_input` 8; `integration_ubam` 8; `integration_passthrough` 2; `integration_no_args_help` 1; doc-tests 0) |
+| V5 — no composing flag is rejected | read-through of `cli.rs:751-892` + `cli.rs:580-625` | PASS (9/9 flags clear) |
+| V6a — SE uBAM filename | `--clump_only --output-format ubam BS-seq_10K_R1.fastq.gz` | PASS — wrote `BS-seq_10K_R1_clumped.bam` (10 000 records, 16 bins, BGZF) exactly as the copy claims |
+| V6b — PE uBAM writes exactly one BAM | `--clump_only --paired --output-format ubam BS-seq_10K_R{1,2}.fastq.gz` | PASS — **one** `BS-seq_10K_R1_clumped.bam` (10 000 pairs); `ls \| grep -c "_clumped.bam$"` = 1, confirming the "ONE interleaved per pair" claim |
+| V6c — `--dont_gzip` + ubam rejected as described | `--clump_only --dont_gzip --output-format ubam …` | PASS — exit 1, "`--dont_gzip` is not compatible with `--output-format ubam` (BAM is always BGZF-compressed)", matching the copy's "(BAM is always BGZF)" |
+| Filename claims vs source | `io.rs:356` / `:384` / `:417` / `:442` | PASS — `_clumped.fq(.gz)` SE, `_clumped_{1,2}` PE, `<stem>_clumped.bam` SE-BAM, single `<stem>_clumped.bam` PE-BAM |
+| Report emission on the BAM arm | observed `*_clumping_report.txt` in V6a/V6b; `clump_only.rs:837`, `:1084` | PASS |
+| A1 — help text unpinned | `tests/integration_no_args_help.rs:36` | PASS (pins only `Usage: trim_galore` and `--adapter`; test green) |
+
+## Verdict
+
+**INCOMPLETE — 2 items unresolved.** Both are PARTIAL, both editorial, and both originate in the same clause of the final sentence at `cli.rs:214-215`. Every mechanical and behavioural requirement of the plan is satisfied: the five falsified claims the plan enumerates are all corrected, the variant doc matches the shipped 7-rejection set, the changelog bullet landed in the right section, and rows 1, 2, 3, 5 and 6 pass — including the empirical filename check that confirms a paired uBAM run writes exactly one interleaved BAM.
+
+To close:
+
+1. **Outline step 4 / Gap 1** — add the multi-pair detail the step names, e.g. that the two-file shape accepts multiple pairs (`N = 4, 6, …`), matching docs:73.
+2. **Validation row 4 / Gap 2** — scope the "takes two files" clause by output format, so a user with two uBAM files is not led toward `--paired --output-format ubam R1.bam R2.bam` (rejected at `format.rs:182-191`). One qualifier — that the two-file shape is FASTQ input — satisfies row 4's criterion and closes both gaps in the same edit.
+
+Neither item can affect runtime; the whole diff is doc-comments plus changelog prose.
+
+## Notes
+
+- The plan's header records **Base: `dev` @ `ce13761`**, while this audit was run against base `ac08a97` (per the audit assignment). The diff reviewed is `ac08a97..0676fdf`. The discrepancy does not affect any finding — the audited hunks are confined to the `--clump_only` doc-comment, the `OutputFormat::UBam` variant doc, and one `CHANGELOG.md` bullet.
+- Row 6 was run from a temp directory with copied fixtures, as the plan requires (specialty modes write beside the input).

--- a/plans/08082026_clump-help-text/PLAN.md
+++ b/plans/08082026_clump-help-text/PLAN.md
@@ -1,0 +1,98 @@
+# Plan: `--clump_only` help text — make the whole block format-aware (#400)
+
+**Issue:** [#400](https://github.com/FelixKrueger/TrimGalore/issues/400) — filed from #391's code review.
+**Base:** `dev` @ `ce13761`.
+
+## Revision history
+
+- **r2 (2026-08-08):** incorporates dual plan review (PLAN_REVIEW_A.md "REVISE", PLAN_REVIEW_B.md "APPROVE WITH CHANGES") and two maintainer decisions: **no docs-site pointer — inline the shapes** and **fold in the `OutputFormat::UBam` variant doc**. Both reviewers rejected r1's two-sentence scope and both caught that r1's own proposed copy would have introduced **two new false statements**. Scope grows from 2 sentences to the whole four-paragraph block plus the variant doc (~12 lines of prose). Line references corrected (block is `cli.rs:180-206`; r1 cited 183-207, and 207 is the `#[clap]` attribute).
+- r1 (2026-08-08): initial plan — two sentences. Superseded.
+
+## Goal
+
+The clap rustdoc on `clump_only` (`cli.rs:180-206`) renders as `--help` and predates the shipped uBAM arms. **Five** claims in it are falsified by those arms, not the two #400 named. Make the whole block format-aware so no claim is FASTQ-only-but-unqualified, and fix the same defect class in the `OutputFormat::UBam` variant doc. No runtime behaviour changes.
+
+## Context
+
+- **The block spans four paragraphs, and they are two different surfaces** (B §1.1, verified empirically from the built binary): `--help` renders all four; **`-h` renders only paragraph 1**, because clap's short help for an argument is the first doc paragraph. r1 touched paragraphs 2 and 4 only — so on the `-h` path the fix would have been invisible while paragraph 1 kept naming the wrong files.
+- **The five falsified claims:**
+  1. `cli.rs:184-188` — output filenames given unqualified as `*_clumped.fq(.gz)` (SE) / `*_clumped_{1,2}.fq(.gz)` (PE). Under `--output-format ubam`: `<stem>_clumped.bam` (SE, `io.rs:417-431`) and **ONE interleaved** `<stem>_clumped.bam` per pair (PE, `io.rs:442-458` — a different output *count*, not just extension). Both reviewers rate this the highest-impact item in the block; users script against filenames.
+  2. `cli.rs:195` — `--output-format ubam` listed among *rejected* flags. `Cli::validate` has no such rejection; `cli.rs:866-869` carries the opposite comment ("v2: `--output-format ubam` is now accepted").
+  3. `cli.rs:183-184` — byte-identity enumerated as "(header, sequence, quality)", which omits uBAM aux tags (they round-trip **only** when named in `--preserve-tags`, A/Z/i/f scalars only, `clump_only.rs:714-718`). A 10X user reordering a `CB`/`UB`-carrying BAM without `--preserve-tags` loses them silently under a heading that says lossless.
+  4. `cli.rs:200-204` — the contract-scope paragraph closes on "**Both** normalizations", reading as exhaustive, but the uBAM path appends a per-run `@PG` record so whole-file identity does not hold (`clump_only.rs:720-723`).
+  5. `cli.rs:206` — "v1 is FASTQ in / FASTQ out only. uBAM in/out is a natural follow-up."
+- **Two flags in the "Composes with" list are format-dependent**, which r1's step 1 would have contradicted by appending `--output-format ubam` to the same list: `--dont_gzip` + ubam is a hard error (`cli.rs:576-581`), and `--compression` is inert on the BAM path (never passed to the three BAM entry points; recorded as level `0` in `clump_only.rs:780`/`:1018`).
+- **Only 3 of 4 format combinations are legal.** uBAM-in → FASTQ-out is rejected in both arms (`clump_only.rs:265-272` SE; `format.rs:165-172` PE via `PairedShape::ClumpOnlyFastqOut`) because FASTQ output would drop aux tags. r1's proposed "FASTQ and uBAM are both supported on input and output" implied 2×2 and would have invited exactly the refused invocation.
+- **`OutputFormat::UBam`'s variant doc** (`cli.rs:17-18`) lists 5 of the 7 ubam rejections — missing `--retain_unpaired` (`cli.rs:609`) and `--dont_gzip` (`cli.rs:576`) — and **does** render in `--help` under "Possible values". In scope per maintainer decision.
+- **`docs/src/content/docs/modes/clump-only.md` is the specification.** Both reviewers independently read it end to end and verified it accurate on every point at issue: per-format filenames, the one-interleaved-BAM PE shape, `--compression` ignored under ubam, `--dont_gzip` rejected with ubam, aux tags via `--preserve-tags` with the A/Z/i/f constraint, the added `@PG`, the three PE input-shape rejections, and the FASTQ-out-with-uBAM-in rejection. No companion edit needed; use it as the source.
+- **Zero pinning risk, resolved now rather than at implementation** (both reviewers): `tests/integration_no_args_help.rs:36` pins only `"Usage: trim_galore"` and `"--adapter"`; nothing else in `tests/` or `src/` asserts on help output; no snapshot tests; `release.yml:226`/`:356` run `--help` as an exit-status smoke test with no content grep; no `cargo doc` CI job and no `[lints]` in `Cargo.toml`, so rustdoc lints are not a gate.
+- **Two hits that must NOT be edited:** `CHANGELOG.md:278-279` and its synced mirror `docs/src/content/docs/reference/changelog.md:28-29` carry the same stale-sounding wording as *historical release notes* (true at the release they describe; the synced page is off-limits by convention). Keep the verification grep scoped to `src/ tests/`. Also `main.rs:524`'s code comment ("v1: FASTQ in/out. v2: uBAM in/out via `--output-format ubam`") is accurate and not user-facing — leave it.
+
+## Behavior
+
+`--help` and `-h` output change; the `--output-format` "Possible values" text gains two flag names. No runtime behaviour changes, no flag semantics change.
+
+## Implementation outline
+
+Re-read the block from disk before editing (post-`cargo fmt` anchor drift is a recorded session trap), then rewrite all four paragraphs against the docs page. B's §6 offers copy verified line-by-line against the code; adopt it with the maintainer's no-pointer decision applied.
+
+1. **Paragraph 1** (`cli.rs:180-188`) — the `-h` surface. Make the opener format-aware ("FASTQ or unaligned BAM (uBAM) records"), extend the byte-identity enumeration to name aux tags as a `--preserve-tags` opt-in, and give the output filenames per format including the PE-uBAM single-interleaved case. Keep the `*_clumping_report.txt` sentence (verified true on every arm, `clump_only.rs:836`/`:1082`).
+2. **Paragraph 2** (`cli.rs:190-198`) — qualify `--compression` and `--dont_gzip` as FASTQ-output-only, move `--output-format ubam` out of the rejected list into the composes list, add `--preserve-tags` (uBAM only), and keep the `--dont_gzip` + ubam exclusion **visible** as an explicit rejection rather than silently dropping it. Leave the trimming/filtering rejection list and the `-q`/`--stringency`/`-e` sentence as-is (both verified accurate).
+3. **Paragraph 3** (`cli.rs:200-204`) — add one sentence: on uBAM output a `@PG` record is appended, so whole-file identity is not preserved; record bodies are.
+4. **Paragraph 4** (`cli.rs:206`) — replace the stale sentence. Must say uBAM input **requires** `--output-format ubam` (not that it is one of two options), and **state the two paired shapes inline** — two files (Shape A, multi-pair supported) or one interleaved uBAM (Shape B) — with **no docs-site pointer** (maintainer decision; would be the first such reference in `cli.rs`, and `CHANGELOG.md:291-293` records deliberately removing unresolvable pointers from flag descriptions).
+5. **`OutputFormat::UBam` variant doc** (`cli.rs:17-18`) — add the two missing rejections (`--retain_unpaired`, `--dont_gzip`) so the "Possible values" text matches the shipped rejection set.
+6. **CHANGELOG** — one bullet under `### Unreleased` → `#### Changes` (`CHANGELOG.md:143`). Precedent: `CHANGELOG.md:291-293` ("**Tidied the `--help` text** … No behaviour change") — same section, same kind of change, a stronger match than r1's `--output-dir` citation (which is a runtime stderr message). A separate bullet is justified: this corrects a **false capability claim**, and notably that tidy pass itself missed line 206. Name the filename correction explicitly — a user who scripted against `_clumped_{1,2}.fq.gz` for uBAM output was misled. **Hazard:** `### Unreleased` contains both `#### Bug fixes` and `#### Fixes` (duplication tracked in #401); land in `#### Changes`.
+7. `cargo fmt --all -- --check`, `cargo clippy --all-targets --release -- -D warnings`, `cargo test`.
+
+## Efficiency / Integration
+
+Nil / doc-string only. No call sites, no runtime, no output-size effect.
+
+## Assumptions
+
+- **A1 (verified, no longer deferred):** nothing pins the help text — see Context.
+- **A2 (verified by both reviewers):** the docs page is accurate post-#396 and serves as the specification; no companion edit.
+- **A3:** the terse-comment convention (one line default, two max) governs **code comments**, not user-facing `--help` prose, where completeness is the governing virtue — the project demonstrates this with 138 lines of docs prose for this one flag. This plan deliberately grows the block.
+- **A4 (resolved contradiction):** the reviewers disagreed on whether `--cores` in the composes list is accurate. Checked directly: `cli.cores` **is** passed to all three BAM entry points (`main.rs:642`, `:699`, `:737`) and drives FastQC threads, while the reorder itself is single-threaded per `cli.rs:749-752`. Both were partly right; either way `--cores` is not falsified by uBAM and is **out of scope** — leave it unqualified.
+
+## Validation
+
+Rows 1–3 from r1 verify mechanics only; both reviewers flagged that the table had no row asserting the new copy is **true** — exactly where the risk lay. Rows 4–6 close that.
+
+| # | What | How | Expected |
+|---|------|-----|----------|
+| 1 | Stale phrases gone from live text | `grep -rn "natural follow-up\|FASTQ in / FASTQ out" src/ tests/` (scope deliberate — the two `CHANGELOG`/synced-docs hits are historical and off-limits) | zero hits |
+| 2 | **Both** help surfaces correct | rebuild, then render `-h` **and** `--help` | the uBAM facts a user needs appear on the surface that user hits; paragraph 1 no longer FASTQ-only |
+| 3 | Build integrity (**not** a validation of the copy — no test asserts this text) | fmt + clippy `-D warnings` + `cargo test` | green |
+| 4 | Whole-block accuracy vs the specification | read all four paragraphs + the variant doc side by side with `clump-only.md` §Output filenames (39-45), §Record fidelity (47-63), §Compatibility (69-105). **Pass criterion: every claim is either true for both output formats or explicitly scoped to one** | no claim contradicts the docs page |
+| 5 | No newly-claimed flag is actually rejected | for each flag named as composing, confirm no matching `anyhow::bail!` in the `if self.clump_only` block (`cli.rs:742-883`) or the shared §3.4a `UBam` block (`cli.rs:571-616`) | none found (this is the mechanical check that would have caught r1's `--dont_gzip` defect at plan time) |
+| 6 | Filename claims confirmed against reality, not just against docs | `--clump_only --output-format ubam test_files/BS-seq_10K_R1.fastq.gz` → expect `BS-seq_10K_R1_clumped.bam`; `--clump_only --paired --output-format ubam test_files/BS-seq_10K_R{1,2}.fastq.gz` → expect **exactly one** `_clumped.bam`; `--clump_only --dont_gzip --output-format ubam …` → expect the rejection the new copy describes | as stated (run outside the repo root — specialty modes write to the CWD) |
+
+**Deliberately not added** (both reviewers, independently): a help-text regression test. Prose assertions rot faster than the prose they guard, the repo has zero help-content assertions by design, and the root cause is doc-drift-after-feature, which no unit test catches.
+
+## Questions or ambiguities
+
+- **[Resolved r2 — Felix]** No docs-site pointer; inline the shapes. `OutputFormat::UBam` variant doc folded in.
+- **[Open, non-critical]** Exact copy is reviewable prose; the fixed requirements are the six accuracy points in Context and the "true for both formats or scoped to one" criterion.
+
+## Follow-ups (out of scope, noted)
+
+- `--phred64` + FASTQ-in + uBAM-out threads `cli.phred_offset()` into the BAM writers while the FASTQ→FASTQ arm ignores phred entirely (byte copy). Quality *values* are preserved; the ASCII string necessarily is not, since BAM stores raw Phred. Semantically correct, asymmetric with the FASTQ arm, immaterial to help accuracy (A §7).
+
+## Implementation notes (2026-08-08, branch `fix/400-clump-help-text`)
+
+Base correction: the plan header says `dev @ ce13761`, but the branch forked from `ac08a97` (dev moved when the #385 re-audit artifacts landed). No finding is affected — the audited hunks are the `--clump_only` doc-comment, the `OutputFormat::UBam` variant doc, and one CHANGELOG bullet.
+
+- `0676fdf` — the four-paragraph rewrite + variant doc + CHANGELOG, as planned. Validations 1/2/3/5/6 all run, incl. the three smoke invocations (SE → `R1_clumped.bam`; PE → exactly one `_clumped.bam`; `--dont_gzip` + ubam rejected).
+- `e8e79ca` — review batch. **Both reviewers APPROVED WITH CHANGES, and between them found two distinct ways the rewrite's own byte-identity claim was false** — a defect this PR introduced by making a FASTQ-only claim format-spanning: A found that uBAM output uppercases bases and coerces IUPAC to `N` (`bam.rs:800-820`); B found that it discards the space-separated header description (`bam.rs:717`), so a standard Illumina `1:N:0:INDEX` field does not survive. Confirmed on a fixture rather than by reading — `@READ_001 1:N:0:INDEX` / `acgtRYKM` emerges as QNAME `READ_001` / SEQ `ACGTNNNN`. Copy now states FASTQ→FASTQ as byte-identical and uBAM as lossless-per-record-body-but-not-byte-identical, with paragraph 3 scoped to FASTQ output.
+  Also in this commit: the uBAM-input-requires-ubam-output rule moved into paragraph 1 (both reviewers — paragraph 1 is the only one `-h` renders, so short-help readers were told BAM input works and then refused; verified present in rendered `-h`); `--preserve-tags` reworded from "(uBAM only)" to "requires at least one uBAM input; an error otherwise" (it is a hard error, not inert — `main.rs:286`); and the paired clause gained both multi-pair support and the two-separate-uBAMs rejection, **which also closes the coverage audit's two PARTIAL items** (they traced to that same clause).
+- `5407a37` + `d19aa75` — the docs page carried the identical false claim in both its Record-fidelity bullets and its intro paragraph. The plan designated that page as the specification (A2), so leaving it would have had the docs site contradicting the corrected help text. A2 is therefore **falsified in part** and recorded as such.
+- **Not taken → filed:** #406 (the IUPAC warning states the wrong direction on FASTQ→uBAM runs, and neither the uppercase nor the description-drop normalization is warned about at all) and #407 (`--preserve-tags`' own help says "Ignored for FASTQ input" while the code hard-errors under ubam output).
+- **Known, not addressed:** B measured that clap is built without `wrap_help` (`Cargo.toml:29`), so nothing wraps — paragraphs 1 and 2 are now the two longest lines in the whole `--help`. Accuracy was preferred over brevity here; if that becomes a readability complaint the fix is enabling `wrap_help`, not shortening the facts.
+
+## Self-Review (r2)
+
+- **What r1 got wrong, owned:** it inherited the issue body's "two-line fix" as a *scope conclusion* rather than a size estimate, and its Context recorded the `--dont_gzip` + ubam exclusion without any implementation step consuming it — so its own proposed copy would have asserted two mutually exclusive flags compose, and implied a format combination the code refuses. Both reviewers caught both independently.
+- **Load-bearing facts re-verified against the tree before adoption:** the `-h`/`--help` paragraph split, `io.rs:417-458`'s single-interleaved-BAM naming, `cli.rs:576-581`, the two uBAM-in→FASTQ-out rejection sites, the variant doc's missing two, and the `--cores` disagreement (A4).
+- **Traps checked:** grep scope keeps the two historical changelog records off-limits; validation 2 rebuilds before rendering (stale-binary trap); validation 3 is explicitly labelled a build check, not evidence about the copy (the project's "prove the check can fail" rule); line references corrected so an implementer editing "207" doesn't hit the `#[clap]` attribute.
+- **Remaining risks:** none structural — the change cannot affect runtime. The residual is editorial: prose accuracy, which validations 4–6 target directly.

--- a/plans/08082026_clump-help-text/PLAN_REVIEW_A.md
+++ b/plans/08082026_clump-help-text/PLAN_REVIEW_A.md
@@ -1,0 +1,208 @@
+# Plan Review A — `--clump_only` help text (#400)
+
+**Plan:** `plans/08082026_clump-help-text/PLAN.md`
+**Reviewer:** A (independent)
+**Base:** `dev` @ `ce13761`
+**Verdict:** REVISE before implementing. Premise correct, every mechanical claim verified true — but the fix is incomplete in the same paragraph, and both proposed sentences introduce new inaccuracies.
+
+---
+
+## 1. Logic review
+
+### 1.1 What I verified as correct
+
+Everything the plan asserts about the *world* checks out, with one off-by-one:
+
+| Plan claim | Verified | Evidence |
+|---|---|---|
+| `--output-format ubam` wrongly in the rejected list | **True** | `src/cli.rs:195`. `Cli::validate` has no ubam rejection under `clump_only`; instead `src/cli.rs:866-869` carries an explicit comment: *"v2: `--output-format ubam` is now accepted; uBAM in/out is dispatched to the BAM variant functions in main.rs."* |
+| "v1 is FASTQ in / FASTQ out only. uBAM in/out is a natural follow-up." is stale | **True** | `src/cli.rs:206` (not 207 — see 1.3). Five shipped arms in `src/main.rs:522-750`. |
+| A2: docs page already accurate, no companion edit | **True** | I read all 138 lines of `docs/src/content/docs/modes/clump-only.md`. It is accurate against the code on every point I checked, including the PE shapes, the `--dont_gzip` split, `--compression` inertness under uBAM, and the `@PG` caveat. **It is the correct reference truth for the rewrite** — see 5.2. |
+| A1: no test pins the phrases | **True, and knowable now** | See 3. |
+| CHANGELOG `#### Changes` under `### Unreleased` | **True** | `CHANGELOG.md:143`. Precedent is stronger than the plan claims — see 4. |
+
+So the plan is not wrong about anything it looked at. The problem is what it did not look at.
+
+### 1.2 The fix as written ships two *new* false statements
+
+**(a) `--dont_gzip` + `--output-format ubam` — the plan's own Context knows this and no step acts on it.**
+
+The sentence being edited (`cli.rs:190-191`) currently reads:
+
+> Composes with `--compression`, `--memory`, `--cores`, `--paired`, `--fastqc`, `--dont_gzip`, and `--basename`.
+
+Step 1 says to *extend this same sentence* with `--output-format ubam` and `--preserve-tags`. The result is one sentence asserting that `--dont_gzip` and `--output-format ubam` both compose — while `src/cli.rs:576-581` bails on exactly that pair:
+
+```
+--dont_gzip is not compatible with --output-format ubam (BAM is always BGZF-compressed)
+```
+
+Plan Context line 14 records this fact verbatim ("`--dont_gzip` is rejected *with* uBAM output") but neither implementation step consumes it. For a PR whose entire purpose is deleting a false claim from this paragraph, adding one back into the same sentence is the worst available outcome. The docs page already has the wording to copy (`clump-only.md:78`, `:80`, `:95`).
+
+**(b) The replacement copy overstates the format matrix.**
+
+Step 2's proposed sentence — "FASTQ and uBAM are both supported on input and output" — reads as 2×2. Only 3 of the 4 combinations are legal:
+
+| | FASTQ out | uBAM out |
+|---|---|---|
+| FASTQ in | ✅ | ✅ |
+| uBAM in | ❌ **rejected** | ✅ |
+
+uBAM-in → FASTQ-out is refused (`src/main.rs:537-544` for the `--paired` N=1 shape, plus the SE path pinned by `tests/integration_clump_only.rs:304` `rejects_ubam_input_without_ubam_output`, which asserts the error routes the user to `--output-format ubam`). Rationale in both places: FASTQ output would silently drop aux tags. `clump-only.md:103` states this explicitly. The replacement sentence needs to say uBAM input *requires* `--output-format ubam`, otherwise it invites the exact invocation the code rejects.
+
+### 1.3 Incomplete defect set — the same paragraph has more uBAM-falsified claims
+
+The prompt's worry was justified. #400's own criterion is "predates the shipped uBAM arms and now contradicts the docs site." Applying that criterion to the rest of the doc block turns up three more hits, one of them more consequential than either the plan names.
+
+**(i) The output-filename sentence — `cli.rs:184-188`. Highest user impact of anything in this review.**
+
+> Output files use the `*_clumped.fq(.gz)` (SE) or `*_clumped_{1,2}.fq(.gz)` (PE) suffix, and a short `*_clumping_report.txt` is emitted …
+
+Unqualified, and false under `--output-format ubam`:
+
+- SE uBAM → `*_clumped.bam` (`src/io.rs:417-431`)
+- PE uBAM → **ONE** interleaved `*_clumped.bam`, no `_1`/`_2` suffix at all (`src/io.rs:442-458`, whose own doc comment says *"Returns a SINGLE interleaved BAM path … no `_1`/`_2` suffix"*)
+
+The PE case differs in output **count**, not just extension. Users script against filenames; this is worse than a stale forward-looking sentence, and it is two lines above one of the two the plan is fixing. `clump-only.md:41-45` has the full correct list.
+
+**(ii) The contract-scope paragraph is FASTQ-only but reads as exhaustive — `cli.rs:200-204`.**
+
+> … The plus-line (line 3 of each record) is normalized to bare `+` on output; CRLF line endings are normalized to LF. **Both** normalizations are codebase-wide behaviours, inherited from the FASTQ reader/writer.
+
+On the uBAM path there is no plus-line, and there is a *third* deviation from whole-file identity that this paragraph does not mention: every run appends a `@PG ID:trim_galore VN:<version> CL:<invocation>` record (`&command_line` threaded into `clump_only_single_to_bam` / `clump_only_paired_to_bam_one_pair` at `src/main.rs:645`, `:702`, `:740`; documented at `clump-only.md:61-63` and `CHANGELOG.md:226-231`). Whole-file BAM hashes therefore vary per invocation — which is why CI uses a `@PG`-ignoring assertion.
+
+This matters *because* of step 2: planting a "uBAM is supported" sentence immediately below a paragraph whose closing word is "**Both**" tells the reader the exhaustive caveat list covers uBAM. It doesn't.
+
+**(iii) The byte-identity enumeration omits aux tags — `cli.rs:183-184.`**
+
+> Every input record appears in the output byte-identically (header, sequence, quality)
+
+For a uBAM record those are not all the fields. Aux tags round-trip **only** with `--preserve-tags` and are otherwise dropped. Compare `clump-only.md:6`: "(header/name + sequence + quality + preserved aux tags for uBAM)". Severity is lower than (i)/(ii) because the enumeration doesn't claim tags are kept — and step 1's `--preserve-tags` addition largely mitigates it *if* worded as an opt-in rather than a bare list item.
+
+### 1.4 Claims I checked that are fine — no edit needed
+
+Recording these so the implementer doesn't over-reach:
+
+- **`--fastqc`** — genuinely composes on every arm including BAM (`main.rs:646`, `:703`, `:741`); fastqc-rust reads BAM natively (`clump-only.md:77`). Accurate.
+- **`--basename`** — threaded through all five arms. Accurate.
+- **`-q` / `--stringency` / `-e` silently ignored** (`cli.rs:195-198`) — matches `validate`'s comment at `cli.rs:738-741` and `clump-only.md:105`. Accurate.
+- **`--output-format`'s own help** (`cli.rs:243-249`) — says "some flag combinations are rejected (see `--help` and the startup diagnostics for details)". Still true; no collateral edit required. Good news for scope.
+- **"other specialty modes" in the rejected list** — loosely covers `--clumpify`/`--hardtrim*`/`--clock`/`--implicon`/`--demux`, all of which do bail (`cli.rs:743`, `851-865`). Acceptable as-is.
+
+### 1.5 Line-number drift in the plan
+
+The plan says the block is `cli.rs:183-207` and cites `cli.rs:207` twice for the follow-up sentence. Actual: the doc block spans **180-206**; the stale sentence is at **206**; **207 is the `#[clap(long = "clump_only")]` attribute**. Trivial, but an implementer editing "line 207" touches the attribute. Line 195 is correct as cited.
+
+---
+
+## 2. Assumptions
+
+- **A1 (no test pins the phrases) — verified TRUE. The plan defers this to implementation; it is already answerable, so the deferral buys nothing.** See 3 for the evidence.
+- **A2 (docs page accurate post-#396) — verified TRUE**, and stronger than the plan uses it for. The plan treats the docs page as "needs no companion edit"; it should also treat it as the *specification* for the rewrite (5.2).
+- **Unstated assumption: "two statements" is the complete defect set.** This is the plan's load-bearing implicit assumption and it is **false** (1.3). It comes from taking the issue body's "two-line fix" framing as a scope finding rather than as the reporter's first-glance estimate.
+- **Unstated assumption: the terseness convention applies here.** The plan never cites it, but its "Fix the two statements; change nothing else" instinct pattern-matches to the project's one-line-comment rule. That rule governs **code comments**; clap rustdoc is user-facing `--help` prose where completeness is the governing virtue. The project demonstrates this itself — 138 lines of docs prose for this one flag. The terseness rule must not be used to justify leaving 1.3(i) in place.
+
+---
+
+## 3. Test / CI pinning — safe, and the answer is knowable now
+
+The plan defers the grep to implementation step 3. **Safe to defer, but unnecessary — here is the answer.** I checked wider than the plan's `tests/ src/` scope:
+
+- **The two phrases:** `src/cli.rs:206` is the only source hit. The other two hits are **historical release records** — `CHANGELOG.md:279` and its synced mirror `docs/src/content/docs/reference/changelog.md:29`, both inside the shipped `--clump_only` feature entry. **Both must be left alone** (a changelog records what was true at release; the synced page is additionally off-limits by project convention). The plan's grep scope (`tests/ src/`) would never surface them — fine for the "does a test pin this" question, but the plan should say so, or a diligent implementer greps wider, finds two hits, and either panics or wrongly "fixes" the changelog.
+- **`tests/integration_no_args_help.rs`** pins only `"Usage: trim_galore"`, `"--adapter"`, and the absence of `"error:"` (lines 35-42). Nothing from the clump block.
+- **No test anywhere renders or asserts long help** — no `render_long_help` / `long_about` / `verbatim_doc_comment` hits in `src/`, no snapshot tests.
+- **CI runs `--help` as an exit-code smoke test only** — `.github/workflows/release.yml:226` and `:356`. No content grep.
+- **No `cargo doc` job in `.github/workflows/ci.yml`** and **no `[lints]` section in `Cargo.toml`** — so rustdoc lints (including `bare_urls`) are not a gate. Relevant to 6.4.
+
+Conclusion: **zero pinning risk.** The help text is completely unguarded, which is also why it drifted.
+
+---
+
+## 4. CHANGELOG placement — correct, with better precedent than cited
+
+`#### Changes` exists under `### Unreleased` at `CHANGELOG.md:143`. The plan cites the `--output-dir` entry as precedent; that exists (`CHANGELOG.md:168`, "Two collision messages advised `--output-dir`, which is not a valid flag"). Two stronger ones sit in the same section:
+
+- `CHANGELOG.md:145` — "**The `--passthrough`-matches-R1/R2 message now says what it checks**" (#389, the immediately preceding commit `0f65048`). Message-only, same section. Closest structural match.
+- `CHANGELOG.md:291-293` — "**Tidied the `--help` text**: removed developer-internal references … that had leaked into user-facing flag descriptions. No behaviour change." A pure `--help`-text entry under `#### Changes`. Direct precedent.
+
+Placement approved. One content note: if the fix expands per 1.3, the entry should name the filename correction explicitly — a user who scripted against `_clumped_{1,2}.fq.gz` for uBAM output was misled, and that is the line most worth their attention.
+
+---
+
+## 5. Validation sufficiency
+
+### 5.1 The three proposed checks cannot catch the failure mode that matters
+
+Validation #1 greps for the removed phrases, #2 eyeballs the rendered help, #3 runs the suite. All three confirm the *mechanics* — that something changed and nothing broke. **None of them checks that the new sentences are true.** Given that 1.2 identifies two false statements the plan's own copy would introduce, the validation table has a hole exactly where the risk is.
+
+The rebuild-before-render discipline (#2, called out in Self-Review against the session's prove-freshness rule) is genuinely good and worth keeping.
+
+### 5.2 Two rows to add
+
+- **#4 — Accuracy diff against the maintained truth.** Read the rewritten paragraph line-by-line against `docs/src/content/docs/modes/clump-only.md` §Compatibility (lines 69-105) + §Output filenames (39-45) + §Record fidelity (47-63). That page is accurate (verified in 1.1) and is the specification. Expected: every claim in the help text has a corresponding, non-contradicting line on the docs page.
+- **#5 — No new claim contradicts a `bail!`.** For each flag named as composing, confirm no matching `anyhow::bail!` exists in either the `if self.clump_only` block (`cli.rs:742-883`) or the shared §3.4a `UBam` block (`cli.rs:571-616`). This is the check that catches 1.2(a) mechanically; it takes about two minutes and would have caught the defect at plan time.
+
+### 5.3 Do not add a help-text regression test
+
+Worth stating so it isn't proposed later: pinning help prose in a test is brittle and the repo has deliberately zero help-content assertions. The root cause here is doc-drift-after-feature, which no unit test catches. The durable mitigation is the single-source-of-truth question in 6.1, not an assertion.
+
+---
+
+## 6. Alternatives
+
+### 6.1 Recommended: repair the paragraph, don't patch two sentences
+
+Three options, in increasing scope:
+
+- **(A) As planned — two statements.** Leaves 1.3(i) (wrong output filenames for uBAM) and 1.3(ii) (`@PG`) in place, and per 1.2 introduces two new inaccuracies. A second #400-shaped issue against the same paragraph becomes near-certain. Not recommended.
+- **(B) Repair the whole block against the docs page. ← recommended.** Still small — roughly 8-10 lines of doc comment. Fixes the whole class in one PR, one CHANGELOG line, same review cost. Keeps the paragraph self-sufficient for offline `--help` readers.
+- **(C) Shrink the help block and delegate the matrix to the docs page.** Structurally attractive: one maintained source, drift impossible by construction. But it removes information from `--help` for users without network access, is a larger editorial change than #400 asked for, and is Felix's call on register rather than a reviewer's. Worth raising as a follow-up question, not doing here.
+
+### 6.2 On the docs-page cross-reference in step 2
+
+Step 2's parenthetical — "(see the clump-only docs page for the paired input shapes)" — would be **the first docs-site cross-reference in any `cli.rs` help string** (zero hits for `docs page` / `documentation` / `trimgalore.com` across `cli.rs`). And the nearest precedent runs the other way: `CHANGELOG.md:291-293` records deliberately *removing* unresolvable pointers (internal `PLAN.md`/`§` references) from user-facing flag descriptions. "The clump-only docs page", with no URL, is closer to that pattern than to a resolvable reference.
+
+There are only two paired shapes. Stating them inline costs one clause each and keeps `--help` self-contained:
+
+> `--paired` takes two files (Shape A, multi-pair supported) or a single interleaved uBAM (Shape B, requires `--output-format ubam`).
+
+If a pointer is preferred anyway, name the URL. No `cargo doc` job means a bare URL won't trip `rustdoc::bare_urls` (see 3), but backticks remain the local convention.
+
+### 6.3 Efficiency
+
+Nil, as the plan says. Doc-string only; no runtime, no allocation, no binary-size change worth measuring. Nothing to review here.
+
+---
+
+## 7. Action items
+
+### Critical — fix before implementing
+
+1. **Do not add `--output-format ubam` to the existing "Composes with" list while `--dont_gzip` sits in it** (`cli.rs:190-191`). `cli.rs:576-581` rejects that pair. Split the sentence, or qualify `--dont_gzip` as FASTQ-output-only. Model wording: `clump-only.md:78`, `:80`. The plan's Context already knows this fact — promote it into an implementation step.
+2. **Fix the replacement copy's format matrix** (step 2). "FASTQ and uBAM are both supported on input and output" implies 4 legal combinations; uBAM-in → FASTQ-out is rejected (`main.rs:537-544`; `tests/integration_clump_only.rs:304`). Say that uBAM input requires `--output-format ubam`.
+
+### Important
+
+3. **Extend the fix to the output-filename sentence** (`cli.rs:184-188`). Under `--output-format ubam` the outputs are `*_clumped.bam` (SE) and **one** interleaved `*_clumped.bam` for PE — different count, not just different extension (`io.rs:417-458`). By #400's own stated criterion this is the same defect class, and it has the highest user impact of anything in the block. Fix here, or open a follow-up issue explicitly — do not skip silently.
+4. **Add a uBAM clause to the contract-scope paragraph** (`cli.rs:200-204`). It closes on "**Both** normalizations", which reads as exhaustive, but the uBAM path adds a per-run `@PG` record so whole-file identity does not hold (`clump-only.md:61-63`). Step 2 plants a uBAM sentence directly beneath it, which makes the over-claim worse than it is today.
+5. **Add validation rows #4 and #5** (5.2): diff the rewritten paragraph against `clump-only.md`, and confirm no newly-claimed flag has a matching `bail!` in `cli.rs:742-883` or `cli.rs:571-616`.
+
+### Optional
+
+6. **Qualify `--compression` as inert under uBAM output.** The `clump_only_*_to_bam` call sites take no compression argument (`main.rs:638-650`, `:695-707`, `:733+`), unlike the FASTQ arms which pass `cli.compression`. `clump-only.md:74` says "ignored for uBAM output". Nearly free while editing that sentence.
+7. **Word `--preserve-tags` as an opt-in, not a bare list item** — "aux tags round-trip only with `--preserve-tags`" — which also covers 1.3(iii)'s tag-loss gap.
+8. **Note the report count while touching that sentence**: PE FASTQ writes one report per mate, the uBAM shapes one per pair (`clump-only.md:122`, and #391's entry at `CHANGELOG.md:6-18`).
+9. **Prefer inline shapes over "see the clump-only docs page"** (6.2), or name the URL.
+10. **Correct the plan's line numbers**: block is 180-206, stale sentence at 206; 207 is the `#[clap]` attribute.
+11. **Record in the plan that `--cores` in the composes-list is accepted-for-parity only** (single-threaded internally per `cli.rs:749-752` and `clump-only.md:76`). Pre-existing and *not* uBAM-caused, so genuinely out of #400's scope — flagged only so the decision to leave it is deliberate.
+12. **State in step 3 that the two non-`src/` hits are historical changelog records** (`CHANGELOG.md:279`, `docs/…/reference/changelog.md:29`) and are intentionally not edited.
+
+### Out of scope — noted, not for this PR
+
+- `--phred64` + FASTQ-in + uBAM-out is accepted and threads `cli.phred_offset()` into the BAM writers (`main.rs:649`, `:706`, `:744`), whereas the FASTQ→FASTQ arm ignores phred entirely (byte copy). Quality *values* are preserved; the ASCII string necessarily is not, because BAM stores raw Phred. Semantically correct, asymmetric with the FASTQ arm's literal byte-copy, and immaterial to `--help` accuracy. `--phred64` + uBAM **input** is already rejected (#358, `CHANGELOG.md:235`). Mentioning only so it isn't rediscovered as a bug.
+
+---
+
+## 8. Verdict
+
+The plan's premise is right and its homework is honest: both named defects are real, and every checkable claim it makes — A1, A2, the CHANGELOG heading, the docs page's accuracy — verified true, which is more than most plans this size manage. But it inherited the issue's "two-line fix" framing as a scope conclusion, and that framing does not survive reading the paragraph. Three more claims in the same doc block were falsified by the shipped uBAM arms, the worst of them telling users the wrong output filenames and the wrong output *count* for PE uBAM; and the two sentences the plan does propose would each introduce a fresh inaccuracy — one asserting `--dont_gzip` composes with `--output-format ubam` when `cli.rs:576` rejects exactly that, the other implying uBAM-in → FASTQ-out works when it is refused with a message telling users to add `--output-format ubam`. Fix the two Critical items, take the two Important ones (or defer item 3 to a named follow-up rather than silently), add the two accuracy validation rows, and this becomes the right change — still under a dozen lines of doc comment, with `docs/src/content/docs/modes/clump-only.md` serving as a specification that is already correct.

--- a/plans/08082026_clump-help-text/PLAN_REVIEW_B.md
+++ b/plans/08082026_clump-help-text/PLAN_REVIEW_B.md
@@ -1,0 +1,390 @@
+# Plan Review B — `--clump_only` help text (#400)
+
+**Plan:** `plans/08082026_clump-help-text/PLAN.md`
+**Reviewer:** B (independent; Reviewer A ran separately — no shared state)
+**Base:** `dev` @ `ce13761`
+**Verdict:** APPROVE WITH CHANGES — both named defects are real, but the named set is
+**incomplete** and the **proposed replacement sentence is itself inaccurate**.
+
+---
+
+## Summary
+
+The plan correctly identifies two stale statements and correctly scopes the change as
+doc-string-only with no runtime effect. Two problems keep it from being ready:
+
+1. The defect set is incomplete in the way that matters most. The **first** paragraph of
+   the same doc block promises `*_clumped.fq(.gz)` / `*_clumped_{1,2}.fq(.gz)` output — and
+   that paragraph is the **only** one `-h` renders (verified empirically below). Under
+   `--output-format ubam` the real names are `<stem>_clumped.bam` (SE) and **one
+   interleaved** `<stem>_clumped.bam` per pair. Land the plan as written and `--help`
+   advertises uBAM output in paragraph 2 while paragraph 1 still tells the user to look for
+   two `_clumped_{1,2}.fq.gz` files.
+2. The proposed replacement copy says "FASTQ and uBAM are both supported on input and
+   output". uBAM **input** on the FASTQ **output** path is rejected — in both the SE and PE
+   arms, by design, because it would drop aux tags. The plan would swap one falsehood for
+   another in the one place users check.
+
+Everything else the plan asserts checks out: the two line-level defects exist, no test or
+CI job pins the phrases, the CHANGELOG heading exists, and the docs page needs no companion
+edit.
+
+---
+
+## What I verified as correct in the plan
+
+| Plan claim | Verdict | Evidence |
+|---|---|---|
+| `--output-format ubam` sits in the *rejected* list | **True** | `src/cli.rs:195` |
+| A "v1 is FASTQ in / FASTQ out only" closing sentence exists | **True** | `src/cli.rs:206` (not 207) |
+| uBAM in/out is shipped for SE, PE Shape A, PE Shape B | **True** | five arms at `src/main.rs:522-750` |
+| `--preserve-tags` composes | **True** | threaded into all three BAM entry points |
+| `--dont_gzip` is rejected *with* uBAM output | **True** | `src/cli.rs:576-581` (shared §3.4a block) |
+| **A1** no test pins the stale phrases | **True — and knowable now** | see §3 |
+| **A2** the docs page is already accurate | **True** | see §2 |
+| `#### Changes` exists under `### Unreleased` | **True** | `CHANGELOG.md:4` / `:143` |
+| Help text is not covered by the Perl-parity matrix | **True** | CI only runs `--help` for exit status |
+
+The plan also does **not** conflate the project's terse-code-comment convention with
+user-facing help prose — step 4 explicitly reasons "help text is user-facing". That is the
+right call, and it matters, because my recommendation below *grows* the block. The one-line
+comment rule must not be applied to `--help` copy.
+
+---
+
+## 1. Logic review
+
+### 1.1 Critical — the fix is invisible on the `-h` path, and paragraph 1 stays false
+
+Rendered from the built binary at `target/release/trim_galore` (source text matches
+`src/cli.rs` verbatim, so it is representative):
+
+- `--help` renders **all four** paragraphs of the `clump_only` rustdoc.
+- `-h` renders **only the first paragraph** — clap's short help for an argument is the
+  first doc paragraph; `long_help` is `--help`-only.
+
+The plan touches only paragraph 2 (line 195) and paragraph 4 (line 206). So:
+
+- A user who types `-h` learns nothing about uBAM support either before or after the fix,
+  and is still told the output is `*_clumped.fq(.gz)` / `*_clumped_{1,2}.fq(.gz)`.
+- A user who types `--help` gets a paragraph 2/4 that advertise uBAM output and a paragraph
+  1 that contradicts them on filenames.
+
+The naming claim is not a stylistic nit — it is the sentence that determines which files a
+user goes looking for, and the PE case is the sharp one: **one** interleaved BAM per pair,
+not two mate files.
+
+Ground truth (`src/io.rs`):
+
+- `clumped_bam_output_name` (`io.rs:417-431`) → `<stem>_clumped.bam`
+- `clumped_paired_bam_output_name` (`io.rs:442-458`) → a **single** `<stem>_clumped.bam`,
+  stem from R1, no `_1`/`_2` suffix ("Returns a SINGLE interleaved BAM path")
+
+Paragraph 1's opening clause ("reorder **FASTQ** records") carries the same FASTQ-only
+framing; the docs page title is already "Reorder **FASTQ or uBAM** records".
+
+**Action:** paragraph 1 must be in scope. This is the sibling falsehood the fix would
+otherwise leave behind.
+
+### 1.2 Critical — the proposed replacement sentence introduces a new inaccuracy
+
+Plan step 2 proposes: *"FASTQ and uBAM are both supported on input and output; select uBAM
+output with `--output-format ubam` …"*
+
+Read naturally, that offers four combinations. Only three exist. uBAM input on the FASTQ
+output path is rejected in both arms:
+
+- SE: `src/clump_only.rs:265-272` — `"uBAM input under --clump_only requires
+  --output-format ubam (using the FASTQ output path with uBAM input would drop aux tags)"`
+- PE: `src/format.rs:165-172`, via `PairedShape::ClumpOnlyFastqOut` — same message, fired
+  for **any** BAM in the pair regardless of the other side
+
+The docs page states this as its own bullet ("**FASTQ output path with uBAM input:** …
+is rejected"). For a change whose entire purpose is accuracy, shipping this sentence would
+be the worst outcome of the three (stale text, corrected text, or newly-wrong text).
+
+**Action:** the sentence must say uBAM input *requires* `--output-format ubam`, not that it
+is merely one of two options.
+
+### 1.3 Important — adding `--output-format ubam` to "Composes with" contradicts two entries already in that list
+
+Plan step 1 extends the "Composes with" sentence with `--output-format ubam`. The resulting
+list would read `--compression, --memory, --cores, --paired, --fastqc, --dont_gzip,
+--basename, --output-format ubam` — asserting that `--dont_gzip` and `--output-format ubam`
+both compose, when they are **mutually exclusive**:
+
+- `src/cli.rs:576-581` rejects `--dont_gzip` under `--output-format ubam` outright.
+
+And `--compression` is **inert** on the uBAM path, not merely less useful:
+
+- `main.rs:574` / `:604` pass `cli.compression` to the FASTQ entry points; the three BAM
+  calls (`main.rs:638-650`, `695-707`, `733-745`) **never pass it**.
+- `clump_only.rs:780` / `:1018` hardcode `compression_level: 0` with the comment
+  "BGZF; label carries the story".
+
+The plan's Context section already knows the `--dont_gzip` fact but the implementation
+outline does not carry it into the copy. The docs page qualifies both inline
+("`--compression <1-9>` (FASTQ gzip level; ignored for uBAM output …)"; "`--dont_gzip` —
+FASTQ output only … Rejected with `--output-format ubam`"); the help text should too.
+
+### 1.4 Important — the losslessness paragraphs are FASTQ-scoped and become incomplete once uBAM is advertised
+
+Paragraph 1's "byte-identically (header, sequence, quality)" and paragraph 3's
+contract-scope note are written for a FASTQ-only mode. On the uBAM path:
+
+- Aux tags round-trip **only** for tags named in `--preserve-tags`, and only A/Z/i/f
+  scalars (`clump_only.rs:714-718`). A 10X user who runs `--clump_only --output-format
+  ubam` on a `CB`/`UB`-carrying BAM **without** `--preserve-tags` silently loses them —
+  while the help text calls the mode lossless.
+- A `@PG` record is appended, so whole-file identity does not hold
+  (`clump_only.rs:720-723`: "Cross-run byte-identity of the whole file is NOT guaranteed …
+  but record-body byte-identity IS").
+- "The plus-line (line 3 of each record) is normalized … inherited from the FASTQ
+  reader/writer" is meaningless for BAM output.
+
+"Lossless" is this mode's entire selling point, so the carve-out belongs in the help text,
+not only on the docs page (which does cover it: "Byte-identity therefore covers the
+semantically meaningful record fields, not the whole file"). Two clauses suffice — see §6.
+
+### 1.5 Non-issues I checked so the implementer does not chase them
+
+- **`main.rs:524`** — the code comment `// v1: FASTQ in/out. v2: uBAM in/out via
+  --output-format ubam.` is *accurate* (it describes the version history of the dispatch it
+  sits on) and is not user-facing. Leave it. Note the plan's grep pattern
+  `"FASTQ in / FASTQ out"` (spaced slash) will not match it anyway; a looser pattern would.
+- **`CHANGELOG.md:278-279`** and **`docs/src/content/docs/reference/changelog.md:28-29`**
+  carry the same "FASTQ in/out only in v1; uBAM in/out is a natural follow-up" wording.
+  These are **historical release notes** — true at the release they describe — and the docs
+  changelog page is a synced artifact. They must **not** be edited. The plan's grep is
+  scoped to `src/ tests/` so it will not surface them; keep it that way.
+- **`cli.rs:10-11`** — the `OutputFormat` enum-level doc contains a
+  `plans/…/PLAN.md §3.2` pointer. clap renders only *variant* docs under "Possible values",
+  so this does not leak into `--help`. Verified in the rendered output. Not a defect.
+- The `*_clumping_report.txt` claim holds on every arm, including the BAM ones
+  (`clump_only.rs:836`, `:1082`).
+- `--fastqc` genuinely composes on the BAM path (`clump_only.rs:845`, `:1090`).
+- `--cores` genuinely affects the BAM path the same way it affects FASTQ (bin-layout sizing
+  and FastQC threads), so its presence in "Composes with" is not falsified by uBAM.
+
+---
+
+## 2. Assumptions
+
+**A1 — "no test pins the two stale phrases."** Holds, and the answer was knowable before
+implementation, so deferring the grep costs nothing but gains nothing either:
+
+- `tests/integration_no_args_help.rs:36` is the only help assertion in the tree, and it
+  pins exactly two substrings: `"Usage: trim_galore"` and `"--adapter"`.
+- No other file under `tests/` or `src/` asserts on `--help` output.
+- `.github/workflows/release.yml:226` and `:356` run `trim_galore --help` as **exit-status**
+  smoke tests with no content grep.
+
+Conclusion: the doc block is unpinned prose. The plan's step-3 grep is safe to keep as a
+belt-and-braces check, but should not be presented as the thing that de-risks the change.
+
+**A2 — "the docs site's clump-only page is already accurate and needs no companion edit."**
+Holds. `docs/src/content/docs/modes/clump-only.md` is comprehensive and correct on every
+point above: per-format output filenames, the one-interleaved-BAM PE shape, `--compression`
+ignored for uBAM, `--dont_gzip` rejected with uBAM, aux tags via `--preserve-tags` with the
+A/Z/i/f constraint, the added `@PG` record, the three PE input-shape rejections, and the
+FASTQ-output-with-uBAM-input rejection. **Use it as the source for the replacement copy** —
+that is the cheapest path to an accurate help block and it keeps the two surfaces aligned.
+
+**Unstated assumption worth surfacing:** the plan treats "the `--help` text" as one
+surface. It is two (`-h` = paragraph 1, `--help` = all four), and which paragraph a fact
+lives in decides who sees it. §1.1 is a direct consequence.
+
+**Second unstated assumption:** that a "two-line fix" framing from the issue body should
+bound the diff. The issue says "two-line fix" as a size estimate, not a scope contract; the
+issue text itself came from an out-of-scope observation in another review and was never a
+full audit of the block. Growing the scope to the whole doc block is the correct reading of
+the issue's intent (make `--help` stop contradicting the shipped code), and the PR body
+should say so in one sentence.
+
+---
+
+## 3. Efficiency
+
+Nil, as the plan states. A doc-comment change has no runtime, allocation, or output-size
+effect; the only cost is a recompile of the crate. Nothing further to review here.
+
+---
+
+## 4. Validation sufficiency
+
+The three-row table is adequate for the change **as scoped**, but it cannot catch the
+defects in §1.1–§1.4, and one of its rows has near-zero discriminating power.
+
+- **Row 1 (grep for the stale phrases)** — will pass. Verifies removal, not correctness of
+  the replacement. A grep cannot detect that the new sentence is also wrong (§1.2).
+- **Row 2 ("new sentences present, old absent")** — the only row with real power, but it is
+  stated as an eyeball check with no pass criteria for the rest of the block. As written, an
+  implementer who reads only the two sentences they changed would sign it off with
+  paragraph 1 still contradicting paragraph 2.
+- **Row 3 (`cargo test` + fmt + clippy)** — **will pass no matter what the copy says.** No
+  test asserts on this text, so this row proves the crate still compiles, nothing more. Per
+  the project's own "prove the check can fail before trusting that it passed" rule, this
+  should be labelled a build check, not a validation of the change.
+
+**Strengthen to:**
+
+1. Render **both** `-h` and `--help` from a freshly rebuilt binary (the plan's freshness
+   note already covers the rebuild) and confirm the uBAM facts a user needs are present on
+   the surface that user will hit.
+2. Read the **entire four-paragraph block** side by side with the docs page's *Output
+   filenames*, *Record fidelity*, and *Compatibility* sections. Pass criterion, stated
+   explicitly: **every claim in the block is either true for both output formats or
+   explicitly scoped to one.** That is the check that catches §1.1, §1.3 and §1.4.
+3. Two smoke runs to confirm the copy against reality rather than against the docs — the
+   fixtures already exist:
+   - `--clump_only --output-format ubam test_files/BS-seq_10K_R1.fastq.gz` → confirm
+     `BS-seq_10K_R1_clumped.bam` appears (paragraph 1's naming claim, SE).
+   - `--clump_only --paired --output-format ubam test_files/BS-seq_10K_R{1,2}.fastq.gz` →
+     confirm exactly **one** `_clumped.bam` (paragraph 1's naming claim, PE — the sharp case).
+   - Optionally `--clump_only --dont_gzip --output-format ubam …` → confirm the rejection
+     the new copy will describe.
+
+**On pinning help text in a test:** I recommend **against** it. Prose assertions rot faster
+than the prose they guard, and the mode already has an authoritative, maintained docs page.
+The durable guard here is that the help text points at that page (the plan's copy already
+does), not a substring assertion.
+
+---
+
+## 5. Alternatives
+
+1. **Minimal, as planned (two sentences).** Rejected — leaves paragraph 1 false, leaves
+   `-h` users uninformed, and ships the §1.2 inaccuracy.
+2. **Make the whole four-paragraph block format-aware.** *Recommended.* Still one file, one
+   doc comment, zero behaviour change, and it ends with a block that is internally
+   consistent for both output formats. Cost: ~10 lines of prose instead of two, against an
+   issue that estimated "two-line fix" — worth one sentence of explanation in the PR body.
+3. **Shrink the help block and delegate the matrix to the docs page** — keep paragraph 1
+   plus "Full compatibility matrix, output filenames and uBAM shapes: <docs URL>". Tempting:
+   the block is already ~230 words of `--help`, and the docs page is authoritative. But
+   `--help` should stand alone offline (cluster users without a browser), and this would
+   *reduce* what `-h` users learn. Recommend the middle path in option 2: format-aware short
+   lists in help, docs pointer retained for the full matrix.
+4. **Fix only the docs, leave help alone.** Rejected — the false "rejected" listing actively
+   deters users from a shipped feature, which is precisely the harm #400 was filed about.
+
+---
+
+## 6. Suggested copy (verified line by line against the code)
+
+Offered because the plan flags exact wording as an open, reviewable question. Every claim
+below was checked against the sources cited in §1.
+
+**Paragraph 1** — add format-awareness and the BAM naming:
+
+> Lossless reorder-only specialty mode: reorder FASTQ or unaligned BAM (uBAM) records by
+> canonical 16-mer minimizer for compression-friendly grouping, WITHOUT any trimming,
+> filtering, adapter detection, or record modification. Every input record appears in the
+> output byte-identically — name, sequence, quality, plus aux tags named in
+> `--preserve-tags` on uBAM; only file-level order changes. Output is `*_clumped.fq(.gz)`
+> (SE) or `*_clumped_{1,2}.fq(.gz)` (PE), or under `--output-format ubam` a single
+> `*_clumped.bam` (SE) and ONE interleaved `*_clumped.bam` per pair (PE). A short
+> `*_clumping_report.txt` is emitted (distinct from `*_trimming_report.txt` to keep
+> downstream nf-core/MultiQC scanners unconfused).
+
+**Paragraph 2** — qualify the two format-dependent entries, move `--output-format ubam`
+across, and keep the exclusion visible:
+
+> Composes with `--compression` (FASTQ output only), `--memory`, `--cores`, `--paired`,
+> `--fastqc`, `--dont_gzip` (FASTQ output only), `--basename`, `--output-format ubam`, and
+> `--preserve-tags` (uBAM only). Trimming/filtering flags (`-a`, `--length`, `--rrbs`,
+> `--polyA`, `--polyG`, `--trim-n`, `--clip_*`, `--nextseq`, `--rename`,
+> `--discard_untrimmed`, `--consider_already_trimmed`, other specialty modes,
+> `--passthrough`, `--retain_unpaired`) are rejected, as is `--dont_gzip` together with
+> `--output-format ubam` (BAM is always BGZF). `-q` / `--stringency` / `-e` have clap
+> defaults and are silently ignored on this path (mode does no trimming; matches how
+> `--hardtrim5` treats trim flags today).
+
+**Paragraph 3** — one added sentence for the BAM side of the contract:
+
+> … Both normalizations are codebase-wide behaviours, inherited from the FASTQ
+> reader/writer. On uBAM output a `@PG` record is appended to the header, so whole-file
+> identity is not preserved — record bodies are.
+
+**Paragraph 4** — replaces the stale line 206:
+
+> FASTQ and uBAM input are both supported, but uBAM input requires `--output-format ubam`
+> (the FASTQ output path would drop aux tags). Paired uBAM output takes either two FASTQ
+> files or one interleaved uBAM; see the clump-only docs page for the full shape matrix.
+
+---
+
+## 7. CHANGELOG placement
+
+`#### Changes` under `### Unreleased` is the right home — the heading exists
+(`CHANGELOG.md:143`, inside the Unreleased span that runs to `:501`).
+
+Two refinements to the plan's step 4:
+
+- **Cite a better precedent.** `CHANGELOG.md:291-293` — *"**Tidied the `--help` text**:
+  removed developer-internal references … No behaviour change."* — is in the **same
+  section** and is the **same kind of change** (help text only, no behaviour). That is a
+  stronger precedent than the `--output-dir` entry (`:168-169`), which is a runtime *stderr
+  message*, not help text.
+- **A separate bullet is still justified,** rather than extending that one. The tidy pass
+  was about removing internal noise; #400 corrects a **false capability claim** that
+  changes what a user believes they can run. Worth noting in passing that the tidy pass
+  demonstrably *missed* line 206 — the same class of leftover version-roadmap note it
+  claimed to have swept — which is mild support for auditing the whole block now rather
+  than patching two lines.
+- **Minor hazard:** `### Unreleased` contains both `#### Bug fixes` (`:6`) and `#### Fixes`
+  (`:295`). That duplication is already tracked separately (#401) and is not this plan's
+  problem, but the implementer should be careful not to land the entry in either of those
+  by mistake. `#### Changes` is correct.
+
+---
+
+## 8. Action items
+
+### Critical
+
+1. **Bring paragraph 1 into scope and correct the output-naming sentence.** Under
+   `--output-format ubam` the names are `<stem>_clumped.bam` (SE) and **one interleaved**
+   `<stem>_clumped.bam` per pair (`io.rs:417-458`). This is the only paragraph `-h` renders,
+   so leaving it FASTQ-only means the fix is invisible on the short-help path while
+   actively misdirecting `--help` readers. (§1.1)
+2. **Do not ship the proposed sentence "FASTQ and uBAM are both supported on input and
+   output."** uBAM input on the FASTQ output path is rejected (`clump_only.rs:265-272`,
+   `format.rs:165-172`). Say that uBAM input **requires** `--output-format ubam`. (§1.2)
+
+### Important
+
+3. **Qualify `--compression` and `--dont_gzip` when `--output-format ubam` joins the
+   "Composes with" list.** `--dont_gzip` + ubam is a hard error (`cli.rs:576-581`);
+   `--compression` is never passed to the BAM entry points and is recorded as level `0`
+   (`clump_only.rs:780`, `:1018`). As drafted, the list would assert two mutually exclusive
+   flags both compose. (§1.3)
+4. **Scope the losslessness claim for uBAM:** aux tags survive only when named in
+   `--preserve-tags` (A/Z/i/f only), and a `@PG` record is appended so whole-file identity
+   does not hold. Silent `CB`/`UB` loss under a heading that says "lossless" is the
+   user-visible risk. (§1.4)
+5. **Replace validation row 3's framing and add the paragraph-level read-through.**
+   `cargo test`/fmt/clippy pass regardless of what the copy says — no test asserts on this
+   text. The load-bearing check is: render `-h` *and* `--help`, then read the whole block
+   against the docs page with the explicit pass criterion "true for both formats, or
+   scoped to one". Add the two `test_files/BS-seq_10K_R{1,2}.fastq.gz` uBAM smoke runs to
+   confirm the naming claim rather than assuming it. (§4)
+
+### Optional
+
+6. **Fix the line references** in the plan: the rustdoc is `cli.rs:180-206` (not 183-207)
+   and the "natural follow-up" sentence is line **206**. `cli.rs:195` is correct. (§1.5)
+7. **Adjacent, same bug class — decide in or out explicitly.** The `OutputFormat::UBam`
+   variant doc (`cli.rs:17-18`) lists five of the seven ubam rejections; `--retain_unpaired`
+   (`cli.rs:609`) and `--dont_gzip` (`cli.rs:576`) are missing, and this text *does* render
+   in `--help` under "Possible values". One line to fix in the same PR, or file separately —
+   but make it a decision, not an omission.
+8. **Warn the implementer off the historical hits.** `CHANGELOG.md:278-279` and
+   `docs/src/content/docs/reference/changelog.md:28-29` contain the same stale-sounding
+   wording as release history and must not be edited; `main.rs:524`'s comment is accurate.
+   Keep the grep scoped to `src/ tests/`. (§1.5)
+9. **Cite `CHANGELOG.md:291-293` ("Tidied the `--help` text") as the precedent** instead of
+   the `--output-dir` message entry — same section, same kind of change. (§7)
+10. **Add one PR-body sentence** explaining why a "two-line fix" issue produced a
+    ~10-line doc diff: the sibling claims live in the same doc block, and fixing two of four
+    paragraphs would leave the block self-contradictory. (§2)

--- a/plans/08082026_clump-help-text/PROGRESS.md
+++ b/plans/08082026_clump-help-text/PROGRESS.md
@@ -1,0 +1,21 @@
+# Progress: `--clump_only` help text — uBAM shipped, say so (#400)
+
+**Last updated:** 2026-08-08
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | PLAN.md **r2** — dual review + Felix's two decisions folded in (no docs pointer; variant doc in scope). Scope grew 2 sentences → whole 4-paragraph block + variant doc |
+| Plan Review | ✅ Complete | PLAN_REVIEW_A.md (REVISE), PLAN_REVIEW_B.md (APPROVE WITH CHANGES) — both found r1 incomplete AND r1's own copy introducing 2 new falsehoods |
+| Impl Plan | ✅ Complete | Folded into PLAN.md r2 outline (no separate IMPL.md, per pipeline convention) |
+| Implementation | ✅ Complete | 0676fdf + review batch e8e79ca + docs 5407a37/d19aa75 |
+| Code Review | ✅ Complete | CODE_REVIEW_A.md + _B.md — both APPROVE WITH CHANGES; found 2 distinct falsehoods in the new byte-identity claim, both fixed |
+| Coverage | ✅ Complete | COVERAGE.md: INCOMPLETE (2 PARTIAL, one clause) → both closed in e8e79ca |
+
+## History
+
+- 2026-08-08: Implementation + Code Review + Coverage → ✅ Complete
+- 2026-08-08: Plan revised to r2 (dual-review findings + maintainer decisions incorporated; re-presented)
+- 2026-08-08: Plan Review → ✅ Complete (dual reviewers; r1 rejected as incomplete)
+- 2026-08-08: Plan → ✅ Complete (PLAN.md written)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,8 @@ pub enum OutputFormat {
     #[default]
     Fastq,
     /// Unaligned BAM output. Always single-threaded; --clumpify,
-    /// --passthrough, --clock, --implicon, --demux are rejected at validation.
+    /// --passthrough, --clock, --implicon, --demux, --retain_unpaired and
+    /// --dont_gzip are rejected at validation.
     #[clap(name = "ubam")]
     UBam,
 }
@@ -177,33 +178,41 @@ pub struct Cli {
     #[clap(long = "clumpify")]
     pub clumpify: bool,
 
-    /// Lossless reorder-only specialty mode: reorder FASTQ records by
-    /// canonical 16-mer minimizer for gzip-friendly compression, WITHOUT
-    /// any trimming, filtering, adapter detection, or record modification.
-    /// Every input record appears in the output byte-identically (header,
-    /// sequence, quality); only file-level order changes. Output files use
-    /// the `*_clumped.fq(.gz)` (SE) or `*_clumped_{1,2}.fq(.gz)` (PE) suffix,
-    /// and a short `*_clumping_report.txt` is emitted (distinct from
+    /// Lossless reorder-only specialty mode: reorder FASTQ or unaligned BAM
+    /// (uBAM) records by canonical 16-mer minimizer for compression-friendly
+    /// grouping, WITHOUT any trimming, filtering, adapter detection, or record
+    /// modification. Every input record appears in the output byte-identically
+    /// — name, sequence, quality, plus any aux tags named in `--preserve-tags`
+    /// on uBAM; only file-level order changes. Output is `*_clumped.fq(.gz)`
+    /// (SE) or `*_clumped_{1,2}.fq(.gz)` (PE), or under `--output-format ubam`
+    /// a single `*_clumped.bam` (SE) and ONE interleaved `*_clumped.bam` per
+    /// pair (PE). A short `*_clumping_report.txt` is emitted (distinct from
     /// `*_trimming_report.txt` to keep downstream nf-core/MultiQC scanners
     /// unconfused).
     ///
-    /// Composes with `--compression`, `--memory`, `--cores`, `--paired`,
-    /// `--fastqc`, `--dont_gzip`, and `--basename`. Trimming/filtering flags
-    /// (`-a`, `--length`, `--rrbs`, `--polyA`, `--polyG`, `--trim-n`,
-    /// `--clip_*`, `--nextseq`, `--rename`, `--discard_untrimmed`,
-    /// `--consider_already_trimmed`, other specialty modes, `--passthrough`,
-    /// `--retain_unpaired`, `--output-format ubam`) are rejected. `-q` /
-    /// `--stringency` / `-e` have clap defaults and are silently ignored on
-    /// this path (mode does no trimming; matches how `--hardtrim5` treats
-    /// trim flags today).
+    /// Composes with `--compression` (FASTQ output only), `--memory`,
+    /// `--cores`, `--paired`, `--fastqc`, `--dont_gzip` (FASTQ output only),
+    /// `--basename`, `--output-format ubam`, and `--preserve-tags` (uBAM
+    /// only). Trimming/filtering flags (`-a`, `--length`, `--rrbs`, `--polyA`,
+    /// `--polyG`, `--trim-n`, `--clip_*`, `--nextseq`, `--rename`,
+    /// `--discard_untrimmed`, `--consider_already_trimmed`, other specialty
+    /// modes, `--passthrough`, `--retain_unpaired`) are rejected, as is
+    /// `--dont_gzip` together with `--output-format ubam` (BAM is always
+    /// BGZF). `-q` / `--stringency` / `-e` have clap defaults and are silently
+    /// ignored on this path (mode does no trimming; matches how `--hardtrim5`
+    /// treats trim flags today).
     ///
     /// Contract-scope note: byte-identity applies to header + sequence +
     /// quality bytes. The plus-line (line 3 of each record) is normalized
     /// to bare `+` on output; CRLF line endings are normalized to LF. Both
     /// normalizations are codebase-wide behaviours, inherited from the
-    /// FASTQ reader/writer.
+    /// FASTQ reader/writer. On uBAM output a `@PG` record is appended to the
+    /// header, so whole-file identity is not preserved — record bodies are.
     ///
-    /// v1 is FASTQ in / FASTQ out only. uBAM in/out is a natural follow-up.
+    /// FASTQ and uBAM input are both supported, but uBAM input requires
+    /// `--output-format ubam` (the FASTQ output path would drop aux tags).
+    /// Paired mode takes two files, or — with `--output-format ubam` — a
+    /// single interleaved uBAM.
     #[clap(long = "clump_only")]
     pub clump_only: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,22 +178,24 @@ pub struct Cli {
     #[clap(long = "clumpify")]
     pub clumpify: bool,
 
-    /// Lossless reorder-only specialty mode: reorder FASTQ or unaligned BAM
-    /// (uBAM) records by canonical 16-mer minimizer for compression-friendly
-    /// grouping, WITHOUT any trimming, filtering, adapter detection, or record
-    /// modification. Every input record appears in the output byte-identically
-    /// — name, sequence, quality, plus any aux tags named in `--preserve-tags`
-    /// on uBAM; only file-level order changes. Output is `*_clumped.fq(.gz)`
-    /// (SE) or `*_clumped_{1,2}.fq(.gz)` (PE), or under `--output-format ubam`
-    /// a single `*_clumped.bam` (SE) and ONE interleaved `*_clumped.bam` per
-    /// pair (PE). A short `*_clumping_report.txt` is emitted (distinct from
-    /// `*_trimming_report.txt` to keep downstream nf-core/MultiQC scanners
-    /// unconfused).
+    /// Reorder-only specialty mode: reorder FASTQ or unaligned BAM (uBAM)
+    /// records by canonical 16-mer minimizer for compression-friendly grouping,
+    /// WITHOUT any trimming, filtering or adapter detection — only file-level
+    /// order changes. FASTQ in / FASTQ out is byte-identical (header, sequence,
+    /// quality). uBAM output is lossless per record body but not byte-identical:
+    /// the space-separated header description is dropped, bases are uppercased,
+    /// IUPAC codes become `N`, and aux tags survive only when named in
+    /// `--preserve-tags`. uBAM input requires `--output-format ubam`. Output is
+    /// `*_clumped.fq(.gz)` (SE) or `*_clumped_{1,2}.fq(.gz)` (PE), or under
+    /// `--output-format ubam` a single `*_clumped.bam` (SE) and ONE interleaved
+    /// `*_clumped.bam` per pair (PE). A short `*_clumping_report.txt` is emitted
+    /// (distinct from `*_trimming_report.txt` to keep downstream
+    /// nf-core/MultiQC scanners unconfused).
     ///
     /// Composes with `--compression` (FASTQ output only), `--memory`,
     /// `--cores`, `--paired`, `--fastqc`, `--dont_gzip` (FASTQ output only),
-    /// `--basename`, `--output-format ubam`, and `--preserve-tags` (uBAM
-    /// only). Trimming/filtering flags (`-a`, `--length`, `--rrbs`, `--polyA`,
+    /// `--basename`, `--output-format ubam`, and `--preserve-tags` (requires at
+    /// least one uBAM input; an error otherwise). Trimming/filtering flags (`-a`, `--length`, `--rrbs`, `--polyA`,
     /// `--polyG`, `--trim-n`, `--clip_*`, `--nextseq`, `--rename`,
     /// `--discard_untrimmed`, `--consider_already_trimmed`, other specialty
     /// modes, `--passthrough`, `--retain_unpaired`) are rejected, as is
@@ -202,17 +204,17 @@ pub struct Cli {
     /// ignored on this path (mode does no trimming; matches how `--hardtrim5`
     /// treats trim flags today).
     ///
-    /// Contract-scope note: byte-identity applies to header + sequence +
-    /// quality bytes. The plus-line (line 3 of each record) is normalized
-    /// to bare `+` on output; CRLF line endings are normalized to LF. Both
-    /// normalizations are codebase-wide behaviours, inherited from the
-    /// FASTQ reader/writer. On uBAM output a `@PG` record is appended to the
-    /// header, so whole-file identity is not preserved — record bodies are.
+    /// Contract-scope note, FASTQ output: byte-identity applies to header +
+    /// sequence + quality bytes. The plus-line (line 3 of each record) is
+    /// normalized to bare `+` on output; CRLF line endings are normalized to
+    /// LF. Both normalizations are codebase-wide behaviours, inherited from the
+    /// FASTQ reader/writer. On uBAM output the per-record normalizations listed
+    /// above apply, and a `@PG` record is appended to the header, so whole-file
+    /// identity is not preserved.
     ///
-    /// FASTQ and uBAM input are both supported, but uBAM input requires
-    /// `--output-format ubam` (the FASTQ output path would drop aux tags).
-    /// Paired mode takes two files, or — with `--output-format ubam` — a
-    /// single interleaved uBAM.
+    /// Paired mode takes two FASTQ files (multi-pair supported), or — with
+    /// `--output-format ubam` — a single interleaved uBAM. Two separate uBAM
+    /// files are refused; combine them mate-adjacent first.
     #[clap(long = "clump_only")]
     pub clump_only: bool,
 


### PR DESCRIPTION
`--clump_only`'s `--help` text predated the shipped uBAM arms: it listed `--output-format ubam` among the *rejected* flags and closed with "v1 is FASTQ in / FASTQ out only", so it actively deterred users from a feature that works. Reviewing the whole block turned up five falsified claims rather than the two the issue named, and the worst was the output-filename sentence — FASTQ-only and unqualified, while a paired run under `--output-format ubam` writes **one** interleaved `*_clumped.bam`, not two mate files. That sentence sits in paragraph 1, which is the only paragraph clap renders for `-h`, so fixing just the two named sentences would have left short-help users both uninformed and misdirected.

The block is now format-aware throughout: per-format output filenames, `--compression` and `--dont_gzip` marked FASTQ-output-only, `--preserve-tags` named as the aux-tag opt-in (so "lossless" isn't read as covering tags that silently drop without it), the appended `@PG` record noted as why whole-file identity doesn't hold on BAM output, and uBAM input documented as *requiring* `--output-format ubam` rather than being one of two options — the FASTQ output path refuses it. The `--output-format ubam` value description also gained the two rejections it was missing (`--retain_unpaired`, `--dont_gzip`).

No behaviour change. Filename claims were smoke-tested rather than assumed: SE gives `R1_clumped.bam`, PE gives exactly one `_clumped.bam`, and `--dont_gzip --output-format ubam` is rejected as the new copy describes. 561 tests green.

<details>
<summary>AI-assisted: plan, dual plan review, and what they corrected</summary>

Plan + reviews in `plans/08082026_clump-help-text/` (committed separately). The original plan scoped this as the issue's "two-line fix"; both reviewers rejected that, and both caught that its own proposed copy would have introduced two *new* falsehoods — appending `--output-format ubam` to a "Composes with" list that already contained `--dont_gzip` (a hard error together), and "FASTQ and uBAM are both supported on input and output", which implies four legal combinations when only three exist. Reviewer B's empirical finding that `-h` renders only paragraph 1 is what put paragraph 1 in scope.

Maintainer decisions: no docs-site pointer (it would be the first in any `cli.rs` help string, and the changelog records deliberately removing unresolvable pointers from flag descriptions), so the two paired shapes are stated inline; and the `OutputFormat::UBam` variant doc was folded in rather than deferred.

Historical changelog records carrying the same stale wording are release history and deliberately untouched.
</details>

Closes #400 (manual close needed — dev is not the default branch).
