### PR TITLE
fix(main): SE uBAM trim no longer destroys a report-named input (#409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 #### Bug fixes
 
+- **`--output-format ubam` no longer destroys an input named like a trimming
+  report** ([#409](https://github.com/FelixKrueger/TrimGalore/issues/409)).
+  `trim_galore --output-format ubam sample.fastq sample.fastq_trimming_report.txt`
+  overwrote input 2 with input 1's trimming report and only then failed reading
+  it — so the error ("not recognised as FASTQ") described damage the run had just
+  caused, and gave the user no hint their file was gone. The single-end uBAM
+  arm's collision pre-flight planned only the primary `.bam` outputs; the two
+  trimming reports it also writes never entered the candidate list, so the
+  output-vs-input check could not see them. The single-end FASTQ path was never
+  affected — it routes secondaries through the same helper the pre-flight reads.
+  Fifth instance of the family behind #383, #385, #388 and #391.
+
 - **`--clump_only --paired` no longer silently overwrites one mate's clumping
   report with the other's**
   ([#391](https://github.com/FelixKrueger/TrimGalore/issues/391)). Primaries

--- a/src/main.rs
+++ b/src/main.rs
@@ -1978,11 +1978,19 @@ fn run_ubam_output(cli: &Cli, output_dir: Option<&Path>, command_line: &str) -> 
 
     // Single-end loop.
     // #383 — same hole as the FASTQ SE loop.
-    let planned: Vec<std::path::PathBuf> = cli
+    let mut planned: Vec<std::path::PathBuf> = cli
         .input
         .iter()
         .map(|input| naming::single_end_bam_output_name(input, output_dir, cli.basename.as_deref()))
         .collect();
+    // #409 — run_ubam_output_single writes both trimming reports too; without them
+    // an input named like one is overwritten before it is read.
+    if !cli.no_report_file {
+        for input in &cli.input {
+            planned.push(naming::report_name(input, output_dir));
+            planned.push(naming::json_report_name(input, output_dir));
+        }
+    }
     naming::preflight_output_collisions(&planned, &guarded_inputs(cli), None)?;
     for (i, input) in cli.input.iter().enumerate() {
         if i > 0 {

--- a/tests/integration_output_collision.rs
+++ b/tests/integration_output_collision.rs
@@ -1368,3 +1368,65 @@ fn clump_paired_bam_rejects_report_that_aliases_an_input() {
     );
     assert_dir_holds_only(&dir, &["x.fq", "y.fq", "x.fq_clumping_report.txt", "z.fq"]);
 }
+
+// ── SE uBAM-output trim: reports join the pre-flight (#409) ───────────────
+
+/// #409 — the uBAM twin of `se_trim_rejects_output_that_aliases_a_report_input`.
+/// Before the fix this run overwrote input 2 with input 1's trimming report and
+/// only then failed reading it, so the error blamed the input for not being
+/// FASTQ when the run had just made that true.
+#[test]
+fn se_trim_ubam_rejects_output_that_aliases_a_report_input() {
+    let dir = tempdir("409_ubam_alias_report");
+    write_fastq(&dir.join("sample.fastq"), "SRC");
+    write_fastq(&dir.join("sample.fastq_trimming_report.txt"), "REPORTY");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--output-format",
+            "ubam",
+            "sample.fastq",
+            "sample.fastq_trimming_report.txt",
+        ],
+    );
+    assert!(!ok, "expected rejection:\n{stderr}");
+    assert!(
+        stderr.contains(ALIAS_MSG),
+        "expected alias wording:\n{stderr}"
+    );
+    // The data-loss assertion: the victim must still hold its own reads.
+    assert_eq!(
+        count_reads_from(&dir.join("sample.fastq_trimming_report.txt"), "REPORTY"),
+        40,
+        "input 2 was overwritten — this is the #409 data loss"
+    );
+    assert_dir_holds_only(&dir, &["sample.fastq", "sample.fastq_trimming_report.txt"]);
+}
+
+/// Acceptance sibling: with reports off, nothing collides and the run proceeds.
+#[test]
+fn se_trim_ubam_accepts_report_alias_with_no_report_file() {
+    let dir = tempdir("409_ubam_alias_ok");
+    write_fastq(&dir.join("sample.fastq"), "SRC");
+    write_fastq(&dir.join("sample.fastq_trimming_report.txt"), "REPORTY");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--output-format",
+            "ubam",
+            "--no_report_file",
+            "sample.fastq",
+            "sample.fastq_trimming_report.txt",
+        ],
+    );
+    assert!(ok, "expected success:\n{stderr}");
+    assert_eq!(
+        count_reads_from(&dir.join("sample.fastq_trimming_report.txt"), "REPORTY"),
+        40
+    );
+    assert!(dir.join("sample_trimmed.bam").is_file());
+    assert!(
+        dir.join("sample.fastq_trimming_report_trimmed.bam")
+            .is_file()
+    );
+}


### PR DESCRIPTION
`trim_galore --output-format ubam sample.fastq sample.fastq_trimming_report.txt` overwrote input 2 with input 1's trimming report, then failed reading input 2 and reported that it was "not recognised as FASTQ" — an error describing damage the run had just caused. Verified: 40 reads in, 0 reads out, file replaced by a report. A user reading that error concludes they passed a bad file, not that theirs was destroyed.

The single-end uBAM arm planned only the primary `.bam` outputs, while `run_ubam_output_single` also writes `report_name` and `json_report_name`. Those never entered the candidate list, so the pre-flight's output-vs-input check couldn't see them. The single-end **FASTQ** twin was never exposed — it routes secondaries through `planned_secondary_outputs`, which the pre-flight does read. Fixed by adding both report paths to that arm's list, gated on `no_report_file` to match the writer (the #388/#391 shape).

Regression pair added, and the rejection test was confirmed to **fail against the unpatched tree** before the fix landed. 563 tests green.

<details>
<summary>AI-assisted: how this was found, and one deliberate non-choice</summary>

Found while planning #397 (pre-flight provenance), by probing the arms that change rather than reading them — five live probes against the built binary. Independently reproduced before filing.

I deliberately did **not** reuse `planned_secondary_outputs` here, even though it is the obvious helper: it interleaves reports per-input, so reusing it would reorder the FASTQ path's candidate list — and candidate order decides which path a collision message names, which existing tests rely on. Minimal shape chosen instead.

This is the **fifth** instance of the #383/#385/#388/#391 family, and worth stating plainly: a *missing* candidate is invisible to every guard currently in the tree, including the provenance typing #397 proposes (a type cannot detect an entry nobody wrote). The durable fix is deriving the candidate list and the writes from one source, or extending #391's exact-set assertion across all 11 pre-flight arms.
</details>

Closes #409 (manual close needed — dev is not the default branch).
