### PR TITLE
feat(io): collision refusals name the inputs behind each output (#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,21 @@
 
 #### Changes
 
+- **Output-collision refusals now name the inputs you have to change**
+  ([#397](https://github.com/FelixKrueger/TrimGalore/issues/397)). The pre-flight
+  compared prospective output paths without recording which input each was named
+  from, so a report collision printed the same path twice — `out/reads.fq_trimming_report.txt
+  and out/reads.fq_trimming_report.txt would be written to the same file` — and then
+  advised "rename one input" without being able to say which. Refusals now carry
+  that provenance: two inputs racing for one path name both, aliased spellings show
+  both paths *and* both sources, and an output that would clobber an input names the
+  input its output was derived from. One case gains genuinely new advice: where a
+  single file supplies two colliding candidates (a file passed as a mate of two
+  different pairs, which validation permits), "rename one input" was impossible to
+  follow, so that branch now says to list each input once. Which runs are accepted
+  or refused is unchanged.
+
+
 - **`--preserve-tags`' help no longer says "ignored" for a case that aborts**
   ([#407](https://github.com/FelixKrueger/TrimGalore/issues/407)). With all-FASTQ
   inputs it is a warning, but combined with `--output-format ubam` it is a hard

--- a/src/io.rs
+++ b/src/io.rs
@@ -85,41 +85,111 @@ pub fn collision_key(p: &Path) -> String {
 const GENERIC_ADVICE: &str = "Check that inputs produce distinct output paths \
                               (e.g., different source directories or `--output_dir`).";
 
+/// Which input(s) a planned output is named from. The pre-flight cannot tell a user to
+/// "rename one input" without it (#397).
+#[derive(Clone, Debug)]
+pub enum OutputSource {
+    /// Named from one input: reports, SE primaries, `--demux` per-barcode files.
+    Input(PathBuf),
+    /// Named from a pair. Paired primaries take the filename from one mate and the
+    /// directory from R1, so neither mate alone explains the path.
+    Pair(PathBuf, PathBuf),
+}
+
+impl OutputSource {
+    /// Case-**sensitive** identity, for "did these two candidates come from the same
+    /// input?". Folding here would call `X` and `x` one source on a case-sensitive
+    /// filesystem — the D8/D13 mistake, in a new place.
+    fn identity(&self) -> String {
+        match self {
+            OutputSource::Input(p) => path_identity_key(p),
+            // `\0` cannot occur in a path, so it cannot make two distinct pairs collide.
+            OutputSource::Pair(a, b) => {
+                format!("{}\0{}", path_identity_key(a), path_identity_key(b))
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for OutputSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OutputSource::Input(p) => write!(f, "{}", p.display()),
+            OutputSource::Pair(a, b) => write!(f, "{} + {}", a.display(), b.display()),
+        }
+    }
+}
+
+/// A prospective output path and the input(s) it is named from.
+pub type PlannedOutput = (PathBuf, OutputSource);
+
 /// Reject duplicate output paths, or an output that would overwrite an input, before
 /// any file is opened. Called by every `main.rs` dispatch path that writes more than
 /// one file: SE trim, `--paired` trim, `--hardtrim5/3`, `--clock`/`--implicon` and
 /// `--clump_only` — all four output formats. A new dispatch path needs a call here too.
+///
+/// Each candidate carries the input it is named from, so a refusal can name the files the
+/// user has to change (#397). Note what the tuple does and does not buy: it makes an
+/// *unattributed* candidate impossible, but it cannot detect a *missing* one — which is
+/// what #383, #385, #388, #391 and #409 all were.
 pub fn preflight_output_collisions(
-    planned: &[PathBuf],
+    planned: &[PlannedOutput],
     inputs: &[PathBuf],
     hint: Option<&str>,
 ) -> Result<()> {
     let input_keys: std::collections::HashMap<String, &PathBuf> =
         inputs.iter().map(|p| (collision_key(p), p)).collect();
-    let mut seen: std::collections::HashMap<String, PathBuf> =
+    let mut seen: std::collections::HashMap<String, PlannedOutput> =
         std::collections::HashMap::with_capacity(planned.len());
 
-    for p in planned {
-        let key = collision_key(p);
+    for (path, source) in planned {
+        let key = collision_key(path);
         if let Some(input) = input_keys.get(&key) {
             anyhow::bail!(
-                "Output path collision (case-insensitive, for APFS/NTFS safety): \
-                 this run would write output to {}, which is also one of its inputs. \
+                "Output path collision (case-insensitive, for APFS/NTFS safety): the output \
+                 named from {} would be written to {}, which is also one of its inputs. \
                  If that file is an earlier run's output, drop it from the input list; \
                  otherwise use `--output_dir` to write elsewhere.",
+                source,
                 input.display()
             );
         }
-        if let Some(existing) = seen.insert(key, p.clone()) {
-            // The hint replaces the generic advice; on CWD-naming modes the generic
-            // advice is false, so appending would contradict itself.
-            anyhow::bail!(
-                "Output path collision (case-insensitive, for APFS/NTFS safety): \
-                 {} and {} would be written to the same file. {}",
-                existing.display(),
-                p.display(),
-                hint.unwrap_or(GENERIC_ADVICE)
-            );
+        if let Some((prev_path, prev_source)) = seen.insert(key, (path.clone(), source.clone())) {
+            let same_path = prev_path == *path;
+            let same_source = prev_source.identity() == source.identity();
+            if same_path && same_source {
+                // 2c — one input feeding two candidates. The hint is deliberately ignored:
+                // "rename one input" cannot be followed when there is only one to rename.
+                anyhow::bail!(
+                    "Output path collision (case-insensitive, for APFS/NTFS safety): two \
+                     outputs named from {} would be written to the same file, {}. List each \
+                     input once — a file that appears in more than one pair is reported once \
+                     per pair — or pass `--no_report_file` if only the reports collide.",
+                    source,
+                    path.display()
+                );
+            } else if same_path {
+                // 2a — two sources, one rendered path: print the path once.
+                anyhow::bail!(
+                    "Output path collision (case-insensitive, for APFS/NTFS safety): the \
+                     outputs named from {} and {} would be written to the same file, {}. {}",
+                    prev_source,
+                    source,
+                    path.display(),
+                    hint.unwrap_or(GENERIC_ADVICE)
+                );
+            } else {
+                // 2b — the spellings differ (fold-equal or `./x` vs `x`), so show both.
+                anyhow::bail!(
+                    "Output path collision (case-insensitive, for APFS/NTFS safety): {} \
+                     (from {}) and {} (from {}) would be written to the same file. {}",
+                    prev_path.display(),
+                    prev_source,
+                    path.display(),
+                    source,
+                    hint.unwrap_or(GENERIC_ADVICE)
+                );
+            }
         }
     }
     Ok(())
@@ -1028,9 +1098,21 @@ mod tests {
         PathBuf::from(s)
     }
 
+    /// A planned output attributed to its own synthetic input (#397). Distinct
+    /// sources on purpose: these cases are about two *different* inputs racing for
+    /// one path, which is shape 2a/2b — `po_same` covers the one-input shape 2c.
+    fn po(s: &str) -> PlannedOutput {
+        (pb(s), OutputSource::Input(pb(&format!("src_of_{s}"))))
+    }
+
+    /// Two planned outputs from the *same* input — shape 2c.
+    fn po_from(src: &str, s: &str) -> PlannedOutput {
+        (pb(s), OutputSource::Input(pb(src)))
+    }
+
     #[test]
     fn preflight_accepts_distinct_outputs() {
-        let planned = [pb("a_trimmed.fq.gz"), pb("b_trimmed.fq.gz")];
+        let planned = [po("a_trimmed.fq.gz"), po("b_trimmed.fq.gz")];
         let inputs = [pb("a.fastq.gz"), pb("b.fastq.gz")];
         assert!(preflight_output_collisions(&planned, &inputs, None).is_ok());
     }
@@ -1039,14 +1121,14 @@ mod tests {
     fn preflight_accepts_empty_and_single() {
         assert!(preflight_output_collisions(&[], &[], None).is_ok());
         assert!(
-            preflight_output_collisions(&[pb("a_trimmed.fq.gz")], &[pb("a.fastq.gz")], None)
+            preflight_output_collisions(&[po("a_trimmed.fq.gz")], &[pb("a.fastq.gz")], None)
                 .is_ok()
         );
     }
 
     #[test]
     fn preflight_rejects_identical_outputs() {
-        let planned = [pb("x_trimmed.fq.gz"), pb("x_trimmed.fq.gz")];
+        let planned = [po("x_trimmed.fq.gz"), po("x_trimmed.fq.gz")];
         let err = preflight_output_collisions(&planned, &[], None)
             .unwrap_err()
             .to_string();
@@ -1061,7 +1143,7 @@ mod tests {
     /// in case cannot coexist on APFS.
     #[test]
     fn preflight_rejects_case_only_variants() {
-        let planned = [pb("Sample_trimmed.fq.gz"), pb("SAMPLE_trimmed.fq.gz")];
+        let planned = [po("Sample_trimmed.fq.gz"), po("SAMPLE_trimmed.fq.gz")];
         let err = preflight_output_collisions(&planned, &[], None)
             .unwrap_err()
             .to_string();
@@ -1075,7 +1157,7 @@ mod tests {
     /// one file, so the reported bug survived its own fix.
     #[test]
     fn preflight_rejects_dot_slash_alias() {
-        let planned = [pb("./x_trimmed.fq.gz"), pb("x_trimmed.fq.gz")];
+        let planned = [po("./x_trimmed.fq.gz"), po("x_trimmed.fq.gz")];
         let err = preflight_output_collisions(&planned, &[], None)
             .unwrap_err()
             .to_string();
@@ -1089,7 +1171,10 @@ mod tests {
     #[test]
     fn preflight_rejects_absolute_versus_relative_alias() {
         let abs = std::env::current_dir().unwrap().join("x_trimmed.fq.gz");
-        let planned = [abs, pb("x_trimmed.fq.gz")];
+        let planned = [
+            (abs, OutputSource::Input(pb("src_abs"))),
+            po("x_trimmed.fq.gz"),
+        ];
         let err = preflight_output_collisions(&planned, &[], None)
             .unwrap_err()
             .to_string();
@@ -1099,11 +1184,36 @@ mod tests {
         );
     }
 
+    /// #397 shape 2c — two candidates from ONE input. "Rename one input" cannot be
+    /// followed here, so this branch supplies its own advice and ignores the
+    /// call-site hint, exactly as the output-vs-input branch already does.
+    #[test]
+    fn preflight_same_source_collision_replaces_the_advice() {
+        let planned = [
+            po_from("d/x.fq", "d/x.fq_report.txt"),
+            po_from("d/x.fq", "d/x.fq_report.txt"),
+        ];
+        let err = preflight_output_collisions(&planned, &[], Some("EXTRA-HINT."))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("would be written to the same file"),
+            "got: {err}"
+        );
+        assert!(err.contains("List each input once"), "got: {err}");
+        assert!(
+            !err.contains("EXTRA-HINT.") && !err.contains("different source directories"),
+            "2c supplies its own advice and must not carry the hint: {err}"
+        );
+        // The one source is named, and the path appears once, not twice.
+        assert!(err.contains("d/x.fq"), "got: {err}");
+    }
+
     /// REGRESSION (#383). An output that would overwrite an input gets its own
     /// message: "same file" is untrue here and its remedies do not apply.
     #[test]
     fn preflight_rejects_output_that_aliases_an_input() {
-        let planned = [pb("s_trimmed.fq.gz")];
+        let planned = [po("s_trimmed.fq.gz")];
         let inputs = [pb("s.fastq.gz"), pb("s_trimmed.fq.gz")];
         let err = preflight_output_collisions(&planned, &inputs, None)
             .unwrap_err()
@@ -1121,7 +1231,7 @@ mod tests {
     /// The alias check is keyed the same way, so a `./` spelling still catches it.
     #[test]
     fn preflight_rejects_input_alias_across_spellings() {
-        let planned = [pb("./s_trimmed.fq.gz")];
+        let planned = [po("./s_trimmed.fq.gz")];
         let inputs = [pb("s_trimmed.fq.gz")];
         assert!(preflight_output_collisions(&planned, &inputs, None).is_err());
     }
@@ -1131,7 +1241,7 @@ mod tests {
     /// reported bug reproducing through its own fix.
     #[test]
     fn preflight_rejects_dotdot_alias() {
-        let planned = [pb("a/../x_trimmed.fq.gz"), pb("x_trimmed.fq.gz")];
+        let planned = [po("a/../x_trimmed.fq.gz"), po("x_trimmed.fq.gz")];
         assert!(preflight_output_collisions(&planned, &[], None).is_err());
     }
 
@@ -1139,13 +1249,19 @@ mod tests {
     /// differing only below a kept `..` stay distinct.
     #[test]
     fn preflight_keeps_unfoldable_paths_distinct() {
-        let planned = [pb("../x_trimmed.fq.gz"), pb("../y_trimmed.fq.gz")];
+        let planned = [po("../x_trimmed.fq.gz"), po("../y_trimmed.fq.gz")];
         assert!(preflight_output_collisions(&planned, &[], None).is_ok());
     }
 
     #[test]
     fn preflight_appends_hint_only_when_given() {
-        let planned = [pb("x_trimmed.fq.gz"), pb("x_trimmed.fq.gz")];
+        // Two *different* inputs racing for one path — shape 2a, which is where the
+        // hint applies. Shape 2c (one input, two candidates) deliberately carries
+        // neither hint nor generic advice; pinned separately below.
+        let planned = [
+            po_from("srcA.fq", "x_trimmed.fq.gz"),
+            po_from("srcB.fq", "x_trimmed.fq.gz"),
+        ];
         let with = preflight_output_collisions(&planned, &[], Some("EXTRA-HINT."))
             .unwrap_err()
             .to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,20 +92,23 @@ fn planned_secondary_outputs(
     cli: &Cli,
     output_dir: Option<&Path>,
     gzip: bool,
-) -> Result<Vec<std::path::PathBuf>> {
+) -> Result<Vec<naming::PlannedOutput>> {
     let mut v = Vec::new();
     for input in &cli.input {
+        let src = || naming::OutputSource::Input(input.clone());
         if !cli.no_report_file {
-            v.push(naming::report_name(input, output_dir));
-            v.push(naming::json_report_name(input, output_dir));
+            v.push((naming::report_name(input, output_dir), src()));
+            v.push((naming::json_report_name(input, output_dir), src()));
         }
         if let Some(ref barcode_file) = cli.demux {
             let barcodes = demux::read_barcode_file(barcode_file)?;
             let trimmed =
                 naming::single_end_output_name(input, output_dir, cli.basename.as_deref(), gzip);
-            v.extend(demux::demux_output_paths(
-                &trimmed, &barcodes, gzip, output_dir,
-            ));
+            v.extend(
+                demux::demux_output_paths(&trimmed, &barcodes, gzip, output_dir)
+                    .into_iter()
+                    .map(|p| (p, src())),
+            );
         }
     }
     Ok(v)
@@ -119,13 +122,19 @@ fn clump_report_candidates(
     no_report_file: bool,
     report_inputs: &[impl AsRef<Path>],
     output_dir: Option<&Path>,
-) -> Vec<std::path::PathBuf> {
+) -> Vec<naming::PlannedOutput> {
     if no_report_file {
         return Vec::new();
     }
     report_inputs
         .iter()
-        .map(|input| naming::clumping_report_name(input.as_ref(), output_dir))
+        .map(|input| {
+            let input = input.as_ref();
+            (
+                naming::clumping_report_name(input, output_dir),
+                naming::OutputSource::Input(input.to_path_buf()),
+            )
+        })
         .collect()
 }
 
@@ -136,16 +145,19 @@ fn planned_hardtrim_outputs(
     end: specialty::HardtrimEnd,
     output_dir: Option<&Path>,
     gzip: bool,
-) -> Vec<std::path::PathBuf> {
+) -> Vec<naming::PlannedOutput> {
     cli.input
         .iter()
-        .map(|input| match cli.output_format {
-            trim_galore::cli::OutputFormat::Fastq => {
-                specialty::hardtrim_output_name(input, keep, end, output_dir, gzip)
-            }
-            trim_galore::cli::OutputFormat::UBam => {
-                specialty::hardtrim_bam_output_name(input, keep, end, output_dir)
-            }
+        .map(|input| {
+            let path = match cli.output_format {
+                trim_galore::cli::OutputFormat::Fastq => {
+                    specialty::hardtrim_output_name(input, keep, end, output_dir, gzip)
+                }
+                trim_galore::cli::OutputFormat::UBam => {
+                    specialty::hardtrim_bam_output_name(input, keep, end, output_dir)
+                }
+            };
+            (path, naming::OutputSource::Input(input.clone()))
         })
         .collect()
 }
@@ -485,9 +497,16 @@ fn main() -> Result<()> {
             "Clock",
             Some(CWD_OUTPUT_HINT),
             |r1, r2| {
+                let src = naming::OutputSource::Pair(r1.to_path_buf(), r2.to_path_buf());
                 vec![
-                    specialty::clock_output_name(r1, "R1", output_dir, gzip),
-                    specialty::clock_output_name(r2, "R2", output_dir, gzip),
+                    (
+                        specialty::clock_output_name(r1, "R1", output_dir, gzip),
+                        src.clone(),
+                    ),
+                    (
+                        specialty::clock_output_name(r2, "R2", output_dir, gzip),
+                        src,
+                    ),
                 ]
             },
             |r1, r2| specialty::clock(r1, r2, gzip, output_dir, cli.cores, cli.compression),
@@ -500,9 +519,16 @@ fn main() -> Result<()> {
             "IMPLICON",
             Some(CWD_OUTPUT_HINT),
             |r1, r2| {
+                let src = naming::OutputSource::Pair(r1.to_path_buf(), r2.to_path_buf());
                 vec![
-                    specialty::implicon_output_name(r1, umi_len, "R1", output_dir, gzip),
-                    specialty::implicon_output_name(r2, umi_len, "R2", output_dir, gzip),
+                    (
+                        specialty::implicon_output_name(r1, umi_len, "R1", output_dir, gzip),
+                        src.clone(),
+                    ),
+                    (
+                        specialty::implicon_output_name(r2, umi_len, "R2", output_dir, gzip),
+                        src,
+                    ),
                 ]
             },
             |r1, r2| {
@@ -554,7 +580,9 @@ fn main() -> Result<()> {
                             let (o1, o2) = naming::clumped_paired_output_names(
                                 r1, r2, output_dir, basename, gzip,
                             );
-                            let mut v = vec![o1, o2];
+                            let src =
+                                naming::OutputSource::Pair(r1.to_path_buf(), r2.to_path_buf());
+                            let mut v = vec![(o1, src.clone()), (o2, src)];
                             v.extend(clump_report_candidates(
                                 cli.no_report_file,
                                 &[r1, r2],
@@ -581,10 +609,15 @@ fn main() -> Result<()> {
                     )?;
                 } else {
                     // SE FASTQ pre-flight (issues #216, #383).
-                    let mut planned: Vec<std::path::PathBuf> = cli
+                    let mut planned: Vec<naming::PlannedOutput> = cli
                         .input
                         .iter()
-                        .map(|input| naming::clumped_output_name(input, output_dir, basename, gzip))
+                        .map(|input| {
+                            (
+                                naming::clumped_output_name(input, output_dir, basename, gzip),
+                                naming::OutputSource::Input(input.clone()),
+                            )
+                        })
                         .collect();
                     // #391 — reports join so the input check covers them too.
                     planned.extend(clump_report_candidates(
@@ -621,11 +654,14 @@ fn main() -> Result<()> {
                         // its condition is a strict subset of the `--paired`
                         // N=1 non-BAM guard in main() — and was retired with
                         // #363. Retained note so the absence is intentional.
-                        let mut planned = vec![naming::clumped_paired_bam_output_name(
-                            &cli.input[0],
-                            None,
-                            output_dir,
-                            basename,
+                        let mut planned = vec![(
+                            naming::clumped_paired_bam_output_name(
+                                &cli.input[0],
+                                None,
+                                output_dir,
+                                basename,
+                            ),
+                            naming::OutputSource::Input(cli.input[0].clone()),
                         )];
                         // #391 — defensive symmetry: with one input the report (filename
                         // plus a suffix) can never alias it; the arm keeps its siblings' shape.
@@ -658,13 +694,16 @@ fn main() -> Result<()> {
                         // two-BAM-vs-mixed distinction right, and the model for
                         // the shared helper (#363).
                         // Multi-pair collision pre-flight (case-folded per issue #216).
-                        let mut planned: Vec<std::path::PathBuf> = Vec::new();
+                        let mut planned: Vec<naming::PlannedOutput> = Vec::new();
                         for chunk in cli.input.chunks(2) {
-                            planned.push(naming::clumped_paired_bam_output_name(
-                                &chunk[0],
-                                Some(&chunk[1]),
-                                output_dir,
-                                basename,
+                            planned.push((
+                                naming::clumped_paired_bam_output_name(
+                                    &chunk[0],
+                                    Some(&chunk[1]),
+                                    output_dir,
+                                    basename,
+                                ),
+                                naming::OutputSource::Pair(chunk[0].clone(), chunk[1].clone()),
                             ));
                             // #391 — ONE report per pair, keyed on the pair's first input
                             // (clump_only.rs writes clumping_report_name(inputs[0], …)).
@@ -718,9 +757,12 @@ fn main() -> Result<()> {
                     }
                 } else {
                     // SE BAM. Case-folded collision pre-flight across inputs.
-                    let mut planned: Vec<std::path::PathBuf> = Vec::new();
+                    let mut planned: Vec<naming::PlannedOutput> = Vec::new();
                     for input in &cli.input {
-                        planned.push(naming::clumped_bam_output_name(input, output_dir, basename));
+                        planned.push((
+                            naming::clumped_bam_output_name(input, output_dir, basename),
+                            naming::OutputSource::Input(input.clone()),
+                        ));
                     }
                     // #391 — reports join so the input check covers them too.
                     planned.extend(clump_report_candidates(
@@ -788,7 +830,7 @@ fn main() -> Result<()> {
 
     if cli.paired {
         // Pre-flight across pairs before any I/O; see io::collision_key for the key.
-        let mut planned: Vec<std::path::PathBuf> = Vec::new();
+        let mut planned: Vec<naming::PlannedOutput> = Vec::new();
         for chunk in cli.input.chunks(2) {
             let (o1, o2) = naming::paired_end_output_names(
                 &chunk[0],
@@ -797,7 +839,12 @@ fn main() -> Result<()> {
                 cli.basename.as_deref(),
                 gzip,
             );
-            let mut candidates = vec![o1, o2];
+            // Uniform Pair for paired primaries (#397 decision C2): _val_1 takes its
+            // stem from R1 but its directory from R1 too, and _val_2 mixes both — naming
+            // one mate would encode a claim about which supplies the directory, which is
+            // exactly what #398 may change.
+            let pair_src = naming::OutputSource::Pair(chunk[0].clone(), chunk[1].clone());
+            let mut candidates = vec![(o1, pair_src.clone()), (o2, pair_src.clone())];
             if cli.retain_unpaired {
                 let (u1, u2) = naming::unpaired_output_names(
                     &chunk[0],
@@ -806,27 +853,31 @@ fn main() -> Result<()> {
                     cli.basename.as_deref(),
                     gzip,
                 );
-                candidates.push(u1);
-                candidates.push(u2);
+                candidates.push((u1, pair_src.clone()));
+                candidates.push((u2, pair_src));
             }
             // --passthrough adds a third output path per pair. v1 only
             // supports a single pair (Cli::validate enforces input.len() == 2
             // when passthrough is set), so this either contributes zero or
             // one extra candidate to the collision set.
             if let Some(ref pt_input) = cli.passthrough {
-                candidates.push(naming::passthrough_output_name(
-                    pt_input,
-                    output_dir,
-                    cli.basename.as_deref(),
-                    gzip,
+                candidates.push((
+                    naming::passthrough_output_name(
+                        pt_input,
+                        output_dir,
+                        cli.basename.as_deref(),
+                        gzip,
+                    ),
+                    naming::OutputSource::Input(pt_input.clone()),
                 ));
             }
             // #388 — report names carry no _val_ discriminator, so two inputs
             // with distinct primaries can still collide on reports.
             if !cli.no_report_file {
                 for input in [&chunk[0], &chunk[1]] {
-                    candidates.push(naming::report_name(input, output_dir));
-                    candidates.push(naming::json_report_name(input, output_dir));
+                    let src = naming::OutputSource::Input(input.clone());
+                    candidates.push((naming::report_name(input, output_dir), src.clone()));
+                    candidates.push((naming::json_report_name(input, output_dir), src));
                 }
             }
             planned.extend(candidates);
@@ -893,11 +944,19 @@ fn main() -> Result<()> {
         // Single-end: process each input file independently
         // (matches Perl TrimGalore behavior of looping over all positional args)
         // #383 — SE trim was the only trim path without the #216 pre-flight.
-        let planned: Vec<std::path::PathBuf> = cli
+        let planned: Vec<naming::PlannedOutput> = cli
             .input
             .iter()
             .map(|input| {
-                naming::single_end_output_name(input, output_dir, cli.basename.as_deref(), gzip)
+                (
+                    naming::single_end_output_name(
+                        input,
+                        output_dir,
+                        cli.basename.as_deref(),
+                        gzip,
+                    ),
+                    naming::OutputSource::Input(input.clone()),
+                )
             })
             .collect();
         let mut planned = planned;
@@ -1919,19 +1978,23 @@ fn run_ubam_output(cli: &Cli, output_dir: Option<&Path>, command_line: &str) -> 
         // two-BAM case from the mixed case (#363). The per-pair loop that used to
         // stand here emitted the two-BAM message for either.
         // Pre-flight: one BAM output per pair; collision on case-folded path.
-        let mut planned: Vec<std::path::PathBuf> = Vec::new();
+        let mut planned: Vec<naming::PlannedOutput> = Vec::new();
         for chunk in cli.input.chunks(2) {
-            planned.push(naming::paired_bam_output_name(
-                &chunk[0],
-                &chunk[1],
-                output_dir,
-                cli.basename.as_deref(),
+            planned.push((
+                naming::paired_bam_output_name(
+                    &chunk[0],
+                    &chunk[1],
+                    output_dir,
+                    cli.basename.as_deref(),
+                ),
+                naming::OutputSource::Pair(chunk[0].clone(), chunk[1].clone()),
             ));
             // #388 — same report-collision hole as the FASTQ paired path.
             if !cli.no_report_file {
                 for input in [&chunk[0], &chunk[1]] {
-                    planned.push(naming::report_name(input, output_dir));
-                    planned.push(naming::json_report_name(input, output_dir));
+                    let src = naming::OutputSource::Input(input.clone());
+                    planned.push((naming::report_name(input, output_dir), src.clone()));
+                    planned.push((naming::json_report_name(input, output_dir), src));
                 }
             }
         }
@@ -1978,17 +2041,23 @@ fn run_ubam_output(cli: &Cli, output_dir: Option<&Path>, command_line: &str) -> 
 
     // Single-end loop.
     // #383 — same hole as the FASTQ SE loop.
-    let mut planned: Vec<std::path::PathBuf> = cli
+    let mut planned: Vec<naming::PlannedOutput> = cli
         .input
         .iter()
-        .map(|input| naming::single_end_bam_output_name(input, output_dir, cli.basename.as_deref()))
+        .map(|input| {
+            (
+                naming::single_end_bam_output_name(input, output_dir, cli.basename.as_deref()),
+                naming::OutputSource::Input(input.clone()),
+            )
+        })
         .collect();
     // #409 — run_ubam_output_single writes both trimming reports too; without them
     // an input named like one is overwritten before it is read.
     if !cli.no_report_file {
         for input in &cli.input {
-            planned.push(naming::report_name(input, output_dir));
-            planned.push(naming::json_report_name(input, output_dir));
+            let src = naming::OutputSource::Input(input.clone());
+            planned.push((naming::report_name(input, output_dir), src.clone()));
+            planned.push((naming::json_report_name(input, output_dir), src));
         }
     }
     naming::preflight_output_collisions(&planned, &guarded_inputs(cli), None)?;
@@ -2543,11 +2612,11 @@ fn run_specialty_paired<NameFn, RunFn>(
     mut run_pair: RunFn,
 ) -> Result<()>
 where
-    NameFn: FnMut(&Path, &Path) -> Vec<std::path::PathBuf>,
+    NameFn: FnMut(&Path, &Path) -> Vec<naming::PlannedOutput>,
     RunFn: FnMut(&Path, &Path) -> Result<()>,
 {
     // Pre-flight across pairs before any I/O; see io::collision_key for the key.
-    let mut planned: Vec<std::path::PathBuf> = Vec::new();
+    let mut planned: Vec<naming::PlannedOutput> = Vec::new();
     for chunk in cli.input.chunks(2) {
         planned.extend(pair_outputs(&chunk[0], &chunk[1]));
     }

--- a/tests/integration_output_collision.rs
+++ b/tests/integration_output_collision.rs
@@ -874,9 +874,41 @@ fn paired_rejects_same_filename_r1_r2_into_shared_output_dir() {
         stderr.contains(DUP_MSG),
         "expected collision wording:\n{stderr}"
     );
+    // #397 — the message must name BOTH inputs the user has to choose between.
+    // Before provenance it printed the colliding path twice and named neither.
+    assert!(
+        stderr.contains("A/reads.fq") && stderr.contains("B/reads.fq"),
+        "the refusal must name both source inputs:\n{stderr}"
+    );
     assert!(
         std::fs::read_dir(&out).unwrap().next().is_none(),
         "a refused run must write nothing"
+    );
+}
+
+/// #397 — one file passed as a mate of two different pairs. `validate` permits it
+/// (only exact duplicate pairs are rejected), and the old message told the user to
+/// "rename one input", which cannot be done for a file colliding with itself.
+#[test]
+fn paired_one_file_in_two_pairs_gets_followable_advice() {
+    let dir = tempdir("397_same_source");
+    write_fastq(&dir.join("A.fq"), "A");
+    write_fastq(&dir.join("B.fq"), "B");
+    write_fastq(&dir.join("C.fq"), "C");
+    let (ok, stderr) = run_in(&dir, &["--paired", "A.fq", "B.fq", "B.fq", "C.fq"]);
+    assert!(!ok, "expected rejection:\n{stderr}");
+    assert!(stderr.contains(DUP_MSG), "got:\n{stderr}");
+    assert!(
+        stderr.contains("two outputs named from") && stderr.contains("B.fq"),
+        "must attribute both candidates to the one input:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("List each input once"),
+        "must give advice that can actually be followed:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("rename one input"),
+        "the unfollowable advice must be gone:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
The pre-flight hashed prospective output paths without recording which input each was named from, so its advice could not be followed. A report collision printed the same path twice —

```
out/reads.fq_trimming_report.txt and out/reads.fq_trimming_report.txt would be
written to the same file … rename one input
```

— and then told the user to rename an input it could not name. Now:

```
the outputs named from a/reads.fq and b/reads.fq would be written to the same
file, out/reads.fq_trimming_report.txt
```

`preflight_output_collisions` takes `&[(PathBuf, OutputSource)]`, where `OutputSource` is `Input(p)` or `Pair(a, b)`. Four message shapes: output-vs-input names the input the offending output derives from; two sources sharing one rendered path name both and print the path once; differing spellings (fold-equal, or `./x` vs `x`) show both paths with their sources; and **one input feeding two candidates gets its own advice**.

That last shape is the new behaviour and the reason it was in scope: `trim_galore --paired A.fq B.fq B.fq C.fq` is permitted by validation (only *exact* duplicate pairs are rejected) and was refused with advice nobody could act on, since a file cannot be renamed apart from itself. It now says to list each input once.

Which runs are accepted or refused is unchanged. Every pinned substring is preserved — `PREFIX`, `DUP_MSG`, `ALIAS_MSG`, and the CI-grepped `case-insensitive, for APFS/NTFS safety` — so no existing assertion or `ci.yml` grep changes. 570 tests green.

<details>
<summary>AI-assisted: the design decisions, and an honest limit on what the type buys</summary>

Scope was 11 call sites, 4 helper signatures, 13 test call expressions — mapped by a planning pass, then re-derived from the compiler rather than trusted, since two merges had shifted the plan's line numbers.

**Paired primaries use a uniform `Pair` source** rather than the more pointed `Input(r1)` for `_val_1`. `Input(r1)` is exact today, but it encodes a claim about which mate supplies the directory — precisely what #398 may change. Uniform `Pair` keeps this landable before #398 is decided. The clump paired-BAM per-pair report keeps `Input(chunk[0])` despite its siblings saying `Pair`, because R1 genuinely is the source there and renaming R2 would not resolve the collision; truthful beats symmetric.

**What the type does not buy.** It makes an *unattributed* candidate impossible, but it cannot detect a *missing* one — which is what #383, #385, #388, #391 and #409 all were. The durable fix for that family is one derivation feeding both the candidate list and the writers, or #391's exact-set assertion extended across all 11 arms. Recorded in the function's own doc comment so the next reader isn't misled about the guarantee.

One test needed re-scoping rather than fixing: `preflight_appends_hint_only_when_given` began failing because my test helper derived each source from its path, so two identical paths produced the *same* source and correctly landed in the one-input shape — which ignores the hint by design. Re-scoped to the two-source shape, with a separate test pinning the hint-suppression. Had I "fixed" it by making that shape carry the hint, I'd have reintroduced the unfollowable advice.
</details>

Closes #397 (manual close needed — dev is not the default branch).
