### PR TITLE
fix(main): refuse --rename into uBAM where the annotation cannot be represented (#408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@
 
 #### Bug fixes
 
+- **`--rename` was neutralised by `--output-format ubam` on FASTQ input, with no
+  flag-specific diagnostic**
+  ([#408](https://github.com/FelixKrueger/TrimGalore/issues/408)). `--rename`
+  appends `:clip5:SEQ`/`:clip3:SEQ` to the end of the read ID. When a FASTQ header
+  carries text after the first space the annotation lands inside that text — and
+  BAM read names cannot contain whitespace, so the whole tail was discarded and
+  the explicitly-requested annotation went with it. The combination is now refused
+  when at least one input is FASTQ, including on the `--hardtrim5`/`--hardtrim3`
+  paths, which reach the same annotation code via `specialty.rs`. **uBAM input is
+  unaffected and keeps working**: BAM read names carry no description by spec, so
+  there the annotation lands on the name itself and preserved aux tags round-trip
+  intact. The header-description notice added for #406 did report the dropped
+  text, but a user who passed `--rename` had no reason to connect a general note
+  about header descriptions to their own annotation being gone. The output guide
+  is corrected alongside: it described `--rename` as `--rename PREFIX` replacing
+  the output filename stem, which is `--basename` — a flag the guide did not
+  document at all.
+
 - **`--output-format ubam` no longer destroys an input named like a trimming
   report** ([#409](https://github.com/FelixKrueger/TrimGalore/issues/409)).
   `trim_galore --output-format ubam sample.fastq sample.fastq_trimming_report.txt`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,24 @@
   carries text after the first space the annotation lands inside that text — and
   BAM read names cannot contain whitespace, so the whole tail was discarded and
   the explicitly-requested annotation went with it. The combination is now refused
-  when at least one input is FASTQ, including on the `--hardtrim5`/`--hardtrim3`
-  paths, which reach the same annotation code via `specialty.rs`. **uBAM input is
+  when at least one input is FASTQ **and** a clipping flag is set, including on the
+  `--hardtrim5`/`--hardtrim3` paths, which reach the same annotation code via
+  `specialty.rs`. `--rename` on its own appends nothing, so that case is still
+  accepted — a wrapper that passes the flag unconditionally alongside an optional
+  `--clip_R1` keeps working in its no-clip configuration. **uBAM input is
   unaffected and keeps working**: BAM read names carry no description by spec, so
   there the annotation lands on the name itself and preserved aux tags round-trip
-  intact. The header-description notice added for #406 did report the dropped
-  text, but a user who passed `--rename` had no reason to connect a general note
-  about header descriptions to their own annotation being gone. The output guide
-  is corrected alongside: it described `--rename` as `--rename PREFIX` replacing
-  the output filename stem, which is `--basename` — a flag the guide did not
-  document at all.
+  intact. Whether a given header loses the annotation is a per-record property, so
+  the refusal is deliberately coarser than the loss; deciding per record would mean
+  failing part-way through a BAM. The header-description notice added for #406 did
+  report the dropped text, but a user who passed `--rename` had no reason to
+  connect a general note about header descriptions to their own annotation being
+  gone. The output guide is corrected alongside: it described `--rename` as
+  `--rename PREFIX` replacing the input filename stem in the output names, which is
+  `--basename` — a flag with no dedicated section in the output guide, though it is
+  documented on the clump-only and passthrough pages. `--basename`'s own limits are
+  now stated too: reports keep input-derived names, and the specialty modes ignore
+  it.
 
 - **`--output-format ubam` no longer destroys an input named like a trimming
   report** ([#409](https://github.com/FelixKrueger/TrimGalore/issues/409)).

--- a/docs/src/content/docs/guide/outputs.md
+++ b/docs/src/content/docs/guide/outputs.md
@@ -95,7 +95,7 @@ Most FASTQ-shaped features work with uBAM output. Rejected at startup, before an
 - `--passthrough` — carrier FASTQ shape is FASTQ-specific
 - `--retain_unpaired` — would produce singleton BAMs; not in v1
 - `--clumpify` — in-place reorder is FASTQ-shape-specific (note: `--clump_only --output-format ubam` **is** supported — see [Clump-only](/modes/clump-only/))
-- `--rename` — **only when at least one input is FASTQ.** The `:clip5:`/`:clip3:` annotation is appended to the end of the read ID, so a FASTQ header carrying text after the first space puts the annotation inside that text — and BAM read names cannot contain whitespace, so none of that tail survives. uBAM input is accepted: BAM read names carry no description, so the annotation lands on the name itself. This one is checked after input-format detection rather than at CLI-validate time, because the rule depends on the format
+- `--rename` — only when at least one input is FASTQ, and only when a clipping flag is set; uBAM input is accepted (see [Annotating read IDs](#annotating-read-ids) below)
 
 ## Output directory
 
@@ -103,11 +103,22 @@ Most FASTQ-shaped features work with uBAM output. Rejected at startup, before an
 
 ## Custom output basename
 
-`--basename BASE` replaces the input filename stem in the output names — `BASE_trimmed.fq.gz` for single-end, `BASE_val_1.fq.gz` / `BASE_val_2.fq.gz` for paired-end. Useful for pipelines that thread sample IDs through trimming separately from input filenames. Only valid for one file (single-end) or one pair (paired-end); longer input lists are refused, because the output naming would be ambiguous.
+`--basename BASE` replaces the input filename stem in the **trimmed output** names:
+
+| Mode | Output |
+|------|--------|
+| Single-end | `BASE_trimmed.fq.gz`, or `BASE_trimmed.bam` with `--output-format ubam` |
+| Paired-end | `BASE_val_1.fq.gz` / `BASE_val_2.fq.gz`, or a single `BASE_val.bam` with `--output-format ubam` |
+
+Useful for pipelines that thread sample IDs through trimming separately from input filenames. Only valid for one file (single-end) or one pair (paired-end); longer input lists are refused, because the output naming would be ambiguous.
+
+Two limits worth knowing. Trimming reports keep their input-derived names (`INPUT_trimming_report.txt`) rather than following `BASE` — matching v0.6.x. And the specialty modes (`--hardtrim5/3`, `--clock`, `--implicon`) ignore `--basename` entirely; their outputs are always named from the input's basename.
 
 ## Annotating read IDs
 
-`--rename` does not affect filenames. It is a boolean that appends `:clip5:SEQ` and/or `:clip3:SEQ` to the **read IDs**, recording the bases removed by `--clip_R1/R2`, `--three_prime_clip_R1/R2` or `--hardtrim5/3` — each half only when that side was clipped. Commonly used to keep UMIs recoverable downstream. Not available with `--output-format ubam` when any input is FASTQ (see [Feature compatibility](#feature-compatibility) above).
+`--rename` does not affect filenames. It is a boolean that appends `:clip5:SEQ` and/or `:clip3:SEQ` to the **read IDs**, recording the bases removed by `--clip_R1/R2`, `--three_prime_clip_R1/R2` or `--hardtrim5/3` — each half only when that side was clipped. Without one of those flags it appends nothing. Commonly used to keep UMIs recoverable downstream.
+
+Two combinations are refused. `--clump_only` rejects `--rename` at any output format, because it preserves record contents byte-identically. And `--output-format ubam` rejects it when **at least one input is FASTQ** and a clipping flag is set: the annotation is appended to the end of the read ID, so a header carrying text after the first space puts the annotation inside that text, and BAM read names cannot contain whitespace, so none of that tail reaches the output. Whether that happens depends on the individual header, so the whole run is refused rather than decided per record — a mid-stream refusal would leave a partial BAM. uBAM input is accepted: BAM read names carry no description, so there the annotation lands on the name itself.
 
 ## FastQC
 

--- a/docs/src/content/docs/guide/outputs.md
+++ b/docs/src/content/docs/guide/outputs.md
@@ -87,7 +87,7 @@ FASTQ input has no source tags to carry, so `--preserve-tags` does nothing there
 
 ### Feature compatibility
 
-Most FASTQ-shaped features work with uBAM output. Rejected at CLI-validate time (v1 scope):
+Most FASTQ-shaped features work with uBAM output. Rejected at startup, before anything is written (v1 scope):
 
 - `--dont_gzip` — gzip flag is FASTQ-output-specific; uBAM is BGZF-framed unconditionally
 - `--clock`, `--implicon` — specialty modes encode UMI in the FASTQ header, which can't round-trip through the BAM record
@@ -95,14 +95,19 @@ Most FASTQ-shaped features work with uBAM output. Rejected at CLI-validate time 
 - `--passthrough` — carrier FASTQ shape is FASTQ-specific
 - `--retain_unpaired` — would produce singleton BAMs; not in v1
 - `--clumpify` — in-place reorder is FASTQ-shape-specific (note: `--clump_only --output-format ubam` **is** supported — see [Clump-only](/modes/clump-only/))
+- `--rename` — **only when at least one input is FASTQ.** The `:clip5:`/`:clip3:` annotation is appended to the end of the read ID, so a FASTQ header carrying text after the first space puts the annotation inside that text — and BAM read names cannot contain whitespace, so none of that tail survives. uBAM input is accepted: BAM read names carry no description, so the annotation lands on the name itself. This one is checked after input-format detection rather than at CLI-validate time, because the rule depends on the format
 
 ## Output directory
 
 `--output_dir DIR` writes outputs to `DIR/` instead of the current working directory. The trimmed FASTQ filename stem is unchanged; only the parent directory differs.
 
-## Renaming outputs
+## Custom output basename
 
-`--rename PREFIX` replaces the input filename stem in the output names. Useful for pipelines that thread sample IDs through trimming separately from input filenames.
+`--basename BASE` replaces the input filename stem in the output names — `BASE_trimmed.fq.gz` for single-end, `BASE_val_1.fq.gz` / `BASE_val_2.fq.gz` for paired-end. Useful for pipelines that thread sample IDs through trimming separately from input filenames. Only valid for one file (single-end) or one pair (paired-end); longer input lists are refused, because the output naming would be ambiguous.
+
+## Annotating read IDs
+
+`--rename` does not affect filenames. It is a boolean that appends `:clip5:SEQ` and/or `:clip3:SEQ` to the **read IDs**, recording the bases removed by `--clip_R1/R2`, `--three_prime_clip_R1/R2` or `--hardtrim5/3` — each half only when that side was clipped. Commonly used to keep UMIs recoverable downstream. Not available with `--output-format ubam` when any input is FASTQ (see [Feature compatibility](#feature-compatibility) above).
 
 ## FastQC
 

--- a/plans/08092026_rename-ubam-rejection/CODE_REVIEW_A.md
+++ b/plans/08092026_rename-ubam-rejection/CODE_REVIEW_A.md
@@ -1,0 +1,461 @@
+# Code Review A — `fix/408-rename-ubam-rejection` @ `3f1b0fe`
+
+**Reviewer:** A (independent; no shared state with Reviewer B)
+**Target:** `git diff dev...HEAD` — one commit, `3f1b0fe`
+**Base:** `aa9f764` (dev)
+**Date:** 2026-08-09
+**Constraint honoured:** no fixes applied, no tracked file modified, no branch switch. Control build made
+via `git archive aa9f764 | tar -x -C $TMPDIR/tg408_ctrl` (no worktree, no `.git` mutation).
+
+---
+
+## Summary
+
+The change is small, correctly sited, and does what it says: one `anyhow::bail!` on the startup path,
+plus docs/CHANGELOG/test surface. No output-producing code path is touched. I independently confirmed
+the core mechanism, the siting property ("nothing written"), the uBAM-input acceptance path (annotation
+really does reach the QNAME, in SE *and* interleaved PE), the hardtrim arm, the `--clump_only`
+ordering, and the plan's un-asked-for claim that `--hardtrim5 20 --rename` genuinely annotates on the
+FASTQ path. The `bam.rs` doc-comment reasoning is sound. The docs `--basename` / `--rename` sections
+match `cli.rs`. Every factual claim I could check in the CHANGELOG entry is true, including the
+`#406`-notice claim.
+
+Two findings are worth acting on, both about *diagnostics* rather than correctness:
+
+1. **The refusal pre-empts two more-specific structural errors** (`--paired` with a single FASTQ;
+   `--paired` with a mixed FASTQ+uBAM pair). The user gets a lecture about `:clip5:`
+   representability when their real problem is a forgotten R2 or a mis-typed filename. This is the
+   *same* defect class the plan congratulates itself for avoiding with `--clump_only` — and the fix is
+   the same move: site the gate a few lines later, still ahead of `ensure_output_dir`. **CONFIRMED by
+   running both invocations with and without `--rename`.**
+2. **The message's headline clause is false for a describable share of real input.** A FASTQ whose
+   headers carry no description loses nothing today — I ran it on the control build and the QNAME came
+   out `plainhdr:clip5:ACG` — yet the message opens with "`--rename` cannot be honoured … when any
+   input is FASTQ". The body hedges correctly ("whenever a FASTQ header carries text after the first
+   space"), so the message contradicts itself within four lines. The *gate* is defensible (per-record
+   knowledge isn't available up front); the *wording* asserts more than the code knows.
+
+Everything else is nits.
+
+---
+
+## Verification performed
+
+| # | What I ran | Result |
+|---|---|---|
+| V1 | `cargo build --release` on the branch | clean |
+| V2 | control build at `aa9f764` from `git archive` | clean; guard-string count in `src/main.rs` = 0 |
+| V3 | patched: `--rename --clip_R1 3 --output-format ubam sp.fastq` | exit 1, refusal message |
+| V4 | patched, `-o $D/should_not_exist`, no other args | exit 1; **cwd unchanged, `-o` dir not created** |
+| V5 | patched: `--clip_R1 5 --rename --output-format ubam test_files/ubam_test_with_tags.bam` | exit 0; QNAMEs `SRR24827378.1:clip5:AATTA` … ; `UB` present |
+| V6 | patched: `--paired --clip_R1 5 --rename --output-format ubam test_files/ubam_paired_test.bam` | exit 0; interleaved out, R1 `…:clip5:AATTA` flag `0x4d`, R2 unannotated `0x8d` — correct (only R1 clipped) |
+| V7 | patched: mixed FASTQ+uBAM, both argument orders | exit 1 both ways |
+| V8 | patched: `--hardtrim3 20 --rename --output-format ubam` | exit 1, same message (hardtrim3 arm covered, not just hardtrim5) |
+| V9 | control: description-**free** FASTQ + `--rename --clip_R1 3 --output-format ubam` | **exit 0, QNAME `plainhdr:clip5:ACG` — lossless** |
+| V10 | control: `--rename` with **no clip flag** + ubam out | exit 0, QNAME `plainhdr` — annotation never attempted |
+| V11 | control: `--hardtrim5 20 --rename` FASTQ out | `@withspace 1:N:0:ACGTAC:clip5:ACGTACGT` — plan's claim **confirmed** |
+| V12 | control: FASTQ-with-description + `--rename` + ubam out, stderr | `NOTE: … First dropped: "1:N:0:ACGTAC:clip5:ACG"` — the #406 notice does fire and does echo the annotation |
+| V13 | `test_files/ubam_test_with_tags.bam` | exists, git-tracked, 587 B → C1 guard's `SKIP` branch is not what passes |
+| V14 | full `cargo test`, `cargo fmt --check`, `cargo clippy --all-targets --release -- -D warnings` | 575 passed / 0 failed across 14 targets; fmt exit 0; clippy exit 0 and genuinely recompiled — see "Test suite" below |
+
+BAM QNAMEs were read with a standalone BGZF/BAM parser (python, `zlib` wbits=31 multi-member), not via
+the crate under review, so the read side is independent of the code being reviewed.
+
+---
+
+## Logic
+
+### L1 — CONFIRMED — The gate pre-empts two better error messages (Medium)
+
+`src/main.rs:316-333` sits **before** the two structural format checks at `src/main.rs:350-356`
+(`--paired` with a single non-BAM input) and `src/main.rs:377-392`
+(`reject_bam_format_mismatch_in_pair`, issue #363).
+
+Observed, `--output-format ubam` throughout:
+
+```
+$ trim_galore --paired --rename --clip_R1 3 --output-format ubam sp.fastq
+Error: --rename cannot be honoured with --output-format ubam when any input is FASTQ. …
+
+$ trim_galore --paired          --clip_R1 3 --output-format ubam sp.fastq
+Error: --paired with a single input file is only legal if that file is a uBAM.
+       Provide R1 and R2 as separate files for FASTQ paired-end mode.
+```
+
+```
+$ trim_galore --paired --rename --clip_R1 3 --output-format ubam sp.fastq ubam_paired_test.bam
+Error: --rename cannot be honoured with --output-format ubam when any input is FASTQ. …
+
+$ trim_galore --paired          --clip_R1 3 --output-format ubam sp.fastq ubam_paired_test.bam
+Error: --paired requires both inputs of a pair to be the same format. Got mixed: sp.fastq is
+       FASTQ (plain) and …ubam_paired_test.bam is uBAM. Pass two FASTQ files, or a single
+       interleaved uBAM. If you meant two FASTQ files, check for a mis-typed filename.
+```
+
+In both cases the run is broken *independently* of `--rename`, and the pre-empted message is the one
+that names the actual defect — including a mis-typed-filename hint that the #363 author wrote
+deliberately. A user has to drop a flag they wanted, re-run, and only then learn what is really wrong.
+
+This is precisely the failure the plan celebrates avoiding for `--clump_only` (`PLAN.md:35`, "keeps its
+accurate mode-specific message … instead of being pre-empted by a mechanical one"). The same argument
+applies one level down and was not carried through.
+
+**Recommendation:** move the block to immediately after `reject_bam_format_mismatch_in_pair` (i.e.
+after `src/main.rs:392`). That is still ahead of `naming::ensure_output_dir` at `src/main.rs:406` and
+ahead of every dispatch arm, so the "nothing written" property — which I verified at V4 — is
+untouched. The `--clump_only` ordering test keeps passing (that guard is in `validate()`, far
+earlier). Nothing else reads `cli.rename` in between.
+
+### L2 — CONFIRMED — The refusal withdraws a path that is lossless today (Medium)
+
+Two sub-cases, both verified against the control build:
+
+**(a) FASTQ with no header description.** `append_to_id` (`src/fastq.rs:173-181`) appends to the end;
+`parse_name_and_data` (`src/bam.rs:709`) splits on the first `['\t', ' ']`. With no space and no tab
+there is nothing to split, so the whole annotated ID becomes the read name:
+
+```
+control @ aa9f764:  @plainhdr + --rename --clip_R1 3 --output-format ubam
+                 →  QNAME  plainhdr:clip5:ACG      (exit 0, annotation intact)
+patched @ 3f1b0fe:  same invocation → exit 1, refused
+```
+
+That is not an exotic shape — SRA/ENA `@SRR…​.N`, `samtools fastq`-derived FASTQ, and most synthetic
+or simulator output have no description at all. For those files the flag was being honoured exactly
+as asked.
+
+**(b) `--rename` with no clipping flag.** `trimmer.rs:258-275` only calls `append_to_id` inside
+`if let Some(n) = clip_5 / clip_3`, so without `--clip_R1/R2` or `--three_prime_clip_R1/R2` (and
+outside hardtrim) `--rename` never touches the ID:
+
+```
+control: --rename --output-format ubam plain.fastq → exit 0, QNAME plainhdr (nothing appended)
+patched: same → exit 1
+```
+
+A wrapper that threads `--rename` unconditionally into every invocation (the flag's stated use is UMI
+bookkeeping, so pipeline-level defaults are plausible) now hard-fails on runs where it previously did
+nothing at all.
+
+`PLAN.md:26` records sub-case (a) in its boundary table and Behavior 1 chose format-level gating
+anyway, so this is a *recorded* decision, not an oversight — I am flagging the consequence, not
+claiming it was missed. Sub-case (b) is not in the plan at all.
+
+I do **not** recommend making the gate per-record or per-header: reading the first record to decide
+would make the refusal data-dependent and untestable, and letting the run proceed until the first
+description appears would leave a partly-written BAM. The format-level gate is the right shape. What
+needs fixing is what the message *asserts* — see M1.
+
+### L3 — clean — Siting w.r.t. writers
+
+Verified by reading `src/main.rs:229-480` end to end. Between `cli.validate()` (`:229`) and the new
+block (`:316`) the only file access is `sanity_check_any` (`:241`) and `detect_input_format` (`:247`),
+both read-only. The first write of any kind is `naming::ensure_output_dir` (`:406`), then the specialty
+pre-flights and dispatch arms (`:450` onward). Empirically confirmed at V4: after a refusal the cwd
+contains only the input, and an absent `-o` directory is **not** created.
+
+Every arm that can reach a writer is downstream: `--hardtrim5` (`:450`), `--hardtrim3`, `--clock`,
+`--implicon`, `--clump_only`, `run_ubam_output`, and the SE/PE trim dispatch. `--clock` / `--implicon`
+never reach the gate in a way that matters — `cli.rs:606-616` rejects them with `--output-format ubam`
+inside `validate()`, i.e. earlier. `--clump_only --rename` likewise (`cli.rs:851`).
+
+### L4 — clean — The gate predicate
+
+`input_formats.iter().any(|f| !matches!(f, InputFormat::UnalignedBam))` is the right test for the
+three variants that exist (`FastqPlain`, `FastqGz`, `UnalignedBam`, `src/format.rs:31-40`):
+
+- **Mixed FASTQ + uBAM** → refused, both argument orders (V7). Correct: SE mode processes each input
+  independently, so the FASTQ member would silently lose the annotation while the BAM member kept it.
+  Refusing the whole run matches how `any_bam` gates `--phred64` at `:276`.
+- **Single interleaved uBAM under `--paired`** → accepted (V6), and the annotation really lands on the
+  QNAME of the R1 half. `input_formats` has exactly one element and it is `UnalignedBam`, so `.any()`
+  is false. Correct.
+- **Empty input** → unreachable; `input` is `required = true`, so `.any()` on an empty slice can't be
+  hit.
+- **A future fourth variant** → refused, because the predicate is negative. Deviation note 4 in
+  `PLAN.md:124` calls that conservative and cites `main.rs:332` as precedent; the live precedent is
+  now `main.rs:350` (`!matches!(input_formats[0], InputFormat::UnalignedBam)`), same shape. I agree
+  with the direction. Worth knowing that if the fourth variant were CRAM or BINSEQ — both of which
+  also forbid whitespace in read names — the gate would refuse a lossless path. That is the safe
+  failure and needs no change now.
+
+### L5 — clean — `bam.rs` doc-comment reasoning (`src/bam.rs:1026-1029`)
+
+The removed example ("`--rename`'s own `:clip5:` annotation") is genuinely unreachable now.
+`emit_description_dropped_once` fires only from `parse_name_and_data`'s space branch
+(`src/bam.rs:717-721`), which requires a space in `FastqRecord::id`. For that space to coexist with a
+`--rename` annotation you need FASTQ input (refused) or a uBAM record carrying a description
+(impossible per SAM spec, and `BamReader` builds the id from `name()` + tab-joined tags). The two
+remaining `--rename`-adjacent routes are also closed: `--clump_only --rename` is rejected at
+`cli.rs:851`, and `--clock`/`--implicon` — whose `append_to_id` calls at `specialty.rs:312/413` are
+unconditional, not `--rename`-gated — are rejected with `--output-format ubam` at `cli.rs:606-616`.
+Sound.
+
+---
+
+## Efficiency
+
+Clean. One `Iterator::any` over a slice that is at most a handful of elements and was already
+materialised for the `--phred64` and `--preserve-tags` rules. No allocation, no I/O, short-circuits on
+`cli.rename` first. Nothing to say.
+
+---
+
+## Errors / message accuracy
+
+### M1 — CONFIRMED — The message asserts unrepresentability where the code proves representability (Medium)
+
+`src/main.rs:325-331`. Clause by clause:
+
+| Clause | True? |
+|---|---|
+| "`--rename` cannot be honoured with `--output-format ubam` when any input is FASTQ" | **No** — V9/V10. Description-free FASTQ honours it exactly; `--rename` without a clip flag has nothing to honour |
+| "The `:clip5:`/`:clip3:` annotation is appended to the end of the read ID" | Yes for FASTQ input (`fastq.rs:179`). Slightly loose in general — with a tab tail it splices *before* the tab (`fastq.rs:177`) — but the sentence is scoped to the FASTQ case it is describing |
+| "so whenever a FASTQ header carries text after the first space the annotation lands in that text" | Yes — CONFIRMED V12, dropped text was `1:N:0:ACGTAC:clip5:ACG` |
+| "and BAM read names cannot contain whitespace" | Yes, SAM spec; enforced by `parse_name_and_data`'s split |
+| "so none of that tail can be represented in the output" | Yes |
+| "Use FASTQ output, or drop `--rename`." | Correct, and correctly avoids `samtools import` |
+| "uBAM input is unaffected: BAM read names carry no description, so there the annotation lands on the name itself." | Yes — CONFIRMED V5/V6 |
+
+So the only defect is the headline sentence, and it is contradicted by the message's own next sentence:
+"cannot be honoured … when any input is FASTQ" versus "**whenever** a FASTQ header carries text after
+the first space". A user whose headers are bare will read this, check their headers, find no spaces,
+and conclude the tool is wrong about their data.
+
+The plan's Behavior 4 (`PLAN.md:69`) asks for exactly this property — "states **unrepresentability**,
+not a prediction of loss" — and the headline breaks it in the other direction: it *over*-states,
+asserting impossibility for inputs where the annotation demonstrably survives.
+
+**Recommendation:** make the headline say what the check actually is — a format-level refusal, because
+representability is per-header and cannot be known before the run. E.g. lead with "`--rename` is
+refused with `--output-format ubam` when any input is FASTQ, because whether the annotation can be
+represented depends on each header and cannot be established up front", then keep the existing
+mechanism and remediation sentences unchanged. That is honest about the gate's granularity, keeps every
+verified clause, and pre-empts the "but my headers have no spaces" bug report.
+
+### M2 — no findings
+
+No unhandled conditions, no panics, no security surface. `anyhow::bail!` on the startup path, exit
+code 1 confirmed. No unwrap/expect added to library code.
+
+---
+
+## Structure / style
+
+### S1 — Low — the two uBAM-acceptance tests are near-duplicates
+
+`tests/integration_ubam_out.rs:1035` (`rename_into_ubam_accepted_for_ubam_input`, new) runs the
+*identical* invocation to `:394` (`ubam_out_rename_with_preserve_tags_keeps_tags_intact`,
+pre-existing) — same fixture, same `--clip_R1 5 --rename --output-format ubam --preserve-tags CB,UB`.
+Only the assertions differ (annotation reaches the QNAME vs `UB` value not polluted). Both are worth
+asserting; two full binary invocations to do it is duplication. Not worth churning the C1 guard for —
+if anything, a doc-comment cross-reference between the two would stop a future reader deleting one as
+redundant.
+
+### S2 — clean — comment policy
+
+The new comment (`src/main.rs:316-317`) is two lines, states the current-state fact ("sited here …
+because the rule is format-gated"), narrates no prior state, and points at the sibling rule rather
+than restating its rationale. Compliant, and notably leaner than the 20-line `--phred64` block
+directly above it. The `bam.rs` edit removes text; nothing added.
+
+### S3 — clean — idiom and naming
+
+Fully-qualified `trim_galore::cli::OutputFormat::UBam` matches the surrounding usages at `:305`,
+`:384`, `:412`. `matches!` over an exhaustive `match` matches the file's prevailing style (and, per
+`PLAN.md:124`, avoids `clippy::match_like_matches_macro` under `-D warnings`). No new imports, no dead
+code.
+
+---
+
+## Test quality
+
+None of the five is vacuous. Each was checked for the specific failure modes named in the brief.
+
+| Test | Verdict | Notes |
+|---|---|---|
+| `rename_into_ubam_refused_for_fastq_input` (`:1000`) | **Sound** | Asserts non-zero, message substring, **and** `sp_trimmed.bam` absent. Non-vacuous: the control build writes that file and exits 0 (V9-class). 28 bp seq, `--clip_R1 3` → 25 bp, clears default `--length 20`; qual is `I`×n so `-q 20` can't interfere. |
+| `rename_into_ubam_accepted_for_ubam_input` (`:1035`) | **Sound, and load-bearing** | This is the test that stops the gate silently becoming blanket. I reproduced its assertions by hand (V5). No `SKIP` branch — a missing fixture would fail, not pass. Runs from crate root, so the relative `test_files/` path resolves. |
+| `rename_with_fastq_output_still_annotates_the_id` (`:1074`) | **Sound** | `assert_eq!` on the whole ID (`@withspace 1:N:0:ACGTAC:clip5:ACG`) is the strongest form available and pins the Perl-matching format byte-for-byte. Reads `sp_trimmed.fq` (plain input → plain output), correct. |
+| `rename_into_ubam_refused_for_hardtrim_fastq_input` (`:1098`) | **Sound, slightly weaker than its sibling** | Non-vacuous — control writes `sp.20bp_5prime.bam` and annotates (V11). It asserts non-zero + message but **not** that nothing was written, unlike the trim arm. See T1. |
+| `clump_only_rename_keeps_its_own_message` (`:1126`) | **Sound** | Asserts the mode-specific text present *and* the new text absent — a genuine ordering assertion that a `validate()` unit test could not make. |
+
+### T1 — Low — the hardtrim refusal test does not assert absence
+
+`tests/integration_ubam_out.rs:1098-1124`. The trim arm asserts `!dir.join("sp_trimmed.bam").exists()`;
+the hardtrim arm asserts nothing about the filesystem. The specialty arm is the one where the guard's
+position matters most — `naming::preflight_output_collisions` and the writers sit at `main.rs:452+`,
+downstream of the gate, and a future re-siting of the gate (including the L1 move I recommend) would
+be caught by the trim arm but not here. Adding `assert!(!dir.join("sp.20bp_5prime.bam").exists())` —
+the exact filename the control build produces — would close it for one line.
+
+### T2 — Low — "nothing written" is asserted narrowly
+
+The trim arm checks one filename. The run would also produce `sp.fastq_trimming_report.txt` /
+`.json` if it got that far. Asserting the directory contains exactly `sp.fastq` would state the
+property the comment claims ("the refusal must precede every writer") rather than a proxy for it. I
+verified the strong form by hand (V4) — the cwd stays clean and an absent `-o` dir is not created — so
+this is test-expressiveness, not a gap in behaviour.
+
+### T3 — The untouched C1 guard is genuinely still exercising its claim
+
+`tests/integration_ubam_out.rs:393-440`, unmodified by this commit (`git show --stat` lists
+`tests/integration_ubam_out.rs | 172 +++`, all additions; `git show 3f1b0fe -- tests/` shows a single
+`@@ -978,3 +978,175 @@` hunk, a pure append, and the guard's name appears nowhere in the diff).
+
+Its `SKIP` branch (`:400-403`) requires `test_files/ubam_test_with_tags.bam` to be missing. The file
+exists, is git-tracked, 587 B (V13), so `SKIP` is not what passes. Its input is uBAM, so the new gate
+does not fire — and it should not: I confirmed the same invocation succeeds and the annotation reaches
+the QNAME (V5). The guard still asserts what it claims (`UB` value free of `:clip5:`).
+
+---
+
+## Docs
+
+`docs/src/content/docs/guide/outputs.md`
+
+### D1 — clean — the `--basename` section (`:106`) is accurate
+
+Checked against `cli.rs:156-159` (`Option<String>`, "replaces input filename stem"), `cli.rs:640-644`
+and `cli.rs:667-671` (SE >1 file and PE >1 pair both refused, "ambiguous output naming"), and
+`io.rs:326`/`:357`/`:462` (`BASE_val_1` / `BASE_val_2` naming, with the Perl v0.6.5+ note). Every
+clause holds, including "longer input lists are refused, because the output naming would be
+ambiguous".
+
+### D2 — clean — the `--rename` section (`:110`) is accurate
+
+Matches `cli.rs:300-301` almost word for word ("Appends `:clip5:SEQ` and/or `:clip3:SEQ` to the read
+ID (each half only when that side was clipped)"), and "does not affect filenames" is confirmed by
+there being no `cli.rename` reference anywhere in `io.rs`. Naming the three flag families that
+actually drive it (`--clip_R1/R2`, `--three_prime_clip_R1/R2`, `--hardtrim5/3`) is right —
+`--clock`/`--implicon`'s ID appends at `specialty.rs:312/413` are unconditional and not `--rename`'s
+doing, so leaving them out is correct rather than an omission.
+
+### D3 — clean — the compatibility-list preamble (`:90`) is true of all eight bullets
+
+"Rejected at startup, before anything is written (v1 scope)". Seven bullets are `validate()`-time
+(`cli.rs:587-632`). The eighth is `main.rs:316`, and I verified empirically (V4) that a refused run
+writes nothing and does not even create an absent `--output_dir`. Deviation note 2 in `PLAN.md:122` is
+the right call — appending under the old "Rejected at CLI-validate time" would have reproduced the
+defect class being fixed.
+
+### D4 — Low — the new bullet carries M1's overclaim, and breaks the list's register
+
+`:98`. "**only when at least one input is FASTQ.** … so a FASTQ header carrying text after the first
+space puts the annotation inside that text — and BAM read names cannot contain whitespace, so none of
+that tail survives." Accurate as written, but like the error message it never says that a
+description-free FASTQ is refused too, which is the case a reader will hit and be puzzled by. Should
+track whatever wording M1 settles on.
+
+Separately: every sibling bullet is one clause; this one is four sentences plus a meta-note about
+*where* the check lives. The implementation detail ("checked after input-format detection rather than
+at CLI-validate time") is now redundant with the preamble the same commit rewrote — the preamble no
+longer claims CLI-validate time, so there is nothing left to except this bullet from. Trimming the
+bullet to its user-visible rule and dropping the siting note would match the list.
+
+### D5 — Low — `--rename`'s own `--help` text does not mention the restriction
+
+`cli.rs:300-301` is unchanged. Compare `--preserve-tags` (`cli.rs:249-250`), which spells out "a hard
+error when combined with `--output-format ubam`" right in its help. `--output-format`'s own help
+(`cli.rs:259-260`) only says "some flag combinations are rejected (see `--help` and the startup
+diagnostics for details)", so there is no enumerated list to add to — which leaves `--rename`'s help
+as the only place a `--help` reader would look, and it is silent. One clause there would match the
+established precedent.
+
+---
+
+## CHANGELOG
+
+`CHANGELOG.md:8-24`. I checked every factual claim; all hold.
+
+| Claim | Verdict |
+|---|---|
+| "`--rename` appends `:clip5:SEQ`/`:clip3:SEQ` to the end of the read ID" | True on the FASTQ path (`fastq.rs:179`). Same mild looseness as M1's second clause (tab tails splice earlier); acceptable in a changelog |
+| "When a FASTQ header carries text after the first space the annotation lands inside that text … the whole tail was discarded" | **CONFIRMED** V12 — dropped text was `1:N:0:ACGTAC:clip5:ACG` |
+| "now refused when at least one input is FASTQ, including on the `--hardtrim5`/`--hardtrim3` paths" | **CONFIRMED** for both — V8 covers `--hardtrim3`, which no test exercises (see T-note below) |
+| "**uBAM input is unaffected and keeps working** … annotation lands on the name itself and preserved aux tags round-trip intact" | **CONFIRMED** V5 (SE, `UB` intact) and V6 (interleaved PE) |
+| "The header-description notice added for #406 did report the dropped text" | **CONFIRMED** V12 — the notice fires and echoes the annotation verbatim. This is the claim most at risk of being wishful, and it is true |
+| "a user who passed `--rename` had no reason to connect a general note about header descriptions to their own annotation being gone" | Fair characterisation of the V12 stderr |
+| "it described `--rename` as `--rename PREFIX` replacing the output filename stem, which is `--basename` — a flag the guide did not document at all" | Substantively true. Minor misquote: the old line said "replaces the **input** filename stem in the output names", not "the output filename stem". Immaterial |
+
+The entry does not overclaim "silent" anywhere, consistent with the plan's Behavior 4. Good.
+
+One coverage note rather than an accuracy one: the changelog asserts `--hardtrim3` coverage and only
+`--hardtrim5` has a test. The gate is mode-independent so the risk is nil, and V8 confirms the
+behaviour — but the asserted arm is untested.
+
+---
+
+## Test suite, fmt, clippy — all verified on this branch
+
+**`cargo test` from the crate root: 575 passed, 0 failed, 0 ignored, across 14 targets.** Matches the
+stated baseline exactly. Per-target counts, summed rather than eyeballed:
+`411 + 0 + 15 + 12 + 15 + 11 + 1 + 8 + 48 + 11 + 2 + 8 + 33 + 0 = 575`. The two zero-count targets are
+empty harnesses, not filtered-out runs.
+
+Each new test confirmed to actually execute, by exact name (the plan's iteration-log trap #2 —
+interleaved stdout breaking a `^test` grep anchor — avoided by using `-- --exact` and reading the
+`passed` count, not the "ok"):
+
+```
+rename_into_ubam_refused_for_fastq_input             1 passed; 32 filtered out
+rename_into_ubam_accepted_for_ubam_input             1 passed; 32 filtered out
+rename_with_fastq_output_still_annotates_the_id      1 passed; 32 filtered out
+rename_into_ubam_refused_for_hardtrim_fastq_input    1 passed; 32 filtered out
+clump_only_rename_keeps_its_own_message              1 passed; 32 filtered out
+ubam_out_rename_with_preserve_tags_keeps_tags_intact 1 passed; 32 filtered out   ← the C1 guard
+```
+
+33 total in `integration_ubam_out`, consistent with the suite line above. The C1 guard run with
+`--nocapture` prints **zero** `SKIP` lines, so it is passing on its real assertions (T3).
+
+`cargo fmt --all -- --check` → exit 0.
+
+`cargo clippy --all-targets --release -- -D warnings` → exit 0, zero `warning`/`error` lines. This was
+a genuine compile, not a cache hit: the run emitted `Compiling trim-galore v2.3.0` and took 2.48 s
+(the repo's known trap is a sub-second "success"; a second, cached invocation is what would be
+instant).
+
+---
+
+## Recommendations, by priority
+
+**Critical** — none.
+
+**High** — none.
+
+**Medium**
+
+1. **L1 — move the gate behind the two structural format checks.** Relocate `src/main.rs:316-333` to
+   just after `reject_bam_format_mismatch_in_pair` (`:392`). Restores the more useful message for
+   `--paired`-with-one-FASTQ and mixed-pair invocations; keeps every property the current siting has
+   (still ahead of `ensure_output_dir` at `:406` and every dispatch arm — V4 property preserved);
+   costs nothing. This is the same move the plan already made once, for `--clump_only`.
+2. **M1 — fix the message's headline clause.** It currently asserts impossibility for inputs where the
+   annotation demonstrably survives (V9, V10), and contradicts its own following sentence. Reframe as
+   a format-level refusal whose granularity is stated, keeping the mechanism and remediation text
+   unchanged.
+3. **L2 — decide consciously about the withdrawn-but-lossless cases and record it.** Description-free
+   FASTQ (recorded in the plan) and `--rename` without any clip flag (not recorded) both worked before
+   and are refused now. I think the format-level gate is right and neither should change behaviour —
+   but sub-case (b) should be in the plan's boundary table, and if a bare-header user opens an issue
+   the answer should already be written down.
+
+**Low**
+
+4. **T1** — assert `!sp.20bp_5prime.bam` in the hardtrim refusal test, matching the trim arm.
+5. **D5** — add one clause to `--rename`'s `--help` text (`cli.rs:300-301`) naming the
+   `--output-format ubam` restriction, matching `--preserve-tags`' precedent.
+6. **D4** — trim the new docs bullet to its user-visible rule; the "checked after input-format
+   detection rather than at CLI-validate time" note is now redundant with the preamble the same commit
+   rewrote.
+7. **T2** — strengthen "nothing written" from one filename to the whole directory listing.
+8. **S1** — cross-reference the two near-identical uBAM-acceptance tests so neither looks redundant.
+9. Optional: a one-line `--hardtrim3` case, since the CHANGELOG names that arm.
+
+**Not recommended**
+
+- Making the gate per-header or per-record. Data-dependent refusals are worse than a conservative
+  format-level one, and a mid-stream refusal would leave a partial BAM.
+- Touching `tests/integration_ubam_out.rs:393-440`. The C1 guard is correct as-is and still exercises
+  its claim (T3).

--- a/plans/08092026_rename-ubam-rejection/CODE_REVIEW_B.md
+++ b/plans/08092026_rename-ubam-rejection/CODE_REVIEW_B.md
@@ -1,0 +1,278 @@
+# Code Review B — `fix/408-rename-ubam-rejection` @ `3f1b0fe`
+
+**Reviewer:** B (independent; no shared state with Reviewer A)
+**Date:** 2026-08-09
+**Target:** `git diff dev...HEAD` — `src/main.rs` +18, `src/bam.rs` +3/−4, `tests/integration_ubam_out.rs` +172, `docs/…/guide/outputs.md` +11/−5, `CHANGELOG.md` +18
+**Verdict:** **APPROVE with recommendations.** Nothing Critical. Two Medium findings, both about
+accuracy of user-facing text and one unenforced invariant; no defect in the executable change.
+**No fixes applied** (per the review brief — two reviewers share this tree).
+
+---
+
+## Verification performed
+
+Everything below was run, not read off the plan.
+
+| Check | Method | Result |
+|---|---|---|
+| Full suite | `cargo test --release`, all 14 targets, per-target counts summed by hand | **575 passed / 0 failed** — matches the stated baseline exactly |
+| The 5 new tests + the C1 guard | `cargo test --release --test integration_ubam_out` | **33 passed / 0 failed**; all five new names appear in the `^test` list; `ubam_out_rename_with_preserve_tags_keeps_tags_intact` passes |
+| C1 guard is not taking its `SKIP` branch | `git ls-files --stage test_files/ubam_test_with_tags.bam` | tracked, blob `4cd4670`, 587 B → `.exists()` true, the guard really ran |
+| `cargo fmt --all -- --check` | direct | exit 0 |
+| `cargo clippy --all-targets --release -- -D warnings` | run in an **isolated** `CARGO_TARGET_DIR` (fresh 205 MB target, 45 `Compiling` units, log line 188 `Compiling trim-galore v2.3.0`) | exit 0, zero warnings — **and I proved the invocation can fail**: injected `let unused_probe = 1;` into a `git archive`-pinned copy of the tree and clippy errored `unused variable: unused_probe … could not compile trim-galore (test "integration_ubam_out")`. So the green result is real, not a cache hit. (The crate is `trim-galore` with a hyphen — grepping the log for `trim_galore` finds nothing and looks like a false negative.) |
+| Siting precedes every writer | line numbers in `src/main.rs` | guard **:316–333**; `ensure_output_dir` :406; hardtrim5 :450; hardtrim3 :481; clock :512; implicon :534; clump_only :566; `run_ubam_output` :828. Nothing between :229 and :333 writes to disk (`sanity_check_any` :241 and `detect_input_format` :250 are read-only). **Confirmed.** |
+| Plan's claim that `--hardtrim5 20 --rename` genuinely annotates on the FASTQ path | ran the built binary | `@withspace 1:N:0:ACGTAC:clip5:ACGTACGT` (space header) and `@nospacehere:clip5:ACGTACGT` (space-free). **Independently confirmed** — validation 5 refuses something that really worked. |
+| Mechanism | read `fastq.rs::append_to_id` :173–181, `bam.rs::parse_name_and_data` :707–726 | append-to-end (splice before first TAB), then split on the **first** of `\t` or `' '`. Confirmed. |
+| `--paired` + single interleaved uBAM + `--rename` + ubam out | ran on `test_files/ubam_paired_test.bam` | **accepted**; `ubam_paired_test_val.bam` written, 10 `clip5` occurrences in the QNAMEs. The gate correctly admits the N==1 interleaved case. |
+| All eight compatibility bullets really are refused before any write | read `cli.rs` §3.4a (`:584–630`) for the seven; `main.rs:316` for the eighth | **preamble is accurate** — `--dont_gzip`, `--clumpify`, `--passthrough`, `--clock`, `--implicon`, `--demux`, `--retain_unpaired` all `bail!` inside `Cli::validate()`, which runs at `main.rs:229` before the banner and before `sanity_check_any`. Deviation 2 was necessary and is correct. |
+
+---
+
+## Issues by area
+
+### 1. Logic
+
+**Clean on the gate predicate itself.** `input_formats.iter().any(|f| !matches!(f, InputFormat::UnalignedBam))`
+is the right shape for the three cases I probed:
+
+- mixed FASTQ + uBAM (SE, multi-input) → refused. Correct: the FASTQ member would lose the annotation.
+- `--paired` with one interleaved uBAM → accepted (`input_formats.len() == 1`, all uBAM). Confirmed by running it.
+- a hypothetical future `InputFormat` variant → refused, i.e. conservative. `InputFormat` has exactly
+  three variants today (`format.rs:31–40`); deviation 4's reasoning holds, and the negative form is
+  the right default here.
+
+`cli.rename` has exactly one definition (`cli.rs:302–303`) and is never set implicitly, so the
+predicate's first conjunct can't fire spuriously.
+
+**M-1 (Medium) — the gate is coarser than the loss, and nothing says so.**
+`src/main.rs:318–333`, `docs/…/guide/outputs.md:98`.
+
+Two classes of invocation are refused although the annotation would survive intact:
+
+1. **FASTQ input with no header description.** CONFIRMED by running the binary:
+   `--rename --clip_R1 3 --output-format ubam` on a header `@nospacehere` is refused, yet the
+   annotation demonstrably round-trips — I fed the annotated ID `@nospacehere:clip5:ACGTACGT`
+   through `--output-format ubam` and the BAM QNAME came out as
+   `nospacehere:clip5:ACGTACGT`, intact. This is not a rare shape: simulated data, many
+   `samtools fastq`-derived FASTQs, and Trim Galore's own output from a description-free input all
+   look like this.
+2. **`--rename` with no `--clip_*` / `--hardtrim*` flag at all.** CONFIRMED:
+   `trim_galore --rename --output-format ubam ns.fastq` is refused. But `append_to_id` is only
+   reached under `if let Some(n) = clip_5 / clip_3` (`trimmer.rs:257–275`) and the hardtrim
+   equivalents, so with no clip flag `--rename` is a pure no-op and nothing could be lost. A
+   pipeline that passes `--rename` unconditionally alongside *optional* `--clip_R1` now hard-fails
+   on uBAM output even in its no-clip configuration.
+
+Neither is a bug in the sense of wrong output — the design decision to gate on format rather than
+per-record is right (a per-record decision would mean failing mid-write, which is worse). The defect
+is in the **text**: both the error message and the docs bullet describe a *conditional,
+data-dependent* mechanism ("whenever a FASTQ header carries text after the first space…") next to
+*unconditional* behaviour, and neither says the refusal is deliberately coarser than the loss. The
+user whose headers are clean reads the message, concludes it does not apply to their data, and has
+no route forward — the message offers only "use FASTQ output, or drop `--rename`".
+
+This matters more than a normal wording nit because the whole point of the #408 fold-in was to fix
+a docs sentence that misdescribed a flag; and because the plan (Behavior 4) explicitly set out to
+state "unrepresentability, not a prediction of loss" — which is exactly the distinction the current
+wording blurs.
+
+*Recommendation:* one clause in both places, e.g. after "…cannot be represented in the output":
+"Trim Galore refuses the combination for any FASTQ input rather than deciding per record, because
+whether the annotation survives would otherwise depend on each individual header." That makes the
+behaviour and the text agree without changing a line of logic.
+
+**M-2 (Medium, pre-existing — this PR inherits it rather than introducing it) — assumption A5 is a
+spec property, not an enforced one, and the hole loses aux tags.**
+`src/bam.rs:891–898` (`bam_record_to_fastq`).
+
+The format gate's justification is that "BAM read names cannot carry a description by SAM spec".
+`bam_record_to_fastq` performs no whitespace validation on QNAME, and samtools will happily build a
+BAM that violates the rule. CONFIRMED end-to-end:
+
+```
+# samtools view -b from a SAM whose QNAME is literally "name with space"
+trim_galore --rename --clip_R1 3 --output-format ubam --preserve-tags CB bad.bam
+→ exit 0; output QNAME is "name"; :clip5:ACG gone; CB:Z:AAACCC gone
+   NOTE: … First dropped: "with space:clip5:ACG	CB:Z:AAACCC"
+```
+
+So on the arm the gate deliberately *admits*, a spec-violating input silently drops the preserved
+aux tag — the exact C1 corruption class the tab-splice in `append_to_id` exists to prevent. The
+#406 NOTE does fire and echoes the dropped text, so it is disclosed rather than silent, and the
+behaviour is identical with and without this commit — **this change regresses nothing.** But the
+plan's "safe by construction, not by luck" is stronger than what the code guarantees, and a
+one-line `bail!` on `name.contains(|c: char| c.is_ascii_whitespace())` in `bam_record_to_fastq`
+would turn a silent aux-tag loss into an error for every mode, not just this one.
+
+*Recommendation:* not a blocker for this PR. File a follow-up issue; if it lands, A5 becomes true
+of the code and not only of the spec.
+
+**L-1 (Low) — on a mixed `--paired` pair, the #408 message pre-empts the more fundamental one, and
+its closing sentence points at a dead end.** `src/main.rs:316` vs `:377–392`.
+
+CONFIRMED: `--paired --rename --clip_R1 3 --output-format ubam ns.fastq test_files/ubam_test.bam`
+emits the #408 refusal, not `reject_bam_format_mismatch_in_pair`'s message. A mixed pair is
+unsupported with or without `--rename`, so the user gets a two-step fix journey. Worse, the message
+ends "uBAM input is unaffected", which invites converting the FASTQ mate to uBAM — and a two-BAM
+pair is itself rejected (`ubam_out_two_bam_pair_rejected`), because paired uBAM wants one
+interleaved file. Narrow, and arguably acceptable ordering, but worth knowing.
+
+### 2. Efficiency
+
+**Clean.** One boolean conjunction on the startup path, reusing `input_formats` that `:247–251`
+already computed for `any_bam`. `.any()` short-circuits. Nothing measurable.
+
+### 3. Errors
+
+**Clean.** The only executable addition is an `anyhow::bail!`, sited ahead of `ensure_output_dir`
+and every dispatch branch (verified by line number above, and asserted by
+`rename_into_ubam_refused_for_fastq_input`'s `!dir.join("sp_trimmed.bam").exists()`). No new
+unwraps, no new I/O, no ordering hazard. No security surface.
+
+### 4. Structure and tests
+
+**Test quality: good, none vacuous.** I checked each for the failure modes the brief names:
+
+- All five assert on the *specific* message text or the *exact* ID, so none can pass because the
+  run failed early for an unrelated reason. `clump_only_rename_keeps_its_own_message` is the
+  strongest of the five: it asserts `byte-identically` **present** and `--rename cannot be honoured`
+  **absent**, which pins the ordering between `Cli::validate()` and the new guard — something a
+  library unit test genuinely could not do. Deviation 1 (dropping the planned `cli.rs` unit tests as
+  unreachable) is correct: the guard needs `input_formats`, which only the `[[bin]]` has.
+- No silent skips. None of the five has a `SKIP` branch. `rename_into_ubam_accepted_for_ubam_input`
+  reads the tracked fixture directly and would fail loudly if it vanished — arguably better than the
+  C1 guard's `SKIP`, which it sits next to.
+- **Length filter cleared.** `write_one_record` (`:878–881`) writes `"I".repeat(len)` → Phred 40, so
+  default `-q 20` trims nothing; 28 bp − `--clip_R1 3` = 25 bp ≥ default `--length 20`. The
+  uBAM-accepted test uses the tracked fixture with `--clip_R1 5` and produced records. All confirmed
+  by the tests passing with real assertions on output content.
+- **The untouched C1 guard is genuinely still live.** `git diff -U0` on the test file is a single
+  append hunk, the guard's name appears nowhere in the diff, the fixture is git-tracked (587 B, so
+  the `SKIP` return is not what passed), and it passes by name in the 33-test run. Confirmed three
+  ways. Its assertion (UB tag value free of `:clip5:`) still means what it claims.
+
+**L-2 (Low) — `run_in` duplicates the existing `run_capturing_stderr`.**
+`tests/integration_ubam_out.rs:983–995` vs `:883–890`. Same body, same `current_dir`, differing only
+in whether the exit status is returned. Cleaner to give `run_capturing_stderr` a `(bool, String)`
+return and update its three existing callers, or express one in terms of the other. Cosmetic.
+
+**Comment policy: compliant.** The new `main.rs:316–317` comment is two lines, states the fact
+(why it is sited there), and never references the state being fixed. It is the third comment in
+`main()` making the same "validate() cannot see the format" point (`:271–275`, `:299–304`), so a
+purist could shorten it to `// #408 — format-gated, so it cannot live in Cli::validate(). See §3.4b.`
+— but as written it is within policy.
+
+**`bam.rs` doc-comment rewording: sound.** I verified the removed example really is unreachable.
+`emit_description_dropped_once` fires only on FASTQ→uBAM with a space in the header; with `--rename`
+now refused for FASTQ input, and uBAM input carrying no description, the annotation can no longer be
+part of the dropped text. The other two `append_to_id` families that could have reached it
+(`specialty.rs:312/313` `--clock`, `:413/414` `--implicon` — note these are *not* `--rename`-gated)
+are both rejected at CLI-validate with `--output-format ubam`, so they cannot reach it either. The
+two surviving examples are real. Dropping the `#408` cross-reference rather than rewording it
+matches the repo's "current state only" policy. (Aside: the plan's "six call sites in `specialty.rs`"
+counts the clock/implicon pairs, which are unconditional rather than `--rename`-driven — a plan
+inaccuracy only, no effect on the code.)
+
+### 5. Docs
+
+**L-3 (Low, but it is the same defect class the PR is correcting) — the new `--basename` paragraph
+overclaims in two ways.** `docs/…/guide/outputs.md:106`.
+
+"`--basename BASE` replaces the input filename stem in the output names" is unqualified. CONFIRMED
+by running the binary:
+
+- `--hardtrim5 20 --basename MYSAMPLE ns.fastq` → output is `ns.20bp_5prime.fq`. **`--basename` is
+  silently ignored by the specialty modes** (no `basename` reference exists anywhere in
+  `src/specialty.rs`, and `cli.rs` does not reject the combination).
+- On the normal SE path the trimmed file is `MYSAMPLE_trimmed.fq` as documented, but the reports are
+  `ns.fastq_trimming_report.{txt,json}` — **reports keep the input-derived name.** (That is correct,
+  Perl-matching behaviour; it is the sentence that is loose.)
+
+Also, the section sits directly under the uBAM output documentation yet omits the uBAM forms, which
+`io.rs:282–291` implements: `BASE_trimmed.bam` and `BASE_val.bam`. `docs/…/modes/clump-only.md:79`
+already documents its own `BASE_clumped.bam`, so the omission is visible.
+
+The rest of the paragraph is accurate — I checked "only valid for one file (single-end) or one pair
+(paired-end)" against `cli.rs:640` (`!paired && input.len() > 1`) and `:667`
+(`paired && input.len() > 2`). ✓
+
+**L-4 (Low) — the new "Annotating read IDs" section is accurate but incomplete.**
+`docs/…/guide/outputs.md:110`. Every clause checks out against `cli.rs:301–303` and the call sites:
+boolean ✓, does not affect filenames ✓, `:clip5:`/`:clip3:` ✓, the three clip-flag families ✓, "each
+half only when that side was clipped" ✓ (`trimmer.rs:257–275`), anchor `#feature-compatibility`
+resolves ✓. What is missing: `--rename` is also refused by `--clump_only` **regardless of output
+format** (`cli.rs:851`, "preserves record contents byte-identically"). A section that names one
+incompatibility and not the other reads as exhaustive.
+
+**L-5 (Low) — the new compatibility bullet is the only multi-sentence entry in a seven-bullet
+one-clause list**, and its final sentence ("checked after input-format detection rather than at
+CLI-validate time, because the rule depends on the format") is implementation detail that the
+generalised preamble already makes unnecessary. Style only.
+
+### 6. CHANGELOG
+
+Every mechanical claim checks out — I verified the append-to-end behaviour, the whitespace
+constraint, the tail discard, the hardtrim coverage via `specialty.rs`, the uBAM-input aux-tag
+round-trip, and the careful non-overclaiming framing of the #406 notice. The entry is
+appropriately placed (newest-first, above #409) and correctly avoids "silently dropped".
+
+**L-6 (Low) — one factual overclaim.** "`--basename` — a flag the guide did not document at all"
+is not true. `grep -rn -- "--basename" docs/src/` finds it documented in
+`docs/…/modes/clump-only.md:79` (including its uBAM naming) and `docs/…/modes/passthrough.md:28`.
+What is true is that it had no dedicated section in `guide/outputs.md`. Also, the entry paraphrases
+the old sentence as "replacing the **output** filename stem" where it said "replaces the **input**
+filename stem in the output names" — trivial, but the entry is making a point about wrong
+descriptions of flags.
+
+**Not a finding:** `docs/…/reference/changelog.md` (the synced copy) was not updated. It is equally
+stale for #397, #406 and #409 (`grep -c "issues/N"` → 0 for all four), so this PR follows existing
+practice.
+
+---
+
+## Recommendations, by priority
+
+**Critical:** none.
+
+**High:** none.
+
+**Medium**
+1. **M-1** — add one clause to the error message (`src/main.rs:324–332`) and to the docs bullet
+   (`outputs.md:98`) saying the refusal is deliberately format-level rather than per-record.
+   Without it the text describes a conditional mechanism beside unconditional behaviour, and a user
+   with description-free headers is refused a path I confirmed works, with no explanation and no
+   alternative. Text-only; no logic change.
+2. **M-2** — file a follow-up to validate whitespace in `bam_record_to_fastq` (`src/bam.rs:891–898`).
+   Confirmed data loss (annotation **and** preserved aux tag) on a samtools-producible
+   spec-violating uBAM, on the arm this gate admits. Pre-existing and unchanged by this commit —
+   should not block the merge, but it is the one hole in the assumption the gate rests on.
+
+**Low**
+3. **L-3** — qualify the `--basename` paragraph (`outputs.md:106`): specialty modes ignore it
+   (confirmed), reports keep input-derived names, and add the `BASE_trimmed.bam` / `BASE_val.bam`
+   uBAM forms.
+4. **L-6** — soften "a flag the guide did not document at all" in `CHANGELOG.md` to "had no
+   dedicated section in the output guide"; `clump-only.md:79` and `passthrough.md:28` document it.
+5. **L-4** — mention the `--clump_only` incompatibility in the new "Annotating read IDs" section.
+6. **L-1** — consider whether the mixed-`--paired` case should reach
+   `reject_bam_format_mismatch_in_pair` first; at minimum be aware the closing sentence of the
+   message points at a combination that is itself rejected.
+7. **L-2** — fold `run_in` and `run_capturing_stderr` into one helper.
+8. **L-5** — trim the new compatibility bullet to the list's one-clause house style.
+
+None of these blocks the merge. The executable change is correct, minimal, correctly sited, and
+well covered.
+
+---
+
+## Notes for the caller
+
+- I applied **no** fixes and modified **no** tracked file. `git status` shows only the pre-existing
+  untracked entries plus this report.
+- Scratch artefacts live under `$TMPDIR/rev408b*` and `$TMPDIR/tree408b` (a `git archive`-pinned
+  copy used for the clippy negative control, with a deliberate warning appended to its *copy* of
+  `tests/integration_ubam_out.rs` — the repo's file is untouched).
+- Harness traps I hit and worked around, in case they bite the other reviewer: the crate is
+  `trim-galore` (hyphen), so grepping a cargo log for `trim_galore` looks like a false negative;
+  and `cargo clippy` on the shared target dir returns in well under a second as a cache hit, which
+  is why I used an isolated `CARGO_TARGET_DIR` plus an injected-warning control.

--- a/plans/08092026_rename-ubam-rejection/PLAN.md
+++ b/plans/08092026_rename-ubam-rejection/PLAN.md
@@ -1,0 +1,152 @@
+# Plan: refuse `--rename` into uBAM when the annotation cannot be represented (#408)
+
+**Issue:** [#408](https://github.com/FelixKrueger/TrimGalore/issues/408) — filed from #406's plan review.
+**Decisions (Felix):** reject rather than repair; fold in the `outputs.md` docs error; **r2: format-gated — refuse only when at least one input is FASTQ.**
+**Base:** `dev` @ `d0bb76b` (r1 cited this; both reviewers audited at `cbb5ecd`, which additionally carries #397 — no finding depends on the difference).
+
+## Revision history
+
+- **r2 (2026-08-09):** dual plan review (PLAN_REVIEW_A.md, PLAN_REVIEW_B.md — both REVISE; B applied r1's exact patch to a copy and ran the suite). The Perl-parity evidence the decision rests on was **independently confirmed by both**. Four things changed: **scope is now format-gated** (Felix, on both reviewers' finding that uBAM→uBAM is lossless *by spec*), which **relocates the check from `cli.rs` §3.4a to `main.rs` §3.4b** and thereby resolves the `--clump_only` pre-emption for free; **A2 was false** and is corrected; the error message is reframed as unrepresentability rather than prediction; and "silent" is dropped throughout, because #406 — merged before r1 was written — already prints a `NOTE` naming the dropped text.
+- r1 (2026-08-09): blanket rejection in `cli.rs` §3.4a. Superseded.
+
+## Goal
+
+`--rename` asks Trim Galore to record clipped bases in the read ID. On **FASTQ input → uBAM output** that record cannot survive: `append_to_id` appends the `:clip5:`/`:clip3:` suffix after any header description, and BAM read names cannot contain whitespace, so `parse_name_and_data` discards the tail — annotation included. Refuse that combination so an explicitly-requested flag is never quietly neutralised. **uBAM input is untouched**, because there the loss cannot arise.
+
+## Context
+
+### The loss, and its exact boundary
+
+Reproduced (`--rename --clip_R1 3` on `@withspace 1:N:0:ACGTAC`), and confirmed by both reviewers:
+
+| Path | Result |
+|---|---|
+| FASTQ in → FASTQ out | `@withspace 1:N:0:ACGTAC:clip5:ACG` — annotation present |
+| FASTQ in → uBAM out | QNAME `withspace` — **`:clip5:ACG` gone** |
+| FASTQ in (no space in header) → uBAM out | annotation survives |
+| **uBAM in → uBAM out** | **lossless, by SAM spec** — see below |
+
+**Why uBAM input is safe by construction, not by luck.** A BAM read name cannot contain whitespace (`bam.rs:703` notes the spec constraint), so a record read from uBAM never carries a space-separated description. `append_to_id` splices before the first TAB — deliberately, per code-review finding C1 (`fastq.rs:171`) — so the aux-tag tail survives and the annotation lands on the name. Both reviewers verified this end-to-end **including aux tags**. r1 mis-framed this as data-dependent good fortune; it is a guarantee, and refusing it would withdraw a working path for nothing.
+
+### Where the check must live — and the pre-emption it fixes
+
+Format-gating means the check needs `any_bam`, which is computed at `main.rs:240-242` *after* `detect_input_format`. `Cli::validate` cannot know the input format, so §3.4a in `cli.rs` is the wrong home; the right one is `main.rs` beside **§3.4b**, the `--preserve-tags` rule, which is format-dependent for exactly the same reason.
+
+This relocation resolves a defect both reviewers found in r1 for free: `cli.validate()` runs at `main.rs:217`, **before** format detection, so `--clump_only --rename` keeps its accurate mode-specific message (`cli.rs:851`, "preserves record contents byte-identically") instead of being pre-empted by a mechanical one. r1's Behavior 4 reasoned only about ordering *within* §3.4a and missed that the block as a whole precedes the clump-only check.
+
+### Why rejection rather than repair (confirmed evidence)
+
+`append_to_id` is reached from `trim_read` (`trimmer.rs:89`, calls at `:264`/`:273`), shared by both output formats, **and independently from six call sites in `specialty.rs`** (A §1.3; `:166`/`:219` among them) — so no fix inside it could be format-scoped. And the FASTQ path currently matches Perl exactly. Perl v0.6.11 (read from the `0.6.11` tag by all three of us) appends to the end of the whole ID line:
+
+```perl
+$l1 .= ":clip5:$clipped_sequence\n";   # :1098, :1115, :1282, :1298, :1399, :1414, :2209, :2243, :2260
+$identifier .= ":clip5:$clipped_sequence";   # :1910, :2000 — the hardtrim sites
+```
+
+So splicing before a space would diverge from shipped Perl on a Perl-era flag. Two honest footnotes: Perl's own warning at `:3456` states the intent as `readname:clip5:GATC` — the read *name* — which its implementation never does; and the poly-A branch at `:1255` folds whitespace to `_` before appending, so Perl is not even internally uniform. `--rename` is **not** in the byte-identity CI matrix, so this is a judgement about user-visible stability, not a gate.
+
+### What is actually wrong today (r1 overstated this)
+
+**Not "silent".** #406 — merged before r1 was written — added `emit_description_dropped_once` (`bam.rs:1031-1045`), which prints a `NOTE` echoing the dropped text, and `CHANGELOG.md:32-42` documents it in the very section r1 appended to. What is silent is narrower and worth stating precisely: **there is no flag-specific diagnostic**. A user who passed `--rename` sees a general note about header descriptions and has no reason to connect it to their annotation being gone. r1's framing would have regressed the principle #406 established one changelog entry above.
+
+### Scope also covers the hardtrim paths
+
+`--hardtrim5`/`--hardtrim3` with `--rename` reach `append_to_id` via `specialty.rs` and lose the annotation the same way. The refusal covers them — a point in its favour that r1 neither stated nor tested.
+
+### The docs errors (folded in, larger than r1 found)
+
+`docs/.../guide/outputs.md`:
+- **`:103` — the heading itself.** "## Renaming outputs" sits over filename prose; it is a filename heading, so fixing only the sentence beneath leaves the section mis-titled.
+- **`:105` — the sentence.** "`--rename PREFIX` replaces the input filename stem" is wrong in every clause: `--rename` is a **boolean** (`cli.rs:302-303`) that appends `:clip5:SEQ` to read IDs and never touches filenames.
+- **`--basename` is undocumented in the guide entirely** (B §6.2) — which answers r1's step-3 conditional: the stem-replacement description has no home to be moved to and needs one written.
+- **§Feature compatibility (`:90-97`, seven bullets)** enumerates §3.4a's rejections and is missing `--rename`.
+
+## Behavior
+
+1. When `--output-format ubam` is set, `--rename` is set, **and at least one input is FASTQ**, the run is refused after format detection and before any I/O.
+2. All-uBAM input is **accepted** and behaves exactly as today (annotation lands on the QNAME; aux tags intact).
+3. `--clump_only --rename` continues to be refused earlier, by `Cli::validate`, with its own mode-specific message.
+4. The message states **unrepresentability**, not a prediction of loss: a BAM read name cannot hold the annotation when the FASTQ header carries a description, so the flag cannot be honoured. No "silently dropped" claim — that is both untrue for uBAM input and stale for FASTQ input.
+5. The remediation must not name a route that reproduces the loss. **`samtools import` drops the description identically, with and without `-T '*'`** (A §1.8), so "convert afterwards" is out. What remains true: take FASTQ output, or drop `--rename`.
+6. Everything else unchanged — FASTQ-path IDs keep their exact Perl-matching format; nothing reaches `append_to_id`.
+
+## Implementation outline
+
+1. `main.rs`, beside §3.4b (after `any_bam` at `:242`) — add the gated refusal, in that block's established shape. Message along the lines of: `--rename cannot be honoured with --output-format ubam when any input is FASTQ: the :clip5:/:clip3: annotation is appended after the header description, and BAM read names cannot contain whitespace, so it cannot be represented in the output. Use FASTQ output, or drop --rename. (uBAM input is unaffected — its read names carry no description.)`
+2. **Do not touch `tests/integration_ubam_out.rs:393-440`.** Under format-gating the C1 regression guard keeps passing as-is, because its input is uBAM. This is the single largest practical win of the format-gated choice and must be verified, not assumed (validation 3).
+3. `cli.rs` tests + integration test — refusal with a FASTQ input; **acceptance with a uBAM input**; and `--rename` with FASTQ output still working (no over-reach).
+4. `bam.rs:1027-1030` — its comment cites "#408 — `--rename`'s own `:clip5:` annotation" as an example of what the description notice covers. Under this change that example becomes unreachable (FASTQ input refused; uBAM input has no description). Reword so it does not point at a case that can no longer occur.
+5. Docs — fix the `:103` heading and the `:105` sentence, give `--basename` a home in the guide, and add `--rename` to the §Feature compatibility list.
+6. `CHANGELOG.md` — one bullet under `#### Bug fixes`, framed per Behavior 4: an explicitly-requested flag was being neutralised without a flag-specific diagnostic; it is now refused where it cannot be honoured, and untouched where it can. Say plainly that uBAM input is unaffected.
+7. `cargo fmt --all -- --check`, `cargo clippy --all-targets --release -- -D warnings`, `cargo test`.
+
+## Efficiency / Integration
+
+Nil. One conditional on the startup path, beside a check that already computes the same `any_bam`.
+
+## Assumptions
+
+- **A1:** `--rename` is absent from §3.4a and the only existing `self.rename` rejection is the `--clump_only` one — verified by both reviewers.
+- **A2 (CORRECTED — r1 had this false, and deferred verifying it):** `tests/integration_ubam_out.rs:393` **does** assert this combination succeeds. It is the C1 tab-splice regression guard. Under format-gating it keeps passing untouched; under r1's blanket form it would have failed and its coverage would have needed porting. Deferring this grep was not safe.
+- **A3:** `--rename` is not in the Perl byte-identity matrix — verified.
+- **A4:** FASTQ-path behaviour is unchanged, so Perl parity is untouched by construction.
+- **A5 (new):** uBAM input cannot carry a header description, per the SAM spec — the guarantee the format gate rests on.
+
+## Validation
+
+| # | What | How | Expected |
+|---|------|-----|----------|
+| 1 | Refused where unrepresentable | `--rename --output-format ubam` with a FASTQ input | non-zero exit, message per Behavior 4; nothing written |
+| 2 | **Accepted where lossless** | same flags with a uBAM input | succeeds; QNAME carries `:clip5:…`; aux tags intact |
+| 3 | **The C1 guard survives untouched** | `cargo test ubam_out_rename_with_preserve_tags_keeps_tags_intact` with no edit to that test | passes |
+| 4 | No over-reach | `--rename --clip_R1 3`, FASTQ output, space-bearing header | succeeds; ID still ends `:clip5:ACG`, byte-identical to before |
+| 5 | Hardtrim covered | `--hardtrim5 20 --rename --output-format ubam` with FASTQ input | refused by the same guard |
+| 6 | `--clump_only` keeps its own message | `--clump_only --rename --output-format ubam` | the byte-identity message from `cli.rs:851`, not the new one |
+| 7 | Perl parity untouched | byte-identity harness + validation matrix | unchanged |
+| 8 | Expected-fail control | validations 1 and 5 against the unpatched build | they *succeed* there and lose the annotation — the behaviour being removed |
+| 9 | Docs describe real flags | read `:103`, `:105`, the compatibility list and the new `--basename` text against `cli.rs` | accurate; `--rename` present in the rejected list |
+| 10 | No collateral | full `cargo test` + fmt + clippy | green |
+
+## Questions or ambiguities
+
+- **[Resolved — Felix]** Reject not repair; docs folded in; **format-gated scope**.
+- **[Open, minor]** Whether to file a follow-up for carrying the annotation as a BAM aux tag. Both reviewers expect the refusal to invite the request; A recommends filing it. Recommend yes, after this lands.
+
+## Implementation notes (2026-08-09, base `aa9f764`)
+
+Implemented as specified. Surface: `CHANGELOG.md` +18, `docs/…/guide/outputs.md` +11/−5, `src/bam.rs` +3/−4 (doc comment only), `src/main.rs` +18, `tests/integration_ubam_out.rs` +172. **No output-producing code path changed** — the only executable addition is one `anyhow::bail!`.
+
+### Deviations
+
+1. **Step 3's "cli.rs tests" was dropped as unreachable, not skipped.** The guard must see `input_formats`, so it lives in `main.rs` — the `[[bin]]`. Library unit tests in `cli.rs` can only reach `Cli::validate()`, which by design does not carry this rule. All five new tests are therefore binary-driven, in `tests/integration_ubam_out.rs`. Validation 6 (`--clump_only` keeps its own message) is the one that would have been a `validate()` unit test; as an integration test it additionally proves the *ordering* between `validate()` and the new guard, which a unit test could not.
+2. **`outputs.md`'s compatibility-list preamble had to change too.** It read "Rejected at CLI-validate time", true of all seven existing bullets and false of this one. Appending a bullet under it would have reproduced the defect class the change is correcting. Now "Rejected at startup, before anything is written", which is true of all eight.
+3. **The `bam.rs` doc comment lost the `#408` cross-reference entirely** rather than being reworded to mention the now-refused case. Two live examples remain (instrument identifier, Illumina `1:N:0:INDEX`); the history is in the commit message per the repo's comment policy.
+4. **The gate tests `!matches!(f, InputFormat::UnalignedBam)`, not a positive FASTQ match.** Follows the existing precedent at `main.rs:332`, and means a future third input format is refused (conservative) rather than silently admitted. A positive `matches!` on the two FASTQ variants would have inverted that default; an exhaustive `match` would have tripped clippy's `match_like_matches_macro` under `-D warnings`.
+
+### Verification
+
+| # | Validation | Result |
+|---|---|---|
+| 1 | Refused where unrepresentable | `rename_into_ubam_refused_for_fastq_input` — non-zero exit, message asserted, `sp_trimmed.bam` asserted absent |
+| 2 | Accepted where lossless | `rename_into_ubam_accepted_for_ubam_input` — exit 0, QNAME contains `:clip5:`, `UB` tag present |
+| 3 | C1 guard survives untouched | proven twice: `git diff -U0` shows a **single** hunk (`@@ -980,0 +981,172 @@`, pure append) and the guard's name appears nowhere in the diff; and it passes by name. Fixture `test_files/ubam_test_with_tags.bam` confirmed **git-tracked** (587 B), so the test's `SKIP` branch is not what passed |
+| 4 | No over-reach | `rename_with_fastq_output_still_annotates_the_id` — `assert_eq!` on the full ID, `@withspace 1:N:0:ACGTAC:clip5:ACG` |
+| 5 | Hardtrim covered | `rename_into_ubam_refused_for_hardtrim_fastq_input` |
+| 6 | `--clump_only` keeps its own message | `clump_only_rename_keeps_its_own_message` — asserts `byte-identically` present **and** the new text absent |
+| 7 | Perl parity untouched | By construction (A4): no FASTQ-output code changed. Validation 4 pins the ID format byte-for-byte. The Perl md5 harness itself is CI-only and was not run locally |
+| 8 | Expected-fail control | Ran both refusals against an **unpatched build** (detached worktree at `aa9f764`, guard string count 0). Trim arm: exit 0, wrote `sp_trimmed.bam`, first QNAME `withspace` — annotation gone. Hardtrim arm: exit 0, wrote `sp.20bp_5prime.bam`, first QNAME `withspace`. **Additional check the plan did not ask for:** confirmed `--hardtrim5 20 --rename` on the *FASTQ* path really does annotate (`:clip5:ACGTACGT`), so validation 5 refuses something that genuinely worked rather than a no-op |
+| 9 | Docs describe real flags | `--rename` re-documented as the boolean it is under a new "Annotating read IDs" heading; `--basename` given its own section (it had none in the guide); compatibility bullet added |
+| 10 | No collateral | `cargo fmt --all -- --check` clean (after one rustfmt rewrite of two `assert!` calls); `cargo clippy --all-targets --release -- -D warnings` exit 0; `cargo test` **575 passed / 0 failed** across 14 targets. The same suite on the unpatched control gave **570 passed / 0 failed**, so the delta is exactly the five tests added — counted rather than assumed, since equal counts are how a stale-tree verification hides |
+
+### Iteration log
+
+- **#1** First `fmt --check` failed on two `assert!` calls rustfmt wanted expanded. Ran `cargo fmt --all`; re-check clean. No semantic change.
+- **#2** The by-name grep for the five new tests appeared to show `rename_into_ubam_accepted_for_ubam_input` missing. It had in fact run — the test binary's own stdout interleaved on the line, breaking the `^test` anchor. Re-ran with `-- --exact`: 1 passed, 32 filtered out. A grep artefact, not a missing test.
+- **#3** `cargo clippy … | tail` reported success with `CLIPPY EXIT=` empty — `${PIPESTATUS[0]}` is bash, and zsh silently yielded nothing. Re-ran unpiped: exit 0, but in **0.18 s** with no mention of the edited target, i.e. a cache hit. Injected a deliberate `unused_variable` into the new test block; clippy flagged it at `:1001`, proving the target *is* linted. Removed the probe, re-ran with `-D warnings` (cache now invalid, 2.90 s, recompiled): exit 0, zero warnings.
+
+## Self-Review (r2)
+
+- **What r1 got wrong, owned:** it deferred A2's grep and A2 was false — the assumption I explicitly flagged as unverified was the one that broke the patch, for the second time this session. It mis-framed a spec guarantee as luck, which is what made the blanket scope look free. Its remediation advice named `samtools import`, which reproduces the loss. And it called the loss "silent" one merge after we shipped the notice that reports it — regressing #406's own principle in the changelog entry directly below it.
+- **What the format gate bought beyond correctness:** the C1 regression guard survives with no edit, and the `--clump_only` pre-emption disappears because the check moves behind `validate()`. Neither was an argument for it; both are consequences worth recording.
+- **Traps checked:** validation 3 pins the C1 guard explicitly rather than trusting that it still passes; validation 8's control is informative in the unusual direction (pre-patch the run *succeeds* while losing data); validation 2 exists so the gate cannot silently become blanket.
+- **Remaining risk:** the message is prose and reviewable. The change cannot alter any output path.

--- a/plans/08092026_rename-ubam-rejection/PLAN.md
+++ b/plans/08092026_rename-ubam-rejection/PLAN.md
@@ -144,6 +144,36 @@ Implemented as specified. Surface: `CHANGELOG.md` +18, `docs/…/guide/outputs.m
 - **#2** The by-name grep for the five new tests appeared to show `rename_into_ubam_accepted_for_ubam_input` missing. It had in fact run — the test binary's own stdout interleaved on the line, breaking the `^test` anchor. Re-ran with `-- --exact`: 1 passed, 32 filtered out. A grep artefact, not a missing test.
 - **#3** `cargo clippy … | tail` reported success with `CLIPPY EXIT=` empty — `${PIPESTATUS[0]}` is bash, and zsh silently yielded nothing. Re-ran unpiped: exit 0, but in **0.18 s** with no mention of the edited target, i.e. a cache hit. Injected a deliberate `unused_variable` into the new test block; clippy flagged it at `:1001`, proving the target *is* linted. Removed the probe, re-ran with `-D warnings` (cache now invalid, 2.90 s, recompiled): exit 0, zero warnings.
 
+## Code-review round (2026-08-09, `3f1b0fe` → reviewed → revised)
+
+Dual independent reviewers, reports at `CODE_REVIEW_A.md` / `CODE_REVIEW_B.md`. Both APPROVE; neither found a Critical or High. Both verified the executable change independently — A via a `git archive` control build and a standalone Python BGZF parser, B via an isolated `CARGO_TARGET_DIR` plus an injected-warning control proving clippy could fail. No factual contradiction between them; the one divergence was severity on the pre-emption finding (A Medium, B Low).
+
+**Acted on, all of it (Felix's call):**
+
+| Finding | Change |
+|---|---|
+| A-L1 / B-L-1 — the gate pre-empted two better structural messages | Relocated to just after `reject_bam_format_mismatch_in_pair`. `--paired`-with-one-FASTQ and mixed-pair now report their own defect, including #363's deliberate "check for a mis-typed filename" hint. Verified by hand and pinned by `paired_single_fastq_keeps_its_structural_message`. The `#363` comment's "this is the last point before `ensure_output_dir`" was made accurate ("ahead of"), since it no longer is |
+| A-M1 / B-M-1 — the message's headline asserted impossibility where the annotation demonstrably survives, contradicting its own next sentence | Reframed as a format-level refusal that states its own granularity and why it is coarse (a per-record decision would leave a partial BAM). Mirrored in the docs |
+| A-L2(b) / B-M-1(2) — **`--rename` with no clip flag was refused although it is a pure no-op** | Gate narrowed with a clip-flag conjunct. Enumerated every `--rename`-driven `append_to_id` site before writing it — `trimmer.rs:264/273` under `clip_5`/`clip_3`, `specialty.rs:62/106/166/219` under hardtrim — so the list is complete and cannot let a lossy run through. `--clock`/`--implicon` append unconditionally, not via `--rename`, and are rejected with uBAM at validate time. New test `rename_without_clip_flag_is_accepted_into_ubam` |
+| B-L-6 — **my CHANGELOG claim "`--basename` — a flag the guide did not document at all" was false** | Corrected: it had no dedicated section in `guide/outputs.md`, but is documented at `modes/clump-only.md:79` and `modes/passthrough.md:28`. The "output filename stem" misquote fixed to "input filename stem in the output names" |
+| B-L-3 — the new `--basename` paragraph overclaimed | Now a table incl. the uBAM forms (`BASE_trimmed.bam`, `BASE_val.bam` — verified at `io.rs:286-295`), plus the two limits B confirmed by running: reports keep input-derived names, and specialty modes ignore the flag entirely (`grep -c basename src/specialty.rs` → 0) |
+| B-L-4 — "Annotating read IDs" named one incompatibility of two | `--clump_only`'s refusal added |
+| A-D4 / B-L-5 — the compatibility bullet was the only multi-sentence entry, and its siting note was redundant with the preamble the same commit rewrote | Trimmed to one clause, cross-linked to the fuller section |
+| A-D5 — `--rename`'s `--help` was silent on the restriction | Two clauses added, matching `--preserve-tags`' precedent |
+| A-T1 / A-T2 — "nothing written" asserted via one filename | Both refusal arms now assert the whole directory listing via a new `dir_listing` helper. Verified by hand that an absent `-o` dir is not created either |
+| A — `--hardtrim3` claimed in the CHANGELOG, untested | `rename_into_ubam_refused_for_hardtrim3_fastq_input` added |
+| A-S1 — two near-identical uBAM-acceptance tests | Cross-referenced so neither reads as redundant. The C1 guard itself still untouched |
+| B-L-2 — `run_in` duplicated `run_capturing_stderr` | The latter now delegates to the former; its five existing callers unchanged |
+
+**Deferred to follow-up issues, not this change:**
+
+- **B-M-2** — A5 ("BAM read names cannot carry whitespace") is a spec property, not one this code enforces. B built a spec-violating uBAM with samtools and confirmed exit 0 with the annotation *and* the preserved `CB` tag silently dropped, on the arm this gate admits. Pre-existing and unchanged here — B confirmed the behaviour is identical with and without the commit — but it is the one hole in the assumption the gate rests on. A one-line whitespace `bail!` in `bam_record_to_fastq` would make A5 true of the code for every mode.
+- Carrying the annotation as a BAM aux tag, which both plan reviewers expected the refusal to invite.
+
+**Plan inaccuracy B caught, no code effect:** the "six call sites in `specialty.rs`" count includes the `--clock`/`--implicon` pairs, which are unconditional rather than `--rename`-driven. The `--rename`-gated specialty sites number four.
+
+**Verification after the revision:** `cargo test` **578 passed / 0 failed** (570 baseline + 8 new tests); fmt clean; `clippy --all-targets --release -D warnings` exit 0. All eight new tests plus the untouched C1 guard confirmed individually by exact name.
+
 ## Self-Review (r2)
 
 - **What r1 got wrong, owned:** it deferred A2's grep and A2 was false — the assumption I explicitly flagged as unverified was the one that broke the patch, for the second time this session. It mis-framed a spec guarantee as luck, which is what made the blanket scope look free. Its remediation advice named `samtools import`, which reproduces the loss. And it called the loss "silent" one merge after we shipped the notice that reports it — regressing #406's own principle in the changelog entry directly below it.

--- a/plans/08092026_rename-ubam-rejection/PLAN_REVIEW_A.md
+++ b/plans/08092026_rename-ubam-rejection/PLAN_REVIEW_A.md
@@ -1,0 +1,299 @@
+# Plan Review A — reject `--rename` with `--output-format ubam` (#408)
+
+**Reviewer:** A (independent)
+**Plan:** `plans/08092026_rename-ubam-rejection/PLAN.md`
+**Tree reviewed:** `dev` @ `cbb5ecd` (plan states base `d0bb76b`, which is `HEAD~1`)
+**Method:** every factual claim re-derived from source; binary built from a `git archive HEAD` copy under `$TMPDIR` with a private `CARGO_TARGET_DIR`; Perl v0.6.11 read from the `0.6.11` tag.
+
+**Verdict:** the decision (reject, not repair) survives review — the Perl-parity evidence it rests on is **correct**. But three things must change before implementation: an assumption the plan deferred (**A2**) is **false**, the blanket scope destroys a categorically-lossless path that already has a dedicated regression test, and the remediation text tells users to do something that reproduces the exact loss being refused.
+
+---
+
+## Summary of verification
+
+| # | Claim | Verdict |
+|---|---|---|
+| 1 | Reproduction (FASTQ keeps annotation, uBAM QNAME drops it; whitespace-free survives) | **Confirmed exactly** |
+| 2 | Perl v0.6.11 appends `:clip5:` to the end of the whole ID line | **Confirmed** (with one branch nuance + 6 under-cited call sites) |
+| 3 | `append_to_id` is shared by both formats via `trim_read` | **Confirmed** — plus a second locus the plan misses (`specialty.rs`) |
+| 4 | §3.4a is the right home; ordering within the block immaterial | Home ✓, style ✓, in-block ordering ✓ — **but the block as a whole masks the `--clump_only` message** |
+| 5 | A2: nothing asserts `--rename` + uBAM succeeds | **FALSE** — `tests/integration_ubam_out.rs:394` asserts exactly that |
+| 6 | Docs errors at `outputs.md:105` and the compatibility list | **Confirmed**, and one more gap found (`--basename` documented nowhere in that guide) |
+| 7 | Over-rejection is an acceptable cost | **Mis-framed** — the uBAM→uBAM case is lossless *by spec*, not by luck |
+| — | The loss is "silent" | **FALSE at this base** — #406 already emits a `NOTE` naming the dropped text |
+
+---
+
+## 1. Logic review
+
+### 1.1 The reproduction is exact (claim 1 ✓)
+
+Built at `cbb5ecd`, fixture with one space-bearing and one whitespace-free header:
+
+```
+--rename --clip_R1 3 -a AGATCGGAAGAGC --dont_gzip     → @withspace 1:N:0:ACGTAC:clip5:ACG
+                                                        @nospacehere:clip5:ACG
+--rename --clip_R1 3 -a AGATCGGAAGAGC --output-format ubam
+                                                      → QNAME [withspace]                    ← annotation gone
+                                                        QNAME [nospacehere:clip5:ACG]        ← annotation kept
+```
+
+Both halves of the plan's table reproduce, and the whitespace-free contrast that the "data-dependent" claim rests on holds. The mechanism is as described: `append_to_id` (`src/fastq.rs:173-181`) splices before the first TAB but has no SPACE equivalent, so the suffix lands after the description; `parse_name_and_data` (`src/bam.rs:709-723`) then splits on the first space and discards the remainder.
+
+### 1.2 The Perl-parity argument is correct (claim 2 ✓ — the decision's premise holds)
+
+This was the claim the whole decision rests on, so I traced each variable to its assignment rather than reading the append in isolation. All three call-site families append to a **raw, unsplit line**:
+
+| Perl site | Variable | Assignment | Description retained at append? |
+|---|---|---|---|
+| `1098`, `1115` (RRBS+quality branch) | `$l1` | `my $l1 = <TRIM>;` (`:993`) | **Yes** — raw cutadapt line |
+| `1282`, `1298` (poly-A branch) | `$l1` | `my $l1 = <TRIM>;` (`:1219`) | **No** — see nuance below |
+| `1399`, `1414` (default branch) | `$l1` | `my $l1 = <TRIM>;` (`:1372`) | **Yes** — raw cutadapt line |
+| `1910`, `2000` (`--hardtrim5/3`) | `$identifier` | `my $identifier = <$in>;` (`:1893`) | **Yes** — raw input line |
+| `2209`, `2226`, `2243`, `2260` (paired clip) | `$id_1`/`$id_2` | `my $id_1 = <IN1>;` (`:2161`) | **Yes** — raw input line |
+
+Nothing splits on whitespace before the append. The only preprocessing is `$l1 =~ s/\r|\n//g` (line-ending strip), which is exactly what our `id.trim_end()` does. So `@read 1:N:0:IDX` + `--clip_R1 3` under Perl yields `@read 1:N:0:IDX:clip5:ACG` — identical to ours. **Splicing before the space would diverge from shipped Perl. The plan's deciding evidence is sound and the maintainer's choice rests on a true premise.**
+
+**Nuance worth recording (does not change the conclusion).** The poly-A branch is a genuine counterexample: `trim_galore:1255` does `$l1 =~ s/\s+/_/g;` *before* the clip append, so on that path the header is already whitespace-free and `:clip5:` does land on what is effectively a read name. It gets there by mangling the description into underscores rather than by splitting it off, so it is not a precedent for splicing — but it is the one place where Perl's behaviour matches the `readname:clip5:GATC` intent its own warning at `:3456` advertises. If the plan's Context keeps the "irony" aside, this branch is the honest completion of it.
+
+**Under-citation.** The plan cites 5 lines; there are **12**. The missing ones matter for a reason beyond completeness: `1910`/`2000` are the `--hardtrim5`/`--hardtrim3` sites, and that whole mode family is absent from the plan (see §1.4).
+
+### 1.3 `append_to_id` is format-blind (claim 3 ✓), but has a second caller the plan misses
+
+`trim_read` (`src/trimmer.rs:89`) takes `(&mut FastqRecord, &TrimConfig, bool)` — no output-format parameter — and calls `append_to_id` at `:264` / `:273`. It is reached from both the FASTQ writers and the uBAM writers (`src/parallel.rs:463`, `:464`, `:1027`; `src/trimmer.rs:479`, `:480`, `:730`, `:731`). So no fix inside it could be format-scoped without threading the format down. **Confirmed.**
+
+However, `append_to_id` has **six further callers outside `trim_read`**, all in `src/specialty.rs`: `:62`, `:106`, `:166`, `:219` (the `--hardtrim5`/`--hardtrim3` clip annotations) and `:312`/`:313`, `:413`/`:414` (clock/implicon UMI). The plan's Context reasons only about `trim_read`, which understates the surface.
+
+### 1.4 `--hardtrim5` + `--rename` + uBAM is a second, live instance of the same bug — unmentioned
+
+`--rename`'s own help text (`src/cli.rs:300`) says it applies to `--hardtrim5/3`, and those modes are **not** in §3.4a. Verified live:
+
+```
+--hardtrim5 10 --rename --output-format ubam   → exit 0, writes in.10bp_5prime.bam
+  NOTE: ... First dropped: "1:N:0:ACGTAC:clip5:TTTGGGGGGGGGGCCCCCCCCCC"
+  QNAME [withspace]                              ← annotation gone
+  QNAME [nospacehere:clip5:TTTG…]                ← annotation kept
+```
+
+Good news: the plan's guard is a bare `if self.rename` inside the `matches!(self.output_format, UBam)` block, so it covers the hardtrim path **correctly by construction**. But the plan never says so, its reproduction does not exercise it, and its Validation table has no row for it. That is luck rather than design, and a reader auditing coverage later cannot tell which it was.
+
+### 1.5 §3.4a is the right home and the style matches (claim 4, mostly ✓)
+
+`Cli::validate` opens with the §3.4a block at `src/cli.rs:587-632`: seven arms (`--dont_gzip` `:592`, `--clumpify` `:598`, `--passthrough` `:603`, `--clock` `:606`, `--implicon` `:612`, `--demux` `:617`, `--retain_unpaired` `:625`), each a bare `if self.<field> { anyhow::bail!(…) }`. The proposed code is a byte-for-byte stylistic match, including the multi-line string continuation and the parenthesised reason-plus-remedy shape of the `--retain_unpaired` arm it sits beside. **A1 confirmed:** `--rename` appears in `cli.rs` only at `:199` (a doc comment), `:302-303` (the field), `:851-855` (the `--clump_only` rejection) and `:974` (unrelated prose). No existing §3.4a arm.
+
+**Ordering within §3.4a is immaterial as claimed** — every arm bails, none is a precondition for another. But that is the wrong scope for the question (see §1.6).
+
+### 1.6 The new arm silently changes the `--clump_only --rename` message — Behavior #3 is wrong
+
+The plan states (Behavior 3) that "the `--clump_only` rejection stays as-is and keeps its own wording." That holds only for FASTQ output. §3.4a is at `:587`; the `--clump_only` `--rename` bail is at `:852`. So with `--output-format ubam` the new arm fires **first**.
+
+Current behaviour, verified:
+
+```
+--clump_only --rename --output-format ubam
+  → Error: --clump_only preserves record contents byte-identically; --rename would mutate read IDs
+```
+
+After the change this becomes the new §3.4a message, whose stated reason (*"the annotation is appended after any header description, and BAM read names cannot contain whitespace"*) is **not the reason `--clump_only` refuses `--rename`** — `--clump_only` refuses it because the mode is contractually byte-identity-preserving and does no clipping at all, so there is no `:clip5:` to place anywhere. The user is handed a mechanical explanation for a contractual refusal.
+
+The existing test `tests/integration_clump_only.rs:330 rejects_rename_flag` does **not** pass `--output-format ubam`, so it stays green and will not catch this. Fix options, cheapest first: gate the new arm with `&& !self.clump_only`, or hoist the `--clump_only` `--rename` check above §3.4a. Either way Behavior #3 needs rewording.
+
+### 1.7 The "silent" framing is false at this base — #406 already discloses the loss
+
+The plan says "silently discards" (Goal), "silent, data-dependent loss" (Goal), "converts silent loss into a refusal" (Context), "it closes silent data loss" (step 5), and validation 5 predicts the unpatched build "*succeeds* there and **silently** drops the annotation."
+
+At `cbb5ecd` the run prints, on stderr, once per file:
+
+```
+NOTE: BAM read names cannot contain whitespace, so FASTQ header text after the first
+space is not carried into uBAM output. First dropped: "1:N:0:ACGTAC:clip5:ACG"
+```
+
+The dropped text **includes the `:clip5:ACG`**. This is #406's own fix — and `CHANGELOG.md:32-42`, in the same `### Unreleased / #### Bug fixes` section this plan proposes to append to, documents it as "*A one-time `NOTE:` now reports it and echoes the text that was dropped, so what is lost is visible rather than inferred.*" The plan's base commit `d0bb76b` **is** that fix.
+
+This does not overturn the decision — a stderr NOTE in a pipeline log is easy to miss, it fires once per file rather than per record, and it does not say "the flag you explicitly passed has been neutralised." That is still a good reason to refuse. But a CHANGELOG bullet claiming to close *silent* data loss would contradict the bullet ten lines above it. The honest framing is narrower and still compelling: *the flag the user explicitly requested is silently neutralised; only the generic description-dropping NOTE hints at it, and only for the first record.*
+
+### 1.8 The remediation advice does not work
+
+The proposed message ends "*use FASTQ output, or convert afterwards*". The second half is wrong. `samtools import` splits QNAME on whitespace exactly as we do:
+
+```
+FASTQ from --rename:  @withspace 1:N:0:ACGTAC:clip5:ACG
+samtools import       → QNAME withspace                    ← same loss
+samtools import -T '*' → QNAME withspace                   ← same loss
+```
+
+A user who follows the advice reproduces the refused failure with an extra step. "Use FASTQ output" is sound; "convert afterwards" must either be dropped or qualified (the annotation survives conversion only if the description is stripped or folded into the name first).
+
+---
+
+## 2. Assumptions
+
+**A1 — `--rename` absent from §3.4a.** ✓ Verified independently (§1.5).
+
+**A2 — "no test or CI grep asserts that `--rename` + uBAM **succeeds**", deferred to implementation.** ✗ **FALSE, and the deferral was not safe.** `tests/integration_ubam_out.rs:393-440`:
+
+```rust
+fn ubam_out_rename_with_preserve_tags_keeps_tags_intact() {
+    // Code-review C1 regression guard: --rename + --preserve-tags must
+    // NOT corrupt the last preserved tag value. …
+    …args(["--clip_R1","5","--rename","--output-format","ubam",
+           "--preserve-tags","CB,UB"])
+      .arg("test_files/ubam_test_with_tags.bam") …
+    assert!(status.success(), "trim_galore exited non-zero");   // ← line 420
+```
+
+Line 420 asserts precisely what A2 says nothing asserts. The fixture guard at `:400` is not a get-out: `test_files/ubam_test_with_tags.bam` exists (587 bytes, committed 27 Jun), so the test runs rather than skipping. **`cargo test` will fail on the first implementation attempt.** The plan's step 6 runs the suite, so this would be caught — but as a mystery failure during implementation rather than a planned edit, which is the cost the #400 lesson was supposed to prevent. It also means the implementation outline is missing a step.
+
+This matters for more than bookkeeping: the test is the **only** regression guard for the C1 tab-splice in `append_to_id`, and it is the thread that leads to §2's real problem.
+
+**A3 — `--rename` not in the byte-identity matrix.** ✓ Verified. `.github/` has exactly two `rename` hits, both unrelated (`ci.yml:8` a branch-rename comment, `ci.yml:1002` a file rename inside a diff step).
+
+**A4 — FASTQ-path behaviour unchanged, Perl parity untouched by construction.** ✓ Sound. A CLI-validate bail cannot reach `append_to_id`.
+
+**Unstated assumption, and it is the load-bearing one:** that every `--rename` + uBAM-output run is at risk. It is not — see §3.1.
+
+**Base-commit drift:** the plan says base `d0bb76b`; the tree is `cbb5ecd` (`#397`, collision refusals). `d0bb76b` is `HEAD~1`. No conflict with this change, but the header should say `cbb5ecd`.
+
+---
+
+## 3. The scope problem
+
+### 3.1 uBAM-in → uBAM-out is lossless *by specification*, not by luck
+
+The plan's Self-Review accepts over-rejection on these grounds: "whitespace-free headers lose nothing today, so this refusal is stricter than strictly necessary for them. Accepted deliberately: the alternative is a refusal whose firing depends on the shape of the first record, which is worse than a predictable one."
+
+That dichotomy is false, because it treats "whitespace-free" as a property of the *data*. For uBAM input it is a property of the *format*: **SAM forbids whitespace in QNAME**, as our own code says at `src/bam.rs:703` ("The BAM spec rejects whitespace in QNAME"). A `FastqRecord` synthesised from a BAM record (`src/bam.rs:898`) is `@QNAME` plus an optional TAB-delimited tag tail — a space is unreachable. And the TAB case is exactly what the C1 splice already handles.
+
+So uBAM→uBAM with `--rename` cannot lose the annotation. Verified end-to-end:
+
+```
+--clip_R1 5 --rename --output-format ubam --preserve-tags CB,UB  test_files/ubam_test_with_tags.bam
+
+in :  SRR24827378.1                 CB:Z:ATCGATCG-1  UB:Z:GCTAGCTA
+out:  SRR24827378.1:clip5:AATTA     CB:Z:ATCGATCG-1  UB:Z:GCTAGCTA     ← annotation AND tags intact
+      SRR24827378.2:clip5:ACGTA     CB:Z:ATCGATCG-1  UB:Z:GCTAGCTA
+(zero "not carried into uBAM" NOTEs emitted)
+```
+
+The plan would refuse this. It is a working, tested, spec-guaranteed-lossless path — single-cell uBAM carrying `CB`/`UB` through a UMI-aware clip is precisely the workflow `--rename` exists for (`cli.rs:301`: "Useful for UMI handling"), and it is the workflow the C1 fix was written to protect.
+
+**To be explicit: this is not a request to revisit reject-versus-repair.** The maintainer's decision stands and no code inside `append_to_id` need change. The question is only *which inputs* the rejection covers.
+
+### 3.2 The precise guard is cheap and is deterministic
+
+Reject `--rename` + uBAM output when **at least one input is FASTQ**. That is decided by input file format — known before any trimming, independent of record shape — so it is every bit as predictable as a blanket refusal.
+
+It cannot live in `Cli::validate` (no format detection there), but `main.rs` already has the pattern *and* the data. `src/main.rs:247-254` computes `input_formats: Vec<InputFormat>` once, and §3.4b at `:298-315` is an existing format-detection-time rule of exactly this shape (`--preserve-tags` + all-FASTQ → hard error under uBAM output, warning otherwise). A sibling arm right below it needs `input_formats.iter().all(…)` and a `bail!`.
+
+Trade-offs, stated plainly:
+
+| | Blanket, in `cli.rs` §3.4a (as planned) | FASTQ-input-scoped, in `main.rs` §3.4b |
+|---|---|---|
+| Refuses the lossy FASTQ→uBAM direction | yes | yes |
+| Refuses the lossless uBAM→uBAM direction | yes (regression) | no |
+| Fires before any I/O | yes | yes (§3.4b runs before `ensure_output_dir`) |
+| Predictable | yes | yes — keyed on file format, not record shape |
+| Existing C1 test | **must be deleted or rewritten** | **stays green unchanged** |
+| Cost | 6 lines, one file | ~8 lines, one file, one extra `all()` |
+| Mixed FASTQ+uBAM inputs (legal per `CHANGELOG:25`) | refused | refused (`!all_bam`) |
+
+The blanket version is simpler to explain in one sentence, which has real value. But it buys that simplicity by deleting a regression guard for a fix the project made deliberately three commits ago, and by refusing a workflow that provably works. My recommendation is the scoped guard.
+
+**In fairness, there is an in-repo precedent that argues the other way, and it should be weighed.** The `--phred64` + uBAM guard (#358) faced the same choice and chose uniformity, in a comment at `src/main.rs:264-269`:
+
+> Rejected uniformly rather than per-mode. `--hardtrim5/3` and `--clump_only` currently accept the flag as an inert no-op, so this does remove working invocations — but a mode-dependent rule ("rejected unless you're in hardtrim, or clump-only-to-FASTQ, …") is worse to document, worse to test, and one refactor away from being wrong.
+
+That is a direct answer to my recommendation, from this codebase, about this feature area — including the same willingness to "remove working invocations." If Felix applies the same reasoning here, the blanket guard is the consistent choice and §3.3 becomes the required work rather than a fallback.
+
+Two things distinguish the cases, and I think they are enough to tip it the other way, but not decisively:
+
+- **#358's rejected alternative was *mode*-dependent** (hardtrim vs clump-only vs trim — an open-ended list that grows with every new mode). Mine is *input-format*-dependent: a closed, two-valued distinction that cannot grow. `input_formats` is already computed for exactly this kind of decision, and §3.4b at `:298-315` is a format-dependent rule the same codebase accepted without reservation.
+- **#358's uniformity cost nothing that worked correctly** — the flag was an "inert no-op" on the paths it newly refused, so nobody lost output they wanted. Here the refused path produces *correct, tag-preserving output today* and has a test asserting it. That is a materially larger cost than removing a no-op.
+
+The same comment also confirms the mechanics of my suggestion: `:271-273` says the #358 guard is "sited here, not in `Cli::validate()` §3.4a: validate() runs before input format detection and cannot see `any_bam`. Same reason §3.4b below lives in main.rs." So `main.rs` is the established home for precisely this shape of rule.
+
+### 3.3 If the blanket rejection is kept anyway
+
+Then two consequences must be handled explicitly rather than absorbed:
+
+1. `ubam_out_rename_with_preserve_tags_keeps_tags_intact` must become a **rejection** test, and the C1 tab-splice guard must be **re-homed to FASTQ output**, not lost. That route still exercises the splice — verified:
+   ```
+   --clip_R1 5 --rename --preserve-tags CB,UB --dont_gzip   test_files/ubam_test_with_tags.bam
+   → @SRR24827378.1:clip5:AATTA<TAB>CB:Z:ATCGATCG-1<TAB>UB:Z:GCTAGCTA
+   ```
+   So the splice stays reachable and testable after the rejection; without this edit it becomes untested behaviour that a future refactor can quietly break.
+2. The CHANGELOG bullet should say the lossless uBAM→uBAM case is being withdrawn too, and why (one rule beats two). Users of that path get an error where they previously got correct output, and it should not surprise them.
+
+---
+
+## 4. Efficiency / integration
+
+Nil either way, as the plan says: one branch on the argument-parsing path (or one `all()` over an already-materialised `Vec<InputFormat>`). No I/O, no allocation of consequence. Nothing to add.
+
+---
+
+## 5. Validation sufficiency
+
+The table's shape is good — validation 5 as an expected-fail control is the right instinct, and validation 2 guarding against over-reach is the right worry. Gaps:
+
+1. **No row for the existing conflicting test** (A2's real answer). Needs an explicit row: the C1 guard is retargeted, and the tab-splice remains covered somewhere.
+2. **No row for `--hardtrim5`/`--hardtrim3`** — a live instance of the identical loss (§1.4), covered only incidentally.
+3. **No row for uBAM input.** With the scoped guard this is the central positive case ("uBAM→uBAM still succeeds and still carries `:clip5:` plus tags"). With the blanket guard it is the case whose withdrawal needs asserting. Either way it must be tested; today the table cannot distinguish the two designs.
+4. **No paired row.** `--rename` annotates R1 and R2 independently (`trimmer.rs:479-480`, Perl `:2209`/`:2226`), and paired uBAM output is one interleaved BAM. `Cli::validate` runs before the paired split so the guard is format-agnostic, but nothing asserts it.
+5. **Validation 5's prediction is wrong as written** — the unpatched build does not fail *silently*; it prints the #406 NOTE (§1.7). Correct the expectation or the control will look like it found a discrepancy.
+6. **Validation 6** should also confirm `--basename` is documented in `outputs.md` after the edit (§6.2), since the plan's own step 3 leaves that conditional.
+
+---
+
+## 6. Docs (claim 6 ✓, plus one more gap)
+
+### 6.1 Both reported errors are real
+
+`docs/src/content/docs/guide/outputs.md:105` — "`--rename PREFIX` replaces the input filename stem in the output names. Useful for pipelines that thread sample IDs through trimming separately from input filenames." Wrong in every clause: `--rename` is `pub rename: bool` (`cli.rs:302-303`), takes no value, and never touches filenames. The described behaviour is `--basename`'s (`changelog.md:962`). **Confirmed.**
+
+The §Feature compatibility list is missing `--rename`. **Confirmed.** Minor correction: the plan cites `:88-95`; `:88` is the heading and the bullets run `:90-97` (seven, not six — the plan's own count is off by the `--clumpify` bullet).
+
+### 6.2 Nothing else in that list is stale — but `--basename` is missing entirely
+
+I checked each of the seven bullets against §3.4a: `--dont_gzip` (`:592`), `--clock`/`--implicon` (`:606`/`:612`), `--demux` (`:617`), `--passthrough` (`:603`), `--retain_unpaired` (`:625`), `--clumpify` (`:598`). All seven present arms are documented, and the `--clumpify` bullet's `--clump_only` parenthetical is accurate. **The plan is right that `--rename` is the only gap.**
+
+The plan's step 3 hedges: "Check whether the surrounding section already documents `--basename`; if not, one clause." Resolved: **`--basename` does not appear anywhere in `outputs.md`.** It is documented only in `modes/clump-only.md:79`, `modes/passthrough.md:28`, and the changelog. So the guide's `## Renaming outputs` section — the one place a reader looks for output naming — currently describes a flag that does not exist and omits the flag that does the job.
+
+That makes the section heading itself part of the problem. `## Renaming outputs` is about output *filenames*; `--rename` is a read-ID annotation and does not belong under it at any length. Cleanest resolution: make that section about `--basename` (which genuinely renames outputs), and document `--rename` where read-ID mutation belongs — or as a clearly separate subsection with a disambiguating note, since `--rename` / `--basename` is an easy pair to confuse and the current text proves it. The plan's step 3 as written ("replace the sentence with what `--rename` actually does") would leave a read-ID feature sitting under a filename heading.
+
+---
+
+## 7. Alternatives
+
+1. **FASTQ-input-scoped rejection in `main.rs` beside §3.4b — recommended.** §3.2. Same refusal for every lossy case, keeps the spec-lossless one, keeps the C1 test green unchanged.
+2. **Blanket rejection in §3.4a — as planned.** Simplest rule, and backed by the #358 precedent at `main.rs:264-269` (§3.2). Costs the uBAM→uBAM path and forces the C1 guard to be re-homed (§3.3). A legitimate choice if made knowingly; the plan currently makes it without knowing the path is spec-safe.
+3. **Warn instead of reject.** Rejected — already effectively the status quo via #406's NOTE, and §1.7 shows why that is not enough: the NOTE describes description-dropping generically and never says the requested flag was neutralised.
+4. **Splice before space in `append_to_id`.** Correctly ruled out; §1.2 confirms it would diverge from shipped Perl on ten of twelve call sites.
+5. **Move the annotation into a BAM aux tag** (e.g. `XC:Z:ACG`) instead of the QNAME. Out of scope for #408 and a real design question (tag-namespace choice, `--preserve-tags` interaction), but it is the only option that would let `--rename` work for FASTQ→uBAM at all. Worth an issue rather than silence, since the rejection message will prompt users to ask for it.
+
+---
+
+## Action items
+
+### Critical
+
+- **A2 is false — plan an edit to `tests/integration_ubam_out.rs:393-440`.** It asserts `status.success()` on `--clip_R1 5 --rename --output-format ubam --preserve-tags CB,UB` with a committed fixture, so it runs and will fail. Add an explicit implementation step; do not leave this to be discovered by `cargo test`. Correct A2's text — the deferral was not safe.
+- **Decide the guard's scope deliberately, and record the decision.** uBAM→uBAM with `--rename` is lossless by SAM spec (`bam.rs:703`) and verified lossless end-to-end including aux tags (§3.1) — the blanket form refuses a working, tested, single-cell-relevant path, which the plan's Self-Review does not currently account for (it treats the safe case as data-dependent luck). I recommend narrowing to "at least one FASTQ input" in `main.rs` beside §3.4b. **But note the counter-precedent at `src/main.rs:264-269`**, where #358 chose uniform rejection over a conditional rule in this same feature area and explicitly accepted removing working invocations; if Felix follows it, that is defensible and the plan should cite it rather than leave the trade unexamined. Either way: if the blanket form is kept, re-home the C1 tab-splice guard to the FASTQ-output route (§3.3, verified to still exercise it) and disclose the withdrawal of the lossless path in the CHANGELOG.
+- **Fix the remediation text.** "convert afterwards" reproduces the identical loss — `samtools import`, with and without `-T '*'`, drops the description exactly as we do (§1.8). Drop that clause or qualify it.
+
+### Important
+
+- **Stop calling the loss "silent."** #406 already prints a `NOTE` naming the dropped text, and `CHANGELOG.md:32-42` documents that in the very section this plan appends to (§1.7). Reframe to what is actually silent: the explicitly-requested flag is neutralised with no flag-specific diagnostic. Update Goal, Context, step 5, and validation 5's prediction.
+- **Correct Behavior #3 and decide the `--clump_only` overlap.** §3.4a precedes `cli.rs:852`, so `--clump_only --rename --output-format ubam` will switch from the byte-identity message to the new mechanical one, which is the wrong explanation for that mode. Gate with `&& !self.clump_only` or hoist the clump_only check (§1.6). The existing test will not catch this.
+- **Acknowledge the `--hardtrim5`/`--hardtrim3` path.** Same loss, live today, covered by the guard only incidentally (§1.4). Say it is intended and add a validation row.
+- **`--basename` is absent from `outputs.md` entirely**, and `## Renaming outputs` is a filename heading. Resolve the section's structure rather than swapping one sentence into it (§6.2).
+
+### Optional
+
+- Add the six under-cited Perl lines (`1115`, `1298`, `1414`, `1910`, `2000`, `2243`, `2260`) — `1910`/`2000` are the hardtrim sites and connect to the gap above.
+- Record the poly-A branch nuance (`trim_galore:1255` folds whitespace to `_` before appending), which completes the "irony" aside honestly (§1.2).
+- Note that `append_to_id` has six callers in `specialty.rs` beyond `trim_read` (§1.3).
+- Fix line references: base `cbb5ecd` not `d0bb76b`; compatibility bullets `:90-97` not `:88-95` (seven items).
+- Add validation rows for paired-end and for uBAM input (§5).
+- Consider filing a follow-up for carrying the annotation as a BAM aux tag (alternative 5) — the rejection message will invite the request.

--- a/plans/08092026_rename-ubam-rejection/PLAN_REVIEW_B.md
+++ b/plans/08092026_rename-ubam-rejection/PLAN_REVIEW_B.md
@@ -1,0 +1,393 @@
+# Plan Review B — reject `--rename` with `--output-format ubam` (#408)
+
+**Reviewer:** B (independent; Reviewer A works in parallel with no shared state)
+**Plan:** `plans/08092026_rename-ubam-rejection/PLAN.md`
+**Repo:** `/Users/fkrueger/Github/TrimGalore`, branch `dev`
+**Verified against:** `cbb5ecd` (plan states base `d0bb76b`; HEAD has since advanced by #397)
+**Method:** `git archive HEAD` into `$TMPDIR/revB408/src`, private `CARGO_TARGET_DIR`, release build,
+plus the plan's own proposed patch applied to that copy and the full test suite run against it.
+
+**Verdict: REVISE before implementing.** The deciding evidence holds up — but the plan
+as written will fail `cargo test`, and its proposed error message says something that is
+untrue for a whole class of users.
+
+Scope note: the maintainer has decided to reject rather than repair, and to fold in the
+`outputs.md` error. This review takes both as given.
+
+---
+
+## Summary of verification
+
+| # | Claim | Result |
+|---|---|---|
+| 1 | Reproduction (FASTQ keeps annotation, uBAM drops it; data-dependent) | **TRUE**, reproduced byte-exactly |
+| 2 | Perl v0.6.11 appends to the end of the whole ID line | **TRUE**, and more robustly than the plan claims |
+| 3 | `append_to_id` is format-shared via `trim_read` | **TRUE** |
+| 4 | §3.4a is the right home; shape matches; in-block ordering immaterial | **TRUE**, but see I2 — §3.4a pre-empts a *different* block |
+| 5 | A2: nothing asserts the combination succeeds | **FALSE — one test does. Deferral was unsafe.** |
+| 6 | `outputs.md:105` is wrong; compatibility list missing `--rename` | **TRUE**; nothing else in that list is stale |
+| 7 | Over-rejection limited to whitespace-free headers | **Understated** — the whole uBAM-input class is lossless today |
+
+---
+
+## Logic review
+
+### The reproduction is exact (claim 1 — verified)
+
+Built the release binary from `cbb5ecd` and ran the plan's scenario on a two-record
+fixture, one space-bearing header and one without:
+
+```
+FASTQ output  : @withspace 1:N:0:ACGTAC:clip5:ACG
+                @nospace:clip5:ACG
+uBAM QNAMEs   : withspace                  ← :clip5:ACG gone
+                nospace:clip5:ACG          ← preserved
+```
+
+The plan's table and its data-dependence contrast are both correct, and the mechanism is
+as described: `append_to_id` (`src/fastq.rs:173-181`) splices before the first `\t` only,
+and `parse_name_and_data` (`src/bam.rs:707-726`) splits on the first `['\t', ' ']` and
+discards the remainder on the space branch.
+
+### The Perl-parity argument is sound (claim 2 — verified, and stronger than stated)
+
+This is the plan's deciding evidence, so I checked whether `$l1` could already have been
+stripped of its description before the append. It has not been. Every relevant variable is
+a raw filehandle read, and the only mutation before the append is a line-ending strip:
+
+| Perl site | Variable | Assigned at | Mutation before append |
+|---|---|---|---|
+| `:1098`, `:1115` | `$l1` | `:993` `my $l1 = <TRIM>;` | `s/\r|\n//g` only |
+| `:1282`, `:1298` | `$l1` | `:1219` `my $l1 = <TRIM>;` | `s/\r|\n//g` only |
+| `:1399`, `:1414` | `$l1` | `:1372` `my $l1 = <TRIM>;` | `s/\r|\n//g` only |
+| `:2209`, `:2226` | `$id_1`/`$id_2` | `:2161`/`:2166` `= <IN1>`/`<IN2>` | `s/\r|\n//g` only |
+| `:1910`, `:2000` | `$identifier` | `:1893`/`:1977` `= <$in>` | `s/\r|\n//g` only |
+
+I grepped every `$l1` occurrence between the assignment at `:993` and the append at
+`:1098` — there are four, and they are the assignment, a `print`, the line-ending strip,
+and the append itself. No `split`, no whitespace handling. So Perl really does append
+after any space-separated description, at all six sites, on both the trim path and the
+hardtrim path. **The maintainer did not choose on a false premise.**
+
+The plan's noted irony also checks out: `trim_galore:3456` warns the format will be
+`readname:clip5:GATC` — the read *name* — which the implementation does not do.
+
+### Claim 3 confirmed
+
+`trim_read` (`src/trimmer.rs:89`) is reached from both format families, so no fix inside it
+could be format-scoped:
+
+- FASTQ: `run_single_end` (`:319`), `run_paired_end` (`:479`/`:480`), plus `parallel.rs:463/464/1027`
+- uBAM: `run_single_end_to_bam` (`:645`), `run_paired_end_to_bam` (`:730`/`:731`)
+
+### CRITICAL — A2 is false; the plan's own patch breaks a committed test
+
+The plan defers A2 ("no test or CI grep asserts that `--rename` + uBAM **succeeds**") to
+implementation. I resolved it instead: **there is such a test, and it is not a grep-level
+coincidence — it is a deliberate regression guard.**
+
+`tests/integration_ubam_out.rs:393-440`, `ubam_out_rename_with_preserve_tags_keeps_tags_intact`,
+runs `--clip_R1 5 --rename --output-format ubam --preserve-tags CB,UB` and asserts
+`status.success()` at `:420`. Its fixture `test_files/ubam_test_with_tags.bam` **is
+committed and git-tracked**, so the `exists()` guard at `:400` does not skip it.
+
+I applied the plan's exact proposed snippet to my copy of `src/cli.rs` §3.4a and ran the
+full suite:
+
+```
+src/lib.rs unit tests ......................... 411 passed
+integration_adapter2 / clump_only / clump_only_ubam / gzip_non_gz_extension /
+no_args_help / non_restartable_input / output_collision / paired_format_guard /
+passthrough / ubam ............................ all green
+integration_ubam_out .......................... 27 passed; 1 FAILED
+  ---- ubam_out_rename_with_preserve_tags_keeps_tags_intact ----
+  panicked at tests/integration_ubam_out.rs:420:5: trim_galore exited non-zero
+```
+
+Blast radius is precisely one test, which is good news — but the plan's implementation
+outline has no step for it, and step 6 (`cargo test`) would simply fail. The deferral was
+**not** safe: this is exactly the #400 lesson the plan cites, and it landed on the wrong
+side of it.
+
+**Do not just delete the test.** Its C1 mechanism is still live on a legal path —
+uBAM input → FASTQ output → `--rename` still produces a tab-tail ID where the splice
+matters. Verified:
+
+```
+$ trim_galore --clip_R1 5 --rename --preserve-tags CB,UB --dont_gzip ubam_test_with_tags.bam
+@SRR24827378.1:clip5:AATTA<TAB>CB:Z:ATCGATCG-1<TAB>UB:Z:GCTAGCTA
+```
+
+Without the C1 fix the suffix would land after `UB:Z:GCTAGCTA` and corrupt it. So the
+correct remediation is to **port the test to FASTQ output** (swap `--output-format ubam`
+for `--dont_gzip`, assert on the FASTQ header instead of BAM aux), keeping its regression
+value, and add the new rejection test alongside.
+
+### CRITICAL — "silent" is false, and the proposed message is false
+
+Two separate problems, both in the wording the plan intends to ship.
+
+**(a) The loss is already disclosed at runtime**, as of the plan's own stated base commit.
+#406/#412 added `emit_description_dropped_once` (`src/bam.rs:1031-1045`), which fires on
+exactly this path and echoes the dropped text:
+
+```
+NOTE: BAM read names cannot contain whitespace, so FASTQ header text after the first
+space is not carried into uBAM output. First dropped: "1:N:0:ACGTAC:clip5:ACG"
+```
+
+That notice's own doc comment (`src/bam.rs:1027-1030`) even forward-references this issue:
+"or — see #408 — `--rename`'s own `:clip5:` annotation." So the plan describes as "silent,
+data-dependent loss" something the codebase already announces, in a message written
+with #408 in mind. The Goal paragraph, the "silent" framing throughout, and especially
+implementation step 5 ("CHANGELOG … it closes silent data loss") all need correcting —
+otherwise the changelog ships a claim that is refuted by the program's own stderr.
+
+The refusal is still an improvement (a one-time NOTE about "header text" does not tell a
+`--rename` user their annotation specifically is gone, and it is easy to miss in a
+pipeline log). But the justification is "an easily-missed notice becomes an actionable
+refusal", not "silence becomes a refusal".
+
+**(b) The message would be untrue for uBAM-input users.** The proposed text asserts the
+annotation "would be silently dropped". For uBAM input it would not be dropped at all —
+BAM QNAMEs cannot contain whitespace by spec, so a uBAM-derived ID never reaches the space
+branch, and the tab branch handles the tag tail correctly. Verified both ways:
+
+```
+uBAM in → uBAM out, --rename --preserve-tags CB,UB
+  QNAME SRR24827378.1:clip5:AATTA   CB:Z:ATCGATCG-1  UB:Z:GCTAGCTA   ← lossless
+uBAM in → uBAM out, --rename (no --preserve-tags)
+  QNAME SRR24827378.1:clip5:AATTA                                     ← lossless
+  (and no description-dropped NOTE is emitted)
+```
+
+Shipping a rejection whose stated reason is counterfactual for the affected user is the
+precise failure mode #406 was filed about — and the #406 entry sits immediately above the
+new one in `CHANGELOG.md`. The message must be phrased in terms of what cannot be
+*guaranteed* (a FASTQ description makes the annotation unrepresentable in QNAME), not as a
+claim about what will happen.
+
+### IMPORTANT — the over-rejection is materially larger than the plan concedes
+
+The plan's Self-Review treats whitespace-free headers as the only over-reach and calls it
+an accepted edge case. In fact the refusal removes **the entire uBAM-in → uBAM-out
+`--rename` path**, which works losslessly today, has a committed fixture, and has a
+dedicated regression test — and which is the flagship round-trip the `--output-format ubam`
+feature exists to serve. That is not an edge case; it is the feature's core audience.
+
+To be clear, **the decision can still stand**, and there is strong in-tree precedent for
+it that the plan argues around without citing. `src/main.rs:265-269`, on the `--phred64`
+rejection, records the house position almost verbatim:
+
+> Rejected uniformly rather than per-mode. `--hardtrim5/3` and `--clump_only` currently
+> accept the flag as an inert no-op, so this does remove working invocations — but a
+> mode-dependent rule … is worse to document, worse to test, and one refactor away from
+> being wrong.
+
+The plan should cite that rather than re-deriving the argument, and should state the cost
+accurately.
+
+But the plan should also surface the alternative it never considers, because it has an
+established home. A format-gated rule is not novel here: `main.rs:271-275` explains that
+§3.4b lives in `main.rs` precisely because "validate() runs before input format detection
+and cannot see `any_bam`". So `--rename` + uBAM output + any FASTQ input could be rejected
+next to §3.4b, preserving the lossless uBAM-in case. That trades a wider blast radius for
+a rule keyed on input format rather than mode — arguably a different and more defensible
+axis than the "mode-dependent" shape `main.rs:265-269` warns against. **Felix chose
+"reject" over "repair"; he was not offered "reject narrowly", and given the uBAM-in case
+is lossless he should be.**
+
+### IMPORTANT — §3.4a pre-empts the `--clump_only` block
+
+Behavior item 4 says "Ordering within §3.4a is immaterial — every arm bails, so no arm
+masks another." True as far as it goes, but it addresses the wrong ordering question.
+§3.4a is the **first** thing in `validate()` (`src/cli.rs:587`); the `--clump_only` rename
+rejection is at `:851`. So the new arm masks that one.
+
+`--clump_only --output-format ubam` is a supported combination (`outputs.md:96`), so
+`--clump_only --rename --output-format ubam` is reachable. Today:
+
+```
+Error: --clump_only preserves record contents byte-identically; --rename would mutate read IDs
+```
+
+After the change the user instead gets the uBAM message about `:clip5:`/`:clip3:` being
+appended after a header description — a non-sequitur under `--clump_only`, which does no
+clipping at all, so no annotation would ever exist. An accurate message regresses to an
+inaccurate one.
+
+The plan's Open question asks whether to *mention* the `--clump_only` rejection in the new
+message. The real question is whether to *avoid pre-empting* it — e.g. `if self.rename && !self.clump_only`,
+or siting the new arm after the clump-only block. Either is a one-line change; the plan
+should decide it rather than leaving it to discovery.
+
+### IMPORTANT — the hardtrim uBAM paths share the defect and go unmentioned
+
+The plan's Context attributes the loss solely to `trim_read`. There are two more
+independent call sites: `src/specialty.rs:166` (`hardtrim5_to_bam`) and `:219`
+(`hardtrim3_to_bam`), each gated on `rename` and each writing through `BamWriter`.
+`--hardtrim5`/`--hardtrim3` are **not** rejected in §3.4a, and they have real uBAM
+drivers (`main.rs:450`, `:481`). Verified the same loss:
+
+```
+$ trim_galore --hardtrim5 10 --rename --output-format ubam in.fastq
+NOTE: … First dropped: "1:N:0:ACGTAC:clip5:GTACGTACGTACGTACGTACGT"
+QNAMEs: withspace                              ← annotation gone
+        nospace:clip5:GTACGTACGTACGTACGTACGT
+```
+
+This cuts in the plan's favour — the blanket §3.4a arm closes the hardtrim variant too,
+so the fix is broader than the plan realises. But three things follow: the Context section
+is incomplete as written; the Validation table never exercises hardtrim, which is
+plausibly where `--rename` sees most use; and the CHANGELOG bullet should say the refusal
+covers hardtrim as well, or hardtrim users will not connect it to their runs.
+
+### IMPORTANT — `bam.rs:1027-1030` goes stale on merge
+
+That doc comment offers "`--rename`'s own `:clip5:` annotation" as an example of text the
+notice may report as dropped, tagged "see #408". Once `--rename` + uBAM output is refused,
+`:clip5:` can no longer reach `parse_name_and_data` by any route, so the example becomes
+counterfactual — a comment citing the issue whose fix invalidated it. The plan has no step
+for it. One-line edit, but it is the kind of thing #406 was about.
+
+---
+
+## Assumptions
+
+- **A1 (rename absent from §3.4a) — TRUE.** §3.4a spans `src/cli.rs:584-632` and rejects
+  `dont_gzip`, `clumpify`, `passthrough`, `clock`, `implicon`, `demux`, `retain_unpaired`.
+  The only `self.rename` rejection in the file is the `--clump_only` one at `:851-855`.
+  (Line numbers drifted slightly from the plan's "~590-631" — cosmetic.)
+- **A2 — FALSE.** See above. This is the plan's one substantive error.
+- **A3 (not in the byte-identity matrix) — TRUE.** `.github/workflows/ci.yml`'s only
+  `rename` hits are the branch-rename comment at `:8` and a file rename in a diff step at
+  `:1002`. Neither is a `--rename` invocation.
+- **A4 (FASTQ path untouched, Perl parity untouched by construction) — TRUE.** The change
+  cannot reach `append_to_id`.
+- **Unstated assumption, now falsified:** that the loss is silent, and that the uBAM path
+  loses the annotation generally rather than only for space-bearing (i.e. FASTQ-sourced)
+  headers. Both are load-bearing for the Goal paragraph and the message text.
+- **Unstated assumption:** that no *other* validation block depends on running before
+  §3.4a. Only the `--clump_only` one does, and it now loses. See I2.
+
+---
+
+## Efficiency
+
+Nil, as the plan says: one boolean test on the argument-parsing path. Nothing further to add.
+
+---
+
+## Validation sufficiency
+
+The table is well-shaped — row 5's expected-fail control is genuinely informative here —
+but it has gaps, and one row cannot fail.
+
+- **Missing: the test that breaks.** No row anticipates
+  `ubam_out_rename_with_preserve_tags_keeps_tags_intact`. Row 4 ("A2's grep before
+  editing") would have caught it only if the grep were run; it was deferred instead.
+- **Missing: the uBAM-input case.** Nothing checks what the refusal costs a
+  uBAM-in → uBAM-out user, which is the combination that works today. A row asserting the
+  refusal *and* acknowledging the loss of a working path would have surfaced I1 during
+  planning.
+- **Missing: hardtrim.** `--hardtrim5 N --rename --output-format ubam` should appear, both
+  as a rejection case and because it exercises a different `append_to_id` call site.
+- **Missing: `--clump_only` message stability.** Add a row asserting which message
+  `--clump_only --rename --output-format ubam` produces, whichever way I2 is decided.
+- **Row 3 cannot fail.** "Perl parity untouched — the byte-identity harness plus the
+  validation matrix" is a no-op given A3 (correctly) establishes that `--rename` is not in
+  the matrix. It is reassurance, not validation. Row 2 (FASTQ output still ends
+  `:clip5:ACG`) is the row that actually protects parity, and it is good — I confirmed it
+  passes on the patched build's FASTQ path.
+- **Suggest matching sibling conventions** for the new unit test:
+  `output_format_ubam_plus_rename_rejected`, beside `output_format_ubam_plus_demux_rejected`
+  (`src/cli.rs:2146`). The plan's "assert `--rename` alone still validates" already has a
+  model at `output_format_ubam_alone_validates` (`:2052`).
+
+---
+
+## Docs claims (claim 6 — verified)
+
+- **`outputs.md:105` is wrong on every clause**, as the plan says. `--rename` is
+  `pub rename: bool` (`src/cli.rs:303`); it takes no `PREFIX`, touches no filename, and
+  the described behaviour is `--basename`'s.
+- **The compatibility list (`:88` heading, `:90-96` items) is missing `--rename`** — and
+  **nothing else in it is stale**. I checked all seven bullets against §3.4a: they match
+  one-for-one, and the `--clump_only --output-format ubam` parenthetical at `:96` is
+  accurate. The `--preserve-tags` hard error is covered in prose at `:87`. So the plan's
+  "only one gap" reading is correct.
+- **The plan's step-3 conditional resolves to "yes, a clause is needed."** `--basename`
+  appears nowhere in the guide — only in `modes/passthrough.md:28`, `modes/clump-only.md:79`,
+  and the changelog. The outputs page is exactly where it belongs, and it currently
+  documents `--basename`'s behaviour under the wrong flag's name while never naming
+  `--basename` itself.
+- **One thing the plan misses: the heading is wrong too.** `## Renaming outputs` (`:103`)
+  is `--basename`'s subject, not `--rename`'s. Replacing only the sentence leaves a
+  correct sentence about read-ID annotation under a heading about output naming. Either
+  keep the heading for `--basename` and give `--rename` its own, or retitle.
+
+---
+
+## Alternatives
+
+1. **Format-gated rejection in `main.rs` beside §3.4b** (reject only when a FASTQ input is
+   present). Preserves the lossless uBAM-in case; established precedent and an established
+   home; costs a rule that reads off input format. **This is the alternative worth putting
+   to Felix**, because the plan's cost estimate for blanket rejection was too low.
+2. **Blanket rejection as planned**, with the message fixed and `main.rs:265-269` cited as
+   precedent. Defensible, simplest to document and test, consistent with house style. My
+   recommendation *if* Felix still prefers uniformity once he knows the uBAM-in case works.
+3. **Warn instead of refuse**, upgrading the existing NOTE to name `--rename` specifically.
+   Rejected — it keeps a data-dependent outcome, which the plan correctly argues against.
+4. **Repair `append_to_id` with a format flag threaded through `trim_read`.** Correctly
+   ruled out: it either breaks Perl parity or widens `trim_read`'s signature for one flag.
+
+Options 1 and 2 are both reasonable; the plan should not proceed as though only 2 exists.
+
+---
+
+## Action items
+
+### Critical
+
+1. **Fix `tests/integration_ubam_out.rs:393-440`.** A2 is false; the plan's exact patch
+   fails this test. Port it to FASTQ output (`--dont_gzip` in place of
+   `--output-format ubam`, assert on the FASTQ header) so the C1 tab-splice guard survives
+   — verified that path still exercises it. Add an explicit implementation step; do not
+   leave it to `cargo test` to discover.
+2. **Rewrite the error message.** "would be silently dropped" is false for uBAM input
+   (lossless, verified) and overstated for FASTQ input (a NOTE already fires). Phrase it
+   as unrepresentability, not prediction. Shipping the current wording regresses the exact
+   principle #406 established one changelog entry above.
+3. **Drop "silent" from the Goal and the CHANGELOG bullet.** `emit_description_dropped_once`
+   (`src/bam.rs:1031-1045`) exists as of the plan's own base commit and echoes the lost
+   annotation. The honest framing is "an easily-missed notice becomes an actionable refusal".
+
+### Important
+
+4. **Restate the cost of rejection.** The whole uBAM-in → uBAM-out `--rename` path is
+   lossless today and would be refused — not just whitespace-free headers. Correct the
+   Self-Review edge-case bullet, cite `main.rs:265-269` as the precedent for uniform
+   rejection, and put alternative 1 (format-gated, beside §3.4b) to Felix explicitly.
+5. **Decide the `--clump_only` pre-emption.** §3.4a (`:587`) runs before the clump-only
+   block (`:851`), so the new arm replaces an accurate message with an inapplicable one
+   for `--clump_only --rename --output-format ubam`. Behavior item 4 addresses in-block
+   ordering only and misses this.
+6. **Add the hardtrim paths to Context, Validation and the CHANGELOG.**
+   `src/specialty.rs:166`/`:219` are independent `append_to_id` call sites with the same
+   defect; the refusal covers them, which is a point in its favour, but nothing in the plan
+   says so or tests it.
+7. **Update `src/bam.rs:1027-1030`.** Its "see #408 — `--rename`'s own `:clip5:`
+   annotation" example becomes unreachable once the combination is refused.
+8. **Fix the `outputs.md:103` heading**, not just the `:105` sentence. And note that the
+   step-3 conditional is already answered: `--basename` is undocumented in the guide, so
+   the clause is required.
+
+### Optional
+
+9. Refresh the base commit and line numbers: base is now `cbb5ecd` (#397 landed after
+   `d0bb76b`); §3.4a is `src/cli.rs:584-632`.
+10. Replace Validation row 3 with something that can fail, or mark it explicitly as
+    reassurance. Row 2 is the one doing the parity work.
+11. Name the new test `output_format_ubam_plus_rename_rejected` to match the siblings at
+    `src/cli.rs:2059-2160`.

--- a/plans/08092026_rename-ubam-rejection/PROGRESS.md
+++ b/plans/08092026_rename-ubam-rejection/PROGRESS.md
@@ -1,0 +1,20 @@
+# Progress: reject `--rename` with `--output-format ubam` (#408)
+
+**Last updated:** 2026-08-09
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | PLAN.md **r2** — dual review folded in; scope now format-gated (Felix), which relocates the check to main.rs §3.4b and resolves the --clump_only pre-emption for free |
+| Plan Review | ✅ Complete | PLAN_REVIEW_A.md + _B.md — both REVISE; Perl-parity premise CONFIRMED by both; A2 found false (C1 guard asserts success); B applied r1's patch and ran the suite |
+| Impl Plan | 📋 Planned | — |
+| Implementation | 📋 Planned | Only on exact trigger |
+| Code Review | 📋 Planned | — |
+| Coverage | 📋 Planned | — |
+
+## History
+
+- 2026-08-09: Plan revised to r2 (dual-review findings + format-gated scope decision)
+- 2026-08-09: Plan Review → ✅ Complete (dual reviewers)
+- 2026-08-09: Plan → ✅ Complete (Perl-parity evidence gathered from the 0.6.11 tag; reject-vs-repair decided; PLAN.md written)

--- a/src/bam.rs
+++ b/src/bam.rs
@@ -1026,8 +1026,7 @@ fn emit_iupac_warning_write_once() {
 
 /// One-time disclosure that a FASTQ header description was not carried into uBAM
 /// output. Echoes the text actually dropped, because what is lost varies: an
-/// instrument identifier, an Illumina index field, or — see #408 — `--rename`'s
-/// own `:clip5:` annotation.
+/// instrument identifier, or an Illumina `1:N:0:INDEX` field.
 fn emit_description_dropped_once(dropped: &str) {
     static SEEN: OnceLock<()> = OnceLock::new();
     SEEN.get_or_init(|| {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -299,6 +299,8 @@ pub struct Cli {
 
     /// Add clipped sequences to read IDs for --clip_R1/R2, --three_prime_clip_R1/R2, and --hardtrim5/3.
     /// Appends :clip5:SEQ and/or :clip3:SEQ to the read ID (each half only when that side was clipped). Useful for UMI handling.
+    /// Refused with --output-format ubam when any input is FASTQ, because a BAM read name cannot hold the
+    /// annotation once the header carries a description; also refused by --clump_only, which does not mutate IDs.
     #[clap(long = "rename")]
     pub rename: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,6 +313,24 @@ fn main() -> Result<()> {
              The flag is ignored for FASTQ input."
         );
     }
+    // #408 — sited here rather than in `Cli::validate()` §3.4a because the rule is
+    // format-gated, and validate() cannot see `input_formats`. Same reason as §3.4b.
+    if cli.rename
+        && matches!(cli.output_format, trim_galore::cli::OutputFormat::UBam)
+        && input_formats
+            .iter()
+            .any(|f| !matches!(f, InputFormat::UnalignedBam))
+    {
+        anyhow::bail!(
+            "--rename cannot be honoured with --output-format ubam when any input is \
+             FASTQ. The :clip5:/:clip3: annotation is appended to the end of the read \
+             ID, so whenever a FASTQ header carries text after the first space the \
+             annotation lands in that text — and BAM read names cannot contain \
+             whitespace, so none of that tail can be represented in the output. Use \
+             FASTQ output, or drop --rename. uBAM input is unaffected: BAM read names \
+             carry no description, so there the annotation lands on the name itself."
+        );
+    }
     if cli.passthrough.is_some() && any_bam {
         anyhow::bail!(
             "--passthrough is not supported with uBAM input in this release. \

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,24 +313,6 @@ fn main() -> Result<()> {
              The flag is ignored for FASTQ input."
         );
     }
-    // #408 — sited here rather than in `Cli::validate()` §3.4a because the rule is
-    // format-gated, and validate() cannot see `input_formats`. Same reason as §3.4b.
-    if cli.rename
-        && matches!(cli.output_format, trim_galore::cli::OutputFormat::UBam)
-        && input_formats
-            .iter()
-            .any(|f| !matches!(f, InputFormat::UnalignedBam))
-    {
-        anyhow::bail!(
-            "--rename cannot be honoured with --output-format ubam when any input is \
-             FASTQ. The :clip5:/:clip3: annotation is appended to the end of the read \
-             ID, so whenever a FASTQ header carries text after the first space the \
-             annotation lands in that text — and BAM read names cannot contain \
-             whitespace, so none of that tail can be represented in the output. Use \
-             FASTQ output, or drop --rename. uBAM input is unaffected: BAM read names \
-             carry no description, so there the annotation lands on the name itself."
-        );
-    }
     if cli.passthrough.is_some() && any_bam {
         anyhow::bail!(
             "--passthrough is not supported with uBAM input in this release. \
@@ -359,7 +341,7 @@ fn main() -> Result<()> {
     //
     // Sited here for the same reason as the `--phred64` guard above: the
     // decision needs `input_formats`, which `Cli::validate()` cannot see. The
-    // position matters beyond that, though — this is the last point before
+    // position matters beyond that, though — this is ahead of
     // `ensure_output_dir` (below), the three output-collision pre-flights, and
     // every dispatch branch. The three guards this replaces all sat *past* that
     // line: the trim-path one fired only after adapter auto-detection had
@@ -389,6 +371,36 @@ fn main() -> Result<()> {
             (false, false) => PairedShape::Trim,
         };
         reject_bam_format_mismatch_in_pair(&cli.input, &input_formats, shape)?;
+    }
+
+    // #408 — format-gated, so it cannot live in `Cli::validate()`; sited after the
+    // two structural pair checks above so those report their own defect first. The
+    // clip-flag list must match every `--rename`-driven `append_to_id` site
+    // (`trimmer.rs` clip_5/clip_3, `specialty.rs` hardtrim) — without one of them
+    // set, `--rename` appends nothing and there is nothing to lose.
+    if cli.rename
+        && matches!(cli.output_format, trim_galore::cli::OutputFormat::UBam)
+        && (cli.clip_r1.is_some()
+            || cli.clip_r2.is_some()
+            || cli.three_prime_clip_r1.is_some()
+            || cli.three_prime_clip_r2.is_some()
+            || cli.hardtrim5.is_some()
+            || cli.hardtrim3.is_some())
+        && input_formats
+            .iter()
+            .any(|f| !matches!(f, InputFormat::UnalignedBam))
+    {
+        anyhow::bail!(
+            "--rename is refused with --output-format ubam when any input is FASTQ. \
+             Whether the annotation can be represented depends on the individual \
+             header: the :clip5:/:clip3: suffix is appended to the end of the read ID, \
+             so a header carrying text after the first space puts the annotation inside \
+             that text, and BAM read names cannot contain whitespace, so none of that \
+             tail reaches the output. The whole run is refused rather than decided per \
+             record, because a mid-stream refusal would leave a partial BAM behind. Use \
+             FASTQ output, or drop --rename. uBAM input is unaffected: BAM read names \
+             carry no description, so there the annotation lands on the name itself."
+        );
     }
 
     // Output gzip mode. Mirror Perl: by default the output's compression

--- a/tests/integration_ubam_out.rs
+++ b/tests/integration_ubam_out.rs
@@ -881,12 +881,7 @@ fn write_one_record(path: &Path, header: &str, seq: &str) {
 }
 
 fn run_capturing_stderr(cwd: &Path, args: &[&str]) -> String {
-    let out = Command::new(binary())
-        .current_dir(cwd)
-        .args(args)
-        .output()
-        .expect("failed to run trim_galore");
-    String::from_utf8_lossy(&out.stderr).to_string()
+    run_in(cwd, args).1
 }
 
 /// #406 — FASTQ→uBAM must name its own direction. The old shared message said
@@ -994,6 +989,17 @@ fn run_in(cwd: &Path, args: &[&str]) -> (bool, String) {
     )
 }
 
+/// Every filename in `dir`, sorted — for asserting a refusal wrote nothing at all
+/// rather than merely not writing one expected name.
+fn dir_listing(dir: &Path) -> Vec<String> {
+    let mut names: Vec<String> = std::fs::read_dir(dir)
+        .expect("output dir unreadable")
+        .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+        .collect();
+    names.sort();
+    names
+}
+
 /// #408 — FASTQ input cannot represent the annotation in a BAM read name, so the
 /// combination is refused before anything is written.
 #[test]
@@ -1020,17 +1026,52 @@ fn rename_into_ubam_refused_for_fastq_input() {
         "--rename + uBAM output + FASTQ input must exit non-zero"
     );
     assert!(
-        err.contains("--rename cannot be honoured") && err.contains("--output-format ubam"),
+        err.contains("--rename is refused") && err.contains("--output-format ubam"),
         "expected the #408 refusal in stderr:\n{err}"
     );
+    // The whole listing, not one filename: the refusal precedes every writer, so
+    // the trimming reports must be absent too.
+    assert_eq!(
+        dir_listing(&dir),
+        vec!["sp.fastq".to_string()],
+        "a refused run must write nothing"
+    );
+}
+
+/// #408 — `--rename` alone appends nothing (`append_to_id` is reached only under a
+/// clip flag), so refusing it would break wrappers that pass the flag
+/// unconditionally.
+#[test]
+fn rename_without_clip_flag_is_accepted_into_ubam() {
+    let dir = fresh_tmpdir("tg_408_no_clip_accepted");
+    write_one_record(
+        &dir.join("sp.fastq"),
+        "@withspace 1:N:0:ACGTAC",
+        "ACGTACGTACGTACGTACGTACGTACGT",
+    );
+    let (ok, err) = run_in(&dir, &["--rename", "--output-format", "ubam", "sp.fastq"]);
     assert!(
-        !dir.join("sp_trimmed.bam").exists(),
-        "the refusal must precede every writer; sp_trimmed.bam was created"
+        ok,
+        "--rename with no clip flag is a no-op, not an error:\n{err}"
+    );
+    assert!(
+        dir.join("sp_trimmed.bam").exists(),
+        "the run should have produced sp_trimmed.bam"
+    );
+    let tuples = bam_tuples(&dir.join("sp_trimmed.bam"));
+    let name = String::from_utf8_lossy(&tuples.first().expect("no records").0).to_string();
+    assert!(
+        !name.contains(":clip5:") && !name.contains(":clip3:"),
+        "nothing should have been appended; got {name}"
     );
 }
 
 /// #408 — the gate must not become blanket: uBAM in is lossless by SAM spec
 /// (read names carry no description), so the annotation lands on the QNAME.
+///
+/// Complements `ubam_out_rename_with_preserve_tags_keeps_tags_intact`, which runs
+/// the same invocation to assert the mirror property — that the annotation did
+/// *not* land inside the last preserved tag. Neither is redundant.
 #[test]
 fn rename_into_ubam_accepted_for_ubam_input() {
     let dir = fresh_tmpdir("tg_408_ubam_accepted");
@@ -1115,8 +1156,40 @@ fn rename_into_ubam_refused_for_hardtrim_fastq_input() {
     );
     assert!(!ok, "the hardtrim path must be refused too");
     assert!(
-        err.contains("--rename cannot be honoured"),
+        err.contains("--rename is refused"),
         "expected the #408 refusal on the hardtrim path:\n{err}"
+    );
+    assert_eq!(
+        dir_listing(&dir),
+        vec!["sp.fastq".to_string()],
+        "the specialty arm must also write nothing"
+    );
+}
+
+/// #408 — `--hardtrim3` is a separate `append_to_id` site from `--hardtrim5`.
+#[test]
+fn rename_into_ubam_refused_for_hardtrim3_fastq_input() {
+    let dir = fresh_tmpdir("tg_408_hardtrim3_refused");
+    write_one_record(
+        &dir.join("sp.fastq"),
+        "@withspace 1:N:0:ACGTAC",
+        "ACGTACGTACGTACGTACGTACGTACGT",
+    );
+    let (ok, err) = run_in(
+        &dir,
+        &[
+            "--hardtrim3",
+            "20",
+            "--rename",
+            "--output-format",
+            "ubam",
+            "sp.fastq",
+        ],
+    );
+    assert!(!ok, "the hardtrim3 path must be refused too");
+    assert!(
+        err.contains("--rename is refused"),
+        "expected the #408 refusal on the hardtrim3 path:\n{err}"
     );
 }
 
@@ -1146,7 +1219,40 @@ fn clump_only_rename_keeps_its_own_message() {
         "expected the --clump_only message:\n{err}"
     );
     assert!(
-        !err.contains("--rename cannot be honoured"),
+        !err.contains("--rename is refused"),
         "the #408 guard must not pre-empt the mode-specific message:\n{err}"
+    );
+}
+
+/// #408 — the guard sits after the two structural pair checks, so a broken pair
+/// reports its own defect rather than a lecture about `:clip5:` representability.
+#[test]
+fn paired_single_fastq_keeps_its_structural_message() {
+    let dir = fresh_tmpdir("tg_408_paired_single_fastq");
+    write_one_record(
+        &dir.join("sp.fastq"),
+        "@withspace 1:N:0:ACGTAC",
+        "ACGTACGTACGTACGTACGTACGTACGT",
+    );
+    let (ok, err) = run_in(
+        &dir,
+        &[
+            "--paired",
+            "--rename",
+            "--clip_R1",
+            "3",
+            "--output-format",
+            "ubam",
+            "sp.fastq",
+        ],
+    );
+    assert!(!ok, "--paired with one FASTQ must be refused");
+    assert!(
+        err.contains("--paired with a single input file"),
+        "expected the structural message, not the #408 one:\n{err}"
+    );
+    assert!(
+        !err.contains("--rename is refused"),
+        "the #408 guard must not pre-empt the structural check:\n{err}"
     );
 }

--- a/tests/integration_ubam_out.rs
+++ b/tests/integration_ubam_out.rs
@@ -978,3 +978,175 @@ fn plain_header_does_not_trigger_the_notice() {
         "a header with no description must not fire the notice:\n{err}"
     );
 }
+
+// ── #408: --rename into uBAM, gated on input format ───────────────────────
+
+/// Run in `cwd`, returning exit-success and stderr.
+fn run_in(cwd: &Path, args: &[&str]) -> (bool, String) {
+    let out = Command::new(binary())
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .expect("failed to run trim_galore");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+/// #408 — FASTQ input cannot represent the annotation in a BAM read name, so the
+/// combination is refused before anything is written.
+#[test]
+fn rename_into_ubam_refused_for_fastq_input() {
+    let dir = fresh_tmpdir("tg_408_fastq_refused");
+    write_one_record(
+        &dir.join("sp.fastq"),
+        "@withspace 1:N:0:ACGTAC",
+        "ACGTACGTACGTACGTACGTACGTACGT",
+    );
+    let (ok, err) = run_in(
+        &dir,
+        &[
+            "--rename",
+            "--clip_R1",
+            "3",
+            "--output-format",
+            "ubam",
+            "sp.fastq",
+        ],
+    );
+    assert!(
+        !ok,
+        "--rename + uBAM output + FASTQ input must exit non-zero"
+    );
+    assert!(
+        err.contains("--rename cannot be honoured") && err.contains("--output-format ubam"),
+        "expected the #408 refusal in stderr:\n{err}"
+    );
+    assert!(
+        !dir.join("sp_trimmed.bam").exists(),
+        "the refusal must precede every writer; sp_trimmed.bam was created"
+    );
+}
+
+/// #408 — the gate must not become blanket: uBAM in is lossless by SAM spec
+/// (read names carry no description), so the annotation lands on the QNAME.
+#[test]
+fn rename_into_ubam_accepted_for_ubam_input() {
+    let dir = fresh_tmpdir("tg_408_ubam_accepted");
+    let output = Command::new(binary())
+        .args([
+            "--clip_R1",
+            "5",
+            "--rename",
+            "--output-format",
+            "ubam",
+            "--preserve-tags",
+            "CB,UB",
+        ])
+        .arg("test_files/ubam_test_with_tags.bam")
+        .arg("-o")
+        .arg(&dir)
+        .output()
+        .expect("trim_galore failed to run");
+    assert!(
+        output.status.success(),
+        "uBAM input must still be accepted:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let tuples = bam_tuples(&dir.join("ubam_test_with_tags_trimmed.bam"));
+    let first = tuples.first().expect("expected at least one record");
+    let name = String::from_utf8_lossy(&first.0);
+    assert!(
+        name.contains(":clip5:"),
+        "the annotation must reach the QNAME on the uBAM path; got {name}"
+    );
+    assert!(
+        first.4.iter().any(|(tag, _)| tag.as_slice() == b"UB"),
+        "preserved aux tags must survive alongside the annotation"
+    );
+}
+
+/// #408 — no over-reach: FASTQ output keeps its Perl-matching ID format, which
+/// appends after the header description rather than splicing into the name.
+#[test]
+fn rename_with_fastq_output_still_annotates_the_id() {
+    let dir = fresh_tmpdir("tg_408_fastq_out");
+    write_one_record(
+        &dir.join("sp.fastq"),
+        "@withspace 1:N:0:ACGTAC",
+        "ACGTACGTACGTACGTACGTACGTACGT",
+    );
+    let (ok, err) = run_in(&dir, &["--rename", "--clip_R1", "3", "sp.fastq"]);
+    assert!(
+        ok,
+        "FASTQ output must be untouched by the #408 guard:\n{err}"
+    );
+
+    let out = std::fs::read_to_string(dir.join("sp_trimmed.fq")).expect("trimmed FASTQ missing");
+    let id = out.lines().next().expect("empty output");
+    assert_eq!(
+        id, "@withspace 1:N:0:ACGTAC:clip5:ACG",
+        "the FASTQ-path ID format must not change"
+    );
+}
+
+/// #408 — `--hardtrim5` reaches `append_to_id` via specialty.rs and loses the
+/// annotation the same way, so the same guard must cover it.
+#[test]
+fn rename_into_ubam_refused_for_hardtrim_fastq_input() {
+    let dir = fresh_tmpdir("tg_408_hardtrim_refused");
+    write_one_record(
+        &dir.join("sp.fastq"),
+        "@withspace 1:N:0:ACGTAC",
+        "ACGTACGTACGTACGTACGTACGTACGT",
+    );
+    let (ok, err) = run_in(
+        &dir,
+        &[
+            "--hardtrim5",
+            "20",
+            "--rename",
+            "--output-format",
+            "ubam",
+            "sp.fastq",
+        ],
+    );
+    assert!(!ok, "the hardtrim path must be refused too");
+    assert!(
+        err.contains("--rename cannot be honoured"),
+        "expected the #408 refusal on the hardtrim path:\n{err}"
+    );
+}
+
+/// #408 — the guard sits behind `Cli::validate()`, so `--clump_only` keeps its
+/// own mode-specific message instead of being pre-empted by a mechanical one.
+#[test]
+fn clump_only_rename_keeps_its_own_message() {
+    let dir = fresh_tmpdir("tg_408_clump_only_msg");
+    write_one_record(
+        &dir.join("sp.fastq"),
+        "@withspace 1:N:0:ACGTAC",
+        "ACGTACGTACGTACGTACGTACGTACGT",
+    );
+    let (ok, err) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--rename",
+            "--output-format",
+            "ubam",
+            "sp.fastq",
+        ],
+    );
+    assert!(!ok, "--clump_only --rename must still be refused");
+    assert!(
+        err.contains("byte-identically"),
+        "expected the --clump_only message:\n{err}"
+    );
+    assert!(
+        !err.contains("--rename cannot be honoured"),
+        "the #408 guard must not pre-empt the mode-specific message:\n{err}"
+    );
+}


### PR DESCRIPTION
`--rename` appends `:clip5:SEQ`/`:clip3:SEQ` to the **end** of the read ID — matching Perl v0.6.11, which does the same at all eleven of its append sites. On FASTQ input that puts the annotation after any header description, and BAM read names cannot contain whitespace, so the tail is discarded and the explicitly-requested annotation goes with it. `--rename --output-format ubam` on a header like `@read 1:N:0:ACGTAC` produced the QNAME `read` and nothing else. That combination is now refused when at least one input is FASTQ **and** a clipping flag is set.

The clip-flag half of that condition matters: `--rename` reaches `append_to_id` only under `--clip_R1/R2`, `--three_prime_clip_R1/R2` or `--hardtrim5/3`, so on its own it appends nothing and is still accepted. A wrapper that threads `--rename` unconditionally alongside an optional `--clip_R1` keeps working in its no-clip configuration. All six flags were read off the call sites (`trimmer.rs:264`/`273`, `specialty.rs:62`/`106`/`166`/`219`) rather than inferred, so the list cannot let a lossy run through.

**Format-gated, not blanket.** uBAM input is lossless by SAM spec rather than by luck: a BAM read name cannot carry whitespace, so a record read from uBAM has no description, and `append_to_id` splices before the first TAB (code-review C1) so the aux-tag tail survives and the annotation lands on the name. Refusing that would withdraw a working path and would have broken the C1 regression guard at `tests/integration_ubam_out.rs:393`, which asserts this exact combination **succeeds** on uBAM input. That test is untouched.

The gate lives in `main.rs` rather than `cli.rs` §3.4a because it needs `input_formats`, which `Cli::validate()` cannot see. It sits behind the two structural pair checks, so `--paired` with a single FASTQ, or a mixed FASTQ+uBAM pair, still reports its own defect — including #363's deliberate "check for a mis-typed filename" hint — rather than a lecture about `:clip5:` representability for a run that is broken independently of `--rename`. Still ahead of `ensure_output_dir` and every dispatch arm: a refused run creates nothing, not even an absent `-o` directory. `--clump_only` keeps its own byte-identity message, and `--hardtrim5`/`--hardtrim3` are covered.

The message describes a format-level refusal and says why it is deliberately coarser than the loss — whether a given header loses the annotation is a per-record property, and deciding per record would mean failing part-way through a BAM. It does not claim impossibility (a description-free FASTQ honours the flag exactly), does not say "silently dropped" (#406 already prints a `NOTE` echoing the dropped text), and does not suggest converting afterwards, because `samtools import` drops the description identically, with and without `-T '*'`.

Also folded in: the output guide described `--rename` as "`--rename PREFIX` replaces the input filename stem in the output names", wrong in every clause. That is `--basename`, which had no dedicated section in the output guide; both now have accurate ones, including `--basename`'s two real limits — reports keep input-derived names, and the specialty modes ignore it entirely. The uBAM compatibility list gains `--rename`, and its preamble moves from "Rejected at CLI-validate time" to "Rejected at startup" — true of all eight entries rather than seven. `--rename`'s own `--help` now names both restrictions it is subject to.

Eight integration tests, 578 total, up from 570. Both refusals were run against an **unpatched build** first, where they succeed and lose the annotation.

Two follow-ups filed from the review, neither a regression here: #415 (a spec-violating uBAM QNAME silently drops preserved aux tags — the one hole in the assumption this gate rests on) and #416 (carry the annotation as an aux tag, which would let this refusal be lifted).

<details>
<summary>AI-assisted: what the dual code review changed, and three harness false-greens caught on the way</summary>

**The dual code review moved three things.** Both reviewers approved with no Critical or High, and both verified the mechanism independently on their own control builds — one via `git archive` plus a standalone BGZF parser, one via an isolated `CARGO_TARGET_DIR` plus an injected-warning control proving its clippy run could fail. What they changed: the gate was pre-empting the two structural pair messages, which is the same defect the plan congratulated itself for avoiding with `--clump_only`, one level down; the message's headline asserted impossibility where a description-free FASTQ demonstrably honours the flag, contradicting its own next sentence four lines later; and `--rename` with no clip flag — a pure no-op — was being refused, which neither the plan nor its two plan reviews had noticed. One reviewer also caught a **false claim in my own changelog entry**: I wrote that `--basename` was undocumented, when it is documented on the clump-only and passthrough pages. The accurate statement is that it had no dedicated section in the output guide.


**The plan's r1 was blanket rejection in `cli.rs`, and it would have failed.** Its assumption A2 — that no test asserts this combination succeeds — was false and had been explicitly deferred rather than checked. `tests/integration_ubam_out.rs:393` is the C1 tab-splice regression guard and it does assert exactly that, on uBAM input. Second time in the same session that a deferred pinning grep was the thing that broke a patch. r1 also framed uBAM safety as data-dependent good fortune when it is a spec guarantee, which is what made the blanket scope look free.

Two things the format gate bought beyond correctness, neither of which was an argument for it: the C1 guard survives with no edit, and the `--clump_only` pre-emption disappears because the check moved behind `validate()`.

**One deviation from the approved plan.** Its step 3 asked for `cli.rs` unit tests; those are unreachable, because the guard must see `input_formats` and therefore lives in the `[[bin]]`, which library unit tests cannot reach. All five tests are binary-driven instead. Validation 6 gains something from that: as an integration test it proves the *ordering* between `validate()` and the new guard, which a unit test could not.

**Three false-greens, all caught by checking rather than assuming.** A `${PIPESTATUS[0]}` exit check silently evaluated to nothing under zsh, hiding a `clippy` run that finished in 0.18 s — a cache hit, not a check; I injected a deliberate `unused_variable` to prove clippy actually lints the edited target, then removed it and re-ran on an invalidated cache. A by-name grep appeared to show one of the five tests missing, when the test binary's own stdout had interleaved and broken the `^test` anchor. And the 575 figure is counted against a 570 baseline from a separately-built worktree at the parent commit, because equal test counts are exactly how a stale-tree verification hides.

**One thing the plan did not ask for.** It asserted that `--hardtrim5`/`--hardtrim3` lose the annotation the same way. Rather than trust that, I confirmed `--hardtrim5 20 --rename` genuinely annotates on the FASTQ path (`:clip5:ACGTACGT`) — so the refusal covers a path that actually worked, not a no-op.

Follow-up worth filing separately, and expected by both plan reviewers: carrying the annotation as a BAM aux tag, which would make the refusal unnecessary.
</details>

Closes #408 (manual close needed — dev is not the default branch).
