### PR TITLE
feat(io): one output directory per pair — reports and carrier follow R1 (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 
 ### Unreleased
 
+#### Changes
+
+- **A paired run now writes every output to one directory**
+  ([#398](https://github.com/FelixKrueger/TrimGalore/issues/398)). Without
+  `--output_dir`, the validated FASTQs already went to Read 1's directory, but each
+  trimming report went beside *its own* mate and `--passthrough`'s carrier output
+  went beside the carrier input — so one pair could scatter across three
+  directories. Reports and the carrier now follow the primaries into Read 1's
+  directory. Filenames are unchanged: each report keeps its own input-derived name,
+  so `*_trimming_report.txt` globs and MultiQC still match. This restores the
+  one-directory-per-run behaviour of v0.6.11, which stripped the input's directory
+  and wrote everything to `--output_dir` — though the anchor differs, since Perl's
+  default was the working directory rather than Read 1's.
+
+  **This refuses some invocations that previously ran.** Output names derive from
+  the input filename alone, so two inputs sharing a filename now resolve to the same
+  report path once co-located, and the run stops before writing anything. The layout
+  this affects is reads split by mate rather than by sample —
+  `--paired R1/s1.fq R2/s1.fq R1/s2.fq R2/s2.fq` — where the *whole* invocation is
+  refused, not just the offending pair. Pass `--output_dir` to collect the outputs
+  somewhere unambiguous; `--no_report_file` also clears it but discards the reports.
+  The per-sample layout (`sampleA/reads_1.fq sampleA/reads_2.fq sampleB/…`) is
+  unaffected, because each pair's Read 1 already sits in its own directory.
+
+  One refusal disappears in the other direction: a single file used as the mate of
+  two pairs whose Read 1s live in different directories no longer collides, because
+  its two reports now resolve into those two directories. That run previously failed
+  and now succeeds; nothing is overwritten.
+
+  Also corrected: the output guide stated that without `--output_dir` files go to
+  the current working directory, which was true only of the specialty modes.
+
 #### Bug fixes
 
 - **`--rename` was neutralised by `--output-format ubam` on FASTQ input, with no

--- a/docs/src/content/docs/guide/outputs.md
+++ b/docs/src/content/docs/guide/outputs.md
@@ -3,7 +3,7 @@ title: Output files
 description: Naming conventions for trimmed FASTQ files and trimming reports.
 ---
 
-Trim Galore writes one trimmed FASTQ per input, plus a per-input text and JSON trimming report. File naming matches v0.6.x exactly, so existing pipelines continue to work without changes.
+Trim Galore writes one trimmed FASTQ per input, plus a per-input text and JSON trimming report. File naming matches v0.6.x exactly. Output *locations* match it too, with one exception: see [Output directory](#output-directory) for where a paired run's files land when `--output_dir` is not given.
 
 ## Single-end
 
@@ -23,6 +23,8 @@ Trim Galore writes one trimmed FASTQ per input, plus a per-input text and JSON t
 | `R2_val_2.fq.gz` | Validated Read 2. |
 | `R1.fastq.gz_trimming_report.txt` / `.json` | Read 1 report. |
 | `R2.fastq.gz_trimming_report.txt` / `.json` | Read 2 report. Carries the final pair counts. |
+
+All four land in the same directory — `--output_dir` if given, otherwise Read 1's. Each report keeps its own input-derived name; only the directory is shared. See [Output directory](#output-directory).
 
 ## Singleton (unpaired) reads
 
@@ -99,7 +101,23 @@ Most FASTQ-shaped features work with uBAM output. Rejected at startup, before an
 
 ## Output directory
 
-`--output_dir DIR` writes outputs to `DIR/` instead of the current working directory. The trimmed FASTQ filename stem is unchanged; only the parent directory differs.
+`--output_dir DIR` writes every output to `DIR/`. The filename stems are unchanged; only the parent directory differs.
+
+Without `--output_dir`, the trimming modes write beside the **input**: single-end output lands in that input's directory, and for a pair every output — both validated FASTQs, both trimming reports, and the `--passthrough` carrier — lands in **Read 1's** directory. The specialty modes (`--hardtrim5/3`, `--clock`, `--implicon`) are the exception: they always write to the current working directory.
+
+Because output names derive from the input filename alone, two inputs sharing a filename resolve to the same report path once they land in one directory, and the run is refused before anything is written. That affects the layout where reads are split by mate rather than by sample:
+
+```
+R1/sample1.fq  R1/sample2.fq      # refused without --output_dir:
+R2/sample1.fq  R2/sample2.fq      # sample1.fq's two reports collide in R1/
+```
+
+Pass `--output_dir` to collect the outputs somewhere unambiguous. The per-sample layout needs no change, because each pair's Read 1 already sits in its own directory:
+
+```
+sampleA/reads_1.fq  sampleA/reads_2.fq      # unaffected
+sampleB/reads_1.fq  sampleB/reads_2.fq
+```
 
 ## Custom output basename
 

--- a/docs/src/content/docs/modes/passthrough.md
+++ b/docs/src/content/docs/modes/passthrough.md
@@ -27,6 +27,8 @@ Output files:
 
 With `--basename foo` set, all three outputs use that basename uniformly: `foo_val_1.fq.gz`, `foo_val_2.fq.gz`, `foo_passthrough.fq.gz`.
 
+All of them, the passthrough output included, are written to `--output_dir` if given and otherwise to **Read 1's** directory — so a carrier file kept apart from the read pair still produces its output alongside them. See [Output files](/guide/outputs/#output-directory).
+
 ## How the sync check works
 
 Every record, Trim Galore extracts an ID prefix from R1, R2, and the passthrough read and compares them three-way. The prefix is *everything after the leading `@`, before the first whitespace, with a trailing `/1` / `/2` / `/3` stripped*. That covers both modern Illumina (`@HEADER 1:N:0:CGATCG` → prefix `HEADER`) and legacy SRA/ENA (`@read/1` `@read/2` `@read/3` → prefix `read`).

--- a/plans/08092026_paired-output-dir-unification/PLAN.md
+++ b/plans/08092026_paired-output-dir-unification/PLAN.md
@@ -1,0 +1,306 @@
+# Plan: one output directory per pair — reports and the passthrough carrier follow R1 (#398)
+
+**Issue:** [#398](https://github.com/FelixKrueger/TrimGalore/issues/398) — follow-up from #391's plan review (B §1.3).
+**Decisions (Felix):** reports follow the primaries into R1's parent; **`--passthrough`'s carrier output joins them**; the new report collisions are **accepted as loud pre-write refusals**, reconfirmed after being shown the mate-side-directory layout.
+**Base:** `dev` @ `38deb1ee`.
+
+## Revision history
+
+- **r2 (2026-08-10):** dual plan review (`PLAN_REVIEW_A.md`, `PLAN_REVIEW_B.md` — both REVISE, six Critical findings between them, no contradictions). Both independently verified the extraction is behaviour-preserving across all five namers, the arm table is complete, and A3 holds empirically. Six things changed. **The behavioural footprint is bidirectional**: a refusal also *disappears* (A §1.3), which r1 was silent about. **A second inverted guard exists** on the clump arm (A §1.2) — r1 built a whole warning around one of the pair and left the twin unannounced. **A new output-vs-input hazard** in #409's exact shape (A §1.4), which no r1 validation targeted. **Step 7 as written broke two single-end arms** r1 declared out of scope (B §1.8). The **refused population** is broader than "two mates of one pair" (both reviewers). And r1's **step-6 rationale for `--passthrough` was factually false** (both reviewers).
+- r1 (2026-08-09): first draft. Written after two critical scope questions were resolved by Felix.
+
+### Corrections to the reviews
+
+- Both reviewers instruct changing the docs path prefix to `Docs/src/content/docs/`. **Both are wrong.** `git ls-files` tracks it as lowercase `docs/src/content/docs/guide/outputs.md`; the capital resolves only because APFS is case-insensitive, and `Docs/` would not resolve on a Linux checkout. r1's shorthand stands.
+- A §1.7 asks that `pair_output_dir` "return the empty path rather than `.`". Correct in effect, but the safe instruction is narrower: copy the existing expression **verbatim**. See §Signature.
+
+## Goal
+
+When `--output_dir` is not given, every output of a paired run lands in one directory — R1's parent — instead of up to three. Today the primaries go to R1's parent, each trimming/clumping report goes beside its own mate, and `--passthrough`'s carrier output goes beside the passthrough input.
+
+Single-end is untouched, paths included.
+
+**Perl precedent, which r1 lacked.** v0.6.11 had no per-mate report directories at all: `trim{}` does `my $output_filename = (split (/\//,$filename))[-1];` — stripping the input's directory — then opens the report at `$output_dir.$report`, where `$output_dir` defaults to `''`, i.e. the CWD (verified at `git show 0.6.11:trim_galore`, the `sub trim` header and the `### OUTPUT DIR PATH` block). So Perl put every output of a run in **one** directory. The split layout is a v2 regression against v0.6.x behaviour, not a v0.6.x inheritance — which strengthens decision 1 and constrains what the changelog may claim (see §Integration).
+
+## Context
+
+### The asymmetry, precisely
+
+Every **primary** paired namer in `io.rs` resolves its directory with a character-identical expression — `output_dir`, else `input_r1.parent()`, else `.`:
+
+| Namer | Directory expression |
+|---|---|
+| `paired_bam_output_name` | `io.rs:296-298` |
+| `paired_end_output_names` | `io.rs:337-339` |
+| `unpaired_output_names` | `io.rs:368-370` |
+| `clumped_paired_output_names` | `io.rs:473-475` |
+| `clumped_paired_bam_output_name` | `io.rs:522-524` |
+
+The **report** namers do not. `report_name` (`io.rs:551`), `json_report_name` (`io.rs:567`) and `clumping_report_name` (`io.rs:535`) each take one `input` and fall back to *that* input's parent. They are shared with the single-end paths, where that is correct — so the fix cannot live inside them. `passthrough_output_name` (`io.rs:404-409`) is a third rule, anchored on the carrier's own parent, while `io.rs:385` already calls it one of "the three pair outputs".
+
+Reproduced on `38deb1ee`:
+
+```
+$ trim_galore --paired A/reads.fq B/reads.fq      # exit 0
+A/  reads_val_1.fq  reads_val_2.fq  reads.fq_trimming_report.{txt,json}
+B/                                  reads.fq_trimming_report.{txt,json}
+```
+
+### The behavioural footprint is bidirectional — r1 got this wrong
+
+r1 described exactly one new refusal and was silent on refusals disappearing. Three classes of test change, and **each is a red or newly-green test**. The plan's own thesis is that unpredicted red tests are how this bug family recurs, so all three are enumerated here rather than left to be discovered.
+
+**(a) Two inverted over-rejection guards, not one.** r1 named the trim guard (`tests/integration_output_collision.rs:1029-1041`) and missed its clump twin at **`:1206-1240`** (`clump_report_candidates_do_not_over_reject`), whose comment carries almost the same sentence:
+
+> `Pins that the candidates honour output_dir = None; a builder that resolved reports into one directory would over-reject this.`
+
+Both were written to catch precisely this change. Both must be **rewritten to assert the refusal, never narrowed** — narrowing restores the split layout on the candidate side only, while the writers move. The trim guard is three blocks and only block 3 changes; the clump twin is a single block, so its whole body is rewritten.
+
+**(b) An existing deliberate refusal disappears.** `clump_paired_rejects_shared_mate_report_without_output_dir` (`:1247-1275`) covers `--clump_only --paired p/a.fq d/x.fq q/b.fq d/x.fq`, refused today because both pairs' reports for the shared mate `d/x.fq` resolve to one path. After the change pair 1 anchors on `p/` and pair 2 on `q/`, giving eight distinct paths, and **the run succeeds**. That is correct on the facts — two distinct reordered outputs in two distinct directories, nothing overwritten — so continuing to refuse would be over-rejection. The test must flip to asserting success. **The trim-mode twin of the same shape has no test at all** and would flip refuse→succeed silently; add one.
+
+**(c) A new output-vs-input hazard, in #409's exact shape.** Moving a report into R1's parent can make it land *on an input*. Confirmed on `38deb1ee`:
+
+```
+$ trim_galore --paired A/reads.fq_trimming_report.txt B/reads.fq   # exit 0 today
+A/  reads.fq_trimming_report.txt                      <- R1's input, intact
+B/  reads.fq_trimming_report.{txt,json}               <- R2's report, harmless here
+```
+
+R2's report is `B/reads.fq_trimming_report.txt` today. After the change it becomes `A/reads.fq_trimming_report.txt` — **R1's own input path**. If the candidate builder moves with the writer, the pre-flight's output-vs-input branch (`io.rs:147-156`) refuses, which is correct. If it does not, the writer destroys a named input after the run has read it. That is #409 verbatim, on an arm this change creates. It needs its own test per paired report arm, in both the refusing and the `--no_report_file` accepting direction — the shapes at `tests/integration_output_collision.rs:1411` and `:1440` already model both.
+
+### The refused population, stated correctly
+
+r1 said "two mates share a filename", which is too narrow. The actual rule: **any two report-keyed inputs whose filenames fold-equal (`collision_key` is ASCII-case-folded) and whose pairs anchor on the same directory.** That spans pairs, not just mates within a pair.
+
+The practically important instance is the **mate-side directory layout**, where a facility splits by mate rather than by sample. Confirmed running today:
+
+```
+$ trim_galore --paired R1/s1.fq R2/s1.fq R1/s2.fq R2/s2.fq        # exit 0
+R1/  s1_val_{1,2}.fq  s2_val_{1,2}.fq  s1.fq_trimming_report.*  s2.fq_trimming_report.*
+R2/  s1.fq_trimming_report.*  s2.fq_trimming_report.*
+```
+
+After the change the **entire invocation** is refused before any pair is processed — `main.rs:863-914` builds candidates for every chunk and calls the pre-flight once at `:915`, so this is not "pair 1 fails, pair 2 proceeds". Nothing runs.
+
+The **per-sample** layout is unaffected, and saying so is worth as much as the warning: `sampleA/reads_1.fq sampleA/reads_2.fq sampleB/reads_1.fq sampleB/reads_2.fq` gives each pair its own R1 directory, so nothing collides.
+
+### `OutputSource` attribution — a decision #397 explicitly deferred to #398
+
+`main.rs:872-875`, written by #397:
+
+> `Uniform Pair for paired primaries (#397 decision C2): _val_1 takes its stem from R1 but its directory from R1 too, and _val_2 mixes both — naming one mate would encode a claim about which supplies the directory, which is exactly what #398 may change.`
+
+After this change the report and carrier candidates take their **filename** from one input and their **directory** from R1 — the condition `OutputSource::Pair` exists for (`io.rs:94-96`). **Decision: keep `OutputSource::Input`,** because switching degrades a message that shipped last week:
+
+- `Input` → two distinct sources on one path → the **2a** branch (`io.rs:171-180`): *"the outputs named from A/reads.fq and B/reads.fq would be written to the same file"*. Actionable: rename one input.
+- `Pair(A,B)` → both candidates share one source identity (`io.rs:103-111`) → the **2c** branch: *"List each input once — a file that appears in more than one pair is reported once per pair"*. That advice is **wrong here**: there are two inputs and renaming one does fix it.
+
+### Writers and their pre-flight twins must move together
+
+The pre-flight is only as complete as its candidate list, and this change alters *paths*, so every candidate builder moves in lockstep with its writer. Five recurrences of that family are fixed (#383, #388, #391, #409); #414 exists to make a sixth un-shippable.
+
+| Arm | Writer | Candidates | Net effect |
+|---|---|---|---|
+| Trim paired → FASTQ | `main.rs:1729-1738` | `main.rs:906-912`; carrier `:893-903` | **changes** |
+| Trim paired → uBAM (two FASTQ in) | `main.rs:2352-2358` | `main.rs:2026-2027` | **changes** |
+| Clump paired → FASTQ | `clump_only.rs:535-536` | closure at `main.rs:609-622` | **changes** |
+| Clump paired → BAM | `clump_only.rs:1080-1086` | `main.rs:698`, `:740` | **no-op** — `report_input = &inputs[0]`/`chunk[0]` is already R1, so both sides are behaviour-identical. Change it for uniformity, expect no path to move |
+
+Three arms change behaviour; the fourth is a no-op recorded so nobody hunts for a diff that isn't there.
+
+Out of scope, each by inspection:
+- **Single-end arms** — one input, no second parent to disagree with.
+- **Paired single-interleaved uBAM** — one input path, so the asymmetry is inexpressible.
+- **`--clock` / `--implicon`** — write no reports (`grep -c report src/specialty.rs` → 0) **and**, load-bearingly, their primaries are CWD-anchored (`specialty.rs:488-491`, `:521-524` return a bare filename when `output_dir` is `None`), so R1-anchoring would *change* them. r1 gave only the weaker reason.
+- **`--hardtrim5/3`** — the same CWD rule, with its own `CWD_OUTPUT_HINT`.
+- **`--demux`** — single-end only, enforced at `cli.rs:1009-1012`.
+- **`--clumpify`** (vs `--clump_only`) — writes no separate report; routes through the ordinary trim report path, so it is covered by the trim arms.
+- **`--retain_unpaired`** — `unpaired_output_names` is already R1-anchored (`io.rs:368-370`).
+- **`--fastqc`** — anchored on the *output* file (`fastqc.rs:37-58` passes `output_path` through), so its artifacts follow the primaries and the carrier for free. `--fastqc_args "-o DIR"` is already out of scope at `io.rs:1338-1340`.
+
+## Behavior
+
+1. One derivation decides the directory for every output of a paired run: `--output_dir` when given, else R1's parent.
+2. The five primary namers consume it. **No primary path changes** — pure extraction of an expression they already share.
+3. Both trimming reports of a pair (`.txt` and `.json`) resolve into that directory. Report **filenames** are unchanged — still each mate's own full input filename.
+4. Both clumping reports of a `--clump_only --paired` run likewise.
+5. `--passthrough`'s carrier output likewise. Filename unchanged.
+6. Single-end behaviour is byte-identical, paths included.
+7. **Refusals gained:** any two report-keyed inputs whose filenames fold-equal and whose pairs anchor on the same directory now collide, and the run is refused before anything is written, naming both inputs via the 2a branch. Includes the cross-pair mate-side-directory layout, which refuses the whole invocation.
+8. **Refusals lost:** a mate shared between two pairs whose R1s live in different directories no longer collides, because the two reports now resolve into different directories. The run succeeds. Correct on the facts; nothing is overwritten.
+9. **Output-vs-input:** a relocated report may now equal a named input. The pre-flight refuses it — which requires the candidate to have moved with the writer.
+10. Every candidate builder for the arms above produces exactly the paths its writer will write, with the same `--no_report_file` gating.
+
+### Edge cases
+
+| Case | Expected |
+|---|---|
+| `--paired A/r1.fq A/r2.fq` (same dir) | unchanged |
+| `--paired A/reads.fq B/reads.fq` | **refused** (was: exit 0, split reports) |
+| `--paired R1/s1.fq R2/s1.fq R1/s2.fq R2/s2.fq` (mate-side layout) | **whole invocation refused**, no pair processed |
+| `sampleA/r_1 sampleA/r_2 sampleB/r_1 sampleB/r_2` (per-sample layout) | unchanged, each pair anchors on its own R1 |
+| `--paired A/reads.fq B/reads.fq --no_report_file` | succeeds; only reports collided |
+| `--paired A/reads.fq B/reads.fq -o out` | unchanged — already refused today |
+| `--paired A/r1.fq B/r2.fq --basename foo` | succeeds; reports keep per-input names, now both in `A/` |
+| `--clump_only --paired p/a.fq d/x.fq q/b.fq d/x.fq` | **now succeeds** (was refused) |
+| `--paired p/a.fq d/x.fq q/b.fq d/x.fq` (trim twin) | **now succeeds** (was refused, untested) |
+| `--paired A/reads.fq_trimming_report.txt B/reads.fq` | **refused** — R2's report would land on R1's input (was: exit 0) |
+| same, `--no_report_file` | succeeds; no report to collide |
+| R1 as a bare filename (`reads.fq`) | `parent()` → `Some("")`, so paths stay bare; **stderr spelling must not gain a `./` prefix** |
+| Multi-pair, distinct dirs | each pair anchors on **its own** R1 |
+
+## Signature
+
+```rust
+/// The directory every output of a paired run lands in: `--output_dir` when
+/// given, else R1's parent, else the current directory.
+///
+/// One derivation for primaries, reports and the `--passthrough` carrier alike.
+/// #398 existed because the primaries used this rule while the reports used each
+/// mate's own parent, so a pair could scatter across three directories.
+pub fn pair_output_dir(input_r1: &Path, output_dir: Option<&Path>) -> PathBuf
+```
+
+**Copy the body verbatim from any of the five namers** — `output_dir.map(|d| d.to_path_buf()).unwrap_or_else(|| input_r1.parent().unwrap_or(Path::new(".")).to_path_buf())`. For a bare filename `parent()` yields `Some("")`, so the `unwrap_or(".")` never fires and joined paths stay bare. "Simplifying" it to anything that yields `"."` would prefix every path and every error message with `./`, which is a user-visible diff in stderr. The `unwrap_or(".")` arm is reachable only for a root path.
+
+Reports are then named by passing that directory to the existing namers — `report_name(input_r2, Some(&pair_dir))` — which keeps each report's per-input filename while relocating it. No new report namer and no signature change to the three shared report functions.
+
+## Implementation outline
+
+1. **`io.rs`** — add `pair_output_dir` beside `collision_key`, body copied verbatim.
+2. **`io.rs`** — refactor the five primary namers to call it. Their existing unit tests must pass untouched.
+3. **`main.rs` trim-paired writer** (`:1729-1738`) — compute `let pair_dir = naming::pair_output_dir(input_r1, output_dir);` once, then build both `PairedReportFile`s with `Some(&pair_dir)`.
+4. **`main.rs` trim-paired uBAM writer** (`:2352-2358`) — same.
+5. **`clump_only.rs` paired writers** (`:535-536`; `:1080-1086`'s `report_input` for uniformity, a no-op) — same.
+6. **`--passthrough`** — fold `input_r1` into `passthrough_output_name` and derive via `pair_output_dir`. **r1's rationale for the alternative was false**: the namer already takes `output_dir`, and there are no single-end-shaped callers (`--passthrough` is paired-only, `cli.rs:906-916`). Folding `input_r1` in also keeps the four `output_dir = None` unit tests at `io.rs:854`, `:861`, `:875`, `:889` meaningful; leaving the namer alone strands them asserting a rule production can no longer reach.
+7. **Pre-flight candidates, in the same commit as each writer:**
+   - `main.rs:906-912` — paired trim reports, `Some(&pair_dir)`.
+   - `main.rs:2026-2027` — paired uBAM trim reports.
+   - `main.rs:893-903` — the carrier candidate.
+   - **`clump_report_candidates`** (`main.rs:121-139`) — has **five** call sites, not two. `main.rs:616` (`&[r1, r2]`, one pair) and `:740` (`chunk[0]`) want the pair directory; `:653` and `:798` are handed **all** single-end inputs at once and need per-input parents when `output_dir` is `None`; `:698` is Shape B with one input. **Keep the parameter `Option<&Path>` with its existing "`None` → per-input parent" semantics and have only the paired callers pass `Some(&pair_dir)`.** A signature taking one required directory and applying it to every element would collapse every SE input's report into one directory, producing candidate paths the SE writers never write — the #383 family in mirror image, on an arm this plan declares out of scope.
+   - Keep `OutputSource::Input` at every relocated candidate; see §Context.
+8. **`PAIRED_REPORT_HINT`** (`main.rs:57-62`) — one hint serves three sites (`main.rs:608`, `:915`, `:2031`) **and is printed for primary collisions as well as report collisions**, so the reword must fit both. Its current text blames "`--output_dir` (or a shared input directory)"; after this change neither is required — two mates in different directories collide with no `-o` at all, so the stated cause is **absent in the failing case**. The reword must convey: paired outputs and reports all land in R1's parent unless `--output_dir` says otherwise, so inputs sharing a filename collide wherever they live; rename one, or pass `--output_dir`.
+9. **Tests** — per Validation. Specifically: rewrite block 3 of the trim guard (`:1029-1041`) and the whole body of the clump twin (`:1206-1240`); flip `clump_paired_rejects_shared_mate_report_without_output_dir` (`:1247-1275`) to assert success; add the missing trim twin of that shape; add output-vs-input tests per paired report arm plus `--no_report_file` siblings. Use **`assert_dir_holds_only`** for "nothing was written" — **not** `assert_rejected_cleanly`, which asserts an *empty* directory and cannot express "unchanged beside the inputs"; reaching for it first produces a failure whose obvious fix damages eight other tests.
+10. **Docs** (`docs/src/content/docs/`, lowercase) — `guide/outputs.md:102` is the one place the directory rule is stated and **it is already wrong today** ("writes outputs to `DIR/` instead of the current working directory" — trim outputs go to the *input's* parent, not the CWD); correct it and state the new rule there. `guide/outputs.md:6`'s "existing pipelines continue to work without changes" needs a qualifier: filenames still match v0.6.x, but the mate-side layout now requires `-o`. Add the rule to the Paired-end section (`:20-25`) and to `modes/passthrough.md`, since decision 2 moves the carrier. `guide/paired-end.md:16-19` and `modes/clump-only.md:45`/`:109`/`:122` were checked and carry no directory claim.
+11. **CHANGELOG** — `#### Changes` does not yet exist under `### Unreleased` (only `#### Bug fixes`); the heading is precedented at `:205`, and `#### Behavioural notes (v2.x intentional widenings)` at `:998` is arguably the closer precedent for deliberately refusing a previously-working invocation. State: both layouts by name (mate-side refused, per-sample unaffected), `--output_dir` as the primary remediation — **not** `--no_report_file`, which throws the reports away — and that a shared-mate refusal disappears. The v0.6.11 fact bounds what may be claimed: this restores Perl's one-directory-per-run behaviour in spirit, but Perl's anchor was the CWD, not R1's parent, so "matches v0.6.x" is not available.
+12. `cargo fmt --all -- --check`, `cargo clippy --all-targets --release -- -D warnings`, `cargo test`.
+
+## Efficiency
+
+Nil. One `PathBuf` per pair on the startup path, replacing one that was already being built per report.
+
+## Integration
+
+- **Reads:** `cli.input`, `cli.output_dir`, `cli.no_report_file`, `cli.passthrough`.
+- **Writes:** relocates trimming reports (`.txt` + `.json`), clumping reports, and the carrier on paired arms only.
+- **Report content knock-on:** the R2 text report's passthrough `Output:` line embeds the carrier's path (`report.rs:481`), so it moves with the carrier. JSON is unaffected.
+- **Order:** all changes are at path-derivation time, before the pre-flight, which precedes every writer.
+- **A free win from lockstep, worth recording:** moving a report candidate also moves its output-vs-input check, so a relocated report cannot silently land on a named input — provided step 7 is done with step 3.
+- **Downstream:** two severities, not one. Scripts globbing `<mate>_trimming_report.txt` beside R2's input stop finding it; and runs on a mate-side layout **stop completing at all**. The changelog must state the second.
+- **Perl parity:** no record content changes. Validation 7 is answered, not open — see below.
+
+## Assumptions
+
+- **A1:** The five primary namers' directory expressions are character-identical, so step 2 is a pure extraction. Verified by both reviewers independently.
+- **A2:** The report namers derive filename and directory independently, so passing a directory relocates without renaming. Verified at `io.rs:535-580`.
+- **A3:** Report paths are already pre-flight candidates on all paired report arms (#388, #391, #397), so new collisions are caught rather than silently overwritten. **Verified empirically by both reviewers** — this is the assumption the accepted-refusal decision rests on.
+- **A4:** `--clock`/`--implicon` write no reports. Verified: `grep -c report src/specialty.rs` → 0.
+- **A5:** Single-end paths never call the paired namers. Confirm via the single-end path assertions in validation 5. (r1 mis-cited `main.rs:909` here; that line is a paired candidate.)
+- **A6:** `Path::parent()` on a bare filename yields `Some("")`, **not** `None` — so the `unwrap_or(Path::new("."))` arm never fires for that input and joined paths stay bare. r1 described this as the `unwrap_or` handling the case; it is the opposite, and the wrong reading invites a "simplification" that prefixes every path with `./`. The `unwrap_or` arm is reachable only for a root path.
+- **A7 (new):** `collision_key` is ASCII-case-folded, so "fold-equal filenames" and not "identical filenames" is the collision condition.
+- **A8 (new):** `--passthrough` has no single-end-shaped callers. Verified at `cli.rs:906-916`.
+
+## Validation
+
+| # | What | How | Expected |
+|---|------|-----|----------|
+| 1 | The reported asymmetry is gone | `--paired A/r1.fq B/r2.fq`, no `-o` | both reports and both primaries in `A/`; `B/` holds only its input |
+| 2 | Carrier joins the pair | `--paired A/r1 B/r2 --passthrough C/i1` | carrier output in `A/`; R2 text report's `Output:` line names the new path |
+| 3 | **The accepted refusal fires, nothing written** | `--paired A/reads.fq B/reads.fq` | non-zero; 2a message naming both inputs; `assert_dir_holds_only` on **both** `A/` and `B/` |
+| 4 | Mate-side layout refuses the whole run | `--paired R1/s1 R2/s1 R1/s2 R2/s2` | non-zero; **no pair processed** — neither `s1_val_1` nor `s2_val_1` exists |
+| 5 | Per-sample layout unaffected | `sampleA/r_1 sampleA/r_2 sampleB/r_1 sampleB/r_2` | succeeds; each pair's outputs in its own directory |
+| 6 | `--no_report_file` escape | validation 3 plus the flag | succeeds; primaries in `A/`; no reports |
+| 7 | **Single-end untouched** | SE run, reports asserted at exact paths, plus a **bare-filename** input | byte-identical paths to `38deb1ee`; **stderr shows no `./` prefix** |
+| 8 | **Output-vs-input refusal, per paired report arm** | `--paired A/reads.fq_trimming_report.txt B/reads.fq`, and the clump and uBAM equivalents | non-zero; nothing written; **R1's input intact and unmodified** (assert its content, not just existence) |
+| 9 | …and its acceptance sibling | validation 8 plus `--no_report_file` | succeeds; the report-named input untouched |
+| 10 | **Both inverted guards rewritten, not narrowed** | trim guard `:1029-1041` blocks 1–2 unchanged and passing, block 3 asserts refusal; clump twin `:1206-1240` body asserts refusal | as stated |
+| 11 | **The lost refusals are recorded** | `clump_paired_rejects_shared_mate_report_without_output_dir` flipped to success; new trim twin asserts success | eight distinct paths; all four primaries and all four reports present |
+| 12 | Writers and candidates agree | per arm, run it and compare every created file against that arm's candidate list. **Bound to runs without `--fastqc`** — FastQC paths are deliberately absent from candidate lists (`io.rs:1335-1340`); state that known-unplanned set rather than letting an exact-match assertion fail spuriously and get weakened | exact match on the three changing arms |
+| 13 | Multi-pair anchors per pair | `--paired A/x1 A/x2 B/y1 B/y2` | pair 1 in `A/`, pair 2 in `B/` |
+| 14 | Expected-fail control | validations 1, 2, 3, 4 and 8 against an unpatched build **rebuilt from HEAD** — `target/release/trim_galore` was found stale (stamped `3f1b0fe`) during review, so do not reuse whatever is in `target/` | 1, 2 show the split layout; 3, 4, 8 **succeed** there — the behaviour being removed |
+| 15 | No collateral | full `cargo test` + fmt + clippy | green; count the delta against the **578** baseline rather than reading "ok" |
+
+**Validation 7 of r1 is answered, not open.** Both reviewers checked `.github/workflows/ci.yml`: every output-producing invocation passes `-o`, and every fixture shares `test_files/`, so the Perl byte-identity matrix is unaffected twice over. Recorded here so nobody re-runs it.
+
+## Questions or ambiguities
+
+- **[Resolved — Felix]** Reports follow the primaries into R1's parent.
+- **[Resolved — Felix]** `--passthrough`'s carrier joins them.
+- **[Resolved — Felix]** New collisions are accepted as loud refusals, reconfirmed after seeing the mate-side layout.
+- **[Resolved — this plan]** Keep `OutputSource::Input` for relocated candidates; `Pair` would route the message into the 2c branch whose advice is wrong for a two-input collision.
+- **[Resolved — this plan]** The lost shared-mate refusal is correct behaviour and its test flips to asserting success. Flagged to Felix as a consequence he had not been shown.
+- **[Answered by the Perl fact]** Should `--hardtrim5/3` share this helper? **No** — and now for a reason rather than a preference: v0.6.11 wrote *everything* to `$output_dir`/CWD, so the specialty modes' CWD anchor is the Perl-faithful one and the trim path's input-parent anchor is the v2 innovation. Folding them together would change the mode that currently matches Perl.
+- **[Open, minor]** Whether to emit a one-time `NOTE` when a report's directory differs from its own mate's parent. Recommend no — it would fire on the common, now-correct case.
+- **[Open, deferred]** Both reviewers raise a shape where writer/candidate drift becomes *unrepresentable* rather than tested-for: dedicated paired report namers taking `input_r1`, so no caller can reach the per-input rule by accident. After five recurrences and with #414 open precisely because tests are the weaker guarantee, this deserves a decision rather than a footnote — but it widens the diff beyond #398. **Recommend implementing #398 as specified, then evaluating the namer shape as part of #414.**
+
+## Implementation notes (2026-08-10, branch `fix/398-pair-output-dir`, base `38deb1ee`)
+
+Implemented as specified in r2. **The three predicted test changes were exactly the three that failed** — no unpredicted red test appeared, which was the point of enumerating them:
+
+```
+paired_report_candidates_do_not_over_reject                 (trim guard, block 3)
+clump_report_candidates_do_not_over_reject                  (clump twin — A's Critical 1.2)
+clump_paired_rejects_shared_mate_report_without_output_dir  (vanished refusal — A's Critical 1.3)
+```
+
+### What was done
+
+| Step | Outcome |
+|---|---|
+| 1–2 | `pair_output_dir` added; all five primary namers refactored to it. The five directory expressions were character-identical, so a single `replace_all` was exact; their unit tests passed untouched, confirming the extraction is behaviour-preserving |
+| 3–5 | Report writers on the trim-FASTQ, trim-uBAM and clump-FASTQ arms take `Some(&pair_dir)`. The clump-BAM arm routed through the same helper — a no-op as predicted, done for uniformity |
+| 6 | `passthrough_output_name` gained `input_r1` and derives via `pair_output_dir`. Its six unit tests now put R1 in a **different directory** from the carrier, so a carrier-anchored implementation fails them |
+| 7 | Candidates moved with their writers. **`clump_report_candidates` needed no signature change at all** — keeping `Option<&Path>` and passing `Some(&pair_dir)` from only the two paired sites was sufficient, so the two SE sites that hand it the whole input list keep per-input parents untouched |
+| 8 | `PAIRED_REPORT_HINT` reworded to state the rule (all of a pair's outputs → `--output_dir` or R1's directory) and drop the false "shared input directory" precondition |
+| 9 | Both guards rewritten to assert refusal; the vanished refusal flipped to assert success; 11 new tests |
+| 10–11 | Docs and CHANGELOG per r2, including `outputs.md:102`'s pre-existing error and both layouts by name |
+
+### Deviations
+
+1. **No signature change to `clump_report_candidates`.** r2 said "keep the parameter `Option<&Path>`", and it turned out nothing else was needed — the paired callers pass `Some(&pair_dir)` and the SE callers are untouched. r1's version of this step would have changed the signature and broken `main.rs:653`/`:798`.
+2. **The clump inverted guard was split into two tests, not just rewritten.** `clump_report_candidates_reject_shared_filename_without_output_dir` asserts the refusal, and a new `clump_shared_filename_without_output_dir_runs_without_reports` keeps the acceptance side alive — otherwise the arm would have had no test proving the primaries still work when only the reports collide.
+3. **Both rewritten guards were renamed.** A test called `..._do_not_over_reject` that now asserts a rejection would read as a contradiction to the next person to open the file.
+
+### Verification
+
+| # | Validation | Result |
+|---|---|---|
+| 1 | Asymmetry gone | `paired_reports_follow_the_primaries_into_r1s_directory` — full listing of both dirs |
+| 2 | Carrier joins the pair | `passthrough_output_follows_r1s_directory` — carrier in `A/`, asserted **absent** from `C/`, and the R2 report names the new path and not the old one |
+| 3 | Accepted refusal, nothing written | trim guard block 3 + `clump_report_candidates_reject_shared_filename_without_output_dir`, both with `assert_dir_holds_only` on **both** directories |
+| 4 | Mate-side layout refuses the whole run | `mate_side_directory_layout_refuses_the_whole_invocation` — asserts not even pair 1's primaries exist |
+| 5 | Per-sample layout unaffected | `per_sample_directory_layout_is_unaffected` — each pair's outputs verified by read prefix, so a pair landing in the wrong directory fails |
+| 6 | `--no_report_file` escape | `clump_shared_filename_without_output_dir_runs_without_reports` |
+| 7 | SE untouched + bare filename | `bare_filename_r1_keeps_paths_unprefixed` asserts no `./` prefix in stderr **and** the exact directory contents; `test_pair_output_dir_precedence_and_edges` pins empty-parent, `--output_dir` precedence, and that `.` is reachable only for a root path |
+| 8 | Output-vs-input per arm | `paired_report_that_would_land_on_r1s_input_is_refused` and `clump_paired_report_that_would_land_on_r1s_input_is_refused` — both assert the victim's **read count**, not just its existence |
+| 9 | Acceptance sibling | `paired_report_input_alias_accepted_with_no_report_file` |
+| 10 | Both guards rewritten, not narrowed | trim blocks 1–2 unchanged and passing; both bodies now assert refusal; each carries a comment naming its twin and forbidding the narrowing "fix" |
+| 11 | Lost refusals recorded | `clump_paired_shared_mate_report_runs_when_pairs_anchor_apart` + the previously-untested `paired_shared_mate_report_runs_when_pairs_anchor_apart` |
+| 12 | Writers/candidates agree | every refusal test asserts full directory listings; every acceptance test asserts the exact written set. No `--fastqc` run is asserted exactly, per r2 |
+| 13 | Multi-pair anchors per pair | covered by validations 5 and 11 |
+| 14 | Expected-fail control | Run against a build made **from `38deb1ee` in a fresh worktree** (not `target/`, per the stale-binary finding). All four behave as predicted: V1 shows the split layout (reports in both `A/` and `B/`); the **mate-side layout exits 0** pre-patch, writing all four pairs' outputs; the **report-on-input case exits 0** pre-patch and does *no* damage, because R2's report still goes to `B/` — confirming the hazard is created by this change and must be caught by the moved candidate, not that it pre-exists; and the **shared-mate case exits 1** pre-patch, confirming the refusal that this change removes |
+| 15 | No collateral | `cargo test` **589 passed / 0 failed** (578 baseline + 11); `fmt --check` clean; `clippy --all-targets --release -D warnings` exit 0 with a genuine recompile |
+
+### Iteration log
+
+- **#1** First full run: 3 failures, exactly the three predicted. Fixed by rewriting the two guards and flipping the vanished refusal, per r2 §Context — not by touching candidate derivation.
+- **#2** `cargo build --release` reported zero errors while the test targets were still broken by the `passthrough_output_name` signature change; `cargo test --no-run` surfaced 8. A release build does not compile test targets, so it cannot stand in for a compile check after a signature change.
+- **#3** An `Edit` against the trim guard failed because r2's quoted comment wrapped differently from the file. Re-read the region and matched the real text rather than trusting the quote in the plan.
+
+## Self-Review (r2)
+
+- **What r1 got wrong, owned:** it described a one-directional behaviour change when the footprint is bidirectional; it built a prominent warning around one inverted guard and missed its near-identical twin one arm over; it never considered the output-vs-input direction, which is the shape of the data-loss bug fixed three commits earlier; and its step 7 would have broken two single-end arms it had itself declared out of scope. The pattern across all four is the same: r1 reasoned about the arm it was looking at and generalised without enumerating. The fix in each case came from enumerating call sites and test bodies rather than reasoning about them — which is the same lesson as #408's r1.
+- **What the reviews added beyond corrections:** the v0.6.11 output-directory fact, which converts the `--hardtrim` open question from a preference into an answer and constrains the changelog; and the confirmation that `--fastqc` needs no change because it anchors on the output file.
+- **Where both reviewers were wrong:** the docs path is lowercase `docs/`, not `Docs/`. Adopting their correction would have produced a path that fails on Linux.
+- **Traps checked:** validation 3 asserts full directory listings on both sides, not one absent filename; validation 8 asserts R1's input *content*, since existence alone would pass if the file were truncated; validation 12 states its known-unplanned set so it cannot be quietly weakened when `--fastqc` trips it; validation 14 requires a control rebuilt from HEAD after a stale binary was found during review; validation 7 pins the bare-filename stderr spelling, which is the observable symptom of the A6 misreading.
+- **Remaining risk:** the change refuses invocations that work today, including a real layout convention. The refusal is loud, pre-write, and names both inputs; there is no silent-loss path once step 7 lands with step 3. The three enumerated test flips are the live risk during implementation — each is a red or newly-green test whose obvious "fix" is the wrong one, which is why each is named with its line range and its correct resolution.

--- a/plans/08092026_paired-output-dir-unification/PLAN_REVIEW_A.md
+++ b/plans/08092026_paired-output-dir-unification/PLAN_REVIEW_A.md
@@ -1,0 +1,565 @@
+# Plan Review A — #398 one output directory per pair
+
+**Reviewer:** A (independent; no shared state with Reviewer B)
+**Target:** `plans/08092026_paired-output-dir-unification/PLAN.md` r1
+**Tree:** `dev` @ `38deb1ee`, working tree clean of tracked changes
+**Verdict:** **REVISE** (three Critical findings; the plan's shape is sound)
+
+Verification legend: **[CONFIRMED]** — I read or ran the specific thing named, output
+quoted or summarised. **[DERIVED]** — followed from code I read plus the plan's own
+steps, but not executed (a patched build does not exist). **[SUSPECTED]** — reasoned
+only.
+
+A note on the binary I used as an oracle: `target/release/trim_galore` was stamped
+`3f1b0fe` when I started, which is **not** an ancestor of HEAD — it is the pre-squash
+commit of the same #408 change, and `git diff 3f1b0fe 38deb1e -- src/main.rs src/cli.rs`
+is confined to the `--rename`/uBAM guard, touching no naming or pre-flight code
+**[CONFIRMED]**. I then rebuilt via `cargo test --release` and re-ran the load-bearing
+repro against a binary stamped `38deb1e`; results were identical. Validation 9's
+"unpatched build" control must be rebuilt from HEAD rather than reusing whatever is
+in `target/`.
+
+---
+
+## 1. Logic review
+
+### 1.1 The plan's core claims all hold
+
+I verified every line-numbered assertion in the plan. All of them are correct:
+
+| Plan claim | Verdict |
+|---|---|
+| Five primary paired namers share one directory expression, `io.rs:296-298 / 337-339 / 368-370 / 473-475 / 522-524` | **[CONFIRMED]** identical `output_dir.map(\|d\| d.to_path_buf()).unwrap_or_else(\|\| input_r1.parent().unwrap_or(Path::new(".")).to_path_buf())` in all five; `_input_r2` unused in the two BAM ones |
+| `report_name` `io.rs:551`, `json_report_name` `io.rs:567`, `clumping_report_name` `io.rs:535` derive filename and directory independently | **[CONFIRMED]** |
+| `passthrough_output_name` `io.rs:404-409` anchors on the carrier's own parent; `io.rs:385` already calls it one of "the three pair outputs" | **[CONFIRMED]** |
+| Writers: `main.rs:1729-1738`, `main.rs:2352-2358`, `clump_only.rs:535-536`, `clump_only.rs:1084` | **[CONFIRMED]** all four exist as described |
+| Candidates: `main.rs:906-912`, `main.rs:2026-2027`, `main.rs:893-903`, `clump_report_candidates` `main.rs:121-139` | **[CONFIRMED]** |
+| `PAIRED_REPORT_HINT` at `main.rs:57-62` | **[CONFIRMED]**, and it is shared by three call sites (`main.rs:918`, `main.rs:2034`, `main.rs:608`) |
+| The inverted guard at `tests/integration_output_collision.rs:1029-1041`, comment as quoted | **[CONFIRMED]** verbatim |
+| A4 — `grep -c report src/specialty.rs` → 0 | **[CONFIRMED]** |
+| The repro: `--paired A/reads.fq B/reads.fq` exits 0 with reports beside their own mates | **[CONFIRMED]**, exactly the layout in the plan |
+| A3 — the report paths really are in the candidate list, so the new collision is caught | **[CONFIRMED]** by the `-o` proxy: refused, `out/` empty, message `the outputs named from A/reads.fq and B/reads.fq would be written to the same file, out/reads.fq_trimming_report.txt` — #397 provenance names both inputs as the plan promises |
+| Multi-pair anchors per pair | **[CONFIRMED]** `main.rs:864` `chunks(2)` + `chunk[0]` as R1 into namers that use `input_r1.parent()`; a live 2-pair run put pair 2's primaries in pair 2's R1 directory |
+| `--passthrough`'s carrier is the third directory | **[CONFIRMED]** live: `Passthrough: C/i1.fq → C/i1_passthrough.fq` while primaries went to `A/` |
+
+Arm coverage is, as far as I can enumerate it, **complete**. I walked every paired
+dispatch branch: trim FASTQ→FASTQ (`main.rs:861`), trim BAM(1 file)→FASTQ
+(`run_paired_ubam_single_file`, `main.rs:1795` — reports built from one stem +
+one `dir`, `main.rs:1946-1955`, already unified), trim FASTQ→uBAM (`main.rs:2004`),
+trim BAM(1)→uBAM (`run_ubam_output_paired_single_file`, `main.rs:2396`), clump
+FASTQ→FASTQ (`main.rs:602`), clump FASTQ→BAM Shape A (`main.rs:717`), clump
+BAM(1)→BAM Shape B (`main.rs:681`), `--clock`/`--implicon`, `--hardtrim5/3`.
+`--demux` is `--paired`-incompatible (`src/cli.rs:1865` comment; barcode outputs are
+handled on the SE path in `planned_secondary_outputs`, `main.rs:103-112`), so it is
+correctly absent. `--retain_unpaired` is already R1-anchored (`io.rs:368-370`) and is
+already a candidate (`main.rs:878-888`).
+
+### 1.2 CRITICAL — a **second** inverted guard exists and the plan does not mention it
+
+`tests/integration_output_collision.rs:1206-1240`, `clump_report_candidates_do_not_over_reject`:
+
+```rust
+/// Over-rejection guard: same filename in two dirs WITHOUT -o is legal — both
+/// primaries land in R1's directory, each report beside its own mate. Pins that
+/// the candidates honour output_dir = None; a builder that resolved reports
+/// into one directory would over-reject this.
+```
+
+That is the same sentence, almost word for word, as the guard the plan built its whole
+"read this before implementing" section around — but on the `--clump_only --paired`
+arm. It asserts `ok` for `--clump_only --paired A/reads.fq B/reads.fq` and then
+`assert_dir_holds_only(&dir.join("B"), &["reads.fq", "reads.fq_clumping_report.txt"])`.
+
+**[CONFIRMED]** it passes today (`cargo test --release --test integration_output_collision -- --exact … → 3 passed`) and **[CONFIRMED]** that invocation exits 0 today with the split layout. Under the plan it must refuse, so this test goes red.
+
+Concrete failure this causes: the plan's own §Context argues the single most likely way
+to get this change wrong is an implementer "fixing" a red over-rejection guard by
+narrowing the candidate list. The plan inoculates against that for the trim twin and
+leaves the clump twin as an unannounced red test — the exact trap, one arm over. It
+also breaks validation 10, which claims to cover "the inverted guard" in the singular.
+
+**Fix:** name both guards in step 9 and validation 10; the clump twin's blocks 1-2
+(there are none — it is a single-block test) mean the whole test body is rewritten to
+assert the refusal, mirroring `clump_paired_rejects_shared_report_name` (`:1050`) but
+without `-o`.
+
+### 1.3 CRITICAL — the change **removes** a refusal, and a test asserts that refusal
+
+`tests/integration_output_collision.rs:1247-1275`,
+`clump_paired_rejects_shared_mate_report_without_output_dir`:
+
+```
+--clump_only --paired p/a.fq d/x.fq q/b.fq d/x.fq
+```
+
+**[CONFIRMED]** today this is refused:
+`two outputs named from d/x.fq would be written to the same file, d/x.fq_clumping_report.txt`
+(the 2c branch, `io.rs:160-170`), and the test asserts `!ok` plus three empty-of-output
+directory listings.
+
+**[DERIVED]** after the change, pair 1 anchors on `p/` and pair 2 on `q/`, so the four
+report paths become `p/a.fq_…`, `p/x.fq_…`, `q/b.fq_…`, `q/x.fq_…` and the four
+primaries `p/a_clumped_1.fq`, `p/x_clumped_2.fq`, `q/b_clumped_1.fq`, `q/x_clumped_2.fq`
+— **eight distinct paths, no collision**. The run succeeds and the test fails on
+`assert!(!ok)`.
+
+The trim-mode twin of the same shape (`--paired p/a.fq d/x.fq q/b.fq d/x.fq`) is
+**[CONFIRMED]** refused today with the identical message and has **no test**, so it will
+silently flip from refuse to succeed.
+
+Two things follow, and neither is in the plan:
+
+1. The plan's Behavior section is **one-directional** — it describes exactly one new
+   refusal and says nothing about refusals disappearing. §Behavior 7 and the edge-case
+   table therefore under-describe the change. The maintainer approved "the new
+   collision is accepted as a loud refusal"; they were not shown that an existing
+   deliberate refusal (added by #391, guarded by a test with a written rationale)
+   goes away.
+2. The new behaviour is, on the facts, *fine* — the shared mate produces two distinct
+   reordered outputs in two distinct directories and nothing is overwritten. So this is
+   a "record the decision and update the test", not a defect. But it must be recorded:
+   a red test asserting a refusal that the plan never predicted is precisely the
+   situation where an implementer reaches for the wrong fix.
+
+### 1.4 CRITICAL — a new output-vs-**input** hazard, which is #409's data-loss shape
+
+The plan discusses only report-vs-report collisions. Moving a report into R1's parent
+also makes it possible for a report path to land **on one of the inputs**.
+
+**[CONFIRMED]** on `38deb1ee`:
+
+```
+$ trim_galore --paired A/reads.fq_trimming_report.txt B/reads.fq     # exit 0
+A/  reads.fq_trimming_report_val_1.fq  reads_val_2.fq
+    reads.fq_trimming_report.txt                 <- R1's input, intact (@RPT_ reads)
+    reads.fq_trimming_report.txt_trimming_report.{txt,json}
+B/  reads.fq  reads.fq_trimming_report.{txt,json}
+```
+
+R2's report is `B/reads.fq_trimming_report.txt` today — harmless. After the change it
+becomes `A/reads.fq_trimming_report.txt`, **which is R1's input path**. If the candidate
+builder at `main.rs:906-912` moves with the writer, the pre-flight's output-vs-input
+branch (`io.rs:147-156`) refuses — correct. If it does not, the writer destroys a named
+input after the run has read it. That is #409 verbatim
+(`se_trim_ubam_rejects_output_that_aliases_a_report_input`, `tests/…:1411`), on a new
+arm, created by this change.
+
+No validation in the plan targets this direction. Validation 8 ("compare every file
+created against that arm's candidate list") would only catch it if the fixture happened
+to contain a report-named input, and it does not say to use one. Given the family
+history this needs its own test per paired report arm, in both the refusing and the
+`--no_report_file` acceptance direction (the shape `tests/…:1411` and `:1440` already
+model).
+
+### 1.5 IMPORTANT — `OutputSource` attribution: #397 explicitly left this to #398
+
+`main.rs:872-875`, written by #397:
+
+```rust
+// Uniform Pair for paired primaries (#397 decision C2): _val_1 takes its
+// stem from R1 but its directory from R1 too, and _val_2 mixes both — naming
+// one mate would encode a claim about which supplies the directory, which is
+// exactly what #398 may change.
+```
+
+The previous change left a note saying #398 has to decide this, and the plan does not
+mention it. After the change, both report candidates (`main.rs:908-910`) and the
+passthrough candidate (`main.rs:901`) take their **filename** from one input and their
+**directory** from R1 — the precise condition `OutputSource::Pair` was introduced for
+(`io.rs:94-96`).
+
+My recommendation is to **keep `OutputSource::Input` and say why in the plan**, because
+the message quality argues for it and switching would make it worse:
+
+- Keeping `Input`: two distinct sources, one path → the 2a branch (`io.rs:171-180`),
+  which prints *"the outputs named from A/reads.fq and B/reads.fq would be written to
+  the same file, …"* **[CONFIRMED]** live via the `-o` proxy. Followable: rename one input.
+- Switching to `Pair(A,B)`: both candidates get the same source identity
+  (`OutputSource::identity`, `io.rs:103-111`) → the **2c** branch, which prints *"List
+  each input once — a file that appears in more than one pair is reported once per
+  pair"* **[CONFIRMED]** live (that is what the shared-mate clump case prints). That
+  advice is wrong here: there are two inputs and renaming one does fix it.
+
+So the finding is not "the plan chose wrong" — it is that the plan is silent on a
+decision a previous change explicitly deferred to it, and the naive "improvement"
+degrades a user-facing message that shipped last week.
+
+### 1.6 IMPORTANT — the newly-refused population is larger than the plan states
+
+Behavior §7, the edge-case table, the changelog instruction (step 11) and the hint
+reword (step 8) all describe the new collision as *"two mates share a filename"* —
+i.e. within one pair. The actual rule is broader: **any two report-keyed inputs whose
+filenames fold-equal and whose pairs anchor on the same directory.**
+
+**[CONFIRMED]** the cross-pair case is real and newly refused:
+
+```
+$ trim_galore --paired A/s.fq B/t.fq A/u.fq B/s.fq      # exit 0 today
+A/ s_val_1.fq s_val_2.fq t_val_2.fq u_val_1.fq s.fq_trimming_report.{txt,json} u.fq_…
+B/ s.fq t.fq  s.fq_trimming_report.{txt,json}  t.fq_trimming_report.{txt,json}
+```
+
+Pair 1's R1 and pair 2's R2 share the filename `s.fq`; both pairs anchor on `A/`.
+After the change both reports resolve to `A/s.fq_trimming_report.txt`. The primaries
+are `A/s_val_1.fq` and `A/s_val_2.fq` — distinct — so **the reports are the only
+collision** and this is a genuinely new refusal in a shape the plan does not describe.
+
+I checked the obvious variant where the two *R2s* share a filename
+(`--paired A/x.fq B/y.fq A/z.fq C/y.fq`) and it is **[CONFIRMED]** already refused
+today, on the primary `A/y_val_2.fq` — so that one is not new. The R1-vs-R2 crossing
+above is the one that matters.
+
+Consequences for the plan: the hint reword must not say "mates", the changelog must
+not either, and the edge-case table should carry this row.
+
+Related, on the hint: `PAIRED_REPORT_HINT` is attached to the whole
+`preflight_output_collisions` call, so it is printed for **primary** collisions on those
+arms too — **[CONFIRMED]**, I saw it appended to an `A/y_val_2.fq` refusal. So the
+reword has to read correctly for a primary collision as well, where "a shared input
+directory" is equally not the cause. Something on the shape of *"every output of a pair
+is written to R1's directory (or `--output_dir`) and named from the input filename
+alone, so two inputs sharing a filename collide there"* covers both; the plan's
+instruction ("reword so the stated cause matches the new rule") does not flag that the
+constant is shared with primary-collision messages.
+
+### 1.7 IMPORTANT — A6's stated mechanism is wrong, and the wrong reading is a trap
+
+A6: *"`Path::parent()` on a bare filename yields `Some("")`, and the existing
+`unwrap_or(Path::new("."))` already handles it."*
+
+The first half is right and the second is not: because `parent()` returns `Some("")`,
+`unwrap_or(".")` **does not fire** — the empty path is what carries the behaviour, and
+`Path::new("").join("x")` is `"x"`, not `"./x"`. The `unwrap_or(".")` is effectively
+unreachable for any real input path.
+
+The conclusion (extraction is safe) still holds, but the muddled mechanism invites a
+concrete regression: if `pair_output_dir` normalises the empty case to `"."` — which
+reads like a tidy-up and which A6's wording actively suggests is already happening —
+then **every** paired path printed to stderr gains a `./` prefix, across all five
+primary namers plus the reports and the carrier. Today **[CONFIRMED]**:
+
+```
+  Output R1: r1_val_1.fq
+Report: r1.fq_trimming_report.txt
+```
+
+Collision detection would survive it (`lexical_normalise` absolutises and drops
+`Component::CurDir`, `io.rs:46-63`), so nothing would fail loudly — it is a silent
+cosmetic regression on every paired run. Restate A6 to say what actually happens, and
+add the assertion to validation 5.
+
+### 1.8 IMPORTANT — step 6's rationale for `--passthrough` is factually wrong
+
+Step 6: *"Prefer adding an explicit `output_dir` argument at the call site over changing
+the namer, so the single-pair SE-shaped uses stay put."*
+
+Two errors. `passthrough_output_name` **already** takes `output_dir` as its second
+parameter (`io.rs:387-391`) — there is no argument to add; the minimal change is to pass
+`Some(&pair_dir)`. And there are no SE-shaped uses to protect: **[CONFIRMED]** by grep,
+the only non-test call sites are `main.rs:895` (candidate) and `main.rs:1499` (writer),
+both on the paired path, and `--passthrough` requires `--paired` with exactly two inputs.
+
+Worse, the minimal change leaves debris the plan does not account for:
+
+- The namer's `output_dir == None` branch becomes **unreachable from production**, while
+  its docstring (`io.rs:375-386`) still describes deriving from the carrier's own parent.
+- Four of its six unit tests pass `None` and assert the carrier lands beside the carrier
+  input — `io.rs:853-858`, `:860-865`, `:874-879`, `:888-900`. They keep passing while
+  pinning a path production can no longer produce, i.e. they become **vacuous**. This
+  repo has a written norm against exactly that:
+  `tests/integration_output_collision.rs:803-804` — *"if the two ever drift the guard
+  would silently protect paths the run never touches — invisible to every rejection
+  test."*
+
+See §5 for the alternative I would recommend instead.
+
+### 1.9 Blocks 1-2 of the trim guard are genuinely unaffected
+
+Both use inputs in one directory passed as bare relative names with `run_in`'s cwd set
+there (`tests/…:1007-1014`, `:1018-1027`) **[CONFIRMED]** by reading the helper at
+`:54-64`. R1's parent is `""`, which is already every input's parent, so no path moves.
+The plan's instruction (rewrite block 3, keep 1-2) is correct — subject to §1.7: if
+`pair_output_dir` returns `"."`, blocks 1-2 still pass (they assert `is_file()` on
+absolute joins), so they will *not* catch that regression.
+
+### 1.10 Smaller logic points
+
+- **The clump-paired-BAM row of the writer/candidate table is a no-op, not a change.**
+  `clump_only.rs:1082-1084` keys the single per-pair report on `inputs[0]` — R1 — so its
+  directory is *already* R1's parent, and `main.rs:740-744` already passes
+  `from_ref(&chunk[0])` **[CONFIRMED]**. Listing it as an arm to change is harmless but
+  costs the implementer a puzzled detour; say "already unified, keep it that way".
+- **Validation 8 says "all four arms"; the table lists five.** With the row above being
+  a no-op the true count of changing arms is four, so the number happens to work out —
+  but the plan should not leave the reader to reconcile it.
+- **`clump_report_candidates` has five call sites, not two.** `main.rs:616` (paired
+  FASTQ), `:653` (SE FASTQ), `:698` (paired Shape B, one input), `:740` (paired BAM
+  Shape A), `:798` (SE BAM) **[CONFIRMED]**. Step 7 says "the paired callers pass the
+  pair directory and the SE caller passes `output_dir`" — three of the five are neither
+  cleanly "the SE caller" nor need a pair directory. Adding a required parameter makes
+  this a compile error rather than a silent miss, so the risk is low, but the sentence
+  should enumerate.
+- **The candidate site for clump-paired-FASTQ is a closure, not the helper.** The table
+  cites `main.rs:134` (inside `clump_report_candidates`' body); the site that has to
+  change is the closure at `main.rs:609-622`, invoked per pair by `run_specialty_paired`
+  (`main.rs:2637-2653`). Cite that.
+- **`--fastqc` needs nothing, and the plan should say so.** **[CONFIRMED]** live:
+  `--paired --fastqc A/reads.fq B/reads.fq` puts `reads_val_1_fastqc.{html,zip}` in `A/`
+  beside the trimmed output — `fastqc::run` (`src/fastqc.rs:37-59`) is handed the
+  **output** path, so it follows the primaries, and the carrier's FastQC will follow the
+  carrier automatically once the carrier moves. Add it to the out-of-scope list so the
+  next reader does not have to re-derive it. (Separately, FastQC outputs are in no
+  candidate list at all — pre-existing, `#414`'s business, not this plan's.)
+- **`--basename` cannot mask the new collision, and cannot create one.** Reports ignore
+  `--basename` (`io.rs:551-564`), and `--basename` is rejected for multi-pair, so no
+  cross-pair primary interaction is reachable. The plan's edge-case row is correct.
+
+---
+
+## 2. Assumptions
+
+| | Verdict |
+|---|---|
+| **A1** five primaries share the expression → pure extraction | **[CONFIRMED]** by reading all five. Sound. |
+| **A2** report namers separate filename from directory | **[CONFIRMED]** `io.rs:535-580`. Sound. |
+| **A3** report paths already in the candidate list for all four paired report arms | **[CONFIRMED]** empirically for the trim FASTQ arm via the `-o` proxy (refusal + provenance + empty `out/`); **[CONFIRMED]** by reading for the other three (`main.rs:2023-2029`, `main.rs:616-620`, `main.rs:740-744`). The accepted-refusal decision rests on solid ground. |
+| **A4** `--clock`/`--implicon` write no reports | **[CONFIRMED]** `grep -c report src/specialty.rs` → 0. |
+| **A5** SE paths never call the paired namers | **[CONFIRMED]** by grep: the paired namers' only non-test callers are the paired dispatch branches. |
+| **A6** bare-filename `parent()` | mechanism **wrong**, conclusion right — see §1.7. |
+
+### Unstated assumptions the plan relies on
+
+1. **That the change only ever adds refusals.** False — §1.3.
+2. **That report-vs-report is the only new collision class.** False — output-vs-input,
+   §1.4.
+3. **That `OutputSource` attribution stays correct.** Unexamined, and #397 left a note
+   asking — §1.5.
+4. **That `pair_output_dir` will reproduce the empty-path case exactly.** Load-bearing
+   for stderr output on every paired run — §1.7.
+5. **That the docs paths in step 10 exist.** They do not as written: the tree has
+   `Docs/src/content/docs/guide/outputs.md` (paired table at lines 19-25),
+   `…/guide/paired-end.md`, `…/modes/clump-only.md` **[CONFIRMED]** by `find`. Also
+   **`Docs/src/content/docs/modes/passthrough.md` is missing from the plan's docs list**
+   even though decision 2 moves the carrier — its output table at `:25` and the
+   `--basename` sentence at `:28` describe the three outputs with no directory
+   statement. (Its worked example at `:85-99` passes `--output_dir /tmp`, so the example
+   itself is safe **[CONFIRMED]**.)
+6. **That "File naming matches v0.6.x exactly, so existing pipelines continue to work
+   without changes"** (`Docs/…/guide/outputs.md:6`) survives. It is a filename claim, not
+   a directory claim, so it is not falsified — but it sits four lines above the table the
+   plan is editing and will read as a compatibility promise about the thing that just
+   changed. Worth a qualifying clause.
+
+### A fact that strengthens decision 1, which the plan does not have
+
+**Perl 0.6.11 wrote every output into one directory — the CWD — never beside the input.**
+**[CONFIRMED]** from the tagged source: `git show 0.6.11:trim_galore` line 608,
+`my $output_filename = (split (/\//,$filename))[-1];` strips the input's directory, and
+line 620 opens `$output_dir.$report`, where `$output_dir` is `''` unless `-o` was given
+(lines 3258-3272). Primaries go through the same `$output_dir.$out1` at lines 152-175.
+
+So Perl had **no** asymmetry to inherit: it was already one directory per run. "Beside
+the input" is a v2.x invention, and #398 moves back toward Perl's shape while choosing a
+different anchor. Three implications:
+
+- Decision 1 is *more* defensible than the plan argues — it restores a property the
+  original had.
+- The changelog should not claim or imply v0.6.x directory parity, because R1's parent
+  is not what Perl did either.
+- It is worth the maintainer knowing that the CWD anchor — which `--hardtrim5/3`,
+  `--clock` and `--implicon` already use (`Docs/…/modes/hardtrim.md:42`,
+  `modes/clock.md:49`, `modes/implicon.md:32`: *"never beside the input"*) — is the
+  Perl-faithful one. **I am not reopening decision 1**; R1's parent is a reasonable
+  choice and it is the maintainer's call. But the plan's open question ("should
+  `pair_output_dir` also back the `--hardtrim5/3` CWD rule?") is answered on richer facts
+  than the plan has: after this change the codebase has three directory rules (CWD for
+  specialty, R1's parent for paired, the input's parent for SE) where Perl had one.
+  That is worth one honest sentence in the plan rather than a "recommend no".
+
+---
+
+## 3. Efficiency
+
+Nothing to report. One `PathBuf` per pair at path-derivation time, and if callers compute
+`pair_dir` once and pass `Some(&pair_dir)` the change is net *fewer* allocations than
+today's per-namer rebuild. No new I/O, no new syscalls, nothing inside a per-record loop.
+The plan's "Nil" is right.
+
+`pair_output_dir` returning `PathBuf` by value is the right shape — a `Cow<Path>` to dodge
+one allocation per pair would be noise at this call frequency.
+
+---
+
+## 4. Validation sufficiency
+
+Validations 1-11 are well-constructed for the failure mode the plan is worried about
+(writer/candidate drift on the arms it lists), and validation 3's whole-directory-listing
+assertion and validation 9's inverted control are both the right instincts. The gaps are
+all in classes the plan did not know about.
+
+**Answer to validation 7, done rather than restated.** The Perl matrix is **unaffected**,
+for two independent reasons **[CONFIRMED]** by reading `.github/workflows/ci.yml`:
+
+- Every output-producing invocation passes `-o`. The only `trim_galore` invocations
+  without `-o` are `:466` (odd-count rejection), `:481` (single-FASTQ-under-`--paired`
+  rejection), `:490` (R1==R2 rejection), `:504` (`--basename` multi-pair rejection) — all
+  four assert non-zero exit and write nothing — plus `:551`/`:562` (`--clock`, a
+  CWD-output specialty mode with no reports) and `:687` (SE alias test).
+- Independently, every fixture lives in `test_files/`, one shared directory, so R1's
+  parent *is* R2's parent for every paired invocation in the file.
+
+The Perl-parity steps themselves (`:383-398`, `:411-417`, `:764-789`) all pass `-o` to
+both binaries. Nothing to change, and no fixture needs editing.
+
+### Gaps
+
+| # | Gap | Why it matters |
+|---|---|---|
+| **G1** | No validation for output-vs-**input** (a report landing on the other mate's input) | §1.4 — reachable **[CONFIRMED]**, and drift there is silent data loss, not a refusal. Needs a test per paired report arm plus the `--no_report_file` acceptance sibling. |
+| **G2** | No validation for the newly-refused **cross-pair** shape | §1.6 — `--paired A/s.fq B/t.fq A/u.fq B/s.fq`, where reports are the only collision. |
+| **G3** | No validation for the **un-refused** shared-mate shape | §1.3 — an existing test asserts the opposite; both the clump and the (untested) trim variant need a decision and coverage. |
+| **G4** | Validation 10 names one inverted guard; there are two | §1.2. |
+| **G5** | Nothing asserts stderr paths keep their exact spelling | §1.7 — a `"."`-returning helper is a silent `./`-prefix regression on every paired run. Cheapest home: extend the existing bare-name assertions. |
+| **G6** | Nothing exercises the reworded hint against a **primary** collision | §1.6 — the constant is shared, so a reword tuned to reports can end up nonsense on a `_val_2` collision. |
+| **G7** | Validation 8's fixtures are unspecified | It checks "every file created == the candidate list", which is the right property, but with same-directory fixtures it is satisfied vacuously — the paths do not move. Each arm's fixture must have R2 in a *different* directory from R1, and one variant must include a report-named input (G1). |
+
+One trap the plan gets right and should keep: validation 11's instruction to count the
+delta against the 578 baseline rather than eyeballing "ok". Note the corollary for
+targeted runs — `cargo test --test integration_output_collision -- --exact <names>` and
+check the passed count; I got `3 passed; 45 filtered out`, which is how you know the
+filter bit.
+
+---
+
+## 5. Alternatives for the implementation shape
+
+The three behaviour decisions are fixed; these are about how the code is arranged.
+
+**5.1 Make the writer and its candidate builder call one shared derivation, per arm
+(recommended).** The plan's central stated risk is that eight independent call sites (four
+writers, four candidate builders) must each be given the same directory. Its mitigation is
+discipline — "step 7 is deliberately worded to land with each writer". But the #383 /
+#388 / #391 / #409 family is *exactly* what discipline-based coupling produces. A helper
+per arm that both sides call removes the class instead of guarding it:
+
+```rust
+// io.rs
+pub fn paired_report_paths(r1: &Path, r2: &Path, output_dir: Option<&Path>) -> [PathBuf; 4]
+```
+
+or, better shaped to the existing types, a function returning the two `PairedReportFile`s
+that `main.rs:1729-1738` and `main.rs:2351-2360` both build by hand today, with the
+candidate builders consuming the same function's paths. The two trim arms are already
+near-duplicates of each other (they were pulled into the shared `write_paired_reports`
+for precisely this reason, per the comment at `main.rs:1716-1717`) — the *path*
+derivation is the half that was left un-shared. This is a bigger diff than the plan's,
+and it is the diff that makes instance #6 structurally impossible on these arms rather
+than merely tested for.
+
+**5.2 If the plan's shape is kept, put the invariant where it can be read.** The plan
+ends with "no signature change to the three shared report functions", which means nothing
+at `report_name`'s definition (`io.rs:550-564`) tells the next person that paired callers
+must supply the pair directory. Per the repo's own comment policy — *"put an invariant on
+the thing it constrains, not in the function that relies on it"* — a one-line doc note on
+the three report namers is worth more than the paragraph in `pair_output_dir`'s docstring,
+because the failure mode is a *future* paired caller passing `output_dir` straight through.
+
+**5.3 Fold `input_r1` into `passthrough_output_name` rather than passing `pair_dir` at the
+call site (recommended over step 6).** Every other paired namer takes `input_r1` and
+derives the directory internally; making the carrier's namer match
+(`passthrough_output_name(input_r1, input_passthrough, output_dir, basename, gzip)`)
+(a) puts the rule in one place instead of two call sites, (b) keeps the docstring honest,
+and (c) forces the four `None`-passing unit tests to be updated rather than quietly
+becoming vacuous (§1.8). It is a slightly larger diff and a strictly safer one.
+
+**5.4 Consider `pair_output_dir` for the SE namers too, or say why not.** The SE namers'
+`match output_dir { Some(d) => d.join(f), None => input.parent()…join(f) }` computes the
+same path as the paired `map/unwrap_or_else` form, so one helper could serve all twelve
+namers with no behaviour change. The plan's choice to leave SE alone is the lower-risk
+one and I would keep it — but the plan should say that the *expression* is shared with SE
+and that only the *anchor argument* differs, otherwise the next person reads
+`pair_output_dir` as encoding something paired-specific that it does not.
+
+---
+
+## 6. Action items
+
+### Critical — the plan should not go to implementation without these
+
+1. **§1.2** — Add `tests/integration_output_collision.rs:1206-1240`
+   (`clump_report_candidates_do_not_over_reject`) to step 9 and validation 10 as the
+   second inverted guard, with the same "rewrite, do not narrow" warning. **[CONFIRMED]**
+   it passes today and its invocation exits 0 with the split layout.
+2. **§1.3** — State in Behavior that the change also **removes** refusals, and decide the
+   fate of `clump_paired_rejects_shared_mate_report_without_output_dir`
+   (`tests/…:1247-1275`), which asserts a refusal that disappears. Note the untested
+   trim-mode twin flips the same way. **[CONFIRMED]** pre-change refusal;
+   **[DERIVED]** post-change success.
+3. **§1.4** — Add the output-vs-**input** class to Behavior and to Validation: a mate
+   named like the other mate's prospective report. **[CONFIRMED]** exits 0 today; after
+   the change it must refuse, and a candidate that fails to move destroys an input
+   (#409's shape). Cover each paired report arm plus a `--no_report_file` sibling.
+
+### Important
+
+4. **§1.5** — Record the `OutputSource` decision explicitly (recommend: keep `Input`,
+   because `Pair` drives the message into the 2c branch whose "list each input once"
+   advice is wrong for two-input collisions). `main.rs:872-875` names #398 as the change
+   that has to decide this.
+5. **§1.6** — Restate the newly-refused population as "any two report-keyed inputs whose
+   filenames fold-equal and whose pairs anchor on the same directory", and fix the hint
+   reword, the changelog sentence and the edge-case table accordingly. The cross-pair
+   shape is **[CONFIRMED]** newly refused. Note that `PAIRED_REPORT_HINT` is also printed
+   for primary collisions, so the reword must fit both.
+6. **§1.7** — Rewrite A6 to say what actually happens (`parent()` → `Some("")`, so
+   `unwrap_or(".")` never fires), and require `pair_output_dir` to return the empty path
+   rather than `"."`. Add the stderr-spelling assertion to validation 5.
+7. **§1.8 / §5.3** — Drop step 6's incorrect rationale (`passthrough_output_name` already
+   has an `output_dir` parameter; there are no SE-shaped uses — **[CONFIRMED]** by grep)
+   and prefer folding `input_r1` into the namer, which also keeps `io.rs:853-900`'s four
+   `None`-passing unit tests meaningful instead of vacuous.
+8. **§2.5** — Fix the docs paths (`Docs/src/content/docs/…`) and add
+   `modes/passthrough.md` to step 10, since decision 2 moves the carrier. Consider a
+   qualifying clause on `guide/outputs.md:6`'s "matches v0.6.x exactly".
+9. **§5.1** — Consider the shared writer+candidate derivation. The plan's own diagnosis of
+   the risk argues for removing the coupling rather than documenting it.
+
+### Optional
+
+10. **§1.10** — Mark the clump-paired-BAM row as already unified (a no-op) rather than an
+    arm to change; reconcile validation 8's "four arms" with the five-row table;
+    enumerate `clump_report_candidates`' five call sites; cite `main.rs:609-622` (the
+    closure) rather than `main.rs:134` for the clump-paired-FASTQ candidates.
+11. **§1.10** — Add `--fastqc` to the out-of-scope list with the reason (**[CONFIRMED]**
+    anchored on the output file, so it follows the primaries and the carrier for free).
+12. **§2 (Perl)** — Add the v0.6.11 fact: Perl stripped the input's directory and wrote
+    everything to `$output_dir`, defaulting to CWD **[CONFIRMED]** at
+    `git show 0.6.11:trim_galore` lines 608/620/3258-3272. It strengthens decision 1,
+    changes what the changelog may claim, and gives the "should `--hardtrim` share this
+    helper?" open question a real answer instead of a preference.
+13. **§4** — Record validation 7's answer in the plan (CI is unaffected: every
+    output-producing invocation passes `-o`, and every fixture shares `test_files/`), so
+    nobody re-runs it.
+14. Note that `target/release/trim_galore` was stale when this review began; validation
+    9's control build must come from HEAD.
+
+---
+
+## 7. Verdict
+
+**REVISE.**
+
+The plan is unusually good on the thing it set out to be good at: the extraction is
+genuinely behaviour-preserving (I checked all five namers), the writer/candidate table is
+accurate as far as it goes, A3 — the assumption the whole accepted-refusal decision rests
+on — holds empirically, and the instinct to treat the inverted guard as a decision record
+rather than a broken test is right.
+
+What it misses is that the change's behavioural footprint is wider than "one new refusal
+in one place". There is a **second** inverted guard on the clump arm; an existing
+deliberate refusal **disappears**; and moving reports into R1's parent opens an
+output-vs-**input** path that is the exact shape of the data-loss bug fixed three commits
+ago. Each of the three is a red or newly-green test that the plan does not predict, in a
+change whose own §Context argues that unpredicted red tests are how this bug family
+recurs. They are all fixable on paper — none of them threatens the three decisions — but
+the plan should carry them before an implementer meets them.

--- a/plans/08092026_paired-output-dir-unification/PLAN_REVIEW_B.md
+++ b/plans/08092026_paired-output-dir-unification/PLAN_REVIEW_B.md
@@ -1,0 +1,680 @@
+# Plan Review B — #398 one output directory per pair
+
+**Reviewer:** B (independent; no shared state with Reviewer A)
+**Plan:** `plans/08092026_paired-output-dir-unification/PLAN.md` r1
+**Tree state:** `dev` @ `38deb1ee` (verified `git log --oneline -1`)
+**Method:** every line-number claim in the plan was opened and read; the current
+behaviour was reproduced with `target/release/trim_galore` in fresh directories
+under `$TMPDIR`; `.github/workflows/ci.yml` and the docs tree were grepped
+directly. Findings are marked **CONFIRMED** (I ran or read the specific thing) or
+**SUSPICION** (reasoned, not executed).
+
+**Verdict: REVISE** — the plan is sound in its core mechanism and its arm
+enumeration is complete, but it (a) mis-states the real-world blast radius of the
+accepted refusal, (b) leaves `passthrough_output_name` as a divergent sixth rule
+with four unit tests pinning behaviour production will no longer reach, (c) gives
+a step-7 instruction for `clump_report_candidates` that, taken literally, breaks
+the multi-input single-end callers, and (d) points its docs step at the one table
+that does *not* state the directory rule while missing the two sentences that do
+— one of which is already wrong today. None of these are re-litigations of the
+three fixed decisions.
+
+---
+
+## 1. Logic review
+
+### 1.1 Arm enumeration is complete — I enumerated independently
+
+I did not take the plan's five-row table on trust. I enumerated every
+`preflight_output_collisions` call site (`grep -n preflight_output_collisions
+src/*.rs`) and mapped each to its writer. There are exactly eleven production
+sites, which matches the "all 11 arms" figure in the open #414 task:
+
+| Pre-flight site | Arm | Report candidates | #398 impact |
+|---|---|---|---|
+| `main.rs:464` | `--hardtrim5` | none | none (CWD rule) |
+| `main.rs:495` | `--hardtrim3` | none | none (CWD rule) |
+| `main.rs:658` | clump SE FASTQ | per input | none (SE) |
+| `main.rs:703` | clump paired BAM, Shape B (1 interleaved input) | 1, `inputs[0]` | **no-op** |
+| `main.rs:746` | clump paired BAM, Shape A (two-file, multi-pair) | 1 per pair, `chunk[0]` | **no-op** |
+| `main.rs:803` | clump SE BAM | per input | none (SE) |
+| `main.rs:915` | trim paired FASTQ | 2 per pair (`:906-912`) + carrier (`:893-903`) | **changes** |
+| `main.rs:994` | trim SE FASTQ | via `planned_secondary_outputs` | none (SE) |
+| `main.rs:2031` | trim paired uBAM-out (two FASTQ in) | 2 per pair (`:2026-2027`) | **changes** |
+| `main.rs:2093` | trim SE uBAM-out | `:2089-2090` | none (SE) |
+| `main.rs:2653` | `run_specialty_paired` — `--clock`, `--implicon`, clump paired FASTQ | clump: 2 per pair (`:616-620`); clock/implicon: none | **changes** (clump only) |
+
+CONFIRMED. Nothing that writes a report or a per-pair output in paired mode is
+missing from the plan's table. Specifically:
+
+- **`--retain_unpaired`** — candidates `main.rs:878-888`, writer
+  `main.rs:1506-1511` via `unpaired_output_names`, which is already R1-anchored
+  (`io.rs:368-370`). Correctly out of scope. CONFIRMED.
+- **`--demux`** — genuinely single-end-only, enforced at `cli.rs:1009-1012`
+  ("Demultiplexing is only allowed for single-end files"). CONFIRMED; the plan's
+  implicit assumption holds.
+- **`--clock` / `--implicon`** — `grep -c report src/specialty.rs` → 0, and
+  `clock_output_name` (`specialty.rs:488-491`) / `implicon_output_name`
+  (`specialty.rs:521-524`) return a **bare filename** when `output_dir` is
+  `None`, i.e. CWD. CONFIRMED. Note the plan's stated reason for excluding them
+  ("write no reports") is true but incomplete — the load-bearing reason is that
+  their primaries are CWD-anchored, so R1-anchoring would change them too. The
+  conclusion is right; the justification is weaker than it needs to be.
+- **`--clumpify`** (as opposed to `--clump_only`) writes no separate report; it
+  routes through the ordinary trim report path (`main.rs:1536`, `:1832`), so it
+  is covered by the trim arms. CONFIRMED by grep — `clumping_report_name` appears
+  only in `clump_only.rs`.
+- **`--clump_only` in all output-format combinations** — all four are in the
+  table above; two are no-ops (see 1.2).
+
+### 1.2 Two of the plan's five rows are no-ops, and the plan presents them as changes
+
+`clump_only.rs:1080-1086`:
+
+```rust
+let report_input = &inputs[0];
+let report_path = naming::clumping_report_name(report_input, output_dir);
+```
+
+`inputs[0]` **is R1** on Shape A and is the single interleaved input on Shape B.
+So `clumping_report_name(inputs[0], None)` already resolves to R1's parent, which
+is exactly what `pair_output_dir(input_r1, None)` returns. The candidate side
+matches: `main.rs:740-744` passes `std::slice::from_ref(&chunk[0])`, and
+`main.rs:698-702` passes the single input. CONFIRMED by reading both.
+
+Consequence the plan does not state: for the "Clump paired → BAM" row, both the
+writer change and the candidate change are **behaviour-identical no-ops**. That
+matters two ways:
+
+- An implementer who edits it and observes no test move may conclude the change
+  "didn't take" and go looking for something to break.
+- More usefully, it is a free assertion: the clump-paired-BAM report **already**
+  obeys the #398 rule, and a test pinning that is a genuine regression guard for
+  the R1-anchoring invariant on that arm.
+
+Recommendation: mark the row `no-op by construction (report already keys on R1)`
+and keep the edit for uniformity, or drop the edit and add the assertion.
+
+**Related internal inconsistency:** the table has **five** rows, Behavior §2
+refactors **five** `io.rs` namers (a different five), and Validation 8 says "all
+**four** arms". Three different fives-and-fours in one plan is exactly the kind of
+ambiguity that lets an arm be skipped. Validation 8 must name its arms.
+
+### 1.3 The inverted guard: the plan's instruction is correct, but the obvious helper will fail
+
+I read `tests/integration_output_collision.rs:1004-1042`. CONFIRMED:
+
+- **Block 1** (`:1005-1014`): `--paired --basename foo r1.fq r2.fq`, both inputs
+  in **one** directory. R1-anchoring is a no-op there — R1's parent already *is*
+  both parents. Unaffected, passes untouched.
+- **Block 2** (`:1016-1027`): `sample.fq` + `sample.fastq`, also **one**
+  directory. Unaffected.
+- **Block 3** (`:1029-1041`): `A/reads.fq` + `B/reads.fq`, no `-o`. Both reports
+  resolve to `A/reads.fq_trimming_report.txt` after the change → refusal. Must be
+  rewritten.
+
+So the plan's "rewrite block 3, keep blocks 1–2" is **correct**. CONFIRMED by
+reading, and by running the suite on `38deb1ee`:
+`cargo test --release --test integration_output_collision` → **48 passed, 0
+failed** (0.43 s), so the guard including block 3 is green today and block 3 is
+the only part that must flip. That 48 is the number to re-check after the change:
+the file should stay at 48 (block 3 rewritten in place) or rise to 49 (block 3
+split into its own test, my preference — see below).
+
+**Trap the plan does not flag.** The natural way to write the rewrite is
+`assert_rejected_cleanly(&dir3.join("A"), ok, &stderr, DUP_MSG)`. That helper
+(`:100-121`) asserts the directory is **empty** — and `A/` still holds the input
+`reads.fq`, so it fails. An implementer hitting that failure is one step from
+"fixing" the helper, which would weaken the emptiness assertion for the eight
+other tests that rely on it.
+
+The right helper already exists and is documented for exactly this case:
+`assert_dir_holds_only` (`:74-92`) — *"For rejected runs (nothing written beside
+the inputs — the no-`--output_dir` twin of 'directory is empty')"*. The plan's
+Validation 3 asks for the correct property ("assert the whole directory listing
+of `A/` and `B/` is unchanged") but does not name the helper. Say
+`assert_dir_holds_only(&dir3.join("A"), &["reads.fq"])` explicitly.
+
+**Second trap:** after the rewrite, the test function is named
+`paired_report_candidates_do_not_over_reject` and doc-commented "T6 —
+over-rejection guards at the boundary A1 describes", while containing a rejection
+assertion. Either split block 3 into its own `#[test]` with a #398 name (my
+preference — the two properties are independent and a single failure then tells
+you which one broke), or rename and re-comment the function. The plan says
+"rewrite … keeping its first two blocks", which as written leaves a misnamed
+test.
+
+### 1.4 The refusal class is broader than "two mates of one pair" — and the layout it breaks is a real one
+
+This is my most important finding, and it is not a re-litigation: the decision to
+accept a loud refusal is fixed, but I do not believe the maintainer has been shown
+*which* invocations stop working.
+
+The plan frames the refusal through `--paired A/reads.fq B/reads.fq` — which reads
+as an artificial edge case. The actual rule after the change is: **any two inputs
+in the run that share a filename and whose pairs resolve to the same directory
+now collide.** The practically important instance is the *mate-side directory*
+layout, where a facility splits reads by mate rather than by sample:
+
+```
+R1/s1.fq  R1/s2.fq
+R2/s1.fq  R2/s2.fq
+```
+
+I ran this on `38deb1ee`:
+
+```
+$ trim_galore --paired R1/s1.fq R2/s1.fq R1/s2.fq R2/s2.fq     # exit 0
+R1/  s1_val_1.fq s1_val_2.fq s1.fq_trimming_report.{txt,json}
+     s2_val_1.fq s2_val_2.fq s2.fq_trimming_report.{txt,json}
+R2/  s1.fq_trimming_report.{txt,json}  s2.fq_trimming_report.{txt,json}
+```
+
+CONFIRMED (exit 0, layout as shown). After the change the **entire invocation** is
+refused before any pair is processed: `main.rs:863-914` builds candidates for
+every chunk and then calls the pre-flight once (`:915`), so this is not "pair 1
+fails and pair 2 proceeds" — nothing runs at all. That is a
+layout convention, not a corner case, and it is qualitatively different from the
+plan's §Integration framing:
+
+> "pipelines that glob `<mate>_trimming_report.txt` beside R2's input will stop
+> finding it … the realistic blast radius is hand-rolled scripts"
+
+The blast radius is not only "scripts that look in the wrong place afterwards" —
+it is "runs that previously completed now exit non-zero before writing
+anything". Those are different severities and the changelog needs the second one
+stated plainly, with `-o` (not `--no_report_file`) as the primary remediation,
+since `--no_report_file` throws the reports away.
+
+Conversely, the **per-sample directory** layout is safe, and saying so is worth as
+much as the warning:
+
+```
+sampleA/reads_1.fq sampleA/reads_2.fq  sampleB/reads_1.fq sampleB/reads_2.fq
+```
+
+Each pair's R1 is in its own sample directory, so nothing collides. CONFIRMED by
+running the analogous `--paired A/x1.fq A/x2.fq B/y1.fq B/y2.fq` — pair 1's
+outputs landed in `A/`, pair 2's in `B/`, no cross-talk.
+
+**Action:** add the mate-side-directory layout to the plan's edge-case table as
+its own row, and put both layouts in the changelog and docs. Felix accepted "a
+loud refusal for two same-named mates"; he should see that this reads, in the
+field, as "the R1/-and-R2/ directory layout now requires `-o`".
+
+### 1.5 The refusal message will name a path in R1's directory and will not explain why
+
+Reproduced on `38deb1ee` with `-o out` (the case that already refuses):
+
+```
+Error: Output path collision (case-insensitive, for APFS/NTFS safety): the outputs
+named from A/reads.fq and B/reads.fq would be written to the same file,
+out/reads.fq_trimming_report.txt. Outputs and reports are named from the input
+filename alone, so inputs sharing a filename can collide when --output_dir (or a
+shared input directory) sends them to one place — rename one input, or pass
+--no_report_file if only the reports collide.
+```
+
+CONFIRMED (exit 1, `out/` empty, both inputs named — #397's provenance works, so
+A3 holds).
+
+After the change the same message fires with **no `-o` given** and the path
+`A/reads.fq_trimming_report.txt`. The user sees two inputs in two different
+directories, and a colliding path inside the *first* one. The current hint's
+stated cause — "`--output_dir` (or a shared input directory) sends them to one
+place" — is then flatly false: neither is present. The plan's step 8 correctly
+identifies that the hint must be reworded but supplies no target text and does
+not say what the new text has to *explain*. It must state the R1-anchoring rule,
+or the message actively misleads:
+
+> …every output of a paired run is written to Read 1's directory (or
+> `--output_dir`), and reports are named from the input filename alone, so two
+> mates sharing a filename resolve to one report path — pass `--output_dir`,
+> rename one input, or `--no_report_file` if only the reports collide.
+
+Note `PAIRED_REPORT_HINT` is shared by three sites (`main.rs:915`, `:2031`,
+`:608`), so one rewording covers all of them. CONFIRMED by grep.
+
+### 1.6 Step 6's stated justification rests on a caller that does not exist
+
+Step 6: *"Prefer adding an explicit `output_dir` argument at the call site over
+changing the namer, **so the single-pair SE-shaped uses stay put**."*
+
+Two problems, both CONFIRMED:
+
+1. `passthrough_output_name` **already** takes `output_dir: Option<&Path>` as its
+   second parameter (`io.rs:387-392`). No argument needs adding; the change is
+   passing `Some(&pair_dir)` instead of `output_dir` at `main.rs:1500` and
+   `main.rs:895-900`. The step reads as if a signature change were required.
+2. There are **no SE-shaped uses**. `--passthrough` requires `--paired` and
+   exactly one pair (`cli.rs:906-916`: "`--passthrough` requires `--paired`",
+   "requires exactly one R1/R2 pair"). `grep -n passthrough_output_name src/*.rs`
+   returns exactly two production call sites, both on the paired path. The stated
+   reason for choosing the call-site shape is false on the facts.
+
+The decision may still be the right one, but it needs a real reason — and it has
+a cost the plan does not account for (1.7).
+
+### 1.7 The plan leaves a sixth, divergent directory rule in `io.rs` — with four tests pinning it
+
+After the change, `io.rs` contains five paired namers calling `pair_output_dir`
+and one — `passthrough_output_name` (`io.rs:404-409`) — still deriving the
+directory from the **carrier input's** parent, in a branch no production path can
+reach. Its docstring (`io.rs:375-386`) even calls the carrier one of "the three
+pair outputs" while naming it as if it were not, which the plan itself quotes as
+evidence of the bug.
+
+Worse, four unit tests pin the unreachable branch: `test_passthrough_output_name_bare`
+(`io.rs:854`), `_plain` (`:861`), `_with_basename` (`:875`), `_all_extensions`
+(`:889`) — all pass `output_dir = None` and assert `/data/I1_passthrough.fq.gz`,
+i.e. *beside the carrier*. They will keep passing after the change while
+asserting a rule the binary no longer produces. CONFIRMED by reading all four.
+
+That is the same shape of defect #398 exists to fix: a namer whose documented
+rule differs from what its callers do. It also means the passthrough arm has the
+**weakest safety net of the five** — I checked `tests/integration_passthrough.rs`
+and its only positive test (`passthrough_cli_cores_1_smoke`) passes
+`--output_dir`, so **no existing test pins the carrier's no-`-o` location in
+either direction**. A half-implementation (candidate moved, writer not, or vice
+versa) is invisible to the current suite.
+
+Recommendation, in order of preference:
+
+1. Change `passthrough_output_name` to take `input_r1` and derive the directory
+   via `pair_output_dir`, updating the four unit tests to the new rule. It is
+   paired-only, so this is safe, and it makes the drift structurally impossible.
+2. If keeping the call-site shape: rewrite the docstring to say the directory is
+   the caller's to supply, and repoint the four `None` tests at the pair rule.
+
+Either way, add an integration test for `--passthrough` **without** `-o`
+(Validation 2 asks for this — make sure it lands as a committed test, not just a
+manual check).
+
+### 1.8 Step 7's `clump_report_candidates` instruction breaks the SE callers if taken literally
+
+Step 7: *"give it an explicit directory argument so the paired callers pass the
+pair directory and the SE caller passes `output_dir`. **Do not** let it keep
+deriving per input."*
+
+`clump_report_candidates` (`main.rs:121-139`) is called from **five** sites, not
+two:
+
+| Site | `report_inputs` | Needs |
+|---|---|---|
+| `main.rs:616` | `&[r1, r2]` (one pair) | the pair directory |
+| `main.rs:653` | `&cli.input` — **all** SE FASTQ inputs at once | per-input parent when `output_dir` is `None` |
+| `main.rs:698` | `&cli.input` (len 1, Shape B) | that input's parent |
+| `main.rs:740` | `from_ref(&chunk[0])` | the pair directory (= R1's parent, no-op) |
+| `main.rs:798` | `&cli.input` — **all** SE BAM inputs at once | per-input parent |
+
+CONFIRMED by reading all five. The two SE sites hand it the whole input list, and
+those inputs may live in **different** directories. A signature that takes one
+required directory and applies it to every element is wrong for them: it would
+collapse every SE input's report into one directory, silently producing candidate
+paths the SE writers never write — the #383 family in the mirror direction, and
+this time on a *single-end* arm the plan declares out of scope.
+
+The workable shape is: keep the parameter `Option<&Path>` with the existing
+"`None` → per-input parent" semantics, and have the paired callers pass
+`Some(&pair_dir)`. Then "do not let it keep deriving per input" is true of the
+paired callers only, which is what the plan means but not what it says. Reword
+step 7 so the SE contract is explicit, or the sentence is an invitation to break
+two arms.
+
+### 1.9 The lockstep argument cuts in the plan's favour on one point worth recording
+
+Because `guarded_inputs` (`main.rs:72-81`) feeds the same pre-flight, moving a
+report candidate automatically moves its **output-vs-input** check too. So the new
+risk of a relocated R2 report landing on top of a *named input* in R1's directory
+is covered for free — provided the candidate moves with the writer. That is a
+concrete correctness reason for the plan's insistence on same-commit lockstep,
+stronger than the "instance #6" framing, and worth a sentence in the plan.
+
+### 1.10 The report text embeds the carrier's output path
+
+`report.rs:466-481` writes `Input:` and `Output:` lines for the passthrough block
+into the R2 **text** report. Moving the carrier therefore changes report content,
+not just file location. The JSON report carries counts only
+(`report.rs:1010-1035`), so no JSON value changes. CONFIRMED by reading both.
+Harmless, but §Integration says "Writes: relocates … the passthrough carrier" and
+should add "and the `Output:` line of the R2 text report's passthrough block", so
+a reviewer diffing report fixtures is not surprised.
+
+---
+
+## 2. Assumptions
+
+| # | Claim | Verdict |
+|---|---|---|
+| A1 | All five primary paired namers share an identical directory expression | **CONFIRMED.** Read all five: `io.rs:296-298`, `337-339`, `368-370`, `473-475`, `522-524`. Byte-identical `output_dir.map(\|d\| d.to_path_buf()).unwrap_or_else(\|\| input_r1.parent().unwrap_or(Path::new(".")).to_path_buf())`. Extraction is pure. |
+| A2 | The three report namers derive filename from `file_name()` and directory independently | **CONFIRMED.** `io.rs:535-548`, `551-564`, `567-580`. Passing a directory relocates without renaming. |
+| A3 | Report paths are already in the candidate list, so the new collision is caught not overwritten | **CONFIRMED empirically**, as the plan demands. `--paired -o out A/reads.fq B/reads.fq` on `38deb1ee` → exit 1, message names both inputs and the colliding report path, `out/` left empty. |
+| A4 | `--clock`/`--implicon` write no reports | **CONFIRMED.** `grep -c report src/specialty.rs` → 0. |
+| A5 | Single-end paths never call the paired namers | **CONFIRMED by grep** — no `*_paired_*` namer is reachable from an SE dispatch branch. But see 2.1: one of the line references the plan offers as evidence is wrong. |
+| A6 | `Path::parent()` on a bare filename yields `Some("")` and the existing `unwrap_or(".")` handles it | **Conclusion CONFIRMED, mechanism wrong.** See 2.2. |
+
+### 2.1 A5's supporting citation is wrong
+
+The out-of-scope list cites *"Single-end arms (`main.rs:100-101`, **`:909`-adjacent
+SE paths**, `:1299`, `:2089-2090`, `:2118`)"*. `main.rs:909` is
+`candidates.push((naming::report_name(input, output_dir), src.clone()));` inside
+the **paired** candidate loop (`:906-912`) — it is the very line the change edits,
+not an SE path. The SE candidate builder is `planned_secondary_outputs`
+(`:91-115`, called at `:993`). CONFIRMED by reading. The other four citations are
+correct. A5's conclusion holds, but a list presented as "out of scope by
+inspection, not assumption" containing a mis-citation is worth correcting — it is
+the kind of slip that makes a reviewer wonder what else was skimmed.
+
+### 2.2 A6's mechanism is not the one that fires
+
+`Path::new("reads.fq").parent()` returns `Some("")`, so `unwrap_or(Path::new("."))`
+is **not** reached; the empty path is joined, yielding the bare relative filename.
+`unwrap_or(".")` fires only for a path with no parent at all (`/`). A6 says "so
+the existing `unwrap_or(".")` path is unchanged", which describes the wrong
+branch. The **conclusion** — no panic, no path change — is CONFIRMED empirically:
+`cd bare && trim_galore --paired r1.fq r2.fq` on `38deb1ee` wrote
+`r1_val_1.fq`, `r2_val_2.fq`, `r1.fq_trimming_report.{txt,json}`,
+`r2.fq_trimming_report.{txt,json}` all into the CWD, exit 0. Fix the wording so a
+future reader does not go looking for a `.`-fallback that never executes.
+
+### 2.3 Implicit assumptions the plan does not state
+
+- **`pair_output_dir` gets no unit test of its own.** The plan asserts A6 in prose
+  and relies on the five namers' existing tests for A1, but adds no test for the
+  new function's own contract (`output_dir` precedence; bare-filename parent;
+  root path). Since it becomes the single source of truth for every paired
+  directory decision, it should carry three direct assertions. Not listed in the
+  validation table.
+- **The pre-flight does not plan FastQC output paths, deliberately.** `io.rs:1335-1340`
+  states this explicitly: *"FastQC's `<stem>_fastqc.zip` is not asserted
+  separately … Its one real exception — `--fastqc_args "-o DIR"` … is recorded in
+  the plan as a known residual."* CONFIRMED. This directly bounds Validation 8
+  (see 4.1).
+- **`--basename` neither creates nor masks the new collision.** With
+  `--basename foo` the primaries become `foo_val_{1,2}` (distinct by suffix) while
+  reports keep per-input names, so two same-named mates in different directories
+  still collide **on the reports** — `--basename` is not an escape hatch. And
+  `--basename` is rejected for multi-pair at `cli.rs:669-671` ("--basename cannot
+  be used with multiple paired-end pairs"), so it cannot create a cross-pair
+  collision. The plan's edge-case row is correct. CONFIRMED by reading
+  `paired_end_output_names` (`io.rs:326-341`), `cli.rs:669-671`, and the guard
+  test's block 1, which exercises exactly this and passes today.
+- **Anchoring is per pair, and the primaries already behave that way.**
+  CONFIRMED by running `--paired A/x1.fq A/x2.fq B/y1.fq B/y2.fq` (1.4): pair 1's
+  `x1_val_1.fq` + `x2_val_2.fq` both in `A/`, pair 2's both in `B/`. The reports
+  will match. `run_specialty_paired` (`main.rs:2648-2653`) builds candidates
+  per-chunk via the closure, so the clump arm inherits the same per-pair
+  behaviour for free.
+
+---
+
+## 3. Efficiency
+
+Nothing to report. The plan's "nil" is correct: all five namers already allocate a
+`PathBuf` for the directory (`d.to_path_buf()` / `.to_path_buf()`), so returning
+one from `pair_output_dir` is the same allocation moved, not an extra one. One
+additional `PathBuf` per pair at the writer sites, on a path that then does file
+I/O. No new syscalls, no change in complexity or memory. CONFIRMED by reading the
+five expressions.
+
+Minor: the writer sites could pass `pair_dir.as_path()` down rather than
+recomputing, but `pair_output_dir` is two branches and a clone — not worth
+plumbing.
+
+---
+
+## 4. Validation sufficiency
+
+Validations 1–11 cover the main risk (writer/candidate drift) better than most
+plans in this repo, and Validation 9's inverted control is the right instinct.
+Three gaps.
+
+### 4.1 Validation 8 will fail spuriously, or get weakened, on any `--fastqc` run
+
+Validation 8: *"for each arm, run it and compare every file created against that
+arm's candidate list → exact match; no writer produces an unplanned path."*
+
+That property is **false by design** for two flags: FastQC's `*_fastqc.html` /
+`*_fastqc.zip` are never planned (`io.rs:1335-1340`, CONFIRMED), and `--demux`'s
+per-barcode files are planned only via `planned_secondary_outputs` on the SE arm.
+An implementer running Validation 8 with `--fastqc` on will see unplanned files
+and either report a false failure or — the dangerous outcome — "fix" it by
+relaxing the exactness to a subset check, which is precisely the assertion
+strength #391/#408 fought to get.
+
+**Action:** scope Validation 8 to runs without `--fastqc`, and state the
+known-unplanned set inline so nobody re-derives it under time pressure.
+
+### 4.2 Validation 7 — I checked it, so the plan can stop asking
+
+The plan asks whether CI's SE/PE invocations rely on per-mate report paths. Read
+`.github/workflows/ci.yml` directly:
+
+- Every Perl-comparison invocation passes `-o`: SE at `:383-384`, PE at
+  `:394-395`, `-a2` matrix at `:411-414`, hardtrim5 at `:764-765`, clock at
+  `:773-774`, demux at `:784-786`.
+- Every PE invocation uses `test_files/BS-seq_10K_R{1,2}.fastq.gz` — one shared
+  input directory, distinct filenames. So the change is a no-op there twice over.
+- The md5 oracles compare **FASTQ payloads only** (`gzip -dc … | md5sum`, e.g.
+  `:396-400`); no report is md5'd.
+- The only report-path assertions are `:422` (`grep -q 'a AAATCAAAAAAAC'
+  /tmp/rust_a2/BS-seq_10K_R2.fastq.gz_trimming_report.txt`), `:441-444`
+  (multi-pair `test -f` on four report paths in `/tmp/rust_multi`) and `:843-845`
+  (clumping-report filename discipline in `/tmp/co-det1`). **All three are inside
+  `-o` directories.**
+- The invocations that omit `-o` are all **negative** tests that exit before any
+  write: `:466` (odd count), `:481` (paired + single FASTQ), `:490` (R1==R2),
+  `:504` (basename + multi-pair), `:551`/`:562` (clock dup / odd count).
+
+**CONFIRMED: the Perl validation matrix is entirely unaffected.** Validation 7 can
+be restated as a one-line pin rather than an open question. Worth keeping as a
+*test*, not a question: if someone later drops `-o` from the PE step to save a
+`mkdir`, the matrix starts refusing.
+
+### 4.3 Gaps to add
+
+- **A `pair_output_dir` unit test** (2.3). Three assertions, five lines.
+- **A committed `--passthrough` no-`-o` test** (1.7) — nothing pins the carrier's
+  location today, so this behaviour change is currently unobservable to the suite
+  in either direction.
+- **The mate-side-directory layout as a validation row** (1.4) — the multi-pair
+  refusal is the shape a user will actually hit, and Validation 6 only covers the
+  *accepting* multi-pair case.
+- **An assertion that the clump-paired-BAM report is already R1-anchored** (1.2) —
+  converts a no-op edit into a guard.
+- Validation 11's "count the delta against the 578 baseline" is the right
+  instruction. Add: also check the *passed* count, not just `ok` — a filter that
+  matches nothing prints `test result: ok. 0 passed`.
+
+---
+
+## 5. Alternatives for the implementation shape
+
+The three behaviour decisions are fixed; these are about how to land them.
+
+### 5.1 Paired report namers instead of "everyone calls `pair_output_dir`" (recommended consideration)
+
+The plan's shape leaves two sites per arm each free to pass either `output_dir` or
+`Some(&pair_dir)`. Drift needs only one forgotten call site, and the sites are
+600+ lines apart (`main.rs:895` vs `:1500`; `:906-912` vs `:1729-1738`).
+
+A strictly more drift-proof shape: add one paired-report namer to `io.rs`, e.g.
+
+```rust
+pub fn paired_report_names(input_r1: &Path, input_r2: &Path, output_dir: Option<&Path>)
+    -> [(PathBuf, PathBuf); 2]   // (txt, json) for R1 and R2
+```
+
+and make **both** the candidate builder and the writer call it. Then it is
+impossible for the two sides to disagree, because there is only one expression.
+Same for the carrier: `paired_passthrough_name(input_r1, input_passthrough, …)`.
+Cost: two more functions in `io.rs` and a slightly wider diff. Benefit: the
+failure mode the plan calls "the single most likely way to get this wrong" becomes
+unrepresentable rather than merely tested for.
+
+Given the #383/#388/#391/#409 history — five recurrences of exactly this family —
+I think the structural fix earns its diff. If the plan keeps the
+`pair_output_dir`-everywhere shape, at minimum add a comment at each of the four
+candidate sites pointing at its writer and vice versa.
+
+### 5.2 Make the no-op explicit rather than editing it
+
+For the clump-paired-BAM arm (1.2), prefer an assertion over an edit. Editing
+identical behaviour into identical behaviour adds diff surface with no test
+movement to prove it landed.
+
+### 5.3 Do not fold the CWD rule in
+
+The plan's open question recommends *not* backing `--hardtrim5/3`'s CWD rule with
+`pair_output_dir`. I agree, and I would go further: the docs already state the CWD
+rule as a deliberate, separately-documented behaviour in three places
+(`modes/hardtrim.md:42`, `modes/clock.md:49`, `modes/implicon.md:32`, all
+CONFIRMED, all identical wording from #387). Folding them together would make one
+function answer two questions. Keep them apart.
+
+### 5.4 The other open question (transition NOTE) — agree, no note
+
+Agreed with the plan's "recommend no". A NOTE that fires on the now-correct common
+case is noise. The changelog and the refusal message carry the transition.
+
+---
+
+## 6. Documentation findings (step 10 is pointed at the wrong lines)
+
+The plan's docs path shorthand `guide/outputs.md` resolves to
+`Docs/src/content/docs/guide/outputs.md` (note capital `Docs`). Its claim about
+the Paired-end table at `:20-25` is CONFIRMED — and the table indeed says nothing
+about directories. But the two sentences that *do* speak to this are not in the
+plan:
+
+- **`guide/outputs.md:102`** — *"`--output_dir DIR` writes outputs to `DIR/`
+  instead of **the current working directory**. The trimmed FASTQ filename stem is
+  unchanged; only the parent directory differs."* This is the one place the
+  directory rule is stated, and it is **already wrong today**: trim outputs go to
+  the *input's* parent, not the CWD (only the specialty modes use CWD). This is
+  where the new rule belongs, and it needs correcting either way. CONFIRMED by
+  reading, and by the `bare/` run in 2.2 plus the `A/`-anchored run in 1.4.
+- **`guide/outputs.md:6`** — *"File naming matches v0.6.x exactly, so existing
+  pipelines continue to work without changes."* Filenames still match after
+  #398, so the first clause survives; the second becomes false for the
+  mate-side-directory layout. Needs a qualifier.
+
+Checked the two files the plan asks about, both CONFIRMED clean of any
+directory claim, so nothing to correct there — only the new rule to add if
+desired:
+
+- `guide/paired-end.md:16-19` lists the four paired output filenames, no directory.
+- `modes/clump-only.md:45`, `:109`, `:122` describe report *filenames* and
+  per-mate vs per-pair counts ("Paired FASTQ runs write one report per mate; the
+  uBAM shapes write one per pair (keyed on the pair's first input)" — which
+  independently confirms 1.2), no directory.
+- `guide/outputs.md:125` says FastQC artifacts land "alongside the trimmed
+  output" — correct and unaffected, since FastQC is anchored on the output file
+  (`fastqc.rs:37-58` passes `output_path` and the trim-galore `output_dir`
+  straight through). **Answering the reviewer question directly: `--fastqc` needs
+  no plan change.** Its artifacts already follow the primaries into R1's parent.
+  The one residual is `--fastqc_args "-o DIR"`, already recorded as out of scope
+  at `io.rs:1338-1340`.
+
+**CHANGELOG:** step 11's `#### Changes` heading does not yet exist in the
+`### Unreleased` section (currently only `#### Bug fixes`, `CHANGELOG.md:6`), but
+the heading style is precedented (`:205`), as is `#### Behavioural notes (v2.x
+intentional widenings)` (`:998`) — arguably the closer precedent for a deliberate
+refusal of a previously-working invocation. Either works; just note the heading is
+new to this section.
+
+---
+
+## 7. Action items
+
+### Critical
+
+1. **Reword step 7's `clump_report_candidates` instruction** so the SE contract
+   survives (1.8). Taken literally, "do not let it keep deriving per input" breaks
+   `main.rs:653` and `:798`, which pass **all** SE inputs at once and need
+   per-input parents when `output_dir` is `None`. Specify: parameter stays
+   `Option<&Path>`; paired callers pass `Some(&pair_dir)`; SE callers keep passing
+   `output_dir`. CONFIRMED by reading all five call sites.
+
+2. **Name the layout the refusal breaks, in the plan, the changelog and the docs**
+   (1.4). `R1/s1.fq R2/s1.fq R1/s2.fq R2/s2.fq` runs today (CONFIRMED, exit 0) and
+   will be refused for every pair. Add it as an edge-case row and a validation
+   row; lead the changelog remediation with `--output_dir`, not
+   `--no_report_file`. This is the consequence I judge the maintainer most likely
+   not to have seen.
+
+3. **Specify what the reworded `PAIRED_REPORT_HINT` must explain** (1.5). Without
+   the R1-anchoring rule in the text, the message names a path inside R1's
+   directory while the user passed no `--output_dir` and has inputs in two
+   directories — the stated cause is absent in the failing case. One hint serves
+   all three sites (`main.rs:608`, `:915`, `:2031`).
+
+### Important
+
+4. **Resolve `passthrough_output_name`'s divergence** (1.6, 1.7). Step 6's stated
+   justification is false — there are no SE-shaped callers (`cli.rs:906-916`), and
+   the `output_dir` parameter already exists. Either move its directory derivation
+   to `pair_output_dir(input_r1, …)` or fix its docstring and repoint the four
+   `output_dir = None` unit tests (`io.rs:854`, `:861`, `:875`, `:889`), which
+   otherwise keep asserting a rule production can no longer produce.
+
+5. **Bound Validation 8 to no-`--fastqc` runs and state the known-unplanned set**
+   (4.1). `io.rs:1335-1340` documents that FastQC paths are deliberately absent
+   from candidate lists; an exact-match assertion will otherwise fail spuriously
+   and invite weakening.
+
+6. **Name `assert_dir_holds_only` in Validation 3 / step 9, and split block 3 into
+   its own test** (1.3). `assert_rejected_cleanly` asserts an *empty* directory and
+   cannot express "unchanged beside the inputs"; reaching for it first produces a
+   failure whose obvious fix damages eight other tests.
+
+7. **Fix step 10's docs targets** (§6). Add `guide/outputs.md:102` (states the
+   directory rule, and states it wrongly today) and `:6` ("existing pipelines
+   continue to work without changes"). Correct the path prefix to
+   `Docs/src/content/docs/`.
+
+8. **Mark the clump-paired-BAM row a no-op and reconcile five-vs-four** (1.2).
+   `clump_only.rs:1083`'s `report_input = &inputs[0]` is already R1, so both its
+   writer and its candidate change are behaviour-identical. Validation 8 says
+   "four arms" against a five-row table; name them.
+
+### Optional
+
+9. **Consider the paired-report-namer shape** (5.1) — makes writer/candidate drift
+   unrepresentable rather than tested-for, which is worth weighing after five
+   recurrences of this family.
+
+10. **Add a `pair_output_dir` unit test** (2.3): `output_dir` precedence, bare
+    filename, root path.
+
+11. **Fix A5's `:909` mis-citation and A6's `unwrap_or(".")` mechanism** (2.1,
+    2.2). Both conclusions are correct; both citations point at the wrong thing.
+    `io.rs:286-305` for `paired_bam_output_name` is also off — the function is
+    `285-301` and its directory expression is `296-298`.
+
+12. **Add the report-content knock-on to §Integration** (1.10): the R2 text
+    report's passthrough `Output:` line moves with the carrier
+    (`report.rs:481`). JSON is unaffected.
+
+13. **Record the free win from lockstep** (1.9): moving a report candidate also
+    moves its output-vs-input check, so a relocated report cannot silently land on
+    a named input.
+
+---
+
+## 8. Verdict
+
+**REVISE.**
+
+The mechanism is right, the arm enumeration is complete (I checked all eleven
+pre-flight sites independently), A1–A4 and A6's conclusion all verify, and the
+inverted-guard instruction is correct. Validation 7's open question is now
+answered: the Perl matrix is unaffected, twice over.
+
+What needs to change before implementation: item 1 is a latent break of two
+single-end arms the plan declares out of scope; item 2 is a user-facing
+consequence materially larger than the plan's framing; item 3 leaves the refusal
+message stating a cause that is absent in the failing case; item 4 leaves `io.rs`
+with the same documented-rule-vs-caller-rule divergence that #398 exists to
+remove. Items 5–8 are the difference between a validation suite that catches drift
+and one that gets relaxed when it fires.

--- a/plans/08092026_paired-output-dir-unification/PROGRESS.md
+++ b/plans/08092026_paired-output-dir-unification/PROGRESS.md
@@ -1,0 +1,30 @@
+# Progress: one output directory per pair (#398)
+
+**Last updated:** 2026-08-10
+
+## Status
+
+| Step | Status | Notes |
+|------|--------|-------|
+| Plan | ✅ Complete | PLAN.md **r2** — dual review folded in; behavioural footprint now bidirectional (a refusal disappears), second inverted guard named, output-vs-input class added, step 7's SE contract fixed |
+| Plan Review | ✅ Complete | PLAN_REVIEW_A.md + PLAN_REVIEW_B.md — both REVISE, six Criticals, no contradictions. `PLAN_REVIEW_A2.md` is a stopped redundant respawn; ignore it |
+| Impl Plan | 📋 Planned | — |
+| Implementation | 📋 Planned | Only on exact trigger |
+| Code Review | 📋 Planned | — |
+| Coverage | 📋 Planned | — |
+
+## Notes for the implementer
+
+Three test changes are **predicted** in r2 §Context. Each is a red or newly-green test whose obvious "fix" is the wrong one:
+
+1. **Two inverted guards**, not one — `tests/integration_output_collision.rs:1029-1041` (trim, block 3 only) and `:1206-1240` (clump twin, whole body). Both must be **rewritten to assert the refusal, never narrowed**; narrowing restores the split layout on the candidate side while the writers move.
+2. **A refusal disappears** — `clump_paired_rejects_shared_mate_report_without_output_dir` (`:1247-1275`) flips to asserting success, and the untested trim twin of that shape needs a new test.
+3. **A new output-vs-input hazard** in #409's exact shape — a mate named like the other mate's prospective report. Needs a test per paired report arm plus `--no_report_file` siblings.
+
+Two mechanical traps: use `assert_dir_holds_only`, **not** `assert_rejected_cleanly` (which asserts an *empty* directory — "fixing" that failure damages eight other tests); and `clump_report_candidates` has **five** call sites, two of which pass the whole single-end input list and must keep per-input parents.
+
+## History
+
+- 2026-08-10: Plan → r2 (dual review folded in; six Criticals. Felix reconfirmed the refusal decision after being shown the mate-side-directory layout, with both layouts to be named in plan, CHANGELOG and docs)
+- 2026-08-09: Plan Review → ✅ Complete (A 565 lines, B 680, both REVISE; A wrote non-incrementally so it looked stalled and a redundant A2 respawn was started then stopped)
+- 2026-08-09: Plan → ✅ Complete (r1, after two critical scope questions were resolved by Felix; the pre-existing `--passthrough` third-directory rule and the new collision were both found during investigation, neither was in the issue text)

--- a/src/clump_only.rs
+++ b/src/clump_only.rs
@@ -532,8 +532,10 @@ pub fn clump_only_paired(
     // Per-mate reports (mirrors --clumpify's per-input report convention).
     // Skipped when the caller passed --no_report_file.
     if !no_report_file {
-        let r1_report = naming::clumping_report_name(input_r1, output_dir);
-        let r2_report = naming::clumping_report_name(input_r2, output_dir);
+        // Both reports land where the primaries do; each keeps its own filename (#398).
+        let pair_dir = naming::pair_output_dir(input_r1, output_dir);
+        let r1_report = naming::clumping_report_name(input_r1, Some(&pair_dir));
+        let r2_report = naming::clumping_report_name(input_r2, Some(&pair_dir));
         let r1_stats = ClumpOnlyStats {
             input_bytes: in_bytes_r1,
             output_bytes: out_bytes_r1,
@@ -1081,7 +1083,10 @@ pub fn clump_only_paired_to_bam_one_pair(
     // or Shape B interleaved) input's stem.
     if !no_report_file {
         let report_input = &inputs[0];
-        let report_path = naming::clumping_report_name(report_input, output_dir);
+        // Keyed on the first input already, so this moves nothing; routed through
+        // `pair_output_dir` so every paired report site derives alike (#398).
+        let pair_dir = naming::pair_output_dir(report_input, output_dir);
+        let report_path = naming::clumping_report_name(report_input, Some(&pair_dir));
         write_clump_only_report(&stats, &report_path, report_input, &output_path)
             .with_context(|| format!("Failed to write report: {}", report_path.display()))?;
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -81,6 +81,19 @@ pub fn collision_key(p: &Path) -> String {
     norm_path(&lexical_normalise(p))
 }
 
+/// The directory every output of a paired run lands in: `--output_dir` when given,
+/// else R1's parent.
+///
+/// One derivation for primaries, reports and the `--passthrough` carrier alike (#398).
+/// `parent()` yields `Some("")` for a bare filename, so joined paths stay bare and the
+/// `"."` arm is reachable only for a root path — returning `"."` here would prefix every
+/// path, and every message naming one, with `./`.
+pub fn pair_output_dir(input_r1: &Path, output_dir: Option<&Path>) -> PathBuf {
+    output_dir
+        .map(|d| d.to_path_buf())
+        .unwrap_or_else(|| input_r1.parent().unwrap_or(Path::new(".")).to_path_buf())
+}
+
 /// Remediation offered when nothing mode-specific applies.
 const GENERIC_ADVICE: &str = "Check that inputs produce distinct output paths \
                               (e.g., different source directories or `--output_dir`).";
@@ -293,9 +306,7 @@ pub fn paired_bam_output_name(
         .unwrap_or_else(|| strip_fastq_extensions(input_r1));
     let filename = format!("{}_val.bam", stem);
 
-    let dir = output_dir
-        .map(|d| d.to_path_buf())
-        .unwrap_or_else(|| input_r1.parent().unwrap_or(Path::new(".")).to_path_buf());
+    let dir = pair_output_dir(input_r1, output_dir);
 
     dir.join(&filename)
 }
@@ -334,9 +345,7 @@ pub fn paired_end_output_names(
     let f1 = format!("{}_val_1{}", stem1, ext);
     let f2 = format!("{}_val_2{}", stem2, ext);
 
-    let dir = output_dir
-        .map(|d| d.to_path_buf())
-        .unwrap_or_else(|| input_r1.parent().unwrap_or(Path::new(".")).to_path_buf());
+    let dir = pair_output_dir(input_r1, output_dir);
 
     (dir.join(&f1), dir.join(&f2))
 }
@@ -365,9 +374,7 @@ pub fn unpaired_output_names(
     let f1 = format!("{}_unpaired_1{}", stem1, ext);
     let f2 = format!("{}_unpaired_2{}", stem2, ext);
 
-    let dir = output_dir
-        .map(|d| d.to_path_buf())
-        .unwrap_or_else(|| input_r1.parent().unwrap_or(Path::new(".")).to_path_buf());
+    let dir = pair_output_dir(input_r1, output_dir);
 
     (dir.join(&f1), dir.join(&f2))
 }
@@ -384,7 +391,11 @@ pub fn unpaired_output_names(
 /// compression in `main.rs`), not the passthrough input's own extension —
 /// output compression is uniform across the three pair outputs, see plan
 /// v2 §Assumptions §11.
+///
+/// The directory comes from `pair_output_dir`, not from the carrier's own parent:
+/// the carrier is one of the pair's three outputs and lands with the other two (#398).
 pub fn passthrough_output_name(
+    input_r1: &Path,
     input_passthrough: &Path,
     output_dir: Option<&Path>,
     basename: Option<&str>,
@@ -401,12 +412,7 @@ pub fn passthrough_output_name(
     };
     let filename = format!("{}{}", stem, ext);
 
-    let dir = output_dir.map(|d| d.to_path_buf()).unwrap_or_else(|| {
-        input_passthrough
-            .parent()
-            .unwrap_or(Path::new("."))
-            .to_path_buf()
-    });
+    let dir = pair_output_dir(input_r1, output_dir);
     dir.join(&filename)
 }
 
@@ -470,9 +476,7 @@ pub fn clumped_paired_output_names(
     let f1 = format!("{}_clumped_1{}", stem1, ext);
     let f2 = format!("{}_clumped_2{}", stem2, ext);
 
-    let dir = output_dir
-        .map(|d| d.to_path_buf())
-        .unwrap_or_else(|| input_r1.parent().unwrap_or(Path::new(".")).to_path_buf());
+    let dir = pair_output_dir(input_r1, output_dir);
 
     (dir.join(&f1), dir.join(&f2))
 }
@@ -519,9 +523,7 @@ pub fn clumped_paired_bam_output_name(
         .unwrap_or_else(|| strip_fastq_extensions(input_r1));
     let filename = format!("{}_clumped.bam", stem);
 
-    let dir = output_dir
-        .map(|d| d.to_path_buf())
-        .unwrap_or_else(|| input_r1.parent().unwrap_or(Path::new(".")).to_path_buf());
+    let dir = pair_output_dir(input_r1, output_dir);
 
     dir.join(&filename)
 }
@@ -850,53 +852,87 @@ mod tests {
 
     // ── passthrough_output_name (plan v2 Step 2) ──────────────────────────
 
+    /// #398 — stem from the carrier, directory from R1. R1 is deliberately in a
+    /// different directory here; a carrier-anchored implementation passes only when
+    /// the two happen to coincide.
     #[test]
-    fn test_passthrough_output_name_bare() {
+    fn test_passthrough_output_name_takes_r1s_directory() {
+        let r1 = Path::new("/reads/R1.fq.gz");
         let pt = Path::new("/data/I1.fq.gz");
-        let out = passthrough_output_name(pt, None, None, true);
-        assert_eq!(out, PathBuf::from("/data/I1_passthrough.fq.gz"));
+        let out = passthrough_output_name(r1, pt, None, None, true);
+        assert_eq!(out, PathBuf::from("/reads/I1_passthrough.fq.gz"));
     }
 
     #[test]
     fn test_passthrough_output_name_plain() {
+        let r1 = Path::new("/reads/R1.fq.gz");
         let pt = Path::new("/data/I1.fq.gz");
-        let out = passthrough_output_name(pt, None, None, false);
-        assert_eq!(out, PathBuf::from("/data/I1_passthrough.fq"));
+        let out = passthrough_output_name(r1, pt, None, None, false);
+        assert_eq!(out, PathBuf::from("/reads/I1_passthrough.fq"));
     }
 
     #[test]
     fn test_passthrough_output_name_with_output_dir() {
+        let r1 = Path::new("/reads/R1.fq.gz");
         let pt = Path::new("/in/I1.fq.gz");
-        let out = passthrough_output_name(pt, Some(Path::new("/out")), None, true);
+        let out = passthrough_output_name(r1, pt, Some(Path::new("/out")), None, true);
         assert_eq!(out, PathBuf::from("/out/I1_passthrough.fq.gz"));
     }
 
     #[test]
     fn test_passthrough_output_name_with_basename() {
+        let r1 = Path::new("/reads/R1.fq.gz");
         let pt = Path::new("/data/I1.fq.gz");
-        let out = passthrough_output_name(pt, None, Some("foo"), true);
-        assert_eq!(out, PathBuf::from("/data/foo_passthrough.fq.gz"));
+        let out = passthrough_output_name(r1, pt, None, Some("foo"), true);
+        assert_eq!(out, PathBuf::from("/reads/foo_passthrough.fq.gz"));
     }
 
     #[test]
     fn test_passthrough_output_name_basename_with_output_dir() {
+        let r1 = Path::new("/reads/R1.fq.gz");
         let pt = Path::new("/in/I1.fq.gz");
-        let out = passthrough_output_name(pt, Some(Path::new("/out")), Some("foo"), true);
+        let out = passthrough_output_name(r1, pt, Some(Path::new("/out")), Some("foo"), true);
         assert_eq!(out, PathBuf::from("/out/foo_passthrough.fq.gz"));
     }
 
     #[test]
     fn test_passthrough_output_name_all_extensions() {
         // Every FASTQ extension Trim Galore recognises strips cleanly.
+        let r1 = Path::new("/d/R1.fq.gz");
         for (input, expected) in [
             ("/d/s.fastq.gz", "/d/s_passthrough.fq.gz"),
             ("/d/s.fq.gz", "/d/s_passthrough.fq.gz"),
             ("/d/s.fastq", "/d/s_passthrough.fq.gz"),
             ("/d/s.fq", "/d/s_passthrough.fq.gz"),
         ] {
-            let out = passthrough_output_name(Path::new(input), None, None, true);
+            let out = passthrough_output_name(r1, Path::new(input), None, None, true);
             assert_eq!(out, PathBuf::from(expected), "input={input}");
         }
+    }
+
+    // ── pair_output_dir (#398) ────────────────────────────────────────────
+
+    #[test]
+    fn test_pair_output_dir_precedence_and_edges() {
+        // --output_dir wins over R1's parent.
+        assert_eq!(
+            pair_output_dir(Path::new("/reads/R1.fq"), Some(Path::new("/out"))),
+            PathBuf::from("/out")
+        );
+        // Otherwise R1's parent.
+        assert_eq!(
+            pair_output_dir(Path::new("/reads/R1.fq"), None),
+            PathBuf::from("/reads")
+        );
+        // A bare filename has an EMPTY parent, not `.`, so joined paths stay bare —
+        // returning `.` here would prefix every path and message with `./`.
+        assert_eq!(pair_output_dir(Path::new("R1.fq"), None), PathBuf::from(""));
+        assert_eq!(
+            pair_output_dir(Path::new("R1.fq"), None).join("R1.fq_trimming_report.txt"),
+            PathBuf::from("R1.fq_trimming_report.txt")
+        );
+        // The `.` fallback is reachable only for a root path, which has no parent.
+        assert_eq!(pair_output_dir(Path::new("/"), None), PathBuf::from("."));
     }
 
     // ── clumped_output_name / clumped_paired_output_names / clumping_report_name ──

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,12 +54,14 @@ type ResolvedAdapter = Result<(String, AdapterList, AdapterList, Option<(usize, 
 
 /// Hint for the sites whose report names carry no positional discriminator:
 /// paired trim (FASTQ and uBAM out) and `--clump_only --paired` (#391).
-const PAIRED_REPORT_HINT: &str = "Outputs and reports are named from the input \
-                                  filename alone, so inputs sharing a filename can \
-                                  collide when --output_dir (or a shared input \
-                                  directory) sends them to one place — rename one \
-                                  input, or pass --no_report_file if only the \
-                                  reports collide.";
+const PAIRED_REPORT_HINT: &str = "Every output of a pair — validated reads, reports, \
+                                  and the --passthrough carrier — is written to \
+                                  --output_dir, or to Read 1's directory when that is \
+                                  not given. Names come from the input filename alone, \
+                                  so inputs sharing a filename collide wherever they \
+                                  live: rename one input, give the pairs distinct \
+                                  --output_dir runs, or pass --no_report_file if only \
+                                  the reports collide.";
 
 /// CWD-output modes' remediation; see `PAIRED_REPORT_HINT` for the paired sites.
 const CWD_OUTPUT_HINT: &str = "This mode writes output to the current working directory, \
@@ -613,10 +615,11 @@ fn main() -> Result<()> {
                             let src =
                                 naming::OutputSource::Pair(r1.to_path_buf(), r2.to_path_buf());
                             let mut v = vec![(o1, src.clone()), (o2, src)];
+                            let pair_dir = naming::pair_output_dir(r1, output_dir);
                             v.extend(clump_report_candidates(
                                 cli.no_report_file,
                                 &[r1, r2],
-                                output_dir,
+                                Some(&pair_dir),
                             ));
                             v
                         },
@@ -737,10 +740,13 @@ fn main() -> Result<()> {
                             ));
                             // #391 — ONE report per pair, keyed on the pair's first input
                             // (clump_only.rs writes clumping_report_name(inputs[0], …)).
+                            // Keyed on R1 already, so `pair_output_dir` moves nothing here;
+                            // routed through it so every paired site derives alike (#398).
+                            let pair_dir = naming::pair_output_dir(&chunk[0], output_dir);
                             planned.extend(clump_report_candidates(
                                 cli.no_report_file,
                                 std::slice::from_ref(&chunk[0]),
-                                output_dir,
+                                Some(&pair_dir),
                             ));
                         }
                         naming::preflight_output_collisions(&planned, &guarded_inputs(&cli), None)?;
@@ -871,9 +877,9 @@ fn main() -> Result<()> {
             );
             // Uniform Pair for paired primaries (#397 decision C2): _val_1 takes its
             // stem from R1 but its directory from R1 too, and _val_2 mixes both — naming
-            // one mate would encode a claim about which supplies the directory, which is
-            // exactly what #398 may change.
+            // one mate would encode a claim about which supplies the directory.
             let pair_src = naming::OutputSource::Pair(chunk[0].clone(), chunk[1].clone());
+            let pair_dir = naming::pair_output_dir(&chunk[0], output_dir);
             let mut candidates = vec![(o1, pair_src.clone()), (o2, pair_src.clone())];
             if cli.retain_unpaired {
                 let (u1, u2) = naming::unpaired_output_names(
@@ -893,6 +899,7 @@ fn main() -> Result<()> {
             if let Some(ref pt_input) = cli.passthrough {
                 candidates.push((
                     naming::passthrough_output_name(
+                        &chunk[0],
                         pt_input,
                         output_dir,
                         cli.basename.as_deref(),
@@ -903,11 +910,16 @@ fn main() -> Result<()> {
             }
             // #388 — report names carry no _val_ discriminator, so two inputs
             // with distinct primaries can still collide on reports.
+            //
+            // `Input`, not `Pair`, even though the directory now comes from R1 (#398):
+            // two distinct sources on one path select the message that says which two
+            // inputs collided, where `Pair` would select the "list each input once"
+            // text — wrong advice when renaming one input does fix it.
             if !cli.no_report_file {
                 for input in [&chunk[0], &chunk[1]] {
                     let src = naming::OutputSource::Input(input.clone());
-                    candidates.push((naming::report_name(input, output_dir), src.clone()));
-                    candidates.push((naming::json_report_name(input, output_dir), src));
+                    candidates.push((naming::report_name(input, Some(&pair_dir)), src.clone()));
+                    candidates.push((naming::json_report_name(input, Some(&pair_dir)), src));
                 }
             }
             planned.extend(candidates);
@@ -1496,8 +1508,8 @@ fn run_paired(
     // --passthrough wiring (plan v2 Step 8). Compute the third output path
     // when active and eprintln! it for visibility, matching the R1/R2 idiom.
     let passthrough_input: Option<&Path> = cli.passthrough.as_deref();
-    let passthrough_output: Option<std::path::PathBuf> =
-        passthrough_input.map(|pt| naming::passthrough_output_name(pt, output_dir, basename, gzip));
+    let passthrough_output: Option<std::path::PathBuf> = passthrough_input
+        .map(|pt| naming::passthrough_output_name(input_r1, pt, output_dir, basename, gzip));
     if let (Some(pt_in), Some(pt_out)) = (passthrough_input, passthrough_output.as_deref()) {
         eprintln!("  Passthrough: {} → {}", pt_in.display(), pt_out.display());
     }
@@ -1726,14 +1738,17 @@ fn run_paired(
             })
             .collect();
 
+        // Both mates' reports land where the primaries do (#398). Each keeps its own
+        // input-derived filename; only the directory is shared.
+        let pair_dir = naming::pair_output_dir(input_r1, output_dir);
         let r1 = PairedReportFile {
-            txt_path: naming::report_name(input_r1, output_dir),
-            json_path: naming::json_report_name(input_r1, output_dir),
+            txt_path: naming::report_name(input_r1, Some(&pair_dir)),
+            json_path: naming::json_report_name(input_r1, Some(&pair_dir)),
             input_filename: all_input_filenames[0].clone(),
         };
         let r2 = PairedReportFile {
-            txt_path: naming::report_name(input_r2, output_dir),
-            json_path: naming::json_report_name(input_r2, output_dir),
+            txt_path: naming::report_name(input_r2, Some(&pair_dir)),
+            json_path: naming::json_report_name(input_r2, Some(&pair_dir)),
             input_filename: all_input_filenames[1].clone(),
         };
 
@@ -2021,10 +2036,11 @@ fn run_ubam_output(cli: &Cli, output_dir: Option<&Path>, command_line: &str) -> 
             ));
             // #388 — same report-collision hole as the FASTQ paired path.
             if !cli.no_report_file {
+                let pair_dir = naming::pair_output_dir(&chunk[0], output_dir);
                 for input in [&chunk[0], &chunk[1]] {
                     let src = naming::OutputSource::Input(input.clone());
-                    planned.push((naming::report_name(input, output_dir), src.clone()));
-                    planned.push((naming::json_report_name(input, output_dir), src));
+                    planned.push((naming::report_name(input, Some(&pair_dir)), src.clone()));
+                    planned.push((naming::json_report_name(input, Some(&pair_dir)), src));
                 }
             }
         }
@@ -2348,14 +2364,15 @@ fn run_ubam_output_paired_two_files(
             .to_string();
         let all_input_filenames = vec![r1_filename.clone(), r2_filename.clone()];
 
+        let pair_dir = naming::pair_output_dir(input_r1, output_dir);
         let r1_desc = PairedReportFile {
-            txt_path: naming::report_name(input_r1, output_dir),
-            json_path: naming::json_report_name(input_r1, output_dir),
+            txt_path: naming::report_name(input_r1, Some(&pair_dir)),
+            json_path: naming::json_report_name(input_r1, Some(&pair_dir)),
             input_filename: r1_filename,
         };
         let r2_desc = PairedReportFile {
-            txt_path: naming::report_name(input_r2, output_dir),
-            json_path: naming::json_report_name(input_r2, output_dir),
+            txt_path: naming::report_name(input_r2, Some(&pair_dir)),
+            json_path: naming::json_report_name(input_r2, Some(&pair_dir)),
             input_filename: r2_filename,
         };
 

--- a/tests/integration_output_collision.rs
+++ b/tests/integration_output_collision.rs
@@ -1026,19 +1026,23 @@ fn paired_report_candidates_do_not_over_reject() {
     assert!(dir2.join("sample.fq_trimming_report.txt").is_file());
     assert!(dir2.join("sample.fastq_trimming_report.txt").is_file());
 
-    // T1 minus -o: same filename in different dirs, reports beside their own
-    // inputs. Pins that the candidates honour output_dir = None; a builder
-    // that resolved reports into one directory would over-reject this.
-    let dir3 = tempdir("388_ok_no_odir");
+    // #398 — T1 minus -o is now REFUSED: both reports resolve into R1's directory,
+    // where their identical filenames collide. This block previously asserted the
+    // split layout; co-locating reports is now the specified behaviour. Do NOT
+    // narrow the candidate list to make it green again — that restores the old
+    // paths on the pre-flight side while the writers move. Its clump twin is
+    // `clump_report_candidates_reject_shared_filename_without_output_dir`.
+    let dir3 = tempdir("388_reject_no_odir");
     write_fastq(&dir3.join("A/reads.fq"), "N1");
     write_fastq(&dir3.join("B/reads.fq"), "N2");
     let (ok, stderr) = run_in(&dir3, &["--paired", "A/reads.fq", "B/reads.fq"]);
+    assert!(!ok, "co-located reports must be refused:\n{stderr}");
     assert!(
-        ok,
-        "same filename in two dirs without -o must run:\n{stderr}"
+        stderr.contains("reads.fq_trimming_report.txt"),
+        "the colliding path must be named:\n{stderr}"
     );
-    assert!(dir3.join("A/reads.fq_trimming_report.txt").is_file());
-    assert!(dir3.join("B/reads.fq_trimming_report.txt").is_file());
+    assert_dir_holds_only(&dir3.join("A"), &["reads.fq"]);
+    assert_dir_holds_only(&dir3.join("B"), &["reads.fq"]);
 }
 
 // ── --clump_only: clumping reports join the pre-flight (#391) ─────────────
@@ -1199,23 +1203,52 @@ fn clump_paired_rejects_fold_equal_report_names() {
     );
 }
 
-/// Over-rejection guard: same filename in two dirs WITHOUT -o is legal — both
-/// primaries land in R1's directory, each report beside its own mate. Pins that
-/// the candidates honour output_dir = None; a builder that resolved reports
-/// into one directory would over-reject this.
+/// #398 — same filename in two dirs WITHOUT `-o` is refused: both reports now
+/// resolve into R1's directory, where their identical filenames collide. The
+/// primaries were never the problem (`_clumped_1`/`_clumped_2` keep them apart).
+///
+/// This is the clump twin of `paired_report_candidates_do_not_over_reject`'s third
+/// block. Both were written to catch a builder that co-located reports; #398 makes
+/// co-location the specified behaviour, so both assert the refusal instead. If this
+/// goes red again, fix the writers or the candidates — do NOT narrow the candidate
+/// list, which would restore the split layout on one side only.
 #[test]
-fn clump_report_candidates_do_not_over_reject() {
-    let dir = tempdir("clump_ok_no_odir");
+fn clump_report_candidates_reject_shared_filename_without_output_dir() {
+    let dir = tempdir("clump_reject_no_odir");
     write_fastq(&dir.join("A/reads.fq"), "Q1");
     write_fastq(&dir.join("B/reads.fq"), "Q2");
     let (ok, stderr) = run_in(
         &dir,
         &["--clump_only", "--paired", "A/reads.fq", "B/reads.fq"],
     );
+    assert!(!ok, "co-located reports must be refused:\n{stderr}");
     assert!(
-        ok,
-        "same filename in two dirs without -o must run:\n{stderr}"
+        stderr.contains("reads.fq_clumping_report.txt"),
+        "the colliding path must be named:\n{stderr}"
     );
+    // Refused before any writer: both directories hold only their inputs.
+    assert_dir_holds_only(&dir.join("A"), &["reads.fq"]);
+    assert_dir_holds_only(&dir.join("B"), &["reads.fq"]);
+}
+
+/// #398 — the same pair with `--no_report_file` runs, because only the reports
+/// collided. Keeps the acceptance side of the guard alive.
+#[test]
+fn clump_shared_filename_without_output_dir_runs_without_reports() {
+    let dir = tempdir("clump_no_report_no_odir");
+    write_fastq(&dir.join("A/reads.fq"), "Q1");
+    write_fastq(&dir.join("B/reads.fq"), "Q2");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--paired",
+            "--no_report_file",
+            "A/reads.fq",
+            "B/reads.fq",
+        ],
+    );
+    assert!(ok, "only the reports collided:\n{stderr}");
     assert_eq!(
         count_reads_from(&dir.join("A/reads_clumped_1.fq"), "Q1"),
         40
@@ -1226,25 +1259,21 @@ fn clump_report_candidates_do_not_over_reject() {
     );
     assert_dir_holds_only(
         &dir.join("A"),
-        &[
-            "reads.fq",
-            "reads_clumped_1.fq",
-            "reads_clumped_2.fq",
-            "reads.fq_clumping_report.txt",
-        ],
+        &["reads.fq", "reads_clumped_1.fq", "reads_clumped_2.fq"],
     );
-    assert_dir_holds_only(
-        &dir.join("B"),
-        &["reads.fq", "reads.fq_clumping_report.txt"],
-    );
+    assert_dir_holds_only(&dir.join("B"), &["reads.fq"]);
 }
 
-/// Case-free and no `-o`: one file as the mate of two pairs (validate permits
-/// this — only exact duplicate pairs are rejected). Reports collide in the
-/// shared mate's own directory while all four primaries stay distinct, so the
-/// rejection behaves identically on APFS and ext4.
+/// #398 — one file as the mate of two pairs, no `-o`. This was refused before
+/// #398, because both pairs' reports for the shared mate resolved to
+/// `d/x.fq_clumping_report.txt`. Each pair now anchors on its own R1, so the two
+/// reports land in `p/` and `q/` and all eight paths are distinct. Nothing is
+/// overwritten, so continuing to refuse would be over-rejection.
+///
+/// The refusal this replaces was added by #391; the flip is deliberate, not a
+/// weakened assertion.
 #[test]
-fn clump_paired_rejects_shared_mate_report_without_output_dir() {
+fn clump_paired_shared_mate_report_runs_when_pairs_anchor_apart() {
     let dir = tempdir("clump_mate");
     write_fastq(&dir.join("p/a.fq"), "M1");
     write_fastq(&dir.join("d/x.fq"), "MX");
@@ -1260,18 +1289,29 @@ fn clump_paired_rejects_shared_mate_report_without_output_dir() {
             "d/x.fq",
         ],
     );
-    assert!(!ok, "expected rejection:\n{stderr}");
-    assert!(
-        stderr.contains(DUP_MSG),
-        "expected duplicate wording:\n{stderr}"
+    assert!(ok, "eight distinct paths must not be refused:\n{stderr}");
+    // Pair 1 → p/, pair 2 → q/. The shared mate's own directory gains nothing.
+    assert_dir_holds_only(
+        &dir.join("p"),
+        &[
+            "a.fq",
+            "a_clumped_1.fq",
+            "x_clumped_2.fq",
+            "a.fq_clumping_report.txt",
+            "x.fq_clumping_report.txt",
+        ],
     );
-    assert!(
-        stderr.contains("x.fq_clumping_report.txt"),
-        "the colliding path must be the shared mate's report:\n{stderr}"
+    assert_dir_holds_only(
+        &dir.join("q"),
+        &[
+            "b.fq",
+            "b_clumped_1.fq",
+            "x_clumped_2.fq",
+            "b.fq_clumping_report.txt",
+            "x.fq_clumping_report.txt",
+        ],
     );
-    assert_dir_holds_only(&dir.join("p"), &["a.fq"]);
     assert_dir_holds_only(&dir.join("d"), &["x.fq"]);
-    assert_dir_holds_only(&dir.join("q"), &["b.fq"]);
 }
 
 /// `--basename foo` forces `foo_clumped_1`/`foo_clumped_2` primaries — distinct
@@ -1460,5 +1500,199 @@ fn se_trim_ubam_accepts_report_alias_with_no_report_file() {
     assert!(
         dir.join("sample.fastq_trimming_report_trimmed.bam")
             .is_file()
+    );
+}
+
+// ── #398: one output directory per pair ───────────────────────────────────
+
+/// The layout the change is for: mates in different directories, no `-o`. Every
+/// output — both primaries and both reports — lands in R1's directory.
+#[test]
+fn paired_reports_follow_the_primaries_into_r1s_directory() {
+    let dir = tempdir("398_unified");
+    write_fastq(&dir.join("A/r1.fq"), "U1");
+    write_fastq(&dir.join("B/r2.fq"), "U2");
+    let (ok, stderr) = run_in(&dir, &["--paired", "A/r1.fq", "B/r2.fq"]);
+    assert!(ok, "distinct filenames must still run:\n{stderr}");
+    assert_dir_holds_only(
+        &dir.join("A"),
+        &[
+            "r1.fq",
+            "r1_val_1.fq",
+            "r2_val_2.fq",
+            "r1.fq_trimming_report.txt",
+            "r1.fq_trimming_report.json",
+            "r2.fq_trimming_report.txt",
+            "r2.fq_trimming_report.json",
+        ],
+    );
+    assert_dir_holds_only(&dir.join("B"), &["r2.fq"]);
+}
+
+/// The mate-side directory layout (`R1/` and `R2/` rather than per-sample): the
+/// whole invocation is refused, not just the offending pair, because candidates
+/// for every chunk are collected before one pre-flight call.
+#[test]
+fn mate_side_directory_layout_refuses_the_whole_invocation() {
+    let dir = tempdir("398_mate_side");
+    write_fastq(&dir.join("R1/s1.fq"), "A1");
+    write_fastq(&dir.join("R2/s1.fq"), "A2");
+    write_fastq(&dir.join("R1/s2.fq"), "B1");
+    write_fastq(&dir.join("R2/s2.fq"), "B2");
+    let (ok, stderr) = run_in(
+        &dir,
+        &["--paired", "R1/s1.fq", "R2/s1.fq", "R1/s2.fq", "R2/s2.fq"],
+    );
+    assert!(!ok, "co-located reports must be refused:\n{stderr}");
+    // No pair ran: not even the first pair's primaries exist.
+    assert_dir_holds_only(&dir.join("R1"), &["s1.fq", "s2.fq"]);
+    assert_dir_holds_only(&dir.join("R2"), &["s1.fq", "s2.fq"]);
+}
+
+/// The per-sample layout is unaffected — each pair's R1 sits in its own directory,
+/// so nothing collides and each pair's outputs stay with it.
+#[test]
+fn per_sample_directory_layout_is_unaffected() {
+    let dir = tempdir("398_per_sample");
+    write_fastq(&dir.join("sA/reads_1.fq"), "S1");
+    write_fastq(&dir.join("sA/reads_2.fq"), "S2");
+    write_fastq(&dir.join("sB/reads_1.fq"), "T1");
+    write_fastq(&dir.join("sB/reads_2.fq"), "T2");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--paired",
+            "--no_report_file",
+            "sA/reads_1.fq",
+            "sA/reads_2.fq",
+            "sB/reads_1.fq",
+            "sB/reads_2.fq",
+        ],
+    );
+    assert!(ok, "per-sample layout must run:\n{stderr}");
+    // Each pair anchored on its OWN R1 — pair 2 did not land in sA/.
+    assert_eq!(count_reads_from(&dir.join("sA/reads_1_val_1.fq"), "S1"), 40);
+    assert_eq!(count_reads_from(&dir.join("sB/reads_1_val_1.fq"), "T1"), 40);
+    assert!(!dir.join("sA/reads_1_val_1.fq.1").exists());
+}
+
+/// #398 creates a new output-vs-**input** path: R2's report, relocated into R1's
+/// directory, can equal R1's own input. This is #409's shape on a new arm — if the
+/// candidate list had not moved with the writer, the run would destroy an input.
+#[test]
+fn paired_report_that_would_land_on_r1s_input_is_refused() {
+    let dir = tempdir("398_alias_input");
+    write_fastq(&dir.join("A/reads.fq_trimming_report.txt"), "VICTIM");
+    write_fastq(&dir.join("B/reads.fq"), "MATE");
+    let (ok, stderr) = run_in(
+        &dir,
+        &["--paired", "A/reads.fq_trimming_report.txt", "B/reads.fq"],
+    );
+    assert!(
+        !ok,
+        "a report landing on an input must be refused:\n{stderr}"
+    );
+    // The data-loss assertion: content, not just existence — a truncated file exists.
+    assert_eq!(
+        count_reads_from(&dir.join("A/reads.fq_trimming_report.txt"), "VICTIM"),
+        40,
+        "R1's input was overwritten — this is #409's shape on the paired arm"
+    );
+    assert_dir_holds_only(&dir.join("A"), &["reads.fq_trimming_report.txt"]);
+    assert_dir_holds_only(&dir.join("B"), &["reads.fq"]);
+}
+
+/// Acceptance sibling: with reports off there is no report to alias the input.
+#[test]
+fn paired_report_input_alias_accepted_with_no_report_file() {
+    let dir = tempdir("398_alias_ok");
+    write_fastq(&dir.join("A/reads.fq_trimming_report.txt"), "VICTIM");
+    write_fastq(&dir.join("B/reads.fq"), "MATE");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--paired",
+            "--no_report_file",
+            "A/reads.fq_trimming_report.txt",
+            "B/reads.fq",
+        ],
+    );
+    assert!(ok, "expected success:\n{stderr}");
+    assert_eq!(
+        count_reads_from(&dir.join("A/reads.fq_trimming_report.txt"), "VICTIM"),
+        40
+    );
+}
+
+/// The same output-vs-input hazard on the `--clump_only --paired` arm.
+#[test]
+fn clump_paired_report_that_would_land_on_r1s_input_is_refused() {
+    let dir = tempdir("398_clump_alias");
+    write_fastq(&dir.join("A/reads.fq_clumping_report.txt"), "VICTIM");
+    write_fastq(&dir.join("B/reads.fq"), "MATE");
+    let (ok, stderr) = run_in(
+        &dir,
+        &[
+            "--clump_only",
+            "--paired",
+            "A/reads.fq_clumping_report.txt",
+            "B/reads.fq",
+        ],
+    );
+    assert!(
+        !ok,
+        "a report landing on an input must be refused:\n{stderr}"
+    );
+    assert_eq!(
+        count_reads_from(&dir.join("A/reads.fq_clumping_report.txt"), "VICTIM"),
+        40,
+        "R1's input was overwritten"
+    );
+}
+
+/// The trim-mode twin of `clump_paired_shared_mate_report_runs_when_pairs_anchor_apart`,
+/// which had no test before #398 and would otherwise have flipped from refuse to
+/// succeed unobserved.
+#[test]
+fn paired_shared_mate_report_runs_when_pairs_anchor_apart() {
+    let dir = tempdir("398_trim_mate");
+    write_fastq(&dir.join("p/a.fq"), "M1");
+    write_fastq(&dir.join("d/x.fq"), "MX");
+    write_fastq(&dir.join("q/b.fq"), "M2");
+    let (ok, stderr) = run_in(&dir, &["--paired", "p/a.fq", "d/x.fq", "q/b.fq", "d/x.fq"]);
+    assert!(ok, "eight distinct paths must not be refused:\n{stderr}");
+    assert!(dir.join("p/a.fq_trimming_report.txt").is_file());
+    assert!(dir.join("p/x.fq_trimming_report.txt").is_file());
+    assert!(dir.join("q/b.fq_trimming_report.txt").is_file());
+    assert!(dir.join("q/x.fq_trimming_report.txt").is_file());
+    // The shared mate's own directory gains nothing.
+    assert_dir_holds_only(&dir.join("d"), &["x.fq"]);
+}
+
+/// A bare-filename R1 has an EMPTY parent, so paths stay bare. A `pair_output_dir`
+/// that returned `.` would prefix every path here with `./`.
+#[test]
+fn bare_filename_r1_keeps_paths_unprefixed() {
+    let dir = tempdir("398_bare");
+    write_fastq(&dir.join("r1.fq"), "Z1");
+    write_fastq(&dir.join("r2.fq"), "Z2");
+    let (ok, stderr) = run_in(&dir, &["--paired", "r1.fq", "r2.fq"]);
+    assert!(ok, "expected success:\n{stderr}");
+    assert!(
+        !stderr.contains("./r1.fq_trimming_report.txt"),
+        "paths must not gain a ./ prefix:\n{stderr}"
+    );
+    assert_dir_holds_only(
+        &dir,
+        &[
+            "r1.fq",
+            "r2.fq",
+            "r1_val_1.fq",
+            "r2_val_2.fq",
+            "r1.fq_trimming_report.txt",
+            "r1.fq_trimming_report.json",
+            "r2.fq_trimming_report.txt",
+            "r2.fq_trimming_report.json",
+        ],
     );
 }

--- a/tests/integration_passthrough.rs
+++ b/tests/integration_passthrough.rs
@@ -34,9 +34,18 @@ fn fresh_tmpdir(slug: &str) -> PathBuf {
 /// the three paths. Uses plain `.fq` (no gzip) for test speed — the binary's
 /// gzip mode is decided per the R1 input extension, so plain in → plain out.
 fn write_fixture(dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
-    let r1 = dir.join("r1.fq");
-    let r2 = dir.join("r2.fq");
-    let i1 = dir.join("i1.fq");
+    write_fixture_at(&dir.join("r1.fq"), &dir.join("r2.fq"), &dir.join("i1.fq"))
+}
+
+/// As `write_fixture`, but with the three paths given explicitly so they can live
+/// in different directories (#398).
+fn write_fixture_at(r1: &Path, r2: &Path, i1: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let (r1, r2, i1) = (r1.to_path_buf(), r2.to_path_buf(), i1.to_path_buf());
+    for p in [&r1, &r2, &i1] {
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+    }
 
     // 30 records. Every 3rd has a short R1 (under length cutoff 20) so it
     // gets dropped — exercises both Pass and Discard branches and
@@ -199,6 +208,60 @@ fn passthrough_without_paired_rejected() {
     assert!(
         stderr.contains("--passthrough requires --paired"),
         "unexpected stderr: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// #398 — the carrier is one of the pair's three outputs, so with no `--output_dir`
+/// it lands in R1's directory rather than beside its own input. The carrier lives in
+/// a third directory here; anchoring it on its own parent would put the output in
+/// `C/`, and the R2 report would name that path.
+#[test]
+fn passthrough_output_follows_r1s_directory() {
+    let dir = fresh_tmpdir("tg_pt_398_dir");
+    let (r1, r2, i1) = write_fixture_at(
+        &dir.join("A/r1.fq"),
+        &dir.join("A/r2.fq"),
+        &dir.join("C/i1.fq"),
+    );
+
+    let out = Command::new(binary())
+        .arg("--paired")
+        .arg("--passthrough")
+        .arg(&i1)
+        .arg(&r1)
+        .arg(&r2)
+        .output()
+        .expect("spawn trim_galore");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "expected success:\nstderr:\n{stderr}");
+
+    let in_r1_dir = dir.join("A/i1_passthrough.fq");
+    let beside_carrier = dir.join("C/i1_passthrough.fq");
+    assert!(
+        in_r1_dir.is_file(),
+        "carrier output should be in R1's directory\nstderr:\n{stderr}"
+    );
+    assert!(
+        !beside_carrier.exists(),
+        "carrier output must not be written beside its own input"
+    );
+    assert_eq!(
+        count_records(&in_r1_dir),
+        count_records(&dir.join("A/r1_val_1.fq"))
+    );
+
+    // The R2 report embeds the carrier's output path, so it moves too.
+    let r2_report_text =
+        std::fs::read_to_string(dir.join("A/r2.fq_trimming_report.txt")).unwrap_or_default();
+    assert!(
+        r2_report_text.contains("i1_passthrough.fq"),
+        "R2 report should name the carrier output:\n{r2_report_text}"
+    );
+    assert!(
+        !r2_report_text.contains("C/i1_passthrough.fq"),
+        "R2 report still names the old carrier-anchored path:\n{r2_report_text}"
     );
 
     let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
Without `--output_dir`, a paired run could scatter across three directories: the validated FASTQs went to R1's parent, each trimming report went beside *its own* mate, and `--passthrough`'s carrier output went beside the carrier input. All five primary paired namers already shared one directory expression; the report namers did not, because they are shared with the single-end paths where per-input parent is correct. That expression is now `pair_output_dir`, and the reports and the carrier consume it too.

Report **filenames** are unchanged — each keeps its own input-derived name, so `*_trimming_report.txt` globs and MultiQC still match. Only the directory is shared. Single-end is untouched.

Perl v0.6.11 had no per-mate report directories either: `sub trim` strips the input's directory with `(split /\//,$filename)[-1]` and opens the report at `$output_dir`, defaulting to the working directory. The split layout was a v2 regression rather than something inherited — though the anchor still differs, so this isn't "matches v0.6.x".

**This is a behaviour change in both directions, and one of them refuses runs that previously worked.**

Names derive from the input filename alone, so two inputs whose filenames fold-equal now resolve to one report path once co-located, and the run stops before writing anything. The layout that hits is reads split by mate rather than by sample — `--paired R1/s1.fq R2/s1.fq R1/s2.fq R2/s2.fq` — and the **whole invocation** is refused, not just the offending pair, because candidates for every chunk are collected before a single pre-flight call. Pass `--output_dir`; `--no_report_file` also clears it but discards the reports. The per-sample layout (`sampleA/reads_1.fq sampleA/reads_2.fq sampleB/…`) is unaffected, since each pair's R1 already sits in its own directory.

A refusal also **disappears**: a mate shared between two pairs whose R1s live in different directories no longer collides, because its two reports now resolve into those two directories. Eight distinct paths, nothing overwritten — continuing to refuse would be over-rejection. The #391 test asserting that refusal flips to asserting success, and the previously-untested trim twin of the same shape gains a test.

Relocating a report also opens an output-vs-**input** path: R2's report can now equal R1's own input (`--paired A/reads.fq_trimming_report.txt B/reads.fq`). The candidate builders move with the writers, so the pre-flight refuses it — this is #409's shape on an arm the change creates, and the tests assert the victim's read count rather than its mere existence.

11 new tests, 589 total. Every refusal was also run against a build made from `38deb1ee` in a fresh worktree, where the mate-side and report-on-input cases exit 0 and the shared-mate case exits 1.

<details>
<summary>AI-assisted: what the dual plan review changed, and the three test flips it let us predict</summary>

**The plan's r1 described this as one new refusal in one place. It is wider than that**, and the dual review is what established the shape. Both reviewers verified independently that the five-namer extraction is behaviour-preserving and that the arm table was complete — one of them enumerated all eleven pre-flight call sites to check. Between them they raised six Critical findings.

Three of them were behavioural footprint that r1 missed entirely: a **second** over-rejection guard on the clump arm, carrying almost the same "a builder that resolved reports into one directory would over-reject this" comment as the one r1 built a prominent warning around; an existing deliberate refusal that **disappears**; and the output-vs-input direction, which is the exact shape of the data-loss bug fixed three commits earlier. A fourth was a latent break: r1's instruction to stop `clump_report_candidates` deriving per input would have collapsed every single-end input's report into one directory — the same family, mirrored, on an arm r1 had declared out of scope. In the end that helper needed no signature change at all.

Because r2 enumerated those three test changes with line ranges and the correct resolution for each, the first full run produced **exactly three failures and no surprises**. That mattered: the natural way to make a red test named `..._do_not_over_reject` go green is to narrow the candidate list, which would restore the old paths on the pre-flight side while the writers moved — precisely how this bug family recurs. Both rewritten guards now name their twin and say not to do that. They were also renamed, since a test called `do_not_over_reject` that asserts a rejection reads as a contradiction.

Two smaller things worth recording. `cargo build --release` reported zero errors while the test targets were still broken by the `passthrough_output_name` signature change — a release build doesn't compile test targets, so it can't stand in for a compile check. And both reviewers told me to correct the docs path to `Docs/src/content/docs/`; both were wrong, since git tracks it lowercase and the capital only resolves because APFS is case-insensitive.

The reviews also produced the v0.6.11 output-directory fact above, which answers an open question r1 had left as a preference: `--hardtrim5/3` should **not** share this helper, because their current CWD anchor is the Perl-faithful one and the trim path's input-parent anchor is the v2 innovation.

Deferred to #414: dedicated paired report namers taking R1, which would make writer/candidate drift unrepresentable rather than tested-for. Both reviewers raised it; it belongs with the generator work rather than bundled into a behaviour change.
</details>

Closes #398 (manual close needed — dev is not the default branch).
