### PR TITLE
build(deps): bump nanoid to 3.3.18 in /docs (#425)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5683,9 +5683,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Dependabot opened #425 for this against `master`. Security PRs ignore the configured target branch, and master here is a release pin that only ever fast-forwards from `dev` — merging there would make master diverge and the next release FF would stop being a fast-forward. So this lands on dev instead and #425 is closed as superseded. dev was already at 3.3.16, ahead of the 3.3.11 the PR bumped from.

Closes #425.

<details>
<summary>AI-assisted detail</summary>

Hand-edited to the three lockfile lines rather than run `npm install nanoid@3.3.18`, which also adds `nanoid` to `docs/package.json` as a direct dependency (it is transitive, pulled in via postcss) and strips the `libc` platform metadata from four optional entries — churn unrelated to the advisory, and the `libc` fields matter for musl-vs-glibc variant selection. `npm update nanoid --package-lock-only` did the same stripping.

Verified: `npm ci` accepts the edited lockfile and resolves nanoid 3.3.18, and `npm run build` is unchanged at 31 pages.

Not included: `npm audit` also reports **js-yaml high severity** (4.0.0–4.3.0, fix available), which is a separate advisory and not what #425 was about.

</details>