### PR TITLE
fix(cli): refuse --fastqc where no report is written, wire --fastqc_args (#421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 #### Changes
 
+- **Breaking: `--fastqc` is now refused on the four specialty modes and on `--paired` with a
+  single interleaved uBAM writing FASTQ, instead of being silently ignored**
+  ([#421](https://github.com/FelixKrueger/TrimGalore/issues/421)); the same change makes
+  `--fastqc_args` alone activate FastQC under `--clump_only`, where it previously did nothing.
+
 - **A BAM read name containing whitespace, or whitespace other than a space inside a preserved
   aux-tag value, is now refused on every output format**
   ([#415](https://github.com/FelixKrueger/TrimGalore/issues/415)) — see the uBAM section of the

--- a/docs/src/content/docs/guide/flags.md
+++ b/docs/src/content/docs/guide/flags.md
@@ -14,6 +14,7 @@ A few combinations are worth knowing about:
 - **`--paired` + `--length`** discards the whole read pair unless *both* reads pass the length cutoff. To rescue the surviving read when only one becomes too short, add `--retain_unpaired`; the per-side cutoff is governed by `--length_1`/`--length_2` (default 35 bp each).
 - **`--trim-n`** is suppressed under `--rrbs` (matches Perl v0.6.x; N-trimming interacts poorly with RRBS end-repair masking).
 - **`--discard_untrimmed`** keeps only reads where at least one adapter match was found. For paired-end, the pair is discarded only if *neither* read had an adapter.
+- **`--fastqc`** (and `--fastqc_args`, which implies it) is rejected on the four specialty modes and on `--paired` given a single interleaved uBAM with FASTQ output. Those paths write no report, so the flag fails loudly rather than being ignored; for the last one, adding `--output-format ubam` does produce a report. See [FastQC](/guide/outputs/#fastqc).
 - **`--poly_g`** is auto-enabled when the data looks like it came from a 2-colour instrument (sequence-based detection on trailing G-runs). Use `--no_poly_g` to force-disable, or `--poly_g` to force-enable. It is independent of `--nextseq` (which is quality-score-based).
 
 ## RRBS-specific guidance

--- a/docs/src/content/docs/guide/outputs.md
+++ b/docs/src/content/docs/guide/outputs.md
@@ -142,6 +142,8 @@ Two combinations are refused. `--clump_only` rejects `--rename` at any output fo
 
 `--fastqc` runs the bundled [`fastqc-rust`](https://crates.io/crates/fastqc-rust) library on the trimmed output files after pair validation, producing FastQC 0.12.1-compatible HTML + ZIP reports alongside the trimmed output. Works on both FASTQ output (default) and uBAM output (`--output-format ubam`) — `fastqc-rust` reads `.bam` natively, so no intermediate conversion. No Java or external `fastqc` install needed.
 
-For paired-end runs, FastQC is invoked once per output file — so PE FASTQ produces two reports (one per mate), while PE uBAM produces a **single** report per pair (uBAM PE output is one interleaved BAM, and the report covers both mates pooled).
+Two situations write no report and reject the flag rather than ignoring it: the four specialty modes (`--hardtrim5`, `--hardtrim3`, `--clock`, `--implicon`), and `--paired` given a single interleaved uBAM with FASTQ output. For that last one, `--output-format ubam` does produce a report.
+
+For paired-end runs, FastQC is invoked once per trimmed primary output — so PE FASTQ produces two reports (one per mate), while PE uBAM produces a **single** report per pair (uBAM PE output is one interleaved BAM, and the report covers both mates pooled). `--retain_unpaired`'s `*_unpaired_{1,2}` files get no report, and `--passthrough` adds a third report for its carrier output.
 
 `--fastqc_args "..."` passes a subset of FastQC flags through. Currently supported: `--nogroup`, `--expgroup`, `--quiet`, `--svg`, `--nano`, `--nofilter`, `--casava`, `-t`/`--threads`, `-o`/`--outdir`. Other flags emit a warning and are ignored.

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -50,7 +50,7 @@ For non-directional libraries, add `--non_directional`. See the [Bisulfite & RRB
 trim_galore --fastqc input.fastq.gz
 ```
 
-FastQC is built in via the bundled `fastqc-rust` library: no Java or external `fastqc` install needed. Outputs are FastQC 0.12.1-compatible HTML + ZIP files. Works on both FASTQ and uBAM output paths.
+FastQC is built in via the bundled `fastqc-rust` library: no Java or external `fastqc` install needed. Outputs are FastQC 0.12.1-compatible HTML + ZIP files. Works on both FASTQ and uBAM output paths, but is rejected on the specialty modes and on `--paired` with a single interleaved uBAM writing FASTQ — see [FastQC](/guide/outputs/#fastqc).
 
 ## Unaligned BAM (uBAM)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -327,6 +327,10 @@ pub struct Cli {
     /// Run FastQC on the trimmed output files (built in via the bundled
     /// fastqc-rust library; no external Java or FastQC binary needed).
     /// Produces FastQC 0.12.1-compatible *_fastqc.html / *_fastqc.zip artifacts.
+    /// Rejected with the specialty modes (--hardtrim5/3, --clock, --implicon) and with
+    /// --paired given a single input file (the interleaved-uBAM path) writing FASTQ output,
+    /// none of which write a report. For the last, --output-format ubam does produce one;
+    /// otherwise run FastQC separately.
     #[clap(long = "fastqc")]
     pub fastqc: bool,
 
@@ -579,6 +583,14 @@ impl Cli {
             }
         }
         Ok(())
+    }
+
+    /// Whether the run asked for FastQC.
+    ///
+    /// `--fastqc_args`' "Implies --fastqc" is doc text, not a clap `requires`, so `fastqc`
+    /// alone is false on an args-only run.
+    pub fn fastqc_requested(&self) -> bool {
+        self.fastqc || self.fastqc_args.is_some()
     }
 
     /// Validate CLI arguments after parsing.
@@ -1042,6 +1054,47 @@ impl Cli {
                 None => {
                     crate::adapter::parse_adapter_specs_quiet(&self.adapter2)?;
                 }
+            }
+        }
+
+        // #421 — these arms reach no `fastqc::run` call site. Last of the fallible checks,
+        // so malformed values and invalid input lists report their own defect first.
+        if self.fastqc_requested() {
+            if self.hardtrim5.is_some() {
+                anyhow::bail!(
+                    "--fastqc is not supported with --hardtrim5, which writes no QC report; \
+                     run FastQC separately on the hardtrimmed output, or drop --fastqc"
+                );
+            }
+            if self.hardtrim3.is_some() {
+                anyhow::bail!(
+                    "--fastqc is not supported with --hardtrim3, which writes no QC report; \
+                     run FastQC separately on the hardtrimmed output, or drop --fastqc"
+                );
+            }
+            if self.clock {
+                anyhow::bail!(
+                    "--fastqc is not supported with --clock, which writes no QC report; \
+                     run FastQC separately on the UMI-processed output, or drop --fastqc"
+                );
+            }
+            if self.implicon.is_some() {
+                anyhow::bail!(
+                    "--fastqc is not supported with --implicon, which writes no QC report; \
+                     run FastQC separately on the UMI-processed output, or drop --fastqc"
+                );
+            }
+            if self.paired
+                && self.input.len() == 1
+                && !matches!(self.output_format, OutputFormat::UBam)
+                && !self.clump_only
+            {
+                anyhow::bail!(
+                    "--fastqc is not supported with --paired and a single input file: that \
+                     shape is the interleaved-uBAM paired path, which writes FASTQ output with \
+                     no QC report. Pass Read 1 and Read 2 as two files, or — for a genuine \
+                     interleaved uBAM — add --output-format ubam, which does produce a report"
+                );
             }
         }
 
@@ -2141,6 +2194,204 @@ mod tests {
         assert!(
             err.contains("--retain_unpaired") && err.contains("--output-format ubam"),
             "expected retain_unpaired+ubam rejection, got: {err}"
+        );
+    }
+
+    // ── #421: --fastqc refused where no `fastqc::run` call site is reachable ──
+
+    const IP_BAM: &str = "test_files/ubam_paired_test.bam";
+
+    #[test]
+    fn fastqc_plus_hardtrim5_rejected() {
+        let cli = Cli::parse_from(["trim_galore", "--hardtrim5", "20", "--fastqc", R1]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("--fastqc") && err.contains("--hardtrim5"),
+            "expected fastqc+hardtrim5 rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fastqc_plus_hardtrim3_rejected() {
+        let cli = Cli::parse_from(["trim_galore", "--hardtrim3", "20", "--fastqc", R1]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("--fastqc") && err.contains("--hardtrim3"),
+            "expected fastqc+hardtrim3 rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fastqc_plus_clock_rejected() {
+        let cli = Cli::parse_from(["trim_galore", "--clock", "--paired", "--fastqc", R1, R2]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("--fastqc") && err.contains("--clock"),
+            "expected fastqc+clock rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fastqc_plus_implicon_rejected() {
+        let cli = Cli::parse_from(["trim_galore", "--implicon", "--paired", "--fastqc", R1, R2]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("--fastqc") && err.contains("--implicon"),
+            "expected fastqc+implicon rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fastqc_plus_paired_single_file_rejected() {
+        let cli = Cli::parse_from(["trim_galore", "--paired", "--fastqc", IP_BAM]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("--fastqc") && err.contains("single input file"),
+            "expected fastqc+paired-single-file rejection, got: {err}"
+        );
+        // The two-file remedy comes first: the likelier mistake is a forgotten Read 2,
+        // and that user's file is no uBAM.
+        let two_files = err.find("two files").expect("two-file remedy missing");
+        let ubam = err
+            .find("--output-format ubam")
+            .expect("uBAM remedy missing");
+        assert!(two_files < ubam, "two-file remedy must lead, got: {err}");
+    }
+
+    /// `--fastqc_args`' "Implies --fastqc" is doc text, not a clap `requires`, so a refusal
+    /// keyed on `fastqc` alone would leave this shape silently ignored.
+    #[test]
+    fn fastqc_args_alone_also_rejected() {
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--hardtrim5",
+            "20",
+            "--fastqc_args",
+            "--quiet",
+            R1,
+        ]);
+        assert!(!cli.fastqc, "--fastqc_args must not set the fastqc flag");
+        assert!(
+            cli.fastqc_requested(),
+            "but it must count as requesting FastQC"
+        );
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(err.contains("--fastqc"), "expected rejection, got: {err}");
+    }
+
+    // ── #421 acceptance twins: these arms do reach `fastqc::run` ──
+
+    #[test]
+    fn fastqc_plus_paired_ubam_output_single_file_accepted() {
+        // One flag apart from `fastqc_plus_paired_single_file_rejected`, and capable:
+        // `main.rs` routes uBAM output above the interleaved-FASTQ arm.
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--paired",
+            "--output-format",
+            "ubam",
+            "--fastqc",
+            IP_BAM,
+        ]);
+        assert!(cli.validate().is_ok(), "capable arm must stay accepted");
+    }
+
+    #[test]
+    fn fastqc_plus_paired_ubam_output_two_files_accepted() {
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--paired",
+            "--output-format",
+            "ubam",
+            "--fastqc",
+            R1,
+            R2,
+        ]);
+        assert!(cli.validate().is_ok(), "capable arm must stay accepted");
+    }
+
+    /// Arm 5 excludes `--clump_only` so `main.rs`'s own "requires two FASTQ input files"
+    /// message wins. Without this, only an integration test guards the term.
+    #[test]
+    fn fastqc_plus_clump_only_paired_single_file_not_refused_here() {
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--clump_only",
+            "--paired",
+            "--fastqc",
+            IP_BAM,
+        ]);
+        assert!(
+            cli.validate().is_ok(),
+            "validate must defer to main.rs's clump_only diagnosis"
+        );
+    }
+
+    #[test]
+    fn fastqc_plus_paired_fastq_output_accepted() {
+        let cli = Cli::parse_from(["trim_galore", "--paired", "--fastqc", R1, R2]);
+        assert!(
+            cli.validate().is_ok(),
+            "plain paired FASTQ + --fastqc is the commonest FastQC run; it must stay accepted"
+        );
+    }
+
+    #[test]
+    fn fastqc_plus_single_end_accepted() {
+        let cli = Cli::parse_from(["trim_galore", "--fastqc", R1]);
+        assert!(
+            cli.validate().is_ok(),
+            "SE trim + --fastqc must stay accepted"
+        );
+    }
+
+    #[test]
+    fn fastqc_plus_clump_only_accepted() {
+        let cli = Cli::parse_from(["trim_galore", "--clump_only", "--fastqc", R1]);
+        assert!(cli.validate().is_ok(), "clump_only reaches fastqc::run");
+    }
+
+    // ── #421: the guards sit below the value and input-list checks ──
+
+    #[test]
+    fn hardtrim5_range_error_precedes_the_fastqc_refusal() {
+        let cli = Cli::parse_from(["trim_galore", "--hardtrim5", "0", "--fastqc", R1]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("between 1 and 999"),
+            "a malformed value must report its own defect first, got: {err}"
+        );
+    }
+
+    /// `--adapter2` is parsed inside `validate`, so the guard block has to sit below it.
+    /// Spelled long: `parse_from` bypasses `rewrite_perl_short_flags`, so `-a2` would be
+    /// read as an input path.
+    #[test]
+    fn malformed_adapter2_precedes_the_fastqc_refusal() {
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--paired",
+            "--fastqc",
+            "--adapter2",
+            "NOT!A!SEQ",
+            IP_BAM,
+        ]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("only DNA characters"),
+            "a malformed adapter value must report its own defect first, got: {err}"
+        );
+    }
+
+    /// Without `--paired`, so this reaches `--clock`'s own `validate_paired_input` rather
+    /// than the `"Paired-end"` call that fires first whenever `--paired` is set.
+    #[test]
+    fn odd_input_count_precedes_the_fastqc_refusal() {
+        let cli = Cli::parse_from(["trim_galore", "--clock", "--fastqc", R1, R2, R1]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("--clock mode requires"),
+            "a structurally invalid input list must report first, got: {err}"
         );
     }
 

--- a/src/clump_only.rs
+++ b/src/clump_only.rs
@@ -255,7 +255,7 @@ pub fn clump_only_single(
     cores: usize,
     memory_budget_bytes: u64,
     compression: u32,
-    fastqc: bool,
+    fastqc_requested: bool,
     fastqc_args: Option<&str>,
     no_report_file: bool,
 ) -> Result<ClumpOnlyStats> {
@@ -370,7 +370,7 @@ pub fn clump_only_single(
 
     // Optional FastQC — new plumbing (specialty modes previously returned
     // before the fastqc::run call in main.rs).
-    if fastqc {
+    if fastqc_requested {
         fastqc::run(&output_path, fastqc_args, output_dir, cores.max(1))?;
     }
 
@@ -392,7 +392,7 @@ pub fn clump_only_paired(
     cores: usize,
     memory_budget_bytes: u64,
     compression: u32,
-    fastqc: bool,
+    fastqc_requested: bool,
     fastqc_args: Option<&str>,
     no_report_file: bool,
 ) -> Result<ClumpOnlyStats> {
@@ -550,7 +550,7 @@ pub fn clump_only_paired(
         write_clump_only_report(&r2_stats, &r2_report, input_r2, &out_r2_path)?;
     }
 
-    if fastqc {
+    if fastqc_requested {
         fastqc::run(&out_r1_path, fastqc_args, output_dir, cores.max(1))?;
         fastqc::run(&out_r2_path, fastqc_args, output_dir, cores.max(1))?;
     }
@@ -739,7 +739,7 @@ pub fn clump_only_single_to_bam(
     memory_budget_bytes: u64,
     preserve_tags: &[String],
     command_line: &str,
-    fastqc: bool,
+    fastqc_requested: bool,
     fastqc_args: Option<&str>,
     no_report_file: bool,
     input_phred_offset: u8,
@@ -841,7 +841,7 @@ pub fn clump_only_single_to_bam(
             .with_context(|| format!("Failed to write report: {}", report_path.display()))?;
     }
 
-    if fastqc {
+    if fastqc_requested {
         // fastqc-rust reads BAM natively (verified against fastqc-rust-1.0.1
         // src/runner.rs — accepts .bam/.ubam extensions + --format bam).
         fastqc::run(&output_path, fastqc_args, output_dir, cores.max(1))?;
@@ -889,7 +889,7 @@ pub fn clump_only_paired_to_bam_one_pair(
     memory_budget_bytes: u64,
     preserve_tags: &[String],
     command_line: &str,
-    fastqc: bool,
+    fastqc_requested: bool,
     fastqc_args: Option<&str>,
     no_report_file: bool,
     input_phred_offset: u8,
@@ -1091,7 +1091,7 @@ pub fn clump_only_paired_to_bam_one_pair(
             .with_context(|| format!("Failed to write report: {}", report_path.display()))?;
     }
 
-    if fastqc {
+    if fastqc_requested {
         fastqc::run(&output_path, fastqc_args, output_dir, cores.max(1))?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -633,7 +633,7 @@ fn main() -> Result<()> {
                                 cli.cores,
                                 memory_bytes,
                                 cli.compression,
-                                cli.fastqc,
+                                cli.fastqc_requested(),
                                 cli.fastqc_args.as_deref(),
                                 cli.no_report_file,
                             )
@@ -668,7 +668,7 @@ fn main() -> Result<()> {
                             cli.cores,
                             memory_bytes,
                             cli.compression,
-                            cli.fastqc,
+                            cli.fastqc_requested(),
                             cli.fastqc_args.as_deref(),
                             cli.no_report_file,
                         )?;
@@ -712,7 +712,7 @@ fn main() -> Result<()> {
                             memory_bytes,
                             &cli.preserve_tags,
                             &command_line,
-                            cli.fastqc,
+                            cli.fastqc_requested(),
                             cli.fastqc_args.as_deref(),
                             cli.no_report_file,
                             cli.phred_offset(),
@@ -775,7 +775,7 @@ fn main() -> Result<()> {
                                 memory_bytes,
                                 &cli.preserve_tags,
                                 &command_line,
-                                cli.fastqc,
+                                cli.fastqc_requested(),
                                 cli.fastqc_args.as_deref(),
                                 cli.no_report_file,
                                 cli.phred_offset(),
@@ -816,7 +816,7 @@ fn main() -> Result<()> {
                             memory_bytes,
                             &cli.preserve_tags,
                             &command_line,
-                            cli.fastqc,
+                            cli.fastqc_requested(),
                             cli.fastqc_args.as_deref(),
                             cli.no_report_file,
                             cli.phred_offset(),
@@ -1455,7 +1455,7 @@ fn run_single_file(
     }
 
     // Run FastQC if requested (bundled fastqc-rust library — no shell-out)
-    if cli.fastqc || cli.fastqc_args.is_some() {
+    if cli.fastqc_requested() {
         fastqc::run(
             &output_path,
             cli.fastqc_args.as_deref(),
@@ -1774,7 +1774,7 @@ fn run_paired(
     }
 
     // Run FastQC if requested (bundled fastqc-rust library — no shell-out)
-    if cli.fastqc || cli.fastqc_args.is_some() {
+    if cli.fastqc_requested() {
         fastqc::run(
             &output_r1,
             cli.fastqc_args.as_deref(),
@@ -2238,7 +2238,7 @@ fn run_ubam_output_single(
 
     // Run FastQC if requested. fastqc-rust dispatches on file EXTENSION
     // (not content), so this relies on output_path ending in `.bam`.
-    if cli.fastqc || cli.fastqc_args.is_some() {
+    if cli.fastqc_requested() {
         fastqc::run(
             &output_path,
             cli.fastqc_args.as_deref(),
@@ -2395,7 +2395,7 @@ fn run_ubam_output_paired_two_files(
     // Run FastQC if requested. fastqc-rust dispatches on file EXTENSION
     // (not content), so this relies on output_path ending in `.bam`.
     // PE uBAM output is a single interleaved BAM, so one call covers both mates.
-    if cli.fastqc || cli.fastqc_args.is_some() {
+    if cli.fastqc_requested() {
         fastqc::run(
             &output_path,
             cli.fastqc_args.as_deref(),
@@ -2518,7 +2518,7 @@ fn run_ubam_output_paired_single_file(
     // Run FastQC if requested. fastqc-rust dispatches on file EXTENSION
     // (not content), so this relies on output_path ending in `.bam`.
     // PE uBAM output is a single interleaved BAM, so one call covers both mates.
-    if cli.fastqc || cli.fastqc_args.is_some() {
+    if cli.fastqc_requested() {
         fastqc::run(
             &output_path,
             cli.fastqc_args.as_deref(),

--- a/tests/integration_clump_only.rs
+++ b/tests/integration_clump_only.rs
@@ -398,3 +398,27 @@ fn silently_accepts_error_rate_flag() -> Result<()> {
     // same silent-accept semantics as -q under --clump_only.
     assert_silently_accepts("silent_e", &["-e", "0.05"])
 }
+
+/// #421 — `--fastqc_args` alone must activate FastQC on the `--clump_only` drivers.
+#[test]
+fn clump_only_fastqc_args_alone_produces_a_report() -> Result<()> {
+    let dir = tempdir("fastqc_args_only");
+    let status = Command::new(binary())
+        .args(["--clump_only", "--fastqc_args", "--quiet"])
+        .arg(fixture("BS-seq_10K_R1.fastq.gz"))
+        .arg("-o")
+        .arg(&dir)
+        .status()?;
+    assert!(status.success(), "--clump_only --fastqc_args must succeed");
+
+    let reports: Vec<String> = std::fs::read_dir(&dir)?
+        .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().into_owned()))
+        .filter(|n| n.contains("_fastqc."))
+        .collect();
+    assert_eq!(
+        reports.len(),
+        2,
+        "expected _fastqc.html + _fastqc.zip, got {reports:?}"
+    );
+    Ok(())
+}

--- a/tests/integration_paired_format_guard.rs
+++ b/tests/integration_paired_format_guard.rs
@@ -7,7 +7,7 @@
 //! distinguishes the shapes, and runs in the cheap-validation window in `main()`
 //! rather than inside the per-pair worker.
 //!
-//! Three properties are pinned here that unit tests cannot reach:
+//! Four properties are pinned here that unit tests cannot reach:
 //!
 //! 1. The rejection has **no side effects** — no output directory, no adapter
 //!    auto-detection, and on multi-pair input no partial output from earlier
@@ -18,6 +18,9 @@
 //!    a command the binary itself rejects.
 //! 3. A plain+gzip FASTQ pair is still **accepted** — the guard keys on BAM
 //!    count, not format equality.
+//! 4. `--fastqc` is refused on this same `--paired`-with-one-input family, whose
+//!    FASTQ-output path writes no QC report (#421) — and accepted one flag away,
+//!    under `--output-format ubam`, which does.
 //!
 //! Fixtures: `phred64_test.fastq` (plain FASTQ), `BS-seq_10K_R{1,2}.fastq.gz`
 //! (gzipped FASTQ), `ubam_test.bam` / `ubam_paired_test.bam` (two distinct
@@ -436,5 +439,84 @@ fn hardtrim_still_accepts_a_mixed_pair() {
     assert!(
         ok,
         "the paired format guard must not fire for --hardtrim5; stderr: {stderr}"
+    );
+}
+
+/// #421 — `--paired` with one input file is the interleaved-uBAM path, which writes
+/// FASTQ output through `run_paired_ubam_single_file` and reaches no `fastqc::run`.
+#[test]
+fn fastqc_refused_on_paired_interleaved_fastq_output() {
+    let dir = tempdir("fastqc_arm5");
+    let out = nonexistent_out(&dir);
+    let (ok, stderr) = run(&[
+        "--paired",
+        "--fastqc",
+        fixture("ubam_paired_test.bam").to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(!ok, "--fastqc must be refused on this arm");
+    assert!(
+        stderr.contains("--fastqc is not supported") && stderr.contains("single input file"),
+        "expected the FastQC refusal naming the shape; got: {stderr}"
+    );
+    // The remedy has to work for a user who simply forgot Read 2.
+    assert!(
+        stderr.contains("two files"),
+        "message must offer the two-file remedy; got: {stderr}"
+    );
+    assert!(
+        !out.exists(),
+        "a refused run must not create its output dir"
+    );
+}
+
+/// One flag apart from the case above, and capable: uBAM output routes above the
+/// interleaved-FASTQ arm and runs FastQC on the single `_val.bam`.
+#[test]
+fn fastqc_accepted_on_paired_interleaved_ubam_output() {
+    let dir = tempdir("fastqc_arm5_ubam");
+    let (ok, stderr) = run(&[
+        "--paired",
+        "--output-format",
+        "ubam",
+        "--fastqc",
+        fixture("ubam_paired_test.bam").to_str().unwrap(),
+        "-o",
+        dir.to_str().unwrap(),
+    ]);
+    assert!(ok, "uBAM output is FastQC-capable; got: {stderr}");
+    let zips: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.file_name().to_string_lossy().into_owned()))
+        .filter(|n| n.ends_with("_fastqc.zip"))
+        .collect();
+    assert_eq!(zips.len(), 1, "expected exactly one report, got {zips:?}");
+}
+
+/// `--clump_only --paired` with one input keeps its own diagnosis, which names the
+/// actual remedy; the FastQC guard excludes it so that message still wins.
+#[test]
+fn clump_only_paired_single_file_keeps_its_own_message() {
+    let dir = tempdir("fastqc_clump_prec");
+    let out = nonexistent_out(&dir);
+    let (ok, stderr) = run(&[
+        "--clump_only",
+        "--paired",
+        "--fastqc",
+        fixture("ubam_paired_test.bam").to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(!ok, "the combination is still refused");
+    assert!(
+        stderr.contains("requires two FASTQ input files"),
+        "expected --clump_only's own message, not the FastQC one; got: {stderr}"
+    );
+    // Contrast with the sibling above: `Cli::validate` refuses before `ensure_output_dir`
+    // (`main.rs:231` vs `:420`), this refusal after it. Which layer answers is the point.
+    assert!(
+        out.exists(),
+        "main.rs's refusal runs after ensure_output_dir; if this flips, the guard changed layer"
     );
 }

--- a/tests/integration_preflight_tripwire.rs
+++ b/tests/integration_preflight_tripwire.rs
@@ -31,9 +31,10 @@
 //! subset, so no `_fastqc/` directory appears, and `--svg` sets a rendering flag without
 //! writing an `.svg` file.
 //!
-//! `--fastqc` is a silent no-op on `--hardtrim5/3`, `--clock`, `--implicon` and on
-//! paired FASTQ output from a single interleaved uBAM ([#421]). Those arms are marked
-//! `fastqc_incapable`; do not pair them with a FastQC flag expecting artefacts.
+//! `--hardtrim5/3`, `--clock`, `--implicon` and paired FASTQ output from a single
+//! interleaved uBAM reach no `fastqc::run` call site, so `Cli::validate` refuses a FastQC
+//! flag on them ([#421]). `refuses_fastqc_on_every_arm_that_cannot_run_it` pins all five;
+//! every arm that accepts the flag therefore produces artefacts, so the rule is unconditional.
 //!
 //! [#421]: https://github.com/FelixKrueger/TrimGalore/issues/421
 //!
@@ -215,8 +216,8 @@ fn is_fastqc_artifact(path: &Path) -> bool {
     name.ends_with("_fastqc.html") || name.ends_with("_fastqc.zip")
 }
 
-/// Production's gate is `cli.fastqc || cli.fastqc_args.is_some()` (`main.rs:1458` and
-/// four siblings). The disjunction is load-bearing: `--fastqc_args`' "Implies --fastqc"
+/// Production's gate is `Cli::fastqc_requested()`, called at every `fastqc::run` site.
+/// The disjunction inside it is load-bearing: `--fastqc_args`' "Implies --fastqc"
 /// is doc text with no clap `requires`, so `cli.fastqc` is false on an args-only run
 /// while FastQC still runs. Deriving the predicate here, once, from the args keeps one
 /// source of truth for it.
@@ -235,7 +236,6 @@ struct Tripwire<'a> {
     /// file, the last two being what #389 and #409 were about.
     guarded: &'a [&'a str],
     arm: Arm,
-    fastqc_capable: bool,
 }
 
 /// What a case observed, for the few tests that assert something extra.
@@ -251,17 +251,11 @@ impl<'a> Tripwire<'a> {
             args,
             guarded,
             arm: Arm::Planned,
-            fastqc_capable: true,
         }
     }
 
     fn unplanned(mut self) -> Self {
         self.arm = Arm::Unplanned;
-        self
-    }
-
-    fn fastqc_incapable(mut self) -> Self {
-        self.fastqc_capable = false;
         self
     }
 
@@ -302,14 +296,7 @@ impl<'a> Tripwire<'a> {
             panic!("{}: {msg}\nstderr:\n{stderr}", self.tag);
         }
 
-        if let Err(msg) = compare(
-            &root,
-            &created,
-            &planned,
-            self.args,
-            self.arm,
-            self.fastqc_capable,
-        ) {
+        if let Err(msg) = compare(&root, &created, &planned, self.args, self.arm) {
             panic!("{}: {msg}\nstderr:\n{stderr}", self.tag);
         }
 
@@ -345,7 +332,6 @@ fn compare(
     planned: &[(String, PathBuf)],
     args: &[&str],
     arm: Arm,
-    fastqc_capable: bool,
 ) -> Result<(), String> {
     // T4 — liveness. `main.rs:215-230` routes clap's
     // DisplayHelpOnMissingArgumentOrSubcommand to stdout with exit 0, so a case whose
@@ -361,22 +347,12 @@ fn compare(
         .partition(|p| active && is_fastqc_artifact(p));
 
     // The allowance is self-policing, so it cannot quietly widen into the drain this
-    // test dies in. Scoped to arms that can reach `fastqc::run` at all: unscoped, it
-    // would go red on a legitimate specialty case (#421), and a provably-wrong red is
-    // the strongest argument for deleting a guard.
-    match (active, fastqc_capable) {
-        (true, true) if allowed.is_empty() => {
-            return Err("a FastQC flag is set but no FastQC artefact was written; \
-                        the allowance is masking a broken case"
-                .into());
-        }
-        (true, false) if !allowed.is_empty() => {
-            return Err(format!(
-                "arm is marked fastqc_incapable but produced {allowed:?}; \
-                 #421 may have been fixed — drop the marker"
-            ));
-        }
-        _ => {}
+    // test dies in. Unconditional: every arm that accepts a FastQC flag reaches
+    // `fastqc::run`, because `Cli::validate` refuses the ones that do not.
+    if active && allowed.is_empty() {
+        return Err("a FastQC flag is set but no FastQC artefact was written; \
+                    the allowance is masking a broken case"
+            .into());
     }
     // An allowance that swallowed the whole write set would leave T1 comparing empty sets.
     if rest.is_empty() {
@@ -810,7 +786,6 @@ fn hardtrim5_fastq() {
         &["--hardtrim5", "20", "in/a.fastq"],
         &["in/a.fastq"],
     )
-    .fastqc_incapable()
     .run(|root| write_fastq(&root.join("in/a.fastq"), "A_"));
 }
 
@@ -821,7 +796,6 @@ fn hardtrim5_ubam() {
         &["--hardtrim5", "20", "--output-format", "ubam", "in/a.fastq"],
         &["in/a.fastq"],
     )
-    .fastqc_incapable()
     .run(|root| write_fastq(&root.join("in/a.fastq"), "A_"));
 }
 
@@ -832,7 +806,6 @@ fn hardtrim3_fastq() {
         &["--hardtrim3", "20", "a.fastq", "b.fastq"],
         &["a.fastq", "b.fastq"],
     )
-    .fastqc_incapable()
     .run(stage_se2);
 }
 
@@ -843,7 +816,6 @@ fn hardtrim3_ubam() {
         &["--hardtrim3", "20", "--output-format", "ubam", "a.fastq"],
         &["a.fastq"],
     )
-    .fastqc_incapable()
     .run(stage_se);
 }
 
@@ -863,7 +835,6 @@ fn clock_multipair() {
         ],
         &["c1_R1.fastq", "c1_R2.fastq", "c2_R1.fastq", "c2_R2.fastq"],
     )
-    .fastqc_incapable()
     .run(|root| {
         for p in ["c1", "c2"] {
             write_fastq(&root.join(format!("{p}_R1.fastq")), "S_");
@@ -879,7 +850,6 @@ fn implicon_pair() {
         &["--implicon", "--paired", "i_R1.fastq", "i_R2.fastq"],
         &["i_R1.fastq", "i_R2.fastq"],
     )
-    .fastqc_incapable()
     .run(|root| {
         write_fastq(&root.join("i_R1.fastq"), "S_");
         write_fastq(&root.join("i_R2.fastq"), "S_");
@@ -910,6 +880,20 @@ fn clump_only_paired_no_report_file() {
         &["s_R1.fastq", "s_R2.fastq"],
     )
     .run(stage_pair);
+}
+
+/// #421 — `--fastqc_args` alone must reach `fastqc::run` on the `--clump_only` drivers.
+/// This is the case whose absence let the sixth arm ship: the file's own rule requires a
+/// FastQC-flagged run to write artefacts, and no case paired `--clump_only` with the
+/// args-only spelling.
+#[test]
+fn clump_only_se_fastqc_args_only() {
+    Tripwire::new(
+        "clump_only_se_fastqc_args_only",
+        &["--clump_only", "--fastqc_args", "--quiet", "a.fastq"],
+        &["a.fastq"],
+    )
+    .run(stage_se);
 }
 
 // ── sites 661 / 706 / 752 / 809 — clump_only ─────────────────────────────────
@@ -1025,7 +1009,6 @@ fn orphan_paired_fastq_from_interleaved_bam() {
         &["ip.bam"],
     )
     .unplanned()
-    .fastqc_incapable()
     .run(|root| copy_fixture("ubam_paired_test.bam", &root.join("ip.bam")));
 }
 
@@ -1040,7 +1023,6 @@ fn orphan_paired_fastq_retain_unpaired() {
         &["ip.bam"],
     )
     .unplanned()
-    .fastqc_incapable()
     .run(|root| copy_fixture("ubam_paired_test.bam", &root.join("ip.bam")));
 }
 
@@ -1073,7 +1055,7 @@ fn comparison_reports_an_unplanned_path() {
         .collect();
     let planned = synthetic_planned("src/main.rs:1006", &["a_trimmed.fq"]);
 
-    let err = compare(&root, &created, &planned, &["a.fastq"], Arm::Planned, true)
+    let err = compare(&root, &created, &planned, &["a.fastq"], Arm::Planned)
         .expect_err("an unplanned created path must fail");
 
     assert!(err.contains("a.fastq_trimming_report.txt"), "{err}");
@@ -1094,7 +1076,7 @@ fn comparison_accepts_overplanning() {
         &["s_R1_val_1.fq", "s_R1_unpaired_1.fq", "s_R2_unpaired_2.fq"],
     );
 
-    compare(&root, &created, &planned, &["--paired"], Arm::Planned, true)
+    compare(&root, &created, &planned, &["--paired"], Arm::Planned)
         .expect("planned may legitimately exceed created");
 }
 
@@ -1107,7 +1089,6 @@ fn comparison_rejects_an_empty_run() {
         &synthetic_planned("src/main.rs:1006", &["a_trimmed.fq"]),
         &["a.fastq"],
         Arm::Planned,
-        true,
     )
     .expect_err("a run that created nothing must fail, not pass vacuously");
     assert!(err.contains("never reached its arm"), "{err}");
@@ -1117,7 +1098,7 @@ fn comparison_rejects_an_empty_run() {
 fn comparison_rejects_a_missing_dump() {
     let root = case_root("cmp_nodump");
     let created: BTreeSet<PathBuf> = [PathBuf::from("a_trimmed.fq")].into_iter().collect();
-    let err = compare(&root, &created, &[], &["a.fastq"], Arm::Planned, true)
+    let err = compare(&root, &created, &[], &["a.fastq"], Arm::Planned)
         .expect_err("an empty candidate list must fail on a planned arm");
     assert!(err.contains("hook did not fire"), "{err}");
 }
@@ -1179,7 +1160,7 @@ fn comparison_rejects_two_sites_in_one_run() {
     let mut planned = synthetic_planned("src/main.rs:1006", &["a_trimmed.fq"]);
     planned.push(("src/main.rs:927".into(), PathBuf::from("b_val_1.fq")));
 
-    let err = compare(&root, &created, &planned, &["a.fastq"], Arm::Planned, true)
+    let err = compare(&root, &created, &planned, &["a.fastq"], Arm::Planned)
         .expect_err("two dumped sites in one run must fail");
     assert!(err.contains("two pre-flights"), "{err}");
 }
@@ -1194,7 +1175,7 @@ fn comparison_rejects_stray_fastqc_artifacts() {
     let planned = synthetic_planned("src/main.rs:1006", &["a_trimmed.fq"]);
 
     // No FastQC flag, so the allowance must not apply and the artefact is unplanned.
-    let err = compare(&root, &created, &planned, &["a.fastq"], Arm::Planned, true)
+    let err = compare(&root, &created, &planned, &["a.fastq"], Arm::Planned)
         .expect_err("a _fastqc artefact with no FastQC flag must fail");
     assert!(err.contains("no FastQC flag"), "{err}");
 }
@@ -1213,7 +1194,6 @@ fn comparison_rejects_an_allowance_that_takes_everything() {
         &planned,
         &["--fastqc", "a.fastq"],
         Arm::Planned,
-        true,
     )
     .expect_err("an allowance covering every created file leaves T1 vacuous");
     assert!(err.contains("nothing left to check"), "{err}");
@@ -1252,7 +1232,7 @@ fn hook_is_inert_when_env_unset_and_that_goes_red() {
 
     // And with no dump to compare against, the comparison must fail rather than pass.
     let created = snapshot(&root2);
-    compare(&root2, &created, &[], &["a.fastq"], Arm::Planned, true)
+    compare(&root2, &created, &[], &["a.fastq"], Arm::Planned)
         .expect_err("no dump must fail the comparison, not pass it");
 }
 
@@ -1368,4 +1348,44 @@ fn a_refused_run_writes_nothing() {
         created.is_empty(),
         "a refused run must write nothing, found {created:?}"
     );
+}
+
+#[test]
+fn refuses_fastqc_on_every_arm_that_cannot_run_it() {
+    // One case per arm that `Cli::validate` refuses a FastQC flag on (#421).
+    let cases: &[(&str, &[&str])] = &[
+        ("hardtrim5", &["--hardtrim5", "20", "--fastqc", "a.fastq"]),
+        ("hardtrim3", &["--hardtrim3", "20", "--fastqc", "a.fastq"]),
+        (
+            "clock",
+            &["--clock", "--paired", "--fastqc", "r1.fastq", "r2.fastq"],
+        ),
+        (
+            "implicon",
+            &["--implicon", "--paired", "--fastqc", "r1.fastq", "r2.fastq"],
+        ),
+        ("paired_interleaved", &["--paired", "--fastqc", "ip.bam"]),
+    ];
+
+    for (label, args) in cases {
+        let root = case_root(&format!("refuses_fastqc_{label}"));
+        write_fastq(&root.join("a.fastq"), "A_");
+        write_fastq(&root.join("r1.fastq"), "R1_");
+        write_fastq(&root.join("r2.fastq"), "R2_");
+        copy_fixture("ubam_paired_test.bam", &root.join("ip.bam"));
+        let before = snapshot(&root);
+
+        let (ok, stderr) = run_arm(&root, args);
+
+        assert!(!ok, "{label}: a FastQC flag must be refused here\n{stderr}");
+        assert!(
+            stderr.contains("--fastqc is not supported"),
+            "{label}: expected the FastQC refusal:\n{stderr}"
+        );
+        let created: Vec<PathBuf> = snapshot(&root).difference(&before).cloned().collect();
+        assert!(
+            created.is_empty(),
+            "{label}: a refused run must write nothing, found {created:?}"
+        );
+    }
 }


### PR DESCRIPTION
`--fastqc` was accepted and silently ignored on five dispatch arms — the run exited 0, wrote its normal output, produced no QC report and never mentioned FastQC, so a wrapper passing the flag unconditionally got no QC and no warning. Those five (`--hardtrim5`, `--hardtrim3`, `--clock`, `--implicon`, and paired FASTQ output from a single interleaved uBAM) reach no `fastqc::run` call site at all, and are now refused in `Cli::validate` rather than ignored. **Dual plan review found the same defect from the other side**, so it is fixed here too: the four `--clump_only` drivers took a `fastqc: bool` fed with bare `cli.fastqc`, which made `--fastqc_args` alone a silent no-op on a path that is otherwise capable. `Cli::fastqc_requested()` now carries that predicate once and is used at all ten sites, so `--fastqc_args`' documented "Implies --fastqc" is finally true everywhere. 663 → 684 tests.

Addresses #421.

<details>
<summary>AI-assisted detail</summary>

**Arm 5 needs the output format, not just the input shape.** `--paired --output-format ubam <one.bam>` routes *above* the interleaved-FASTQ arm into `run_ubam_output_paired_single_file`, which does run FastQC — `ci.yml:1173` and `tests/integration_ubam_out.rs:572` both assert it produces a report. A condition of `paired && input.len() == 1` alone would have refused a working feature and turned CI red. `--clump_only` is excluded so `main.rs:599`'s "requires two FASTQ input files" still wins, which names the actual remedy.

**Guard placement is load-bearing and took two attempts.** The block is the last fallible check in `validate`. Sited earlier it masks messages the user can act on — a malformed `--hardtrim5` value, an odd input count, a duplicated mate, a malformed `--adapter2` spec. The first implementation put it after the input-existence loop, which still masked the `--adapter2` parse error; that is pinned now by `malformed_adapter2_precedes_the_fastqc_refusal`. The principle is the one `main.rs:344-351` already argues: a malformed *value* reports before an unsupported *combination*.

**The gate was never uniform, which is what hid the sixth arm.** Five `main.rs` sites tested `cli.fastqc || cli.fastqc_args.is_some()`; five others passed bare `cli.fastqc` into the `--clump_only` drivers. The original plan asserted the disjunction held at all twelve call sites on the strength of grepping for `fastqc::run` — grep finds calls, not guards. The drivers' parameter is renamed `fastqc_requested`, because a parameter named `fastqc` is what invited `cli.fastqc` at the call site.

**#422's tripwire loses its FastQC allowance scoping**, which existed as a workaround for this defect (its own comment said so). The surviving rule — a FastQC-flagged run must write artefacts — is now unconditional across all 55 cases instead of being scoped away from five arms. Two new cases: one looping over every refused arm asserting non-zero exit, the message, and that nothing was written; and `clump_only_se_fastqc_args_only`, which puts the sixth arm under that rule. Reverting the five pass-throughs makes the latter fail with *"a FastQC flag is set but no FastQC artefact was written"* — the mechanism that missed the original defect now covers it.

**Verification.** Both code reviewers hunted specifically for over-rejection (the only way this change can do harm) and neither found an invocation that works on the base commit and now fails; one swept 16 invocations through a purpose-built binary. Nine mutations were designed against the guards and all nine go red. A coverage audit re-measured every claimed number, including reproducing both pre-fix defects on a binary it built from the unpatched base itself.

**Docs corrected in four places**, including a blanket "works on both FASTQ and uBAM output paths" promise, a report count that omitted `--passthrough`'s carrier report, and a `--help` remedy that offered `--output-format ubam` for four arms where it does nothing.

</details>
