### PR TITLE
chore(deps): bump js-yaml to 4.3.1 in /docs for the quadratic-omap advisory

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -4158,9 +4158,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Bumps the docs site's transitive `js-yaml` from 4.3.0 to 4.3.1, which is still inside the range of the high-severity quadratic-CPU advisory: 4.3.0 fixed the merge-key-chain variant, and 4.3.1 backports the same guard to `!!omap` duplicate-key resolution. Three hand-edited lockfile lines; `npm ci` reports 0 vulnerabilities and `npm run build` produces all 31 pages.

Dependabot's own PR (#427) targets `master`, which only ever fast-forwards from `dev`, so merging it there would break the next FF — same shape as #425/#430. postcss (#431) needs nothing: `dev` is already at 8.5.23, the patched version for both open postcss advisories.

<details>
<summary>AI-assisted detail</summary>

**Why only one of ten alerts is real.** Dependabot scans the default branch, and `master` is a release pin 70 commits behind `dev`. Comparing every open alert's patched version against `dev`'s resolved versions:

| package | on `dev` | patched | verdict |
|---|---|---|---|
| js-yaml | 4.3.0 | 4.3.1 | **still vulnerable** |
| postcss | 8.5.23 | 8.5.23 | already fixed |
| nanoid | 3.3.18 | 3.3.16 | already fixed (#430) |
| sharp | 0.35.3 | 0.35.0 | already fixed |
| svgo | 4.0.2 | 4.0.2 | already fixed |
| astro | 7.2.0 | 7.0.6 | already fixed |

The other nine clear on their own at the next release fast-forward.

**Why hand-edited.** `npm install js-yaml@4.3.1` also adds the package to `package.json` as a *direct* dependency and strips `"libc"` platform metadata from optional entries; `npm update` strips the same. Only the `node_modules/js-yaml` entry's three lines change here — no requirement ranges, since 4.3.1 satisfies both the `^4.3.0` and `^4.1.1` declarations upstream packages carry.

**Exposure.** `js-yaml` is a build-time dependency of the Astro docs site, parsing our own frontmatter, so the advisory needs adversarial YAML from someone who can already commit. The reason to take it is that a high-severity alert sitting open on a public repo invites questions and the fix is one line — not that the risk is material.

</details>
