### PR TITLE
perf(alloc): use mimalloc as the global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1024,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1786,6 +1804,7 @@ dependencies = [
  "gzp",
  "log",
  "memchr",
+ "mimalloc",
  "noodles",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ fastqc-rust = "=1.0.1"
 # compile. Treat upstream bumps as deliberate-test events.
 # See plans/06252026_ubam-input-support/PLAN.md §5 step 1.
 noodles = { version = "=0.88.0", default-features = false, features = ["bam"] }
+# Global allocator; measurements and platform caveats are in the commit message. Exact-pinned like fastqc-rust and noodles, so treat upstream bumps as deliberate-test events.
+mimalloc = "=0.1.52"
 
 [dev-dependencies]
 serde_json = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,12 @@ use trim_galore::report;
 use trim_galore::specialty;
 use trim_galore::trimmer;
 
+/// mimalloc replaces the platform allocator for the whole binary. Allocation
+/// behaviour is the only thing that changes: no output byte differs, so the
+/// Perl 0.6.11 validation matrix is unaffected.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Format-aware sanity check — dispatches `FastqReader::sanity_check` for
 /// FASTQ input or peek-reads the first BAM record (asserting `is_unmapped()`)
 /// for uBAM. The per-record aligned-BAM check in `BamReader::next_record`


### PR DESCRIPTION
## What

Sets `mimalloc` as the binary's `#[global_allocator]`. Two-line change plus the dependency, exact-pinned at `=0.1.52`.

## Why

The trimming hot loop allocates and frees small, short-lived buffers per record, across `--cores` workers that each own their chunk. mimalloc's sharded free lists have a shorter fast path than the platform malloc for that shape.

The size of the win depends on the path and the platform, so these are scoped rather than headlined. Measured on **4M simulated read pairs** (distinct inserts, 3'-degrading quality, 35% adapter read-through, so the gzip writer does real work), macOS/arm64, 3 runs, mean:

| path | cores | wall (stock → mimalloc) | peak RSS |
|---|---|---|---|
| plain trimming | 1 | 32.9 s → 31.1 s (-5%) | unchanged |
| plain trimming | 4 | 8.6 s → 7.8 s (-9%) | 104 → 103 MB |
| plain trimming | 8 | 4.7 s → 4.4 s (-7%) | unchanged |
| plain trimming | 16 | 3.7 s → 3.2 s (-12%) | unchanged |
| `--clumpify` | 4 | 9.8 s → 8.7 s (-11%) | 1284 → 979 MB (**-24%**) |

The RSS drop is specific to the memory-budgeted `--clumpify` path; plain trimming never holds enough live at once for it to show.

@FelixKrueger's independent replication at 6.8M pairs (macOS/arm64 + 128-core Linux) agrees on direction and lands the same on macOS plain trimming (8% vs my 9%), while showing `--clumpify` at ~18% on both platforms and Linux plain trimming at only 1.5%. That is the writer-bound picture from their profiling, and a compression-heavy dataset drops the Linux `--clumpify` gain to 4-6%. **So: this helps where the run is allocation-heavy rather than deflate-heavy, and least on Linux plain trimming.**

An earlier revision of this PR claimed a flat 25% at `--cores 8`. That number came from a fixture built by concatenating one 10K-read file 40 times, which compresses far too well and keeps the working set unrealistically small. It has been replaced by the table above.

## Why not snmalloc

`snmalloc-rs` 0.7.5 was built and benchmarked head-to-head, since its message-batched cross-thread free targets this producer/consumer shape. It lands **within noise** of mimalloc (CPU 2.38 s / 2.45 s / 2.38 s at 1/4/8 cores on the earlier fixture). Workers allocate and free mostly within their own chunk, and only the finished compressed buffer crosses threads, so the pattern snmalloc optimises for does not dominate here.

Tiebreak is therefore build cost: snmalloc needs a C++17 toolchain plus cmake, mimalloc is pure C and one dependency. `snmalloc-rs` also resolves to 0.3.8 by default under this crate's `rust-version = 1.88` floor.

## Invariants checked

- **Byte-identity**: `_val_1.fq.gz` / `_val_2.fq.gz` are byte-identical (`cmp`) to the pre-change binary on the 4M-pair input, so the `validation` job's md5 comparison against Perl 0.6.11 is unaffected.
- **Reproducible builds**: two `cargo clean` + `cargo build --release` runs under a fixed `SOURCE_DATE_EPOCH` produce the same SHA-256.
- **No external runtime deps**: links statically. Also builds clean for `aarch64-unknown-linux-musl` (+246 KB), though per @FelixKrueger no shipped target or container is musl and the bioconda recipe already declares `{{ compiler('c') }}`, so this costs nothing on shipped channels.
- `cargo test --release`: 729 passed, 0 failed. `cargo fmt --all -- --check` and `cargo clippy --all-targets --release -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)