### PR TITLE
fix(io): pre-flight the two single-file interleaved paired arms (#423, #424, #429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 #### Changes
 
+- **A read name that uBAM output cannot encode is now named in the refusal, along with the SAM
+  QNAME rule it breaks** ([#429](https://github.com/FelixKrueger/TrimGalore/issues/429)) — FASTQ
+  output still accepts those names.
+
 - **A run that is refused part-way through now writes no output file, and leaves a previous
   run's output at that path untouched**
   ([#428](https://github.com/FelixKrueger/TrimGalore/issues/428)) — see `docs/guide/outputs.md`

--- a/src/bam.rs
+++ b/src/bam.rs
@@ -638,9 +638,33 @@ impl BamWriter {
             .set_quality_scores(QualityScores::from(raw_qual))
             .set_data(data)
             .build();
+        // `record.id`, not `name` — that moved into `set_name` above. Shown under the
+        // 60-char cap the tag notices use, with the byte count when it bites, because
+        // a FASTQ id has no length limit and one rejection here is over-long. The
+        // QNAME rule is appended only for `InvalidInput`, so a full disk or a closed
+        // pipe is not relabelled as a read-name problem.
         self.inner
             .write_alignment_record(&self.header, &rec)
-            .context("failed to write BAM record")?;
+            .map_err(|e| {
+                let shown = if record.id.chars().count() > 60 {
+                    format!(
+                        "{}… ({} bytes)",
+                        record.id.chars().take(60).collect::<String>(),
+                        record.id.len()
+                    )
+                } else {
+                    record.id.clone()
+                };
+                let mut msg = format!("while writing BAM record \"{}\"", shown.escape_debug());
+                if e.kind() == std::io::ErrorKind::InvalidInput {
+                    msg.push_str(
+                        " — BAM rejected it. A SAM read name must be 1-254 bytes of \
+                         printable ASCII other than `@` and space. Rename the reads \
+                         before trimming, or write FASTQ output, which accepts them.",
+                    );
+                }
+                anyhow::Error::new(e).context(msg)
+            })?;
         Ok(())
     }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -638,11 +638,14 @@ pub fn paired_report_names(
 
 // ─── Single-file interleaved paired output (#423) ───────────────────────────
 //
-// One derivation per arm, consumed by both the writers and — once #424 lands —
-// the collision pre-flight. Keyed on `file_stem()`, not `file_name()`: these
+// One derivation per arm, consumed by both the writers and the collision
+// pre-flight. Keyed on `file_stem()`, not `file_name()`: these
 // arms have always named their outputs `ip_val_1.fq` from `ip.bam`, where
 // `report_name` would give `ip.bam_trimming_report.txt`. Composing these from
 // `report_name` renames every interleaved report.
+//
+// Every field added here must appear in that type's `planned()`; the exhaustive
+// destructure there makes a field that does not a build error.
 
 /// The two mates' trimming-report paths for a single interleaved pair.
 ///
@@ -664,6 +667,23 @@ impl InterleavedReports {
             r2_txt: dir.join(format!("{stem}_R2_trimming_report.txt")),
             r2_json: dir.join(format!("{stem}_R2_trimming_report.json")),
         }
+    }
+
+    /// txt before json within a mate, the order the two-file paired sites use and
+    /// `tests/integration_output_collision.rs` pins.
+    fn planned(&self, src: &OutputSource) -> Vec<PlannedOutput> {
+        let Self {
+            r1_txt,
+            r1_json,
+            r2_txt,
+            r2_json,
+        } = self;
+        vec![
+            (r1_txt.clone(), src.clone()),
+            (r1_json.clone(), src.clone()),
+            (r2_txt.clone(), src.clone()),
+            (r2_json.clone(), src.clone()),
+        ]
     }
 }
 
@@ -700,6 +720,26 @@ impl InterleavedFastqOutputs {
             reports: reports.then(|| InterleavedReports::new(&stem, &dir)),
         }
     }
+
+    /// The pre-flight candidate list. `src` is the lone input, so every path
+    /// carries the same one.
+    pub fn planned(&self, src: &OutputSource) -> Vec<PlannedOutput> {
+        let Self {
+            val_1,
+            val_2,
+            unpaired,
+            reports,
+        } = self;
+        let mut v = vec![(val_1.clone(), src.clone()), (val_2.clone(), src.clone())];
+        if let Some((up_1, up_2)) = unpaired {
+            v.push((up_1.clone(), src.clone()));
+            v.push((up_2.clone(), src.clone()));
+        }
+        if let Some(reports) = reports {
+            v.extend(reports.planned(src));
+        }
+        v
+    }
 }
 
 /// Every path a uBAM-output single-file interleaved paired run writes.
@@ -717,6 +757,17 @@ impl InterleavedBamOutputs {
             val: dir.join(format!("{stem}_val.bam")),
             reports: reports.then(|| InterleavedReports::new(&stem, &dir)),
         }
+    }
+
+    /// The pre-flight candidate list. `src` is the lone input, so every path
+    /// carries the same one.
+    pub fn planned(&self, src: &OutputSource) -> Vec<PlannedOutput> {
+        let Self { val, reports } = self;
+        let mut v = vec![(val.clone(), src.clone())];
+        if let Some(reports) = reports {
+            v.extend(reports.planned(src));
+        }
+        v
     }
 }
 
@@ -880,8 +931,8 @@ mod tests {
     // ─── #423: the paired report namers, pinned to literal paths ───────────
     //
     // Nothing else in the repo pins the interleaved `_R{1,2}_trimming_report`
-    // names, and after #424 the writer and the pre-flight both derive them from
-    // here — so a rename would be self-consistent and invisible everywhere else.
+    // names, and the writer and the pre-flight both derive them from here — so a
+    // rename would be self-consistent and invisible everywhere else.
 
     #[test]
     fn paired_report_names_share_r1s_directory_and_keep_each_mates_filename() {
@@ -978,6 +1029,96 @@ mod tests {
                 .reports
                 .is_none()
         );
+    }
+
+    /// Renders one arm's candidate list, checking every entry names the lone input.
+    fn planned_paths(planned: &[PlannedOutput], input: &str) -> Vec<String> {
+        planned
+            .iter()
+            .map(|(path, src)| {
+                assert_eq!(src.to_string(), input, "every candidate names one input");
+                path.display().to_string()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn interleaved_fastq_planned_lists_every_field_in_every_option_state() {
+        let src = OutputSource::Input(PathBuf::from("ip.bam"));
+        let paths = |retain, reports| {
+            let o = InterleavedFastqOutputs::new(Path::new("ip.bam"), None, false, retain, reports);
+            planned_paths(&o.planned(&src), "ip.bam")
+        };
+
+        assert_eq!(paths(false, false), ["ip_val_1.fq", "ip_val_2.fq"]);
+        assert_eq!(
+            paths(true, false),
+            [
+                "ip_val_1.fq",
+                "ip_val_2.fq",
+                "ip_unpaired_1.fq",
+                "ip_unpaired_2.fq"
+            ]
+        );
+        assert_eq!(
+            paths(false, true),
+            [
+                "ip_val_1.fq",
+                "ip_val_2.fq",
+                "ip_R1_trimming_report.txt",
+                "ip_R1_trimming_report.json",
+                "ip_R2_trimming_report.txt",
+                "ip_R2_trimming_report.json"
+            ]
+        );
+        assert_eq!(
+            paths(true, true),
+            [
+                "ip_val_1.fq",
+                "ip_val_2.fq",
+                "ip_unpaired_1.fq",
+                "ip_unpaired_2.fq",
+                "ip_R1_trimming_report.txt",
+                "ip_R1_trimming_report.json",
+                "ip_R2_trimming_report.txt",
+                "ip_R2_trimming_report.json"
+            ]
+        );
+    }
+
+    #[test]
+    fn interleaved_bam_planned_lists_every_field_in_every_option_state() {
+        let src = OutputSource::Input(PathBuf::from("ip.bam"));
+        let paths = |reports| {
+            let o = InterleavedBamOutputs::new(Path::new("ip.bam"), None, reports);
+            planned_paths(&o.planned(&src), "ip.bam")
+        };
+
+        assert_eq!(paths(false), ["ip_val.bam"]);
+        assert_eq!(
+            paths(true),
+            [
+                "ip_val.bam",
+                "ip_R1_trimming_report.txt",
+                "ip_R1_trimming_report.json",
+                "ip_R2_trimming_report.txt",
+                "ip_R2_trimming_report.json"
+            ]
+        );
+    }
+
+    /// A refusal on these arms names one input. `OutputSource::Pair` would have
+    /// only `Pair(x, x)` to offer, which renders `ip.bam + ip.bam`. The duplicate
+    /// is synthetic: `planned()` cannot produce one (#424).
+    #[test]
+    fn interleaved_refusal_names_one_input() {
+        let src = OutputSource::Input(PathBuf::from("ip.bam"));
+        let one = InterleavedBamOutputs::new(Path::new("ip.bam"), None, false).planned(&src);
+        let err = preflight_output_collisions(&[one[0].clone(), one[0].clone()], &[], None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("named from ip.bam"), "got: {err}");
+        assert!(!err.contains("ip.bam + ip.bam"), "got: {err}");
     }
 
     #[test]

--- a/src/io.rs
+++ b/src/io.rs
@@ -614,6 +614,123 @@ pub fn json_report_name(input: &Path, output_dir: Option<&Path>) -> PathBuf {
     }
 }
 
+/// Text + JSON trimming-report paths for one mate of a **two-file** pair.
+///
+/// Both land in the pair's output directory — R1's parent unless `--output_dir`
+/// overrides — while the filename stays keyed on the mate's own input. Taking
+/// `input_r1` rather than an already-computed directory is the point: a caller
+/// cannot get the directory rule wrong without passing the wrong mate.
+///
+/// Per-mate, not all four paths at once, because the two writer sites build a
+/// `PairedReportFile` per mate and the two candidate sites push txt-then-json
+/// per mate — an order `tests/integration_output_collision.rs` pins.
+pub fn paired_report_names(
+    input: &Path,
+    input_r1: &Path,
+    output_dir: Option<&Path>,
+) -> (PathBuf, PathBuf) {
+    let dir = pair_output_dir(input_r1, output_dir);
+    (
+        report_name(input, Some(&dir)),
+        json_report_name(input, Some(&dir)),
+    )
+}
+
+// ─── Single-file interleaved paired output (#423) ───────────────────────────
+//
+// One derivation per arm, consumed by both the writers and — once #424 lands —
+// the collision pre-flight. Keyed on `file_stem()`, not `file_name()`: these
+// arms have always named their outputs `ip_val_1.fq` from `ip.bam`, where
+// `report_name` would give `ip.bam_trimming_report.txt`. Composing these from
+// `report_name` renames every interleaved report.
+
+/// The two mates' trimming-report paths for a single interleaved pair.
+///
+/// `_R1`/`_R2` infix rather than per-input names, because both mates come from
+/// one input and would otherwise share a path.
+#[derive(Clone, Debug)]
+pub struct InterleavedReports {
+    pub r1_txt: PathBuf,
+    pub r1_json: PathBuf,
+    pub r2_txt: PathBuf,
+    pub r2_json: PathBuf,
+}
+
+impl InterleavedReports {
+    fn new(stem: &str, dir: &Path) -> Self {
+        Self {
+            r1_txt: dir.join(format!("{stem}_R1_trimming_report.txt")),
+            r1_json: dir.join(format!("{stem}_R1_trimming_report.json")),
+            r2_txt: dir.join(format!("{stem}_R2_trimming_report.txt")),
+            r2_json: dir.join(format!("{stem}_R2_trimming_report.json")),
+        }
+    }
+}
+
+/// Every path a FASTQ-output single-file interleaved paired run writes.
+#[derive(Clone, Debug)]
+pub struct InterleavedFastqOutputs {
+    pub val_1: PathBuf,
+    pub val_2: PathBuf,
+    /// `Some` under `--retain_unpaired`.
+    pub unpaired: Option<(PathBuf, PathBuf)>,
+    /// `None` under `--no_report_file`.
+    pub reports: Option<InterleavedReports>,
+}
+
+impl InterleavedFastqOutputs {
+    pub fn new(
+        input: &Path,
+        output_dir: Option<&Path>,
+        gzip: bool,
+        retain_unpaired: bool,
+        reports: bool,
+    ) -> Self {
+        let (stem, dir) = interleaved_stem_and_dir(input, output_dir);
+        let ext = if gzip { ".fq.gz" } else { ".fq" };
+        Self {
+            val_1: dir.join(format!("{stem}_val_1{ext}")),
+            val_2: dir.join(format!("{stem}_val_2{ext}")),
+            unpaired: retain_unpaired.then(|| {
+                (
+                    dir.join(format!("{stem}_unpaired_1{ext}")),
+                    dir.join(format!("{stem}_unpaired_2{ext}")),
+                )
+            }),
+            reports: reports.then(|| InterleavedReports::new(&stem, &dir)),
+        }
+    }
+}
+
+/// Every path a uBAM-output single-file interleaved paired run writes.
+#[derive(Clone, Debug)]
+pub struct InterleavedBamOutputs {
+    pub val: PathBuf,
+    /// `None` under `--no_report_file`.
+    pub reports: Option<InterleavedReports>,
+}
+
+impl InterleavedBamOutputs {
+    pub fn new(input: &Path, output_dir: Option<&Path>, reports: bool) -> Self {
+        let (stem, dir) = interleaved_stem_and_dir(input, output_dir);
+        Self {
+            val: dir.join(format!("{stem}_val.bam")),
+            reports: reports.then(|| InterleavedReports::new(&stem, &dir)),
+        }
+    }
+}
+
+/// Stem and directory shared by both interleaved arms. `pair_output_dir` with
+/// the lone input standing in for R1.
+fn interleaved_stem_and_dir(input: &Path, output_dir: Option<&Path>) -> (String, PathBuf) {
+    let stem = input
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    (stem, pair_output_dir(input, output_dir))
+}
+
 /// ASCII-case-insensitive suffix strip, preserving the case of what remains (#384).
 ///
 /// Byte-wise on purpose: slicing `&str` at `len - suffix.len()` panics when the
@@ -759,6 +876,109 @@ impl Drop for PendingOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── #423: the paired report namers, pinned to literal paths ───────────
+    //
+    // Nothing else in the repo pins the interleaved `_R{1,2}_trimming_report`
+    // names, and after #424 the writer and the pre-flight both derive them from
+    // here — so a rename would be self-consistent and invisible everywhere else.
+
+    #[test]
+    fn paired_report_names_share_r1s_directory_and_keep_each_mates_filename() {
+        let (txt, json) = paired_report_names(
+            Path::new("R2/s_R2.fastq.gz"),
+            Path::new("R1/s_R1.fastq.gz"),
+            None,
+        );
+        assert_eq!(txt, PathBuf::from("R1/s_R2.fastq.gz_trimming_report.txt"));
+        assert_eq!(json, PathBuf::from("R1/s_R2.fastq.gz_trimming_report.json"));
+    }
+
+    #[test]
+    fn paired_report_names_honours_output_dir() {
+        let (txt, json) = paired_report_names(
+            Path::new("R2/s_R2.fastq.gz"),
+            Path::new("R1/s_R1.fastq.gz"),
+            Some(Path::new("out")),
+        );
+        assert_eq!(txt, PathBuf::from("out/s_R2.fastq.gz_trimming_report.txt"));
+        assert_eq!(
+            json,
+            PathBuf::from("out/s_R2.fastq.gz_trimming_report.json")
+        );
+    }
+
+    /// `file_stem`, NOT `file_name`: `report_name` would give
+    /// `ip.bam_trimming_report.txt` and rename every interleaved report.
+    #[test]
+    fn interleaved_outputs_key_on_the_file_stem() {
+        let o = InterleavedFastqOutputs::new(Path::new("d/ip.bam"), None, false, false, true);
+        assert_eq!(o.val_1, PathBuf::from("d/ip_val_1.fq"));
+        assert_eq!(o.val_2, PathBuf::from("d/ip_val_2.fq"));
+        let r = o.reports.unwrap();
+        assert_eq!(r.r1_txt, PathBuf::from("d/ip_R1_trimming_report.txt"));
+        assert_eq!(r.r1_json, PathBuf::from("d/ip_R1_trimming_report.json"));
+        assert_eq!(r.r2_txt, PathBuf::from("d/ip_R2_trimming_report.txt"));
+        assert_eq!(r.r2_json, PathBuf::from("d/ip_R2_trimming_report.json"));
+    }
+
+    /// A `.gz`-*named* BAM: `gzip` is decided from the extension, so the
+    /// primaries gain `.fq.gz` while the stem keeps the inner `.bam`.
+    #[test]
+    fn interleaved_outputs_two_dot_name_with_gzip() {
+        let o = InterleavedFastqOutputs::new(Path::new("ip.bam.gz"), None, true, true, true);
+        assert_eq!(o.val_1, PathBuf::from("ip.bam_val_1.fq.gz"));
+        assert_eq!(
+            o.unpaired.unwrap().1,
+            PathBuf::from("ip.bam_unpaired_2.fq.gz")
+        );
+        assert_eq!(
+            o.reports.unwrap().r1_txt,
+            PathBuf::from("ip.bam_R1_trimming_report.txt")
+        );
+    }
+
+    /// A bare input name yields bare output names: `Path::new("ip.bam").parent()`
+    /// is `Some("")`, so the `unwrap_or(".")` in `pair_output_dir` never fires.
+    #[test]
+    fn interleaved_outputs_bare_filename_stay_bare() {
+        let o = InterleavedFastqOutputs::new(Path::new("ip.bam"), None, false, false, false);
+        assert_eq!(o.val_1, PathBuf::from("ip_val_1.fq"));
+        assert!(o.unpaired.is_none(), "--retain_unpaired was not requested");
+        assert!(o.reports.is_none(), "--no_report_file was in effect");
+    }
+
+    #[test]
+    fn interleaved_outputs_honours_output_dir() {
+        let o = InterleavedFastqOutputs::new(
+            Path::new("d/ip.bam"),
+            Some(Path::new("out")),
+            false,
+            true,
+            true,
+        );
+        assert_eq!(o.val_1, PathBuf::from("out/ip_val_1.fq"));
+        assert_eq!(o.unpaired.unwrap().0, PathBuf::from("out/ip_unpaired_1.fq"));
+        assert_eq!(
+            o.reports.unwrap().r2_json,
+            PathBuf::from("out/ip_R2_trimming_report.json")
+        );
+    }
+
+    #[test]
+    fn interleaved_bam_outputs_name_one_interleaved_primary() {
+        let o = InterleavedBamOutputs::new(Path::new("d/ip.bam"), None, true);
+        assert_eq!(o.val, PathBuf::from("d/ip_val.bam"));
+        assert_eq!(
+            o.reports.unwrap().r1_txt,
+            PathBuf::from("d/ip_R1_trimming_report.txt")
+        );
+        assert!(
+            InterleavedBamOutputs::new(Path::new("d/ip.bam"), None, false)
+                .reports
+                .is_none()
+        );
+    }
 
     #[test]
     fn partial_output_name_wraps_the_whole_file_name() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -852,13 +852,30 @@ fn main() -> Result<()> {
     // Routes through the single-file paired-uBAM helper which sets up its
     // own output paths and calls `BamReader::open_paired_interleaved`.
     if cli.paired && cli.input.len() == 1 {
+        let outputs = naming::InterleavedFastqOutputs::new(
+            &cli.input[0],
+            output_dir,
+            gzip,
+            cli.retain_unpaired,
+            !cli.no_report_file,
+        );
+        // `Input`, not `Pair`: one input means `Pair` could only be `Pair(x, x)`,
+        // which renders `one.bam + one.bam`.
+        let src = naming::OutputSource::Input(cli.input[0].clone());
+        // Ahead of setup_trimming, which scans up to 1 M reads for adapters — a
+        // refusal must not arrive after that wait.
+        naming::preflight_output_collisions(
+            &outputs.planned(&src),
+            &guarded_inputs(&cli),
+            Some(PAIRED_REPORT_HINT),
+        )?;
         let (_label, adapters_r1, adapters_r2, config) = setup_trimming(&cli, &cli.input[0])?;
         run_paired_ubam_single_file(
             &cli,
             &cli.input[0],
+            &outputs,
             &config,
             gzip,
-            output_dir,
             &adapters_r1,
             &adapters_r2,
         )?;
@@ -1802,25 +1819,18 @@ fn run_paired(
 /// containing interleaved R1/R2 records; `BamReader::open_paired_interleaved`
 /// de-interleaves on the fly via the bounded `MAX_SLACK` buffer.
 ///
-/// Output names: derived from the input BAM's stem (`input.bam` →
-/// `input_val_1.fq[.gz]` + `input_val_2.fq[.gz]`).
+/// Output names come in from the caller, which built them for the pre-flight:
+/// the input BAM's stem plus a suffix (`input.bam` → `input_val_1.fq[.gz]`).
 #[allow(clippy::too_many_arguments)]
 fn run_paired_ubam_single_file(
     cli: &Cli,
     input: &Path,
+    outputs: &naming::InterleavedFastqOutputs,
     config: &trimmer::TrimConfig,
     gzip: bool,
-    output_dir: Option<&Path>,
     adapters_r1: &[(String, String)],
     adapters_r2: &[(String, String)],
 ) -> Result<()> {
-    let outputs = naming::InterleavedFastqOutputs::new(
-        input,
-        output_dir,
-        gzip,
-        cli.retain_unpaired,
-        !cli.no_report_file,
-    );
     let output_r1 = outputs.val_1.clone();
     let output_r2 = outputs.val_2.clone();
 
@@ -2003,10 +2013,23 @@ fn run_paired_ubam_single_file(
 fn run_ubam_output(cli: &Cli, output_dir: Option<&Path>, command_line: &str) -> Result<()> {
     // Paired-uBAM single-file de-interleaved input.
     if cli.paired && cli.input.len() == 1 {
+        let outputs =
+            naming::InterleavedBamOutputs::new(&cli.input[0], output_dir, !cli.no_report_file);
+        // `Input`, not `Pair`: one input means `Pair` could only be `Pair(x, x)`,
+        // which renders `one.bam + one.bam`.
+        let src = naming::OutputSource::Input(cli.input[0].clone());
+        // Ahead of setup_trimming, which scans up to 1 M reads for adapters — a
+        // refusal must not arrive after that wait.
+        naming::preflight_output_collisions(
+            &outputs.planned(&src),
+            &guarded_inputs(cli),
+            Some(PAIRED_REPORT_HINT),
+        )?;
         let (_label, adapters_r1, adapters_r2, config) = setup_trimming(cli, &cli.input[0])?;
         return run_ubam_output_paired_single_file(
             cli,
             &cli.input[0],
+            &outputs,
             &config,
             output_dir,
             command_line,
@@ -2410,16 +2433,17 @@ fn run_ubam_output_paired_two_files(
 /// uBAM-output single-file (one interleaved BAM in, one interleaved BAM out)
 /// paired-end driver. Mirrors `run_paired_ubam_single_file`'s shape for the
 /// FASTQ-output path.
+#[allow(clippy::too_many_arguments)]
 fn run_ubam_output_paired_single_file(
     cli: &Cli,
     input: &Path,
+    outputs: &naming::InterleavedBamOutputs,
     config: &trimmer::TrimConfig,
     output_dir: Option<&Path>,
     command_line: &str,
     adapters_r1: &[(String, String)],
     adapters_r2: &[(String, String)],
 ) -> Result<()> {
-    let outputs = naming::InterleavedBamOutputs::new(input, output_dir, !cli.no_report_file);
     let output_path = outputs.val.clone();
 
     eprintln!("Trimming (paired-end, de-interleaved uBAM):");
@@ -2527,10 +2551,9 @@ fn run_ubam_output_paired_single_file(
 
 /// Per-report-side descriptor for the shared `write_paired_reports` helper.
 ///
-/// The two callers (`run_paired` for two-file FASTQ pairs, and
-/// `run_paired_ubam_single_file` for one-file interleaved uBAM) compute their
-/// report paths differently — one from the input file paths, the other from
-/// a synthesised stem — but the report-writing block downstream is identical.
+/// The four callers compute their report paths differently — the two-file pairs
+/// from the input file paths, the two single-file interleaved arms from a
+/// synthesised stem — but the report-writing block downstream is identical.
 /// This struct is the seam.
 struct PairedReportFile {
     txt_path: std::path::PathBuf,
@@ -2543,8 +2566,7 @@ struct PairedReportFile {
 
 /// Write the standard text + JSON paired-end reports for both R1 and R2.
 ///
-/// Centralises the ~50-line duplicated block previously inlined in both
-/// `run_paired` and `run_paired_ubam_single_file`. Pure I/O helper — no
+/// One implementation for all four paired report sites. Pure I/O helper — no
 /// policy or naming logic; callers supply paths via [`PairedReportFile`].
 ///
 /// `passthrough` is `Some((pt_in, pt_out))` only when `--passthrough` is

--- a/src/main.rs
+++ b/src/main.rs
@@ -880,7 +880,6 @@ fn main() -> Result<()> {
             // stem from R1 but its directory from R1 too, and _val_2 mixes both — naming
             // one mate would encode a claim about which supplies the directory.
             let pair_src = naming::OutputSource::Pair(chunk[0].clone(), chunk[1].clone());
-            let pair_dir = naming::pair_output_dir(&chunk[0], output_dir);
             let mut candidates = vec![(o1, pair_src.clone()), (o2, pair_src.clone())];
             if cli.retain_unpaired {
                 let (u1, u2) = naming::unpaired_output_names(
@@ -919,8 +918,9 @@ fn main() -> Result<()> {
             if !cli.no_report_file {
                 for input in [&chunk[0], &chunk[1]] {
                     let src = naming::OutputSource::Input(input.clone());
-                    candidates.push((naming::report_name(input, Some(&pair_dir)), src.clone()));
-                    candidates.push((naming::json_report_name(input, Some(&pair_dir)), src));
+                    let (txt, json) = naming::paired_report_names(input, &chunk[0], output_dir);
+                    candidates.push((txt, src.clone()));
+                    candidates.push((json, src));
                 }
             }
             planned.extend(candidates);
@@ -1737,15 +1737,16 @@ fn run_paired(
 
         // Both mates' reports land where the primaries do (#398). Each keeps its own
         // input-derived filename; only the directory is shared.
-        let pair_dir = naming::pair_output_dir(input_r1, output_dir);
+        let (r1_txt, r1_json) = naming::paired_report_names(input_r1, input_r1, output_dir);
+        let (r2_txt, r2_json) = naming::paired_report_names(input_r2, input_r1, output_dir);
         let r1 = PairedReportFile {
-            txt_path: naming::report_name(input_r1, Some(&pair_dir)),
-            json_path: naming::json_report_name(input_r1, Some(&pair_dir)),
+            txt_path: r1_txt,
+            json_path: r1_json,
             input_filename: all_input_filenames[0].clone(),
         };
         let r2 = PairedReportFile {
-            txt_path: naming::report_name(input_r2, Some(&pair_dir)),
-            json_path: naming::json_report_name(input_r2, Some(&pair_dir)),
+            txt_path: r2_txt,
+            json_path: r2_json,
             input_filename: all_input_filenames[1].clone(),
         };
 
@@ -1813,32 +1814,28 @@ fn run_paired_ubam_single_file(
     adapters_r1: &[(String, String)],
     adapters_r2: &[(String, String)],
 ) -> Result<()> {
-    // Derive output paths from the single BAM input's stem.
-    let stem = input
-        .file_stem()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_string();
-    let ext = if gzip { ".fq.gz" } else { ".fq" };
-    let dir = output_dir
-        .map(|d| d.to_path_buf())
-        .unwrap_or_else(|| input.parent().unwrap_or(Path::new(".")).to_path_buf());
-    let output_r1 = dir.join(format!("{}_val_1{}", stem, ext));
-    let output_r2 = dir.join(format!("{}_val_2{}", stem, ext));
+    let outputs = naming::InterleavedFastqOutputs::new(
+        input,
+        output_dir,
+        gzip,
+        cli.retain_unpaired,
+        !cli.no_report_file,
+    );
+    let output_r1 = outputs.val_1.clone();
+    let output_r2 = outputs.val_2.clone();
 
     eprintln!("Trimming (paired-end, de-interleaved uBAM):");
     eprintln!("  Input:     {}", input.display());
     eprintln!("  Output R1: {}", output_r1.display());
     eprintln!("  Output R2: {}", output_r2.display());
 
-    let (unpaired_r1_path, unpaired_r2_path) = if cli.retain_unpaired {
-        let up1 = dir.join(format!("{}_unpaired_1{}", stem, ext));
-        let up2 = dir.join(format!("{}_unpaired_2{}", stem, ext));
-        eprintln!("  Unpaired R1: {}", up1.display());
-        eprintln!("  Unpaired R2: {}", up2.display());
-        (Some(up1), Some(up2))
-    } else {
-        (None, None)
+    let (unpaired_r1_path, unpaired_r2_path) = match outputs.unpaired.clone() {
+        Some((up1, up2)) => {
+            eprintln!("  Unpaired R1: {}", up1.display());
+            eprintln!("  Unpaired R2: {}", up2.display());
+            (Some(up1), Some(up2))
+        }
+        None => (None, None),
     };
 
     let (stats_r1, stats_r2, pair_stats) = if cli.cores > 1 || cli.clumpify {
@@ -1956,14 +1953,18 @@ fn run_paired_ubam_single_file(
             .to_string();
         let all_input_filenames = vec![input_filename.clone()];
 
+        let reports = outputs
+            .reports
+            .as_ref()
+            .expect("reports were requested, so the namer built them");
         let r1 = PairedReportFile {
-            txt_path: dir.join(format!("{}_R1_trimming_report.txt", stem)),
-            json_path: dir.join(format!("{}_R1_trimming_report.json", stem)),
+            txt_path: reports.r1_txt.clone(),
+            json_path: reports.r1_json.clone(),
             input_filename: input_filename.clone(),
         };
         let r2 = PairedReportFile {
-            txt_path: dir.join(format!("{}_R2_trimming_report.txt", stem)),
-            json_path: dir.join(format!("{}_R2_trimming_report.json", stem)),
+            txt_path: reports.r2_txt.clone(),
+            json_path: reports.r2_json.clone(),
             input_filename: input_filename.clone(),
         };
 
@@ -2034,11 +2035,11 @@ fn run_ubam_output(cli: &Cli, output_dir: Option<&Path>, command_line: &str) -> 
             ));
             // #388 — same report-collision hole as the FASTQ paired path.
             if !cli.no_report_file {
-                let pair_dir = naming::pair_output_dir(&chunk[0], output_dir);
                 for input in [&chunk[0], &chunk[1]] {
                     let src = naming::OutputSource::Input(input.clone());
-                    planned.push((naming::report_name(input, Some(&pair_dir)), src.clone()));
-                    planned.push((naming::json_report_name(input, Some(&pair_dir)), src));
+                    let (txt, json) = naming::paired_report_names(input, &chunk[0], output_dir);
+                    planned.push((txt, src.clone()));
+                    planned.push((json, src));
                 }
             }
         }
@@ -2362,15 +2363,16 @@ fn run_ubam_output_paired_two_files(
             .to_string();
         let all_input_filenames = vec![r1_filename.clone(), r2_filename.clone()];
 
-        let pair_dir = naming::pair_output_dir(input_r1, output_dir);
+        let (r1_txt, r1_json) = naming::paired_report_names(input_r1, input_r1, output_dir);
+        let (r2_txt, r2_json) = naming::paired_report_names(input_r2, input_r1, output_dir);
         let r1_desc = PairedReportFile {
-            txt_path: naming::report_name(input_r1, Some(&pair_dir)),
-            json_path: naming::json_report_name(input_r1, Some(&pair_dir)),
+            txt_path: r1_txt,
+            json_path: r1_json,
             input_filename: r1_filename,
         };
         let r2_desc = PairedReportFile {
-            txt_path: naming::report_name(input_r2, Some(&pair_dir)),
-            json_path: naming::json_report_name(input_r2, Some(&pair_dir)),
+            txt_path: r2_txt,
+            json_path: r2_json,
             input_filename: r2_filename,
         };
 
@@ -2417,17 +2419,8 @@ fn run_ubam_output_paired_single_file(
     adapters_r1: &[(String, String)],
     adapters_r2: &[(String, String)],
 ) -> Result<()> {
-    // Output stem derived from the BAM input's filename, same as the
-    // FASTQ-output single-file paired path.
-    let stem = input
-        .file_stem()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_string();
-    let dir = output_dir
-        .map(|d| d.to_path_buf())
-        .unwrap_or_else(|| input.parent().unwrap_or(Path::new(".")).to_path_buf());
-    let output_path = dir.join(format!("{}_val.bam", stem));
+    let outputs = naming::InterleavedBamOutputs::new(input, output_dir, !cli.no_report_file);
+    let output_path = outputs.val.clone();
 
     eprintln!("Trimming (paired-end, de-interleaved uBAM):");
     eprintln!("  Input:  {}", input.display());
@@ -2486,14 +2479,18 @@ fn run_ubam_output_paired_single_file(
             .to_string();
         let all_input_filenames = vec![input_filename.clone()];
 
+        let reports = outputs
+            .reports
+            .as_ref()
+            .expect("reports were requested, so the namer built them");
         let r1_desc = PairedReportFile {
-            txt_path: dir.join(format!("{}_R1_trimming_report.txt", stem)),
-            json_path: dir.join(format!("{}_R1_trimming_report.json", stem)),
+            txt_path: reports.r1_txt.clone(),
+            json_path: reports.r1_json.clone(),
             input_filename: input_filename.clone(),
         };
         let r2_desc = PairedReportFile {
-            txt_path: dir.join(format!("{}_R2_trimming_report.txt", stem)),
-            json_path: dir.join(format!("{}_R2_trimming_report.json", stem)),
+            txt_path: reports.r2_txt.clone(),
+            json_path: reports.r2_json.clone(),
             input_filename: input_filename.clone(),
         };
 

--- a/tests/integration_preflight_tripwire.rs
+++ b/tests/integration_preflight_tripwire.rs
@@ -61,8 +61,8 @@
 //! while every fixture path stays relative and the child runs with the root as its CWD.
 //!
 //! A new dispatch arm with **no** pre-flight is not detected. `the_site_inventory_is_complete`
-//! catches a 12th call site; an arm that never calls the pre-flight looks like the two
-//! `Arm::Unplanned` cases, which are on record only because someone listed them.
+//! catches a 14th call site; an arm that never calls the pre-flight has nothing to count.
+//! `Arm::Unplanned` is how such an arm goes on record, and only because someone lists it.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -211,13 +211,12 @@ fn parse_planned(stderr: &str) -> Vec<(String, PathBuf)> {
 enum Arm {
     /// Reaches a pre-flight; the full assertion set applies.
     Planned,
-    /// No pre-flight exists on this dispatch path (#414 §2.3). T1 and T5 cannot
-    /// apply; `planned` must be empty, so the day one is added this goes red.
+    /// No pre-flight exists on this dispatch path. T1 and T5 cannot apply; `planned`
+    /// must be empty, so the day one is added this goes red.
     ///
-    /// Safe today only because both such arms derive their stem with
-    /// `Path::file_stem()` and never read `cli.basename`: `file_stem` strips a
-    /// `.`-prefixed extension while every appended suffix starts with `_`, so an output
-    /// can never equal its input. Honouring `--basename` there would break that.
+    /// No case uses it — #424 gave the last two arms a pre-flight — and it is kept as
+    /// the record shape for the next arm that ships without one.
+    /// `comparison_rejects_an_unplanned_arm_that_dumps` is its only driver.
     Unplanned,
 }
 
@@ -262,11 +261,6 @@ impl<'a> Tripwire<'a> {
             guarded,
             arm: Arm::Planned,
         }
-    }
-
-    fn unplanned(mut self) -> Self {
-        self.arm = Arm::Unplanned;
-        self
     }
 
     fn run(self, stage: impl FnOnce(&Path)) -> Outcome {
@@ -315,7 +309,7 @@ impl<'a> Tripwire<'a> {
 }
 
 /// T3 — no pre-existing file's bytes changed, which is #409's harm asserted directly and
-/// the substantive assertion on the `Arm::Unplanned` cases.
+/// the only assertion that applies to an `Arm::Unplanned` case.
 ///
 /// Pure and separate from `compare` so `comparison_detects_a_modified_input` can prove it
 /// fires. Without that, the only proof was a planted mutation in `main.rs` that gets
@@ -1009,41 +1003,50 @@ fn ubam_out_paired_two_files() {
     .run(stage_pair_split);
 }
 
-// ── the two arms with no pre-flight (#414 §2.3) ──────────────────────────────
+// ── the two single-file interleaved arms (#424) ──────────────────────────────
 
 #[test]
-fn orphan_paired_fastq_from_interleaved_bam() {
+fn interleaved_paired_fastq_from_one_bam() {
     Tripwire::new(
-        "orphan_paired_fastq_from_interleaved_bam",
+        "interleaved_paired_fastq_from_one_bam",
         &["--paired", "ip.bam"],
         &["ip.bam"],
     )
-    .unplanned()
     .run(|root| copy_fixture("ubam_paired_test.bam", &root.join("ip.bam")));
+}
+
+/// A `.gz`-*named* BAM. `gzip` is decided from the extension, so the primaries are
+/// `ip.bam_val_{1,2}.fq.gz`: a candidate list that hardcoded `.fq` would pass every
+/// other case here and guard paths this run never writes.
+#[test]
+fn interleaved_paired_fastq_from_gz_named_bam() {
+    Tripwire::new(
+        "interleaved_paired_fastq_from_gz_named_bam",
+        &["--paired", "ip.bam.gz"],
+        &["ip.bam.gz"],
+    )
+    .run(|root| copy_fixture("ubam_paired_test.bam", &root.join("ip.bam.gz")));
 }
 
 /// Legal here — `--retain_unpaired` is refused only for uBAM *output* — and it adds
-/// two more writers to an arm that has no pre-flight, so the full write set is on
-/// record for the follow-up issue.
+/// two more writers, so the full write set stays on record.
 #[test]
-fn orphan_paired_fastq_retain_unpaired() {
+fn interleaved_paired_fastq_retain_unpaired() {
     Tripwire::new(
-        "orphan_paired_fastq_retain_unpaired",
+        "interleaved_paired_fastq_retain_unpaired",
         &["--paired", "--retain_unpaired", "ip.bam"],
         &["ip.bam"],
     )
-    .unplanned()
     .run(|root| copy_fixture("ubam_paired_test.bam", &root.join("ip.bam")));
 }
 
 #[test]
-fn orphan_paired_ubam_from_interleaved_bam() {
+fn interleaved_paired_ubam_from_one_bam() {
     Tripwire::new(
-        "orphan_paired_ubam_from_interleaved_bam",
+        "interleaved_paired_ubam_from_one_bam",
         &["--paired", "--output-format", "ubam", "ip.bam"],
         &["ip.bam"],
     )
-    .unplanned()
     .run(|root| copy_fixture("ubam_paired_test.bam", &root.join("ip.bam")));
 }
 
@@ -1090,6 +1093,37 @@ fn comparison_accepts_overplanning() {
         .expect("planned may legitimately exceed created");
 }
 
+/// The `Arm::Unplanned` branch, which no case reaches since #424. It is the trap for
+/// the next arm recorded as having no pre-flight: the day one is given one, its case
+/// must be promoted rather than left claiming the arm writes unguarded.
+#[test]
+fn comparison_rejects_an_unplanned_arm_that_dumps() {
+    let root = case_root("cmp_promote");
+    let created: BTreeSet<PathBuf> = [PathBuf::from("ip_val_1.fq")].into_iter().collect();
+    let planned = synthetic_planned("src/main.rs:857", &["ip_val_1.fq"]);
+
+    let err = compare(
+        &root,
+        &created,
+        &planned,
+        &["--paired", "ip.bam"],
+        Arm::Unplanned,
+    )
+    .expect_err("an Unplanned arm that dumped candidates must fail");
+    assert!(err.contains("promote the case"), "{err}");
+    assert!(err.contains("src/main.rs:857"), "{err}");
+
+    // And with no dump, the same arm passes — that is what the variant records.
+    compare(
+        &root,
+        &created,
+        &[],
+        &["--paired", "ip.bam"],
+        Arm::Unplanned,
+    )
+    .expect("an arm with no pre-flight and no dump is the recorded state");
+}
+
 #[test]
 fn comparison_rejects_an_empty_run() {
     let root = case_root("cmp_empty");
@@ -1113,8 +1147,8 @@ fn comparison_rejects_a_missing_dump() {
     assert!(err.contains("hook did not fire"), "{err}");
 }
 
-/// T3's standing proof. It is the substantive assertion on the three `Arm::Unplanned`
-/// cases, where T1 and T5 are skipped, so it must not be the one assertion whose ability
+/// T3's standing proof. It is the only assertion that applies on an `Arm::Unplanned`
+/// case, where T1 and T5 are skipped, so it must not be the one assertion whose ability
 /// to fail rests on a mutation that gets reverted.
 #[test]
 fn comparison_detects_a_modified_input() {
@@ -1138,8 +1172,8 @@ fn comparison_detects_a_modified_input() {
     );
 }
 
-/// `every_site_is_reached_by_some_case` proves 11 hand-listed shapes reach 11 *distinct*
-/// sites. It cannot prove 11 is *all* of them — a 12th dispatch arm would leave that test
+/// `every_site_is_reached_by_some_case` proves 13 hand-listed shapes reach 13 *distinct*
+/// sites. It cannot prove 13 is *all* of them — a 14th dispatch arm would leave that test
 /// green while the new arm has no case and no tripwire. That is this bug family one level
 /// up: coverage silently stops extending to a writer.
 ///
@@ -1156,8 +1190,8 @@ fn the_site_inventory_is_complete() {
     .unwrap();
     let calls = src.matches("preflight_output_collisions(").count();
     assert_eq!(
-        calls, 11,
-        "main.rs has {calls} pre-flight call sites, not 11. If one was added, give it a \
+        calls, 13,
+        "main.rs has {calls} pre-flight call sites, not 13. If one was added, give it a \
          case and add its shape to every_site_is_reached_by_some_case, then update this \
          count — do not just update the count."
     );
@@ -1246,14 +1280,18 @@ fn hook_is_inert_when_env_unset_and_that_goes_red() {
         .expect_err("no dump must fail the comparison, not pass it");
 }
 
-/// Turns "all 11 sites are covered" from prose into an assertion. Collects the site
-/// each representative arm dumps and requires 11 distinct values — no line numbers are
+/// Turns "all 13 sites are covered" from prose into an assertion. Collects the site
+/// each representative arm dumps and requires 13 distinct values — no line numbers are
 /// pinned, so unrelated edits to `main.rs` cannot break it.
+///
+/// This is the half of the pair that goes red on a count bumped without a shape added:
+/// `the_site_inventory_is_complete` counts calls in `main.rs`, and only this one proves
+/// a case reaches each.
 #[test]
 fn every_site_is_reached_by_some_case() {
     let root = case_root("site_coverage");
 
-    let shapes: [(&str, &[&str]); 11] = [
+    let shapes: [(&str, &[&str]); 13] = [
         ("se", &["a.fastq"]),
         ("pe", &["--paired", "s_R1.fastq", "s_R2.fastq"]),
         ("ht5", &["--hardtrim5", "20", "a.fastq"]),
@@ -1299,6 +1337,11 @@ fn every_site_is_reached_by_some_case() {
                 "s_R2.fastq",
             ],
         ),
+        ("il_fastq", &["--paired", "ip.bam"]),
+        (
+            "il_ubam",
+            &["--paired", "--output-format", "ubam", "ip.bam"],
+        ),
     ];
 
     let mut sites: BTreeMap<String, &str> = BTreeMap::new();
@@ -1328,8 +1371,8 @@ fn every_site_is_reached_by_some_case() {
 
     assert_eq!(
         sites.len(),
-        11,
-        "expected 11 distinct pre-flight sites, got {sites:?}"
+        13,
+        "expected 13 distinct pre-flight sites, got {sites:?}"
     );
 }
 

--- a/tests/integration_ubam_out.rs
+++ b/tests/integration_ubam_out.rs
@@ -1256,3 +1256,93 @@ fn paired_single_fastq_keeps_its_structural_message() {
         "the #408 guard must not pre-empt the structural check:\n{err}"
     );
 }
+
+// ─── #429 — a write-side read-name refusal names the read ────────────────────
+//
+// Both failures arrive as `io::ErrorKind::InvalidInput`: `@` in a name gives
+// noodles' "invalid input parameter", a 255-byte name gives a wrapped
+// `TryFromIntError`. anyhow prints the whole chain, so those strings stay as the
+// cause — what these assert is the added context, which #429 asked for.
+
+/// A 254-byte name is the SAM limit and must still be accepted, so the refusal
+/// below is the length rule and not an off-by-one.
+#[test]
+fn ubam_out_accepts_a_254_byte_read_name() {
+    let dir = fresh_tmpdir("tg_429_len_254");
+    let name = "n".repeat(254);
+    write_one_record(
+        &dir.join("x.fastq"),
+        &format!("@{name}"),
+        "ACGTACGTACGTACGTACGTACGTACGT",
+    );
+    let (ok, err) = run_in(&dir, &["--output-format", "ubam", "x.fastq"]);
+    assert!(
+        ok,
+        "254 bytes is the SAM limit and must be accepted:\n{err}"
+    );
+}
+
+/// `shown` is what the message must carry. The 255-byte name is over the 60-char
+/// display cap, so it arrives truncated with its byte count — 256, the id including
+/// the `@`.
+#[test]
+fn ubam_out_refusal_names_the_offending_read_name() {
+    let cases: [(&str, String, String); 2] = [
+        (
+            "at_sign",
+            "bad@name".to_string(),
+            "\"@bad@name\"".to_string(),
+        ),
+        (
+            "len_255",
+            "n".repeat(255),
+            format!("\"@{}… (256 bytes)\"", "n".repeat(59)),
+        ),
+    ];
+
+    for (label, name, shown) in cases {
+        let dir = fresh_tmpdir(&format!("tg_429_{label}"));
+        write_one_record(
+            &dir.join("x.fastq"),
+            &format!("@{name}"),
+            "ACGTACGTACGTACGTACGTACGTACGT",
+        );
+        let (ok, err) = run_in(&dir, &["--output-format", "ubam", "x.fastq"]);
+
+        assert!(!ok, "{label}: the record must be refused:\n{err}");
+        assert!(
+            err.contains(&shown),
+            "{label}: the message must name the read as {shown}:\n{err}"
+        );
+        assert!(
+            err.contains("1-254 bytes of printable ASCII"),
+            "{label}: InvalidInput must carry the QNAME rule:\n{err}"
+        );
+    }
+}
+
+/// #415 admits `@`, non-ASCII, VT and over-254-byte names on the FASTQ path,
+/// because none defeats the FASTQ id's splitters. #429 is a message fix, so the
+/// accepted set must not narrow.
+#[test]
+fn fastq_out_still_accepts_the_names_ubam_out_refuses() {
+    for (label, name) in [
+        ("at_sign", "bad@name".to_string()),
+        ("len_255", "n".repeat(255)),
+        ("non_ascii", "ré\u{e4}d".to_string()),
+        ("vt", "rea\u{0b}d".to_string()),
+    ] {
+        let dir = fresh_tmpdir(&format!("tg_429_fastq_{label}"));
+        write_one_record(
+            &dir.join("x.fastq"),
+            &format!("@{name}"),
+            "ACGTACGTACGTACGTACGTACGTACGT",
+        );
+        let (ok, err) = run_in(&dir, &["x.fastq"]);
+        assert!(ok, "{label}: FASTQ output must still accept this:\n{err}");
+        assert!(
+            dir.join("x_trimmed.fq").exists(),
+            "{label}: the trimmed output must exist"
+        );
+    }
+}


### PR DESCRIPTION
`--paired one.bam` and `--paired --output-format ubam one.bam` were the last write-capable dispatch paths with no output-collision pre-flight, and both hand-rolled every output name they wrote. One namer type per arm now produces the writer's paths *and* the pre-flight's candidate list, so the two cannot disagree about what a run writes. Separately, a uBAM write-side read-name refusal now names the read it rejected instead of printing `invalid input parameter` alone. Closes #423, #424, #429.

Two things worth knowing before merge. No output path changes anywhere — #423 is a pure refactor and #424 adds no reachable refusal, because a collision on those two arms is impossible by construction today; the pre-flight is there for the day something honours `--basename` on them. The only user-visible change is #429's message, and it does not narrow the set of read names Trim Galore accepts.

<details>
<summary>AI-assisted detail</summary>

**Why a struct per arm, not report-only namers.** #423 asked for dedicated namers for the report paths. Done literally, the PR whose first commit deletes two copies of the report strings would have left #424 adding two copies of the *primary* strings — `format!("{}_val_1{}", stem, ext)` and friends. So each arm gets one type covering everything it writes, with `--retain_unpaired` and `--no_report_file` as `Option` fields rather than an `if` repeated at each site.

**What actually makes drift a build error.** `planned()` opens with an exhaustive `let Self { val_1, val_2, unpaired, reports } = self;`. A field added later does not compile until it is enumerated, which is the one mechanism here that earns #423's "unrepresentable" — a `Vec` assembled from `self.foo` accessors does not. This bug family (#383, #388, #391, #398, #409) was always a writer whose path never entered the candidate list, and no type can catch that by describing the candidates that *do* exist.

**Provenance is `OutputSource::Input`, never `Pair`.** These arms have one input, so `Pair` could only be `Pair(x, x)`, which `Display` renders as `one.bam + one.bam`. A unit test drives the refusal message directly to pin that it names a single source.

**Why no test provokes the new refusal.** `file_stem()` strips one `.`-suffix and every appended suffix starts with `_`, so an output can never equal its input; one input means no output-vs-output pair; `guarded_inputs` is a singleton because `--passthrough` needs two inputs and `--demux` is single-end. The tests therefore assert the candidate list's *contents* — over every `Option` combination and `--output_dir` — rather than a refusal.

**The `.gz` row is load-bearing.** `gzip` is `is_gzipped(&cli.input[0])`, which is extension-only, so a `.gz`-*named* BAM produces `.fq.gz` primaries. A candidate list hardcoding `.fq` would pass every other tripwire case here while mis-planning every such run, so there is now a `--paired ip.bam.gz` case; the dump confirms it plans `ip.bam_val_1.fq.gz`.

**The tripwire's three `Arm::Unplanned` cases are promoted, and `fn unplanned` deleted.** It was the variant's only constructor, so leaving it turns `dead_code` into a CI failure under `-D warnings`. The variant and `compare`'s early-return branch stay as the record shape for the next arm that ships without a pre-flight, now driven by their own self-test instead of by three live cases. Both site counts move 11 → 13, with the two shapes added before the count — the order the counter's own failure message asks for.

**Four red tests, not five.** The plan and both plan reviewers predicted that both count assertions would go red at step 5. Only `the_site_inventory_is_complete` does; it reads `main.rs` and counts call sites. `every_site_is_reached_by_some_case` counts distinct sites reached by *its own* hand-listed shapes, so giving an unexercised arm a pre-flight is invisible to it. The two are not redundant — the second is what goes red on a count bumped without a shape added.

**#429's design rested on a wrong assumption, and a probe caught it.** The plan held that a wrapped `TryFromIntError` would not land in `ErrorKind::InvalidInput`, so a kind gate could not cover the 255-byte case. Measured: `@` in a name and a 255-byte name both arrive as `InvalidInput`; 254 bytes is accepted, so the boundary is the SAM limit. One `if` covers both. The gate still earns its place by keeping a full disk or a closed pipe from being relabelled a read-name problem — those get the neutral half alone, which already identifies the record.

**The shown id is capped at 60 characters** with the byte count appended when the cap bites, matching how the aux-tag-framing refusal and the dropped-description notice already show an unbounded value. A FASTQ id has no length limit, and the 255-byte case printed 256 characters on one line before this.

**Verification.** 707 → 722 tests on macOS (720 Linux; the platform-specific four are unchanged). #424's five red-then-green tests were watched go red before step 6 fixed them. #429's message test was proved able to fail by planting the old string back. The `.gz` candidate list, both arms' full candidate lists, and the adversarially-named inputs (`x_val_1.fq`, `y_R1_trimming_report.txt` as BAM inputs — both run to exit 0 with inputs byte-intact) were all measured against the built binary rather than inferred.

**Out of scope, deliberately.** `--gzip` (hidden, Perl-era) is still not consulted by the gzip resolution, which stays extension-only. The `--clump_only` report sites use a different naming scheme and are untouched.

</details>
