### PR TITLE
feat(cli): --library presets expand into end clipping (#440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 
 #### Changes
 
+- **`--library <preset>` names a library prep instead of four clip flags**
+  ([#440](https://github.com/FelixKrueger/TrimGalore/issues/440)). `emseq`, `accel` (aliases
+  `swift`, `xgen`), `zymo`, `scbs` (alias `single_cell`) and `pbat` each expand into
+  `--clip_R1` / `--clip_R2` / `--three_prime_clip_R1` / `--three_prime_clip_R2`, and nothing
+  else: adapters stay auto-detected and `--length` is untouched. The values match
+  nf-core/methylseq's presets of the same names, so a run driven through that pipeline and a
+  run driven straight through Trim Galore trim identically.
+
+  A preset is only a clip bundle, which is why `--rrbs`, `--clock` and `--implicon` stay
+  separate flags, and why Tecan/NuGEN Ovation RRBS is absent (diversity trimming is a
+  different algorithm, and it must run *without* `--rrbs`). An explicit clip flag wins over
+  the preset value it displaces, and both numbers are named in the log; a preset that supplies
+  `--clip_R2` suppresses the `--rrbs` directional auto-clip, exactly as an explicit
+  `--clip_R2` already did. Both trimming reports record the preset name and all four values in
+  force (`parameters.library` in JSON, `null` when no preset was used), so preset values can
+  change in a future release (each change gets an entry here) without making an old report
+  ambiguous. A run that passes no `--library` trims exactly as before and its text report is
+  unchanged; the only difference anywhere is the new `"library": null` key in the JSON report.
+
 - **`--clumpify` peak memory drops 13–17% and its banner figures are now labelled MiB**
   ([#439](https://github.com/FelixKrueger/TrimGalore/issues/439)) — the budget is not yet a
   guaranteed bound at large `--memory` values.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -61,6 +61,7 @@ export default defineConfig({
             { label: 'Adapter trimming', slug: 'guide/adapters' },
             { label: 'Length filtering', slug: 'guide/length' },
             { label: 'Paired-end data', slug: 'guide/paired-end' },
+            { label: 'Library presets', slug: 'guide/library-presets' },
             { label: 'Output files', slug: 'guide/outputs' },
             { label: 'Trimming reports', slug: 'guide/reports' },
             { label: 'Flag reference notes', slug: 'guide/flags' },

--- a/docs/src/content/docs/guide/flags.md
+++ b/docs/src/content/docs/guide/flags.md
@@ -11,6 +11,7 @@ A few combinations are worth knowing about:
 
 - **`--small_rna`** lowers the `--length` default to 18 bp (from 20) and auto-sets `--adapter2` to the Illumina small RNA 5' adapter (`GATCGTCGGACT`) for paired-end data, unless the user provides their own `--adapter2` value. The same holds for `--bgiseq`, which auto-sets the BGISEQ-500 Read 2 adapter.
 - **`--rrbs`** in paired-end directional mode auto-sets `--clip_R2 2` to mask the 2 bp end-repair bias at the start of Read 2, unless the user provides their own `--clip_R2` value. `--non_directional` intentionally skips this auto-clip.
+- **`--library <preset>`** expands into the four clip flags for that kit and nothing else (see [Library presets](/guide/library-presets/)). An explicit `--clip_R1` / `--clip_R2` / `--three_prime_clip_R1` / `--three_prime_clip_R2` wins over the preset value it displaces, and both numbers are logged. A preset that supplies `--clip_R2` also suppresses the `--rrbs` auto-clip described above, since the value is already set.
 - **`--paired` + `--length`** discards the whole read pair unless *both* reads pass the length cutoff. To rescue the surviving read when only one becomes too short, add `--retain_unpaired`; the per-side cutoff is governed by `--length_1`/`--length_2` (default 35 bp each).
 - **`--trim-n`** is suppressed under `--rrbs` (matches Perl v0.6.x; N-trimming interacts poorly with RRBS end-repair masking).
 - **`--discard_untrimmed`** keeps only reads where at least one adapter match was found. For paired-end, the pair is discarded only if *neither* read had an adapter.

--- a/docs/src/content/docs/guide/library-presets.md
+++ b/docs/src/content/docs/guide/library-presets.md
@@ -1,0 +1,81 @@
+---
+title: Library presets
+description: One kit name instead of four clip flags, with --library.
+---
+
+Most modern methylation library preps need a fixed number of bases clipped off each read end to mask chemistry artefacts. Getting that wrong biases methylation calls in a way that is easy to miss, and the numbers historically lived in vendor PDFs rather than in the tool.
+
+`--library <preset>` replaces the four clip flags with the kit name:
+
+```bash
+trim_galore --paired --library emseq sample_R1.fq.gz sample_R2.fq.gz
+```
+
+is exactly:
+
+```bash
+trim_galore --paired \
+  --clip_R1 10 --clip_R2 10 \
+  --three_prime_clip_R1 10 --three_prime_clip_R2 10 \
+  sample_R1.fq.gz sample_R2.fq.gz
+```
+
+## Presets
+
+| `--library` | `--clip_R1` | `--clip_R2` | `--three_prime_clip_R1` | `--three_prime_clip_R2` |
+|---|---|---|---|---|
+| `emseq` | 10 | 10 | 10 | 10 |
+| `accel` (aliases `swift`, `xgen`) | 10 | 15 | 10 | 10 |
+| `zymo` | 10 | 10 | 10 | 10 |
+| `scbs` (alias `single_cell`) | 6 | 6 | 6 | 6 |
+| `pbat` | 8 | 8 | 8 | 8 |
+
+`accel` carries aliases because the kit was resold twice: Accel-NGS Methyl-seq, then Swift, now IDT xGen Methyl-seq. The values match [nf-core/methylseq](https://nf-co.re/methylseq)'s presets of the same names, so trimming is identical whether you drive Trim Galore through that pipeline or directly.
+
+## What a preset does *not* set
+
+A preset is 5' and 3' end clipping, and nothing else:
+
+- **No adapter sequence.** Auto-detection runs per pair and would generally pick better than a preset pinning one sequence.
+- **No `--length`.** That is a filtering choice, not a property of the chemistry.
+- **No mode changes.** `--rrbs`, `--clock` and `--implicon` are not presets and stay separate flags, because they change trimming behaviour rather than expanding into four numbers. Tecan/NuGEN Ovation RRBS is absent for the same reason: it needs diversity trimming, a different algorithm, and it must run *without* `--rrbs`. See [When NOT to use `--rrbs`](/modes/rrbs/#when-not-to-use---rrbs).
+
+## Overrides
+
+An explicit clip flag wins over the preset value it displaces, and both numbers appear in the log:
+
+```bash
+trim_galore --library emseq --clip_R1 12 sample.fq.gz
+```
+
+```
+Library preset 'emseq' selected: --clip_R1 12 --clip_R2 10 --three_prime_clip_R1 10 --three_prime_clip_R2 10
+--clip_R1 12 was given on the command line and overrides the emseq preset value 10
+```
+
+Refusing the combination would send you back to writing all four values by hand, which is what the flag exists to remove.
+
+## Reporting and versioning
+
+Both trimming reports record the preset name **and** the four values that were used. The text report:
+
+```
+Library preset: emseq
+Clipping in force: --clip_R1 12 --clip_R2 10 --three_prime_clip_R1 10 --three_prime_clip_R2 10
+--clip_R1 12 was given on the command line and overrides the emseq preset value 10
+```
+
+and the JSON report, under `parameters.library` (`null` when no preset was used):
+
+```json
+"library": {
+  "preset": "emseq",
+  "clip_r1": 12,
+  "clip_r2": 10,
+  "three_prime_clip_r1": 10,
+  "three_prime_clip_r2": 10,
+  "overrides": [{"flag": "--clip_R1", "preset_value": 10, "user_value": 12}]
+}
+```
+
+Preset values may change between releases when vendor guidance moves; every change gets a `CHANGELOG.md` entry. Because the expanded numbers are in the report, an old run stays reproducible from its own record.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,6 +135,14 @@ pub struct Cli {
     #[clap(long = "three_prime_clip_R2", alias = "three_prime_clip_r2")]
     pub three_prime_clip_r2: Option<usize>,
 
+    /// Library-prep preset: expands into the four end-clipping values that kit needs
+    /// (emseq, accel [swift/xgen], zymo, scbs [single_cell], pbat). Nothing else is set:
+    /// adapters stay auto-detected and --length is untouched. An explicit clip flag wins
+    /// over the preset value it displaces, and both numbers are named in the log and in
+    /// the trimming reports. Presets may change between releases; see CHANGELOG.md.
+    #[clap(long = "library", value_name = "PRESET")]
+    pub library: Option<crate::library::LibraryPreset>,
+
     /// NextSeq/NovaSeq 2-colour quality trimming. Trailing high-quality G bases
     /// are treated as no-signal artifacts and quality-trimmed. The value is the
     /// quality cutoff (replaces -q). Mutually exclusive with --quality.
@@ -838,6 +846,9 @@ impl Cli {
                     "--clump_only does not clip; --three_prime_clip_r2 is not compatible"
                 );
             }
+            if self.library.is_some() {
+                anyhow::bail!("--clump_only does not clip; --library is not compatible");
+            }
             // RRBS
             if self.rrbs {
                 anyhow::bail!("--clump_only does not trim; --rrbs is not compatible");
@@ -1140,6 +1151,24 @@ impl Cli {
     /// Otherwise uses the standard `--quality` value.
     pub fn effective_quality_cutoff(&self) -> u8 {
         self.nextseq.unwrap_or(self.quality)
+    }
+
+    /// Fold a `--library` preset (if any) into the four clip flags (#440).
+    ///
+    /// Every consumer of the clip values goes through here, so a preset cannot
+    /// reach one code path and miss another. The returned value also carries the
+    /// preset name and each displaced number, which is what the log line and both
+    /// trimming reports print.
+    pub fn effective_clips(&self) -> crate::library::ResolvedClips {
+        crate::library::resolve(
+            self.library,
+            crate::library::UserClips {
+                clip_r1: self.clip_r1,
+                clip_r2: self.clip_r2,
+                three_prime_clip_r1: self.three_prime_clip_r1,
+                three_prime_clip_r2: self.three_prime_clip_r2,
+            },
+        )
     }
 }
 
@@ -1618,6 +1647,86 @@ mod tests {
         assert_eq!(cli.clip_r2, Some(2));
         assert_eq!(cli.three_prime_clip_r1, Some(3));
         assert_eq!(cli.three_prime_clip_r2, Some(4));
+    }
+
+    // ── --library presets (#440) ─────────────────────────────────────────
+
+    /// The whole point of the flag: four clip values from one kit name.
+    #[test]
+    fn test_library_preset_supplies_all_four_clip_values() {
+        let cli = Cli::parse_from(["trim_galore", "--paired", "--library", "accel", R1, R2]);
+        let clips = cli.effective_clips();
+        assert_eq!(clips.clip_r1, Some(10));
+        assert_eq!(clips.clip_r2, Some(15));
+        assert_eq!(clips.three_prime_clip_r1, Some(10));
+        assert_eq!(clips.three_prime_clip_r2, Some(10));
+    }
+
+    /// Accel-NGS was resold as Swift and then as IDT xGen; all three names
+    /// have to land on the same preset.
+    #[test]
+    fn test_library_accel_aliases() {
+        for name in ["accel", "swift", "xgen"] {
+            let cli = Cli::parse_from(["trim_galore", "--library", name, R1]);
+            assert_eq!(
+                cli.library,
+                Some(crate::library::LibraryPreset::Accel),
+                "alias {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_library_scbs_aliases() {
+        for name in ["scbs", "single_cell", "single-cell"] {
+            let cli = Cli::parse_from(["trim_galore", "--library", name, R1]);
+            assert_eq!(
+                cli.library,
+                Some(crate::library::LibraryPreset::ScBs),
+                "alias {name}"
+            );
+        }
+    }
+
+    /// Explicit wins. An error here would push the user back to writing all
+    /// four values by hand, which is what the preset exists to remove.
+    #[test]
+    fn test_explicit_clip_flag_overrides_the_preset() {
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--paired",
+            "--library",
+            "emseq",
+            "--clip_R1",
+            "12",
+            R1,
+            R2,
+        ]);
+        cli.validate().expect("override is legal, not an error");
+        let clips = cli.effective_clips();
+        assert_eq!(clips.clip_r1, Some(12));
+        assert_eq!(clips.clip_r2, Some(10));
+        assert_eq!(clips.overrides.len(), 1);
+        assert_eq!(clips.overrides[0].preset_value, 10);
+        assert_eq!(clips.overrides[0].user_value, 12);
+    }
+
+    /// An unknown kit name must fail at parse time rather than trim silently
+    /// with no clipping at all.
+    #[test]
+    fn test_unknown_library_preset_is_rejected() {
+        assert!(Cli::try_parse_from(["trim_galore", "--library", "nugen", R1]).is_err());
+    }
+
+    /// `--clump_only` rejects every clip flag; a preset is four of them.
+    #[test]
+    fn test_clump_only_rejects_library() {
+        let cli = Cli::parse_from(["trim_galore", "--clump_only", "--library", "emseq", R1]);
+        let err = cli.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("--library"),
+            "expected --library incompatibility, got: {err}"
+        );
     }
 
     // ── --clumpify / --compression validation ────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod fastqc;
 pub mod filters;
 pub mod format;
 pub mod io;
+pub mod library;
 pub mod parallel;
 pub mod quality;
 pub mod report;

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,0 +1,283 @@
+//! Library-prep presets (`--library <name>`), issue
+//! [#440](https://github.com/FelixKrueger/TrimGalore/issues/440).
+//!
+//! A preset is nothing more than four end-clipping numbers under a kit name. The
+//! membership criterion is deliberately narrow: a prep belongs here only if it
+//! expands *purely* into 5'/3' clipping. That is why `--rrbs` stays its own flag
+//! (it also changes adapter-trim behaviour and composes with `--non_directional`),
+//! why `--clock` and `--implicon` stay out (they encode UMIs into read IDs), and
+//! why NuGEN Ovation RRBS is absent (diversity trimming is a different algorithm,
+//! and it must run *without* `--rrbs`).
+//!
+//! The numbers match nf-core/methylseq's presets of the same names, so a run
+//! driven through that pipeline and a run driven straight through Trim Galore
+//! trim identically.
+//!
+//! Presets may change between releases (see `CHANGELOG.md`). That is safe because
+//! both trimming reports record the expanded values, so an old report stays
+//! self-describing and a past run is reproducible from its own record.
+
+/// The four end-clipping values a preset expands into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PresetClips {
+    pub clip_r1: usize,
+    pub clip_r2: usize,
+    pub three_prime_clip_r1: usize,
+    pub three_prime_clip_r2: usize,
+}
+
+/// A library-prep preset selected with `--library`.
+///
+/// One enum rather than one boolean per kit: a prep is a single choice, and an
+/// enum makes "two kits at once" unrepresentable instead of needing a conflict
+/// rule for every pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum LibraryPreset {
+    /// NEBNext Enzymatic Methyl-seq (EM-seq).
+    #[value(name = "emseq", alias = "em_seq", alias = "em-seq")]
+    EmSeq,
+    /// Accel-NGS Methyl-seq, sold as Swift and now as IDT xGen Methyl-seq.
+    /// Aliased because the vendor renamed twice and users reach for whichever
+    /// name they bought it under.
+    #[value(name = "accel", alias = "swift", alias = "xgen")]
+    Accel,
+    /// Zymo-Seq / Pico Methyl-Seq.
+    #[value(name = "zymo")]
+    Zymo,
+    /// Single-cell BS-seq (scBS-seq).
+    #[value(name = "scbs", alias = "single_cell", alias = "single-cell")]
+    ScBs,
+    /// Post-Bisulfite Adapter Tagging.
+    #[value(name = "pbat")]
+    Pbat,
+}
+
+impl LibraryPreset {
+    /// The name printed in reports and log lines, whichever alias was typed.
+    pub fn canonical_name(self) -> &'static str {
+        match self {
+            LibraryPreset::EmSeq => "emseq",
+            LibraryPreset::Accel => "accel",
+            LibraryPreset::Zymo => "zymo",
+            LibraryPreset::ScBs => "scbs",
+            LibraryPreset::Pbat => "pbat",
+        }
+    }
+
+    /// The clipping this preset expands into.
+    pub fn clips(self) -> PresetClips {
+        let (c1, c2, t1, t2) = match self {
+            LibraryPreset::EmSeq => (10, 10, 10, 10),
+            LibraryPreset::Accel => (10, 15, 10, 10),
+            LibraryPreset::Zymo => (10, 10, 10, 10),
+            LibraryPreset::ScBs => (6, 6, 6, 6),
+            LibraryPreset::Pbat => (8, 8, 8, 8),
+        };
+        PresetClips {
+            clip_r1: c1,
+            clip_r2: c2,
+            three_prime_clip_r1: t1,
+            three_prime_clip_r2: t2,
+        }
+    }
+}
+
+/// One clip flag given on the command line over a preset that also sets it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClipOverride {
+    /// Flag name as the user would type it, e.g. `--clip_R1`.
+    pub flag: &'static str,
+    pub preset_value: usize,
+    pub user_value: usize,
+}
+
+/// The four clip values a user typed, before any preset is folded in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct UserClips {
+    pub clip_r1: Option<usize>,
+    pub clip_r2: Option<usize>,
+    pub three_prime_clip_r1: Option<usize>,
+    pub three_prime_clip_r2: Option<usize>,
+}
+
+/// Clipping in force for a run, plus the provenance the reports need.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedClips {
+    /// `None` when no `--library` was given; the other fields are then just the
+    /// user's own values passed through.
+    pub preset: Option<LibraryPreset>,
+    pub clip_r1: Option<usize>,
+    pub clip_r2: Option<usize>,
+    pub three_prime_clip_r1: Option<usize>,
+    pub three_prime_clip_r2: Option<usize>,
+    /// Flags the user set that a preset would otherwise have supplied.
+    pub overrides: Vec<ClipOverride>,
+}
+
+impl ResolvedClips {
+    /// The clipping in force, rendered as the command line that would reproduce
+    /// it. Printed in the log and in both trimming reports, so a run stays
+    /// reproducible from its own record even if the preset changes later.
+    pub fn flag_summary(&self) -> String {
+        let mut parts = Vec::new();
+        for (flag, value) in [
+            ("--clip_R1", self.clip_r1),
+            ("--clip_R2", self.clip_r2),
+            ("--three_prime_clip_R1", self.three_prime_clip_r1),
+            ("--three_prime_clip_R2", self.three_prime_clip_r2),
+        ] {
+            if let Some(v) = value {
+                parts.push(format!("{flag} {v}"));
+            }
+        }
+        parts.join(" ")
+    }
+
+    /// True when any of the four values is set, from either source.
+    pub fn any_set(&self) -> bool {
+        self.clip_r1.is_some()
+            || self.clip_r2.is_some()
+            || self.three_prime_clip_r1.is_some()
+            || self.three_prime_clip_r2.is_some()
+    }
+}
+
+/// Fold a preset (if any) into the user's clip flags.
+///
+/// Explicit wins, and every displaced value is recorded so the log and the
+/// reports can name both numbers. An error instead of an override would push the
+/// user back to writing all four values by hand, which is the thing presets exist
+/// to remove; it also matches what `--rrbs` already does with `--clip_R2`.
+pub fn resolve(preset: Option<LibraryPreset>, user: UserClips) -> ResolvedClips {
+    let Some(preset) = preset else {
+        return ResolvedClips {
+            preset: None,
+            clip_r1: user.clip_r1,
+            clip_r2: user.clip_r2,
+            three_prime_clip_r1: user.three_prime_clip_r1,
+            three_prime_clip_r2: user.three_prime_clip_r2,
+            overrides: Vec::new(),
+        };
+    };
+
+    let clips = preset.clips();
+    let mut overrides = Vec::new();
+    let mut pick =
+        |flag: &'static str, user_value: Option<usize>, preset_value: usize| match user_value {
+            Some(v) => {
+                overrides.push(ClipOverride {
+                    flag,
+                    preset_value,
+                    user_value: v,
+                });
+                Some(v)
+            }
+            None => Some(preset_value),
+        };
+
+    ResolvedClips {
+        preset: Some(preset),
+        clip_r1: pick("--clip_R1", user.clip_r1, clips.clip_r1),
+        clip_r2: pick("--clip_R2", user.clip_r2, clips.clip_r2),
+        three_prime_clip_r1: pick(
+            "--three_prime_clip_R1",
+            user.three_prime_clip_r1,
+            clips.three_prime_clip_r1,
+        ),
+        three_prime_clip_r2: pick(
+            "--three_prime_clip_R2",
+            user.three_prime_clip_r2,
+            clips.three_prime_clip_r2,
+        ),
+        overrides,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The table in issue #440, verbatim. These numbers are the feature.
+    #[test]
+    fn preset_table_matches_the_agreed_numbers() {
+        let expect = |p: LibraryPreset, c1, c2, t1, t2| {
+            assert_eq!(
+                p.clips(),
+                PresetClips {
+                    clip_r1: c1,
+                    clip_r2: c2,
+                    three_prime_clip_r1: t1,
+                    three_prime_clip_r2: t2,
+                },
+                "{} preset",
+                p.canonical_name()
+            );
+        };
+        expect(LibraryPreset::EmSeq, 10, 10, 10, 10);
+        expect(LibraryPreset::Accel, 10, 15, 10, 10);
+        expect(LibraryPreset::Zymo, 10, 10, 10, 10);
+        expect(LibraryPreset::ScBs, 6, 6, 6, 6);
+        expect(LibraryPreset::Pbat, 8, 8, 8, 8);
+    }
+
+    #[test]
+    fn preset_supplies_all_four_values_when_user_gave_none() {
+        let r = resolve(Some(LibraryPreset::Accel), UserClips::default());
+        assert_eq!(r.clip_r1, Some(10));
+        assert_eq!(r.clip_r2, Some(15));
+        assert_eq!(r.three_prime_clip_r1, Some(10));
+        assert_eq!(r.three_prime_clip_r2, Some(10));
+        assert!(r.overrides.is_empty());
+    }
+
+    #[test]
+    fn explicit_clip_flag_wins_over_the_preset() {
+        let r = resolve(
+            Some(LibraryPreset::EmSeq),
+            UserClips {
+                clip_r1: Some(12),
+                ..UserClips::default()
+            },
+        );
+        assert_eq!(r.clip_r1, Some(12));
+        assert_eq!(
+            r.clip_r2,
+            Some(10),
+            "untouched values still come from preset"
+        );
+    }
+
+    #[test]
+    fn an_override_records_both_values() {
+        let r = resolve(
+            Some(LibraryPreset::EmSeq),
+            UserClips {
+                clip_r1: Some(12),
+                ..UserClips::default()
+            },
+        );
+        assert_eq!(
+            r.overrides,
+            vec![ClipOverride {
+                flag: "--clip_R1",
+                preset_value: 10,
+                user_value: 12,
+            }]
+        );
+    }
+
+    #[test]
+    fn without_a_preset_user_values_pass_through_untouched() {
+        let r = resolve(
+            None,
+            UserClips {
+                clip_r2: Some(4),
+                ..UserClips::default()
+            },
+        );
+        assert_eq!(r.preset, None);
+        assert_eq!(r.clip_r1, None);
+        assert_eq!(r.clip_r2, Some(4));
+        assert!(r.overrides.is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,14 +386,11 @@ fn main() -> Result<()> {
     // clip-flag list must match every `--rename`-driven `append_to_id` site
     // (`trimmer.rs` clip_5/clip_3, `specialty.rs` hardtrim) — without one of them
     // set, `--rename` appends nothing and there is nothing to lose.
+    // The clip list reads through `effective_clips()` so a `--library` preset
+    // (#440) counts here exactly as the four flags it stands in for would.
     if cli.rename
         && matches!(cli.output_format, trim_galore::cli::OutputFormat::UBam)
-        && (cli.clip_r1.is_some()
-            || cli.clip_r2.is_some()
-            || cli.three_prime_clip_r1.is_some()
-            || cli.three_prime_clip_r2.is_some()
-            || cli.hardtrim5.is_some()
-            || cli.hardtrim3.is_some())
+        && (cli.effective_clips().any_set() || cli.hardtrim5.is_some() || cli.hardtrim3.is_some())
         && input_formats
             .iter()
             .any(|f| !matches!(f, InputFormat::UnalignedBam))
@@ -1113,14 +1110,36 @@ fn setup_trimming(cli: &Cli, input_file: &Path) -> SetupResult {
         }
     });
 
-    // RRBS: auto-set --clip_r2 2 for directional paired-end mode
-    let clip_r2 = if cli.rrbs && !cli.non_directional && cli.paired && cli.clip_r2.is_none() {
+    // #440 — fold a `--library` preset into the four clip flags. Every clip
+    // consumer below reads `clips`, never `cli.clip_*`, so a preset cannot reach
+    // one path and miss another.
+    let clips = cli.effective_clips();
+    if let Some(preset) = clips.preset {
+        eprintln!(
+            "Library preset '{}' selected: {}",
+            preset.canonical_name(),
+            clips.flag_summary()
+        );
+        for o in &clips.overrides {
+            eprintln!(
+                "{} {} was given on the command line and overrides the {} preset value {}",
+                o.flag,
+                o.user_value,
+                preset.canonical_name(),
+                o.preset_value
+            );
+        }
+    }
+
+    // RRBS: auto-set --clip_r2 2 for directional paired-end mode. A preset that
+    // supplies clip_R2 counts as "already set", same as an explicit flag.
+    let clip_r2 = if cli.rrbs && !cli.non_directional && cli.paired && clips.clip_r2.is_none() {
         eprintln!(
             "Setting the option '--clip_r2 2' (to remove methylation bias from the start of Read 2)"
         );
         Some(2)
     } else {
-        cli.clip_r2
+        clips.clip_r2
     };
 
     if cli.rrbs {
@@ -1201,10 +1220,10 @@ fn setup_trimming(cli: &Cli, input_file: &Path) -> SetupResult {
         max_length: cli.max_length,
         max_n,
         trim_n: cli.trim_n,
-        clip_r1: cli.clip_r1,
+        clip_r1: clips.clip_r1,
         clip_r2,
-        three_prime_clip_r1: cli.three_prime_clip_r1,
-        three_prime_clip_r2: cli.three_prime_clip_r2,
+        three_prime_clip_r1: clips.three_prime_clip_r1,
+        three_prime_clip_r2: clips.three_prime_clip_r2,
         rename: cli.rename,
         nextseq: cli.nextseq.is_some(),
         rrbs: cli.rrbs,
@@ -1449,6 +1468,7 @@ fn run_single_file(
             command_line: std::env::args().collect::<Vec<_>>().join(" "),
             input_filename: input_filename.clone(),
             input_filenames: vec![input_filename.clone()],
+            library: Some(cli.effective_clips()),
         };
 
         let file = File::create(&report_path)?;
@@ -2238,6 +2258,7 @@ fn run_ubam_output_single(
             command_line: command_line.to_string(),
             input_filename: input_filename.clone(),
             input_filenames: vec![input_filename.clone()],
+            library: Some(cli.effective_clips()),
         };
 
         let file = File::create(&report_path)?;
@@ -2616,6 +2637,7 @@ fn write_paired_reports(
             command_line: std::env::args().collect::<Vec<_>>().join(" "),
             input_filename: descriptor.input_filename.clone(),
             input_filenames: all_input_filenames.to_vec(),
+            library: Some(cli.effective_clips()),
         };
 
         let file = File::create(&descriptor.txt_path)?;

--- a/src/report.rs
+++ b/src/report.rs
@@ -183,6 +183,9 @@ pub struct TrimConfig {
     pub input_filename: String,
     /// All input filenames — SE: one element, PE: both R1 and R2. Used in JSON report.
     pub input_filenames: Vec<String>,
+    /// `--library` preset and the clipping it expanded into (#440). `None` when
+    /// no preset was selected; the reports then say nothing about presets.
+    pub library: Option<crate::library::ResolvedClips>,
 }
 
 /// Write the trimming report header (parameter summary).
@@ -266,6 +269,24 @@ pub fn write_report_header<W: Write>(w: &mut W, config: &TrimConfig) -> std::io:
     }
     if config.trim_n {
         writeln!(w, "Removing Ns from the end of reads")?;
+    }
+    // #440 — a preset may change between releases, so the report records the
+    // expanded numbers rather than just the kit name it was asked for.
+    if let Some(library) = &config.library
+        && let Some(preset) = library.preset
+    {
+        writeln!(w, "Library preset: {}", preset.canonical_name())?;
+        writeln!(w, "Clipping in force: {}", library.flag_summary())?;
+        for o in &library.overrides {
+            writeln!(
+                w,
+                "{} {} was given on the command line and overrides the {} preset value {}",
+                o.flag,
+                o.user_value,
+                preset.canonical_name(),
+                o.preset_value
+            )?;
+        }
     }
     if config.rrbs {
         writeln!(
@@ -835,6 +856,50 @@ pub fn write_json_report<W: Write>(
     json_bool(w, i2, "non_directional", config.non_directional, true)?;
     json_bool(w, i2, "poly_a", config.poly_a, true)?;
     json_bool(w, i2, "poly_g", config.poly_g, true)?;
+    // #440 — `null` unless a `--library` preset was selected. The four values
+    // repeated here are the ones in force, overrides included, so a consumer
+    // never has to reconstruct them from the preset name.
+    match config.library.as_ref().and_then(|l| {
+        let preset = l.preset?;
+        Some((preset, l))
+    }) {
+        Some((preset, library)) => {
+            writeln!(w, "{}\"library\": {{", i2)?;
+            json_str(w, i3, "preset", preset.canonical_name(), true)?;
+            json_opt_int(w, i3, "clip_r1", library.clip_r1, true)?;
+            json_opt_int(w, i3, "clip_r2", library.clip_r2, true)?;
+            json_opt_int(
+                w,
+                i3,
+                "three_prime_clip_r1",
+                library.three_prime_clip_r1,
+                true,
+            )?;
+            json_opt_int(
+                w,
+                i3,
+                "three_prime_clip_r2",
+                library.three_prime_clip_r2,
+                true,
+            )?;
+            write!(w, "{}\"overrides\": [", i3)?;
+            for (i, o) in library.overrides.iter().enumerate() {
+                write!(
+                    w,
+                    "{{\"flag\": \"{}\", \"preset_value\": {}, \"user_value\": {}}}",
+                    json_escape_string(o.flag),
+                    o.preset_value,
+                    o.user_value
+                )?;
+                if i + 1 < library.overrides.len() {
+                    write!(w, ", ")?;
+                }
+            }
+            writeln!(w, "]")?;
+            writeln!(w, "{}}},", i2)?;
+        }
+        None => writeln!(w, "{}\"library\": null,", i2)?,
+    }
     json_opt_int(w, i2, "clip_r1", extra.clip_r1, true)?;
     json_opt_int(w, i2, "clip_r2", extra.clip_r2, true)?;
     json_opt_int(
@@ -1299,7 +1364,115 @@ mod tests {
             command_line: "trim_galore sample.fq.gz".to_string(),
             input_filename: "sample.fq.gz".to_string(),
             input_filenames: vec!["sample.fq.gz".to_string()],
+            library: None,
         }
+    }
+
+    // ── --library preset reporting (#440) ────────────────────────────────
+
+    /// A preset is only safe to change between releases if every report says
+    /// which numbers the run actually used. Text report, name plus all four.
+    #[test]
+    fn test_text_report_records_preset_name_and_expanded_values() {
+        let mut config = test_config();
+        config.paired = true;
+        config.library = Some(crate::library::resolve(
+            Some(crate::library::LibraryPreset::Accel),
+            crate::library::UserClips::default(),
+        ));
+
+        let mut buf = Vec::new();
+        write_report_header(&mut buf, &config).unwrap();
+        let text = String::from_utf8(buf).unwrap();
+
+        assert!(text.contains("Library preset: accel"), "got:\n{text}");
+        assert!(
+            text.contains(
+                "--clip_R1 10 --clip_R2 15 --three_prime_clip_R1 10 --three_prime_clip_R2 10"
+            ),
+            "got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn test_text_report_names_both_values_for_an_override() {
+        let mut config = test_config();
+        config.library = Some(crate::library::resolve(
+            Some(crate::library::LibraryPreset::EmSeq),
+            crate::library::UserClips {
+                clip_r1: Some(12),
+                ..crate::library::UserClips::default()
+            },
+        ));
+
+        let mut buf = Vec::new();
+        write_report_header(&mut buf, &config).unwrap();
+        let text = String::from_utf8(buf).unwrap();
+
+        assert!(text.contains("--clip_R1 12"), "user value missing:\n{text}");
+        assert!(
+            text.contains("preset value 10"),
+            "displaced preset value missing:\n{text}"
+        );
+    }
+
+    #[test]
+    fn test_text_report_says_nothing_about_presets_when_none_selected() {
+        let config = test_config();
+        let mut buf = Vec::new();
+        write_report_header(&mut buf, &config).unwrap();
+        let text = String::from_utf8(buf).unwrap();
+        assert!(!text.contains("Library preset"), "got:\n{text}");
+    }
+
+    #[test]
+    fn test_json_report_records_library_block() {
+        let mut config = test_config();
+        config.library = Some(crate::library::resolve(
+            Some(crate::library::LibraryPreset::EmSeq),
+            crate::library::UserClips {
+                clip_r1: Some(12),
+                ..crate::library::UserClips::default()
+            },
+        ));
+        let extra = JsonReportParams {
+            clip_r1: Some(12),
+            clip_r2: Some(10),
+            three_prime_clip_r1: Some(10),
+            three_prime_clip_r2: Some(10),
+            ..test_extra_params()
+        };
+
+        let mut buf = Vec::new();
+        write_json_report(&mut buf, &config, &test_stats(), None, 1, &extra).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+
+        let lib = &json["parameters"]["library"];
+        assert_eq!(lib["preset"], "emseq");
+        assert_eq!(lib["clip_r1"], 12);
+        assert_eq!(lib["clip_r2"], 10);
+        assert_eq!(lib["three_prime_clip_r1"], 10);
+        assert_eq!(lib["three_prime_clip_r2"], 10);
+        assert_eq!(lib["overrides"][0]["flag"], "--clip_R1");
+        assert_eq!(lib["overrides"][0]["preset_value"], 10);
+        assert_eq!(lib["overrides"][0]["user_value"], 12);
+    }
+
+    #[test]
+    fn test_json_report_library_is_null_without_a_preset() {
+        let config = test_config();
+        let mut buf = Vec::new();
+        write_json_report(
+            &mut buf,
+            &config,
+            &test_stats(),
+            None,
+            1,
+            &test_extra_params(),
+        )
+        .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert!(json["parameters"]["library"].is_null());
     }
 
     /// Helper to build minimal JsonReportParams for testing.

--- a/tests/integration_library.rs
+++ b/tests/integration_library.rs
@@ -1,0 +1,225 @@
+//! Binary-driven integration tests for `--library` presets
+//! (issue [#440](https://github.com/FelixKrueger/TrimGalore/issues/440)).
+//!
+//! A preset is only worth having if `--library <kit>` and the four clip flags it
+//! stands for produce the same bytes, so the load-bearing test here is a
+//! differential one against hand-written flags rather than an assertion about
+//! internal state. The reporting tests are end-to-end for the same reason the
+//! `-a2` suite is: the defect class this feature can hit is "one dispatch path
+//! never reads the preset", which no unit test of the resolver can catch.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_trim_galore"))
+}
+
+fn tempdir(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir().join(format!("tg_library_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+const R1: &str = "test_files/BS-seq_10K_R1.fastq.gz";
+const R2: &str = "test_files/BS-seq_10K_R2.fastq.gz";
+
+fn run(args: &[&str]) -> (bool, String) {
+    let out = Command::new(binary())
+        .args(args)
+        .output()
+        .expect("failed to run trim_galore");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn read(path: &Path) -> Vec<u8> {
+    std::fs::read(path).unwrap_or_else(|e| panic!("{} unreadable: {e}", path.display()))
+}
+
+fn report_text(dir: &Path) -> String {
+    String::from_utf8_lossy(&read(
+        &dir.join("BS-seq_10K_R1.fastq.gz_trimming_report.txt"),
+    ))
+    .to_string()
+}
+
+fn report_json(dir: &Path) -> serde_json::Value {
+    serde_json::from_slice(&read(
+        &dir.join("BS-seq_10K_R1.fastq.gz_trimming_report.json"),
+    ))
+    .expect("JSON report is not valid JSON")
+}
+
+/// The contract in one test: a preset is exactly its four clip flags.
+#[test]
+fn preset_output_is_identical_to_the_flags_it_stands_for() {
+    let preset_dir = tempdir("accel_preset");
+    let flags_dir = tempdir("accel_flags");
+
+    let (ok, err) = run(&[
+        "--paired",
+        "--dont_gzip",
+        "--library",
+        "accel",
+        "-o",
+        preset_dir.to_str().unwrap(),
+        R1,
+        R2,
+    ]);
+    assert!(ok, "preset run failed:\n{err}");
+
+    let (ok, err) = run(&[
+        "--paired",
+        "--dont_gzip",
+        "--clip_R1",
+        "10",
+        "--clip_R2",
+        "15",
+        "--three_prime_clip_R1",
+        "10",
+        "--three_prime_clip_R2",
+        "10",
+        "-o",
+        flags_dir.to_str().unwrap(),
+        R1,
+        R2,
+    ]);
+    assert!(ok, "explicit-flag run failed:\n{err}");
+
+    for name in ["BS-seq_10K_R1_val_1.fq", "BS-seq_10K_R2_val_2.fq"] {
+        assert_eq!(
+            read(&preset_dir.join(name)),
+            read(&flags_dir.join(name)),
+            "{name} differs between --library accel and its four clip flags"
+        );
+    }
+}
+
+/// Non-vacuity: the preset must actually change the reads. Without this, the
+/// equivalence test above would still pass if presets did nothing at all.
+#[test]
+fn preset_changes_the_output_relative_to_no_clipping() {
+    let with_preset = tempdir("scbs_on");
+    let without = tempdir("scbs_off");
+
+    for (dir, extra) in [
+        (&with_preset, vec!["--library", "scbs"]),
+        (&without, vec![]),
+    ] {
+        let mut args = vec!["--dont_gzip", "-o", dir.to_str().unwrap()];
+        args.extend(extra);
+        args.push(R1);
+        let (ok, err) = run(&args);
+        assert!(ok, "run failed:\n{err}");
+    }
+
+    assert_ne!(
+        read(&with_preset.join("BS-seq_10K_R1_trimmed.fq")),
+        read(&without.join("BS-seq_10K_R1_trimmed.fq")),
+        "--library scbs left the reads untouched"
+    );
+}
+
+/// Explicit wins, and the log names both numbers so the user can see which one
+/// was dropped.
+#[test]
+fn explicit_clip_flag_overrides_the_preset_and_is_logged() {
+    let dir = tempdir("override");
+    let (ok, err) = run(&[
+        "--dont_gzip",
+        "--library",
+        "emseq",
+        "--clip_R1",
+        "12",
+        "-o",
+        dir.to_str().unwrap(),
+        R1,
+    ]);
+    assert!(ok, "run failed:\n{err}");
+    assert!(
+        err.contains("--clip_R1 12") && err.contains("preset value 10"),
+        "override log line missing both values:\n{err}"
+    );
+
+    // And the bytes follow the override, not the preset.
+    let expected = tempdir("override_oracle");
+    let (ok, err2) = run(&[
+        "--dont_gzip",
+        "--clip_R1",
+        "12",
+        "--clip_R2",
+        "10",
+        "--three_prime_clip_R1",
+        "10",
+        "--three_prime_clip_R2",
+        "10",
+        "-o",
+        expected.to_str().unwrap(),
+        R1,
+    ]);
+    assert!(ok, "oracle run failed:\n{err2}");
+    assert_eq!(
+        read(&dir.join("BS-seq_10K_R1_trimmed.fq")),
+        read(&expected.join("BS-seq_10K_R1_trimmed.fq"))
+    );
+}
+
+/// Presets may change between releases, so a report has to be self-describing:
+/// preset name plus the four values that were actually used.
+#[test]
+fn both_reports_record_the_preset_and_its_expanded_values() {
+    let dir = tempdir("reporting");
+    let (ok, err) = run(&[
+        "--dont_gzip",
+        "--library",
+        "pbat",
+        "-o",
+        dir.to_str().unwrap(),
+        R1,
+    ]);
+    assert!(ok, "run failed:\n{err}");
+
+    let text = report_text(&dir);
+    assert!(text.contains("Library preset: pbat"), "got:\n{text}");
+    assert!(
+        text.contains("--clip_R1 8 --clip_R2 8 --three_prime_clip_R1 8 --three_prime_clip_R2 8"),
+        "got:\n{text}"
+    );
+
+    let json = report_json(&dir);
+    assert_eq!(json["parameters"]["library"]["preset"], "pbat");
+    assert_eq!(json["parameters"]["library"]["clip_r1"], 8);
+    assert_eq!(json["parameters"]["library"]["three_prime_clip_r2"], 8);
+    assert_eq!(json["parameters"]["clip_r1"], 8);
+    assert!(
+        json["parameters"]["library"]["overrides"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+}
+
+/// A run without a preset must look exactly as it did before this feature.
+#[test]
+fn a_run_without_a_preset_reports_no_library_block() {
+    let dir = tempdir("no_preset");
+    let (ok, err) = run(&["--dont_gzip", "-o", dir.to_str().unwrap(), R1]);
+    assert!(ok, "run failed:\n{err}");
+
+    assert!(!report_text(&dir).contains("Library preset"));
+    assert!(report_json(&dir)["parameters"]["library"].is_null());
+}
+
+/// An unknown kit name has to stop the run. Trimming with no clipping at all
+/// because of a typo is the failure mode this feature must not introduce.
+#[test]
+fn an_unknown_preset_name_is_refused() {
+    let dir = tempdir("unknown");
+    let (ok, err) = run(&["--library", "nugen", "-o", dir.to_str().unwrap(), R1]);
+    assert!(!ok, "unknown preset was accepted");
+    assert!(err.contains("nugen"), "unhelpful error:\n{err}");
+}


### PR DESCRIPTION
Implements the five decisions in https://github.com/FelixKrueger/TrimGalore/issues/440#issuecomment-5306228841. Closes #440.

## What it does

```bash
trim_galore --paired --library emseq R1.fq.gz R2.fq.gz
```

is exactly

```bash
trim_galore --paired --clip_R1 10 --clip_R2 10 --three_prime_clip_R1 10 --three_prime_clip_R2 10 R1.fq.gz R2.fq.gz
```

| `--library` | `--clip_R1` | `--clip_R2` | `--three_prime_clip_R1` | `--three_prime_clip_R2` |
|---|---|---|---|---|
| `emseq` | 10 | 10 | 10 | 10 |
| `accel` (aliases `swift`, `xgen`) | 10 | 15 | 10 | 10 |
| `zymo` | 10 | 10 | 10 | 10 |
| `scbs` (alias `single_cell`) | 6 | 6 | 6 | 6 |
| `pbat` | 8 | 8 | 8 | 8 |

## Against each decision

**Shape.** A `clap::ValueEnum` on `--library`, so two kits at once is unrepresentable rather than rejected by a conflict rule. `--rrbs`, `--clock`, `--implicon` and Tecan/NuGEN Ovation RRBS are absent, per the clip-bundle membership criterion; that reasoning is recorded in the module docs so the next person proposing `taps` finds the rule rather than the outcome.

**Scope.** Four values, nothing else. No adapter, no `--length`.

**Overrides.** Explicit wins, and both numbers reach the log:

```
Library preset 'emseq' selected: --clip_R1 12 --clip_R2 10 --three_prime_clip_R1 10 --three_prime_clip_R2 10
--clip_R1 12 was given on the command line and overrides the emseq preset value 10
```

**Reporting.** Preset name plus all four values in force, in both reports. Text:

```
Library preset: emseq
Clipping in force: --clip_R1 12 --clip_R2 10 --three_prime_clip_R1 10 --three_prime_clip_R2 10
--clip_R1 12 was given on the command line and overrides the emseq preset value 10
```

JSON, under `parameters.library` (`null` when no preset was used), each override carrying both numbers:

```json
"library": {
  "preset": "emseq",
  "clip_r1": 12, "clip_r2": 10,
  "three_prime_clip_r1": 10, "three_prime_clip_r2": 10,
  "overrides": [{"flag": "--clip_R1", "preset_value": 10, "user_value": 12}]
}
```

**Versioning and where the numbers live.** In the binary, in `src/library.rs`. The `CHANGELOG.md` entry states that preset values may change between releases, and the report records the expanded numbers, so an old run stays reproducible from its own record.

## Implementation note worth reviewing

Resolution is one function, `Cli::effective_clips()`, and every clip consumer reads it rather than `cli.clip_*`. That matters for three call sites in particular:

1. the trimmer config (`setup_trimming`),
2. the `--rename` + `--output-format ubam` clip guard, which now trips on a preset exactly as it does on the flags it stands for,
3. the `--rrbs` directional paired-end auto-clip. A preset that supplies `--clip_R2` suppresses it, on the same "already set" rule an explicit `--clip_R2` has always used. So `--rrbs --library pbat --paired` clips R2 by 8, not by 2. `--library` and `--rrbs` are not rejected as a combination, since I did not want to invent a conflict rule you had not asked for, but say the word if you would rather they were.

## Two small liberties, both easy to revert

- Alias `em_seq` on `emseq`, since nf-core/methylseq spells it that way and parity with that pipeline is the rationale for the numbers. Also `em-seq`, `single-cell`.
- `--clump_only` rejects `--library`, matching how it already rejects each of the four clip flags individually.

Specialty modes (`--hardtrim5/3`, `--clock`, `--implicon`) ignore `--library`, which is what they already do with explicit clip flags. I left that alone rather than adding a new refusal.

## Behaviour without `--library`

Trimming is unchanged and the text report is unchanged. The one difference anywhere is the new `"library": null` key in the JSON report (additive, `schema_version` untouched).

## Tests

Unit: the preset table verbatim from the issue, resolver precedence, flag parsing and every alias, unknown-name rejection, `--clump_only` refusal, and both report renderings.

`tests/integration_library.rs` is deliberately differential, because the defect class this feature can hit is "one dispatch path never reads the preset", which no unit test of the resolver catches:

- `--library accel` output is byte-identical to its four flags (paired, both mates)
- a preset is not a no-op (`--library scbs` output differs from no clipping), so the equivalence test above cannot pass vacuously
- an override's bytes follow the user's number, and the log names both
- both reports carry the block; a run without a preset carries neither
- an unknown kit name fails the run rather than trimming with no clipping

`cargo test`, `cargo fmt --all -- --check` and `cargo clippy --all-targets --release -- -D warnings` all clean.

## Docs

New page `guide/library-presets`, a cross-flag bullet in `guide/flags`, sidebar entry, and the `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
