### PR TITLE
docs(clump): correct the --clumpify memory arithmetic against the shipped model (#439)

### DIFF
--- a/docs/src/content/docs/modes/clump-only.md
+++ b/docs/src/content/docs/modes/clump-only.md
@@ -73,12 +73,29 @@ Composes with:
 - `--paired` — two-file paired input (Shape A, multi-pair `N=4, 6, …` supported) OR single interleaved uBAM (Shape B, N=1 + `--output-format ubam`)
 - `--compression <1-9>` (FASTQ gzip level; ignored for uBAM output — BAM is always BGZF)
 - `--memory <SIZE>` (bin-buffer sizing, e.g. `4G`)
-- `--cores <N>` (accepted for interface parity — v1 is single-threaded internally; parallelism is planned for a later release)
+- `--cores <N>` — v1 is single-threaded internally, so this does not affect speed, but it does set the bin count (`max(16, 4 × cores)`) and therefore the memory floor below. Values 1–4 all give 16 bins; the floor only starts moving at `--cores 5`.
 - `--fastqc` — runs on the reordered output; fastqc-rust reads both FASTQ and BAM natively
 - `--dont_gzip` — FASTQ output only, produces `*_clumped.fq` (plain). Rejected with `--output-format ubam` (BAM is always BGZF-compressed).
 - `--basename BASE` — output becomes `BASE_clumped.fq(.gz)` (SE FASTQ), `BASE_clumped_{1,2}.fq(.gz)` (PE FASTQ), or `BASE_clumped.bam` (uBAM)
 - `--output-format ubam` — produces uBAM output. Composes with all of the above except `--dont_gzip`.
 - `--preserve-tags TAG1,TAG2,…` — uBAM only. Aux tags round-trip through the reorder. A/Z/i/f scalars supported; B (array) and H (hex) rejected at BAM-read time.
+
+## Memory
+
+`--memory` sizes the per-bin sort buffers, using the same formula as [`--clumpify`](/performance/clumpy/#memory) with `workers = 1`, since this mode is single-threaded. At `--cores 1`–`4` the floor is 277 MiB, rising to 454 MiB at `--cores 32`; requesting `--fastqc` adds 24 MiB per thread, capped at 16 threads.
+
+**Below the floor, `--clump_only` fails rather than degrading.** This differs from `--clumpify`, which warns and falls back to plain trimming. The reason is that reordering is the entire job here: falling back would spend the full read-and-write cost to produce a file identical to the input, and exit successfully, so a pipeline checking only the exit code could not tell that the archival recompression it asked for had not happened.
+
+The error names the budget to retry with:
+
+```
+Error: --memory budget too small for --cores 16: after reserving 608 MiB for static
+overhead (allocator, gzip state, IO buffers, FastQC) and 9% margin, the derived bin
+budget is 309806 bytes — below the 1048576-byte per-bin floor. Increase --memory
+(try ≥ 775 MiB) or decrease --cores.
+```
+
+Lowering `--cores` is the cheap fix here — it costs no speed, only coarser read grouping. At `--cores 1`–`4` there is nothing left to lower, so raising `--memory` is the only remedy.
 
 Rejected at CLI validation (would break byte-identity or has no meaning under this mode):
 

--- a/docs/src/content/docs/performance/clumpy.md
+++ b/docs/src/content/docs/performance/clumpy.md
@@ -88,35 +88,42 @@ The minimizer computation uses 2-bit packed integer ops (one O(1) bitwise step p
 
 `--memory` (default `1G`) is a Trim Galore-wide memory budget.
 
-The clumpify dispatcher sizes the per-bin sort runs against it, with the formula picked in an attempt to get the predicted peak RSS ≤ `--memory`:
+The clumpify dispatcher sizes the per-bin sort runs against it, using coefficients fitted to measured peak RSS on both macOS/arm64 and Linux/x86_64:
 
 $$
 \begin{aligned}
 n_{\text{bins}}          &= \max(16,\; 4 \times \text{cores}) \\[0.8em]
-\text{usable}            &= \text{memory} - 512\,\text{MiB}
-  \quad\small\text{(FastQC + allocator + runtime overhead)} \\[0.8em]
-\text{bin\_byte\_budget} &= \frac{4 \times \text{usable}}{5 \times n_{\text{bins}} + 7 \times \text{cores}}
+\text{static}            &= 224\,\text{MiB} \;+\; 24\,\text{MiB} \times \min(\text{FastQC threads},\, 16) \\[0.8em]
+\text{usable}            &= \text{memory} \times \tfrac{10}{11} - \text{static} \\[0.8em]
+\text{bin\_byte\_budget} &= \frac{16 \times \text{usable}}{23 \times n_{\text{bins}} + 64 \times \text{workers}}
 \end{aligned}
 $$
 
-So with `--cores 8 --memory 1G` you get **32 bins × 12 MB**; with `--cores 8 --memory 4G` you get 32 bins × 66 MB. The binary prints those resolved values at startup.
+Three terms need naming. **static** is the resident cost outside the bin pool — allocator, gzip state and I/O buffers — and the FastQC term is charged only when a report is requested, capped at 16 threads because scaling above that is unmeasured. The **10/11** factor holds back ~9% of the budget as headroom for run-to-run variation, which is why the predicted peak the binary prints is always a little under the `--memory` you gave it. **workers** is the number of threads that can hold a batch in flight: `--cores` on the trimming path, and 1 under [`--clump_only`](/modes/clump-only/), which is single-threaded.
+
+So with `--cores 8 --memory 1G` you get **32 bins × 9 MiB**; with `--cores 8 --memory 4G` you get 32 bins × 44 MiB. The binary prints those resolved values at startup.
 
 In theory, bigger budget → bigger per-gzip-member sort runs → better compression. In practice, increasing memory doesn't seem to make very much difference in our tests.
 
+:::caution[Savings figures predate the current sizing]
+The savings in the tables above were measured before the memory model was refitted in v2.4 ([#439](https://github.com/FelixKrueger/TrimGalore/issues/439)), which reduced bin sizes by 24–31% at budgets of 2 GiB and above. Figures at the default `--memory 1G` are unaffected; the RRBS row's `--memory 4G+` entry is the one most likely to have moved and is pending re-measurement.
+:::
+
 #### Below-floor behaviour
 
-`--clumpify` needs a minimum of ~535 MiB to run (mostly from a fixed 512 MiB reservation for FastQC, allocator, and runtime overhead). The exact floor varies slightly with `--cores` but stays in the 535–730 MiB range for any sensible core count.
+`--clumpify` needs a minimum budget that rises with `--cores`, because both the bin pool and the per-worker reservation scale with it. Over `--cores` 2–32 the floor runs from **281 MiB** to **590 MiB** without `--fastqc`, and from **334 MiB** to **1012 MiB** with it. Above `--cores 32` it keeps climbing — at `--cores 64` it is 933 MiB, or 1356 MiB with `--fastqc`, which is above the 1 GiB default.
 
 If `--memory` is below the floor, Trim Galore prints a warning and falls back to plain mode:
 
 ```
-WARNING: --memory 100M is too small for --clumpify at --cores 6 (need ≥ 552 MiB).
+WARNING: --memory 100M is too small for --clumpify at --cores 6 (need ≥ 311 MiB).
          Falling back to plain mode (no read reordering). Increase --memory or
          drop --clumpify to silence this warning.
 ```
 
-The trim itself proceeds normally; only the read-reordering step is skipped.
-Memory usage without `--clumpify` is typically significantly lower, around the 100MB mark.
+The trim itself proceeds normally; only the read-reordering step is skipped. [`--clump_only`](/modes/clump-only/) is the exception: reordering is the entire job there, so a below-floor budget fails rather than degrading.
+
+Memory usage without `--clumpify` depends on read length rather than on file size. Short-read runs sit around the 100 MB mark (104 MiB for 10 M × 51 bp paired at `--cores 4`), but the per-worker batch is a fixed number of *records*, so multi-kb reads use substantially more — see [Threading](/performance/threading/).
 
 ### What doesn't change
 


### PR DESCRIPTION
The memory section of the clumpy page documented the pre-refit formula, so every figure derived from it was wrong — the worked values, the floor range and the sample warning. This corrects them against `resolve_layout` as shipped at `fdade7e`, defines the three terms the page used without introducing (`static`, the `10/11` headroom, `workers`), and adds a `## Memory` section to the clump-only page recording that a below-floor budget there fails rather than falling back. Docs only; no changelog entry, since `CHANGELOG.md` is not a docs file.

<details>
<summary>Detail (AI-assisted)</summary>

Corrected figures, each verified by running the binary:

| | was | is |
|---|---|---|
| `usable` | `memory − 512 MiB` | `memory × 10/11 − static` |
| denominator | `4 × usable / (5·n_bins + 7·cores)` | `16 × usable / (23·n_bins + 64·workers)` |
| `1G/c8` | 32 bins × 12 MB | 32 bins × 9 MiB |
| `4G/c8` | 32 bins × 66 MB | 32 bins × 44 MiB |
| floor | flat ~535 MiB, "535–730 range" | 281–590 MiB (`--cores` 2–32), 334–1012 with `--fastqc` |
| sample warning | need ≥ 552 MiB at `--cores 6` | need ≥ 311 MiB |

The core span is now stated because at `--cores 64` the floor is 933 MiB (1356 with `--fastqc`), above the 1 GiB default.

Other changes:

- `--clump_only`'s `--cores` bullet claimed the flag was accepted only for interface parity. It also sets `n_bins`, and therefore the floor, from `--cores 5` upward.
- The plain-mode sentence keeps its ~100 MB figure — correct for short reads (104 MiB at 10M × 51 bp paired, `--cores 4`) — but now says the batch is a fixed number of *records*, so multi-kb reads use substantially more.
- Savings tables are marked as predating the refit rather than re-estimated. Bins shrank 24–31% at budgets of 2 GiB and up, so the RRBS `--memory 4G+` row needs re-measurement with real libraries.

Two figures were wrong in draft and fixed before commit: a quoted error message carried an invented byte count (917504 against the real 309806), and the plain-mode figure came from a review report rather than a measurement (85 against 104 MiB).

Verified: `npm run build` clean at 32 pages, and the `docs-build` job's assertions run locally — no `katex-error`, no `<del>`, no stray maths outside `clumpy.md`, positive control matched so the null results mean something.

</details>
