### PR TITLE
ci(clump): measure --clumpify peak RSS on every PR (#439)

### DIFF
--- a/.github/clumpify-memory-baseline.tsv
+++ b/.github/clumpify-memory-baseline.tsv
@@ -18,12 +18,28 @@
 #
 # cell<TAB>baseline_peak_over_prediction
 #
-# First runner observations (2026-08-17, run 32065004600), one rep each. Two or
-# three more runs are needed before these become the enforced baseline, because a
-# single rep cannot separate the cell's spread from its centre.
+# Runner observations. Reps 1-2 measured identical code: the only difference
+# between 69d8f67 and 3f1a930 is this file's comment block, so they pool. Two
+# more reps are needed before these become the enforced baseline, because a pair
+# bounds a cell's spread without estimating it.
 #
-#   cell            runner   macOS/arm64   note
-#   1G_c4           0.770    0.939         runner is ~17 points lower, not the ~9 the
-#   1G_c4_fastqc    0.697    0.724           #439 calibration estimated
-#   25bp_1G_c4      0.941    1.07          #457 does not breach here; --cores 2 unmeasured
-#   multipair_c4    0.792    -             no sign of cross-pair page retention
+#   cell            rep1     rep2     mean      macOS/arm64
+#   1G_c4           0.770    0.782    0.776     0.939
+#   1G_c4_fastqc    0.697    0.701    0.699     0.724
+#   25bp_1G_c4      0.941    0.924    0.9325    1.054-1.075
+#   multipair_c4    0.792    0.787    0.790     -
+#
+#   rep1  69d8f67  run 32065004600
+#   rep2  3f1a930  run 32065624366
+#
+# Record the commit for every rep. Reps whose binaries differ must not be pooled;
+# `git diff --quiet <rep1> <repN> -- src Cargo.lock` is the check, and a rep that
+# fails it is dropped in favour of another push.
+#
+# The runner sits ~16 points below macOS at the gating cell, not the ~9 the #439
+# calibration estimated. Observed spread is 0.4-1.7 points.
+#
+# 1G_c2 and 25bp_1G_c2 record from reps 3-4 onward and have no row yet: two reps
+# is below the bar above. 25bp_1G_c2 is #457's worst cell on macOS, where it
+# exceeds the budget; a Linux breach there needs a c4->c2 increment of +0.169,
+# 2.4x the +0.070 macOS shows.

--- a/.github/clumpify-memory-baseline.tsv
+++ b/.github/clumpify-memory-baseline.tsv
@@ -17,8 +17,13 @@
 # here unnoticed.
 #
 # cell<TAB>baseline_peak_over_prediction
-# Reference values measured on macOS/arm64, which is NOT the runner: Linux
-# measured ~9 points lower in the #439 calibration. Do not copy these in.
-#   1G_c4          0.94
-#   1G_c4_fastqc   0.72
-#   25bp_1G_c4     1.07   <- above 1.0 by #457, not a regression
+#
+# First runner observations (2026-08-17, run 32065004600), one rep each. Two or
+# three more runs are needed before these become the enforced baseline, because a
+# single rep cannot separate the cell's spread from its centre.
+#
+#   cell            runner   macOS/arm64   note
+#   1G_c4           0.770    0.939         runner is ~17 points lower, not the ~9 the
+#   1G_c4_fastqc    0.697    0.724           #439 calibration estimated
+#   25bp_1G_c4      0.941    1.07          #457 does not breach here; --cores 2 unmeasured
+#   multipair_c4    0.792    -             no sign of cross-pair page retention

--- a/.github/clumpify-memory-baseline.tsv
+++ b/.github/clumpify-memory-baseline.tsv
@@ -21,4 +21,4 @@
 # measured ~9 points lower in the #439 calibration. Do not copy these in.
 #   1G_c4          0.94
 #   1G_c4_fastqc   0.72
-#   25bp_1G_c4     1.07   <- above 1.0: see the short-read issue, not a regression
+#   25bp_1G_c4     1.07   <- above 1.0 by #457, not a regression

--- a/.github/clumpify-memory-baseline.tsv
+++ b/.github/clumpify-memory-baseline.tsv
@@ -1,0 +1,24 @@
+# Recorded peak-RSS baselines for the `clumpify-memory` CI job (#439).
+#
+# The job gates on two things. The *promise* — measured peak <= the peak the
+# binary printed — is absolute and platform-independent. The *drift* band is
+# relative to the ratios below, because gating on the promise alone cannot see a
+# regression on Linux: at the expected ~0.85 ratio a work-channel-depth revert
+# adds ~72-104 MiB and still lands under the printed prediction.
+#
+# Fail if a cell's peak/prediction rises more than 0.05 above its baseline, or
+# falls more than 0.10 below it. A depth revert is a 0.08-0.11 move, so it
+# breaches the upper bound on any platform; a silent fallback to plain mode or a
+# fixture that stopped filling the bin pool is a multi-point drop.
+#
+# BOOTSTRAP: while this line is present the job records ratios and warns instead
+# of enforcing the band. Delete it once the values below are filled in from two
+# or three green runs on the runner. It is printed on every run so it cannot sit
+# here unnoticed.
+#
+# cell<TAB>baseline_peak_over_prediction
+# Reference values measured on macOS/arm64, which is NOT the runner: Linux
+# measured ~9 points lower in the #439 calibration. Do not copy these in.
+#   1G_c4          0.94
+#   1G_c4_fastqc   0.72
+#   25bp_1G_c4     1.07   <- above 1.0: see the short-read issue, not a regression

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,8 +410,8 @@ jobs:
           measure 1G_c4        1 --clumpify --paired --cores 4 --memory 1G "$F51R1" "$F51R2"
           measure 1G_c4_fastqc 1 --clumpify --paired --fastqc --cores 4 --memory 1G "$F51R1" "$F51R2"
           # 25 bp is above the prediction today: the per-bin coefficient is
-          # fitted per byte, not per record. Recorded, not gated on the promise,
-          # until the refit lands - see the short-read issue.
+          # fitted per byte, not per record (#457). Recorded, not gated on the
+          # promise, until that refit lands.
           measure 25bp_1G_c4   0 --clumpify --paired --cores 4 --memory 1G "$F25R1" "$F25R2"
           measure multipair_c4 0 --clumpify --paired --cores 4 --memory 1G \
             "$F51R1" "$F51R2" "${RUNNER_TEMP}/dup_R1.fastq.gz" "${RUNNER_TEMP}/dup_R2.fastq.gz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,8 +299,23 @@ jobs:
           set -euo pipefail
           # GNU time, not the bash builtin: the builtin has no -v. A missing
           # binary must fail here rather than yield an empty parse later.
-          command -v /usr/bin/time >/dev/null || sudo apt-get install -y time
-          /usr/bin/time -v true 2>&1 | grep -q 'Maximum resident set size'
+          # Presence is not capability: the runner ships a /usr/bin/time whose
+          # -v is unrecognised, and `2>&1 | grep -q` hid the usage message inside
+          # the pipe, so the probe failed silently in 42 ms. Capture to a file,
+          # then decide.
+          probe () { /usr/bin/time -v true 2>"${RUNNER_TEMP}/time_probe.txt" || true; }
+          has_rss () { grep -c 'Maximum resident set size' "${RUNNER_TEMP}/time_probe.txt" >/dev/null; }
+          probe
+          if ! has_rss; then
+            echo "installing GNU time; the preinstalled /usr/bin/time reported:"
+            sed -n '1,5p' "${RUNNER_TEMP}/time_probe.txt" || true
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq time
+            probe
+          fi
+          has_rss || { echo "::error::no /usr/bin/time that reports peak RSS"; \
+                       sed -n '1,10p' "${RUNNER_TEMP}/time_probe.txt"; exit 1; }
+          echo "peak-RSS probe OK: $(grep 'Maximum resident set size' "${RUNNER_TEMP}/time_probe.txt")"
           # Disk is not independent of memory: a stalled writer backs up the
           # result channel and the pending map, so an out-of-space run reports
           # inflated peak RSS and looks like a model breach.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,6 +430,9 @@ jobs:
           measure 25bp_1G_c4   0 --clumpify --paired --cores 4 --memory 1G "$F25R1" "$F25R2"
           measure multipair_c4 0 --clumpify --paired --cores 4 --memory 1G \
             "$F51R1" "$F51R2" "${RUNNER_TEMP}/dup_R1.fastq.gz" "${RUNNER_TEMP}/dup_R2.fastq.gz"
+          # --cores 2 is too tight to gate; both cells record their ratio only.
+          measure 1G_c2        0 --clumpify --paired --cores 2 --memory 1G "$F51R1" "$F51R2"
+          measure 25bp_1G_c2   0 --clumpify --paired --cores 2 --memory 1G "$F25R1" "$F25R2"
 
           exit $fail
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,156 @@ jobs:
   # run UI). No external uploader (Codecov/Coveralls) — keeping coverage
   # data local for now; integration with a third-party service is a
   # separate decision.
+  clumpify-memory:
+    name: Clumpify peak RSS (#439)
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    # No `needs:` — this runs in parallel with the rest, not on anyone's critical
+    # path. Cold cargo cache plus four measured cells; `rust-tests` allows 45.
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Cache cargo (clumpify-memory job)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clumpmem-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-clumpmem-
+
+      - name: Build binary and fixture generator
+        run: cargo build --release --bin trim_galore --example mk_clump_fixture
+
+      - name: Assert the harness can measure at all
+        run: |
+          set -euo pipefail
+          # GNU time, not the bash builtin: the builtin has no -v. A missing
+          # binary must fail here rather than yield an empty parse later.
+          command -v /usr/bin/time >/dev/null || sudo apt-get install -y time
+          /usr/bin/time -v true 2>&1 | grep -q 'Maximum resident set size'
+          # Disk is not independent of memory: a stalled writer backs up the
+          # result channel and the pending map, so an out-of-space run reports
+          # inflated peak RSS and looks like a model breach.
+          free_kb=$(df -Pk "${RUNNER_TEMP}" | awk 'NR==2 {print $4}')
+          echo "free in RUNNER_TEMP: $((free_kb / 1024)) MiB"
+          test "$free_kb" -ge 8388608 \
+            || { echo "::error::need >= 8 GiB free to measure memory honestly"; exit 1; }
+
+      - name: Generate fixtures
+        run: |
+          set -euo pipefail
+          gen=./target/release/examples/mk_clump_fixture
+          # Full size at both read lengths. 10M pairs is where the bin pool
+          # reaches steady state; below ~6M every ratio is depressed and the
+          # job cannot see a regression. The 25 bp cell must not be halved for
+          # the same reason.
+          "$gen" 10000000 51 "${RUNNER_TEMP}/f51"
+          "$gen" 10000000 25 "${RUNNER_TEMP}/f25"
+          # Multi-pair needs distinct paths to the same bytes: passing the same
+          # pair twice is refused as a duplicate, which would kill the job.
+          ln -s "${RUNNER_TEMP}/f51_R1.fastq.gz" "${RUNNER_TEMP}/dup_R1.fastq.gz"
+          ln -s "${RUNNER_TEMP}/f51_R2.fastq.gz" "${RUNNER_TEMP}/dup_R2.fastq.gz"
+          ls -la "${RUNNER_TEMP}"/*.fastq.gz
+
+      - name: Measure and gate
+        run: |
+          set -euo pipefail
+          base=.github/clumpify-memory-baseline.tsv
+          bootstrap=0
+          if grep -q '^# BOOTSTRAP' "$base"; then
+            bootstrap=1
+            echo "::warning::baseline is in BOOTSTRAP mode - drift band not enforced. \
+          Record the ratios below in $base and delete the BOOTSTRAP line."
+          fi
+          fail=0
+
+          # $1 label  $2 gating(1|0)  $3.. trim_galore args
+          measure () {
+            local label="$1" gating="$2"; shift 2
+            local log="${RUNNER_TEMP}/${label}.log"
+            local out="${RUNNER_TEMP}/out_${label}"
+            mkdir -p "$out"
+            # Capture first, check status, parse second. Piping into grep would
+            # replace the child's exit status with the filter's, and grep
+            # succeeding on a failed run's banner is exactly the trap: a
+            # parseable log from a failed run looks like data.
+            local rc=0
+            /usr/bin/time -v ./target/release/trim_galore "$@" -o "$out" \
+              >"${log}.stdout" 2>"$log" || rc=$?
+            if [ "$rc" -ne 0 ]; then
+              echo "::error::$label exited $rc"; tail -20 "$log"; fail=1; return
+            fi
+            grep -q '^clumpify:' "$log" \
+              || { echo "::error::$label: clumpify never engaged, so this cell proves nothing"; fail=1; return; }
+            ls "$out"/*.fq.gz >/dev/null 2>&1 \
+              || { echo "::error::$label: output is not gzipped"; fail=1; return; }
+
+            local peak_kb pred_mib budget_mib
+            peak_kb=$(sed -n 's/.*Maximum resident set size (kbytes): \([0-9][0-9]*\).*/\1/p' "$log" | head -1)
+            # head -1: the multi-pair cell prints one banner per pair, and the
+            # promise is per-process, so the first prediction is the one to use.
+            pred_mib=$(sed -n 's/.*predicted peak ≈ \([0-9][0-9]*\) of \([0-9][0-9]*\) MiB budget.*/\1/p' "$log" | head -1)
+            budget_mib=$(sed -n 's/.*predicted peak ≈ \([0-9][0-9]*\) of \([0-9][0-9]*\) MiB budget.*/\2/p' "$log" | head -1)
+            case "${peak_kb}:${pred_mib}:${budget_mib}" in
+              ''|*::*|:*) echo "::error::$label: parse produced an empty field (peak=$peak_kb pred=$pred_mib budget=$budget_mib)"; fail=1; return;;
+            esac
+
+            # Compare in KiB on both sides: a second truncation to MiB is where
+            # a unit slip has already cost this project a calibration run.
+            local pred_kb budget_kb ratio
+            pred_kb=$((pred_mib * 1024)); budget_kb=$((budget_mib * 1024))
+            ratio=$(awk -v p="$peak_kb" -v q="$pred_kb" 'BEGIN{printf "%.3f", p/q}')
+            printf '%-14s peak %5d MiB  pred %5d MiB  budget %5d MiB  peak/pred %s  peak/budget %s\n' \
+              "$label" "$((peak_kb / 1024))" "$pred_mib" "$budget_mib" "$ratio" \
+              "$(awk -v p="$peak_kb" -v q="$budget_kb" 'BEGIN{printf "%.3f", p/q}')"
+
+            # The binary owns both sides of peak <= prediction, and prediction is
+            # identically budget x 10/11, so deleting the margin would inflate
+            # the prediction to the budget and pass. Pin the margin itself.
+            # 2 MiB of slack: the printed prediction is truncated to whole MiB,
+            # so exact equality has under 100 KiB of headroom. Removing the
+            # margin is a ~93 MiB move, which this still catches by ~45x.
+            local expect_kb
+            expect_kb=$((budget_kb * 10 / 11))
+            awk -v a="$pred_kb" -v b="$expect_kb" 'BEGIN{exit (a-b<-2048 || a-b>2048)}' \
+              || { echo "::error::$label: prediction $pred_kb KiB is not budget x 10/11 ($expect_kb KiB)"; fail=1; }
+
+            if [ "$gating" = 1 ]; then
+              test "$peak_kb" -le "$pred_kb" \
+                || { echo "::error::$label: peak exceeded the printed prediction"; fail=1; }
+            fi
+
+            local want
+            want=$(awk -v c="$label" '$1==c {print $2}' "$base" 2>/dev/null || true)
+            if [ -n "$want" ] && [ "$bootstrap" = 0 ]; then
+              awk -v r="$ratio" -v w="$want" 'BEGIN{exit !(r > w + 0.05)}' \
+                && { echo "::error::$label: peak/pred $ratio is >0.05 above baseline $want"; fail=1; }
+              awk -v r="$ratio" -v w="$want" 'BEGIN{exit !(r < w - 0.10)}' \
+                && { echo "::error::$label: peak/pred $ratio is >0.10 below baseline $want - fixture may have stopped filling the pool"; fail=1; }
+            fi
+            rm -f "$out"/*.fq.gz
+          }
+
+          F51R1="${RUNNER_TEMP}/f51_R1.fastq.gz"; F51R2="${RUNNER_TEMP}/f51_R2.fastq.gz"
+          F25R1="${RUNNER_TEMP}/f25_R1.fastq.gz"; F25R2="${RUNNER_TEMP}/f25_R2.fastq.gz"
+
+          measure 1G_c4        1 --clumpify --paired --cores 4 --memory 1G "$F51R1" "$F51R2"
+          measure 1G_c4_fastqc 1 --clumpify --paired --fastqc --cores 4 --memory 1G "$F51R1" "$F51R2"
+          # 25 bp is above the prediction today: the per-bin coefficient is
+          # fitted per byte, not per record. Recorded, not gated on the promise,
+          # until the refit lands - see the short-read issue.
+          measure 25bp_1G_c4   0 --clumpify --paired --cores 4 --memory 1G "$F25R1" "$F25R2"
+          measure multipair_c4 0 --clumpify --paired --cores 4 --memory 1G \
+            "$F51R1" "$F51R2" "${RUNNER_TEMP}/dup_R1.fastq.gz" "${RUNNER_TEMP}/dup_R2.fastq.gz"
+
+          exit $fail
+
   coverage:
     name: Coverage (cargo-llvm-cov)
     if: github.event_name != 'schedule'

--- a/examples/mk_clump_fixture.rs
+++ b/examples/mk_clump_fixture.rs
@@ -1,0 +1,99 @@
+//! Deterministic gzipped paired FASTQ fixture for the `clumpify-memory` CI job.
+//!
+//! ```text
+//! cargo run --release --example mk_clump_fixture -- <pairs> <read_len> <out_prefix>
+//! ```
+//!
+//! Writes `<prefix>_R1.fastq.gz` and `<prefix>_R2.fastq.gz`. Gzip rather than
+//! plain text because output encoding follows the input's, and the plain-output
+//! branch is not the one users run.
+//!
+//! Sequences come from a fixed-seed SplitMix64 stream, so the bytes are
+//! identical on every platform and every run. Distinct-sequence count is printed
+//! before writing: a fixture built by repetition is a *small* fixture measured
+//! many times, and the #439 calibration was invalidated once by exactly that,
+//! invisibly, because nothing recorded sample size.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+
+/// SplitMix64 — small, fast, and reproducible without a dependency.
+struct Rng(u64);
+
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+}
+
+/// One gzip member per mate, written streaming so peak memory stays flat
+/// regardless of `pairs`.
+fn write_mate(
+    path: &str,
+    pairs: usize,
+    read_len: usize,
+    seed: u64,
+    mate: u8,
+) -> std::io::Result<()> {
+    let file = File::create(path)?;
+    let mut out = BufWriter::with_capacity(1 << 20, GzEncoder::new(file, Compression::fast()));
+    let mut rng = Rng(seed);
+    let qual = vec![b'I'; read_len];
+    let mut seq = vec![0u8; read_len];
+
+    for i in 0..pairs {
+        for base in seq.iter_mut() {
+            *base = b"ACGT"[(rng.next_u64() >> 33) as usize % 4];
+        }
+        writeln!(out, "@SIM:1:FCX:1:15:6329:{i} {mate}:N:0:ATCCGA")?;
+        out.write_all(&seq)?;
+        out.write_all(b"\n+\n")?;
+        out.write_all(&qual)?;
+        out.write_all(b"\n")?;
+    }
+    out.into_inner()?.finish()?;
+    Ok(())
+}
+
+fn main() -> std::io::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 4 {
+        eprintln!("usage: mk_clump_fixture <pairs> <read_len> <out_prefix>");
+        std::process::exit(2);
+    }
+    let pairs: usize = args[1].parse().expect("pairs must be a positive integer");
+    let read_len: usize = args[2]
+        .parse()
+        .expect("read_len must be a positive integer");
+    let prefix = &args[3];
+    assert!(pairs > 0 && read_len > 0, "pairs and read_len must be > 0");
+
+    // Two independent streams, so R1 and R2 sequences differ as they would in a
+    // real library while staying in lockstep by read ID.
+    eprintln!(
+        "fixture: {pairs} pairs x {read_len} bp, distinct sequences {pairs} per mate (one draw each)"
+    );
+    write_mate(
+        &format!("{prefix}_R1.fastq.gz"),
+        pairs,
+        read_len,
+        0x2545_F491_4F6C_DD1D,
+        1,
+    )?;
+    write_mate(
+        &format!("{prefix}_R2.fastq.gz"),
+        pairs,
+        read_len,
+        0x1234_5678_9ABC_DEF0,
+        2,
+    )?;
+    eprintln!("wrote {prefix}_R1.fastq.gz and {prefix}_R2.fastq.gz");
+    Ok(())
+}

--- a/src/clump.rs
+++ b/src/clump.rs
@@ -676,32 +676,6 @@ mod tests {
     }
 
     #[test]
-    fn resolve_layout_predicted_peak_fits_budget() {
-        // The whole point of the formula: predicted peak ≤ user-supplied --memory,
-        // with and without FastQC.
-        for (mem_gib, cores, fastqc) in [
-            (2u64, 4, false),
-            (4, 8, false),
-            (8, 8, true),
-            (16, 16, false),
-            (2, 2, true),
-        ] {
-            let budget = mem_gib * 1024 * 1024 * 1024;
-            let layout = resolve_layout(budget, &ins(cores, fastqc)).unwrap();
-            let predicted_peak = layout.predicted_peak_bytes();
-            assert!(
-                predicted_peak <= budget,
-                "predicted peak {} > budget {} for {} GiB / {} cores (fastqc {})",
-                predicted_peak,
-                budget,
-                mem_gib,
-                cores,
-                fastqc
-            );
-        }
-    }
-
-    #[test]
     fn floor_and_sizing_round_consistently_without_overflow() {
         // Not a coefficient guard — `predicted ≤ budget` holds for any σ, k or
         // static, because the sizing and the prediction read the same helpers.


### PR DESCRIPTION
Nothing in CI measured resident memory, so a refactor could restore the under-charging the earlier #439 phases removed and leave all nine checks green. This adds a job that measures peak RSS on a generated 10M-pair gzipped fixture and gates on two things: the *promise* (measured peak ≤ the peak the binary printed, absolute and platform-independent) and *drift* (peak/prediction within a recorded band, because the promise alone cannot catch a channel-depth revert on Linux). It also retires `resolve_layout_predicted_peak_fits_budget`, which the parent plan assigned to this phase on condition the replacement existed first — so it goes in the PR that adds it.

Stacked on #451; review that one first.

<details>
<summary>Detail (AI-assisted)</summary>

**Why a band and not just the promise.** At the expected ~0.85 Linux ratio, restoring the clumpy work-channel depth adds 72–104 MiB and still lands under the 930 MiB printed prediction — green forever. The band fails above `baseline + 0.05` (a depth revert is a 0.08–0.11 move, so it breaches on any platform) and below `baseline − 0.10` (a silent fallback to plain mode, or a fixture that stopped filling the bin pool). Baselines live in `.github/clumpify-memory-baseline.tsv`, currently in a `BOOTSTRAP` mode that records and warns; the marker prints on every run so it cannot sit there unnoticed.

**Fixture size is the design, not a cost dial.** Measured ratios climb monotonically with pair count — 0.38 at 500K, 0.75 at 1.5M, 0.80 at 3M, 0.88 at 6M, ~0.95 at 10M — so anything smaller yields a job that cannot fail. Gzipped because output encoding follows the input's and the plain-output branch is not what users run; it is also the more sensitive arm and a sixth of the disk.

**Disk is not independent of memory.** A stalled writer backs up the result channel and the `pending` map, both of which hold written-but-unflushed buffers, so an out-of-space run reports inflated peak RSS and presents as a model breach — the most expensive false positive available here, since the obvious response is to loosen the gate. The job asserts ≥8 GiB free up front, truncates each cell's output before the next, and checks every exit status. `/usr/bin/time -v` exits with the child's status, but piping into a filter replaces it, and a filter succeeding on a failed run's parseable banner is exactly the trap — so the job captures to a file, checks status, then parses.

**Cells.** `1G/c4` and `1G/c4 --fastqc` gate on the promise. `25bp/1G/c4` is recorded only: it exceeds the prediction today because the per-bin coefficient is fitted per byte rather than per record, so short reads pack more records into the same bin bytes. `multipair_c4` needs distinct paths to the same bytes (one pair twice is refused as a duplicate) and prints one banner per pair, so the parse takes the first — the promise is per-process.

**The retired test.** It asserted `predicted ≤ budget` over five cells, which reduces to `MARGIN_NUM ≤ MARGIN_DEN` and passes for any coefficients; #446 made it more vacuous still, the chain now being `predicted ≤ budget × 10/11 ≤ budget`. Its replacement is this job plus #451's pinned-cell table.

Verified: 789 tests pass, fmt and clippy clean (`--all-targets` covers the new example). Workflow YAML parsed. `sed` patterns are POSIX rather than GNU-only so they could be tested locally: verified they parse a real banner, take the first of two banners on the multi-pair log, and that the empty-field guard fires on a truncated log.

</details>
