### PR TITLE
fix(cli): stop refusing --rename over a clip flag that applies to no read (#450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 #### Changes
 
+- **`--rename --output-format ubam` no longer refuses over a clip flag that applies to no read**
+  ([#450](https://github.com/FelixKrueger/TrimGalore/issues/450)). A Read 2 clip flag on a single-end
+  run is still warned about and ignored, but no longer blocks the run.
+
 - **`--library <preset>` names a library prep instead of four clip flags**
   ([#440](https://github.com/FelixKrueger/TrimGalore/issues/440)). `emseq`, `accel` (aliases
   `swift`, `xgen`), `zymo`, `scbs` (alias `single_cell`) and `pbat` each expand into

--- a/docs/src/content/docs/guide/outputs.md
+++ b/docs/src/content/docs/guide/outputs.md
@@ -97,7 +97,7 @@ Most FASTQ-shaped features work with uBAM output. Rejected at startup, before an
 - `--passthrough` — carrier FASTQ shape is FASTQ-specific
 - `--retain_unpaired` — would produce singleton BAMs; not in v1
 - `--clumpify` — in-place reorder is FASTQ-shape-specific (note: `--clump_only --output-format ubam` **is** supported — see [Clump-only](/modes/clump-only/))
-- `--rename` — only when at least one input is FASTQ, and only when a clipping flag is set; uBAM input is accepted (see [Annotating read IDs](#annotating-read-ids) below)
+- `--rename` — only when at least one input is FASTQ, and only when a clipping or hardtrim flag that applies to this run is set; uBAM input is accepted (see [Annotating read IDs](#annotating-read-ids) below)
 
 ## Output directory
 
@@ -142,7 +142,7 @@ Two limits worth knowing. Trimming reports keep their input-derived names (`INPU
 
 `--rename` does not affect filenames. It is a boolean that appends `:clip5:SEQ` and/or `:clip3:SEQ` to the **read IDs**, recording the bases removed by `--clip_R1/R2`, `--three_prime_clip_R1/R2` or `--hardtrim5/3` — each half only when that side was clipped. Without one of those flags it appends nothing. Commonly used to keep UMIs recoverable downstream.
 
-Two combinations are refused. `--clump_only` rejects `--rename` at any output format, because it preserves record contents byte-identically. And `--output-format ubam` rejects it when **at least one input is FASTQ** and a clipping flag is set: the annotation is appended to the end of the read ID, so a header carrying text after the first space puts the annotation inside that text, and BAM read names cannot contain whitespace, so none of that tail reaches the output. Whether that happens depends on the individual header, so the whole run is refused rather than decided per record — a per-record decision would keep the annotation for some reads and silently drop it for others. uBAM input is accepted: BAM read names carry no description, so there the annotation lands on the name itself.
+Two combinations are refused. `--clump_only` rejects `--rename` at any output format, because it preserves record contents byte-identically. And `--output-format ubam` rejects it when **at least one input is FASTQ** and a clipping flag is set: the annotation is appended to the end of the read ID, so a header carrying text after the first space puts the annotation inside that text, and BAM read names cannot contain whitespace, so none of that tail reaches the output. Whether that happens depends on the individual header, so the whole run is refused rather than decided per record — a per-record decision would keep the annotation for some reads and silently drop it for others. uBAM input is accepted: BAM read names carry no description, so there the annotation lands on the name itself. Only a flag that applies to the run counts — a Read 2 clip flag on a single-end run reaches no read, so it is warned about and ignored rather than refused.
 
 ## FastQC
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -309,8 +309,9 @@ pub struct Cli {
 
     /// Add clipped sequences to read IDs for --clip_R1/R2, --three_prime_clip_R1/R2, and --hardtrim5/3.
     /// Appends :clip5:SEQ and/or :clip3:SEQ to the read ID (each half only when that side was clipped). Useful for UMI handling.
-    /// Refused with --output-format ubam when any input is FASTQ, because a BAM read name cannot hold the
-    /// annotation once the header carries a description; also refused by --clump_only, which does not mutate IDs.
+    /// Refused with --output-format ubam when any input is FASTQ and a clipping flag applies to the run,
+    /// because a BAM read name cannot hold the annotation once the header carries a description;
+    /// also refused by --clump_only, which does not mutate IDs.
     #[clap(long = "rename")]
     pub rename: bool,
 
@@ -1151,20 +1152,21 @@ impl Cli {
             None
         };
         if let Some((reason, all_four)) = inert {
-            for (flag, value) in [
-                ("--clip_R1", if all_four { self.clip_r1 } else { None }),
-                (
-                    "--three_prime_clip_R1",
-                    if all_four {
-                        self.three_prime_clip_r1
-                    } else {
-                        None
-                    },
-                ),
-                ("--clip_R2", self.clip_r2),
-                ("--three_prime_clip_R2", self.three_prime_clip_r2),
+            use crate::library::ClipFlag;
+            let typed = self.user_clips();
+            // Each read's 5' flag before its 3' one, so a two-flag warning pair
+            // reads in clipping order.
+            for flag in [
+                ClipFlag::ClipR1,
+                ClipFlag::ThreePrimeClipR1,
+                ClipFlag::ClipR2,
+                ClipFlag::ThreePrimeClipR2,
             ] {
-                if let Some(n) = value {
+                if !all_four && !flag.read_2() {
+                    continue;
+                }
+                if let Some(n) = typed.value(flag) {
+                    let flag = flag.name();
                     eprintln!(
                         "WARNING: {flag} {n} was given but is not used in this mode ({reason}). Ignoring."
                     );
@@ -1223,15 +1225,19 @@ impl Cli {
     /// preset name and each displaced number, which is what the log line and both
     /// trimming reports print.
     pub fn effective_clips(&self) -> crate::library::ResolvedClips {
-        crate::library::resolve(
-            self.library,
-            crate::library::UserClips {
-                clip_r1: self.clip_r1,
-                clip_r2: self.clip_r2,
-                three_prime_clip_r1: self.three_prime_clip_r1,
-                three_prime_clip_r2: self.three_prime_clip_r2,
-            },
-        )
+        crate::library::resolve(self.library, self.user_clips())
+    }
+
+    /// The values as typed. Only the inert-flag warning wants these directly, so
+    /// that it cannot report a flag a preset supplied; anything needing the values
+    /// in force goes through `effective_clips()`, which folds the preset in.
+    pub(crate) fn user_clips(&self) -> crate::library::UserClips {
+        crate::library::UserClips {
+            clip_r1: self.clip_r1,
+            clip_r2: self.clip_r2,
+            three_prime_clip_r1: self.three_prime_clip_r1,
+            three_prime_clip_r2: self.three_prime_clip_r2,
+        }
     }
 }
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -16,6 +16,57 @@
 //! Presets may change between releases (see `CHANGELOG.md`). That is safe because
 //! both trimming reports record the expanded values, so an old report stays
 //! self-describing and a past run is reproducible from its own record.
+//!
+//! `ClipFlag` also lives here. It names the four clip flags and the read each
+//! belongs to, which the inert-flag warning and the `--rename` uBAM guard need
+//! with no preset involved.
+
+/// One of the four end-clipping flags.
+///
+/// An enum rather than a string table: the read a flag belongs to is one match
+/// arm rather than a fact each consumer re-derives, and a fifth flag will not
+/// compile until every consumer handles it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClipFlag {
+    ClipR1,
+    ClipR2,
+    ThreePrimeClipR1,
+    ThreePrimeClipR2,
+}
+
+impl ClipFlag {
+    /// The closed set, for `any_effective` and the drift tests. This order is
+    /// deliberately neither display order, so no display site can iterate it and
+    /// still look correct.
+    pub const ALL: [ClipFlag; 4] = [
+        ClipFlag::ClipR2,
+        ClipFlag::ClipR1,
+        ClipFlag::ThreePrimeClipR2,
+        ClipFlag::ThreePrimeClipR1,
+    ];
+
+    /// Flag name as the user would type it. These four strings reach the JSON
+    /// report, so they are output.
+    pub fn name(self) -> &'static str {
+        match self {
+            ClipFlag::ClipR1 => "--clip_R1",
+            ClipFlag::ClipR2 => "--clip_R2",
+            ClipFlag::ThreePrimeClipR1 => "--three_prime_clip_R1",
+            ClipFlag::ThreePrimeClipR2 => "--three_prime_clip_R2",
+        }
+    }
+
+    /// A Read 2 flag.
+    pub fn read_2(self) -> bool {
+        matches!(self, ClipFlag::ClipR2 | ClipFlag::ThreePrimeClipR2)
+    }
+
+    /// This flag names a read the run processes. `paired` means `--paired`; the
+    /// modes that pair two files without it read no clip flag at all.
+    pub fn applies(self, paired: bool) -> bool {
+        paired || !self.read_2()
+    }
+}
 
 /// The four end-clipping values a preset expands into.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -85,12 +136,9 @@ impl LibraryPreset {
 /// One clip flag given on the command line over a preset that also sets it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ClipOverride {
-    /// Flag name as the user would type it, e.g. `--clip_R1`.
-    pub flag: &'static str,
+    pub flag: ClipFlag,
     pub preset_value: usize,
     pub user_value: usize,
-    /// A Read 2 flag, which a single-end run cannot honour.
-    pub read_2: bool,
 }
 
 /// The four clip values a user typed, before any preset is folded in.
@@ -121,28 +169,53 @@ impl ResolvedClips {
     /// R2 values are listed for paired runs only.
     pub fn flag_summary(&self, paired: bool) -> String {
         let mut parts = Vec::new();
-        for (flag, value, read_2) in [
-            ("--clip_R1", self.clip_r1, false),
-            ("--clip_R2", self.clip_r2, true),
-            ("--three_prime_clip_R1", self.three_prime_clip_r1, false),
-            ("--three_prime_clip_R2", self.three_prime_clip_r2, true),
+        // This order is user-visible in both trimming reports: 5' before 3',
+        // Read 1 before Read 2.
+        for flag in [
+            ClipFlag::ClipR1,
+            ClipFlag::ClipR2,
+            ClipFlag::ThreePrimeClipR1,
+            ClipFlag::ThreePrimeClipR2,
         ] {
-            if read_2 && !paired {
+            if !flag.applies(paired) {
                 continue;
             }
-            if let Some(v) = value {
-                parts.push(format!("{flag} {v}"));
+            if let Some(v) = self.value(flag) {
+                parts.push(format!("{} {v}", flag.name()));
             }
         }
         parts.join(" ")
     }
 
-    /// True when any of the four values is set, from either source.
-    pub fn any_set(&self) -> bool {
-        self.clip_r1.is_some()
-            || self.clip_r2.is_some()
-            || self.three_prime_clip_r1.is_some()
-            || self.three_prime_clip_r2.is_some()
+    /// The value in force for `flag`, preset folded in.
+    pub fn value(&self, flag: ClipFlag) -> Option<usize> {
+        match flag {
+            ClipFlag::ClipR1 => self.clip_r1,
+            ClipFlag::ClipR2 => self.clip_r2,
+            ClipFlag::ThreePrimeClipR1 => self.three_prime_clip_r1,
+            ClipFlag::ThreePrimeClipR2 => self.three_prime_clip_r2,
+        }
+    }
+
+    /// True when a clip value in force belongs to a read this run processes.
+    /// Says nothing about whether the *mode* honours clip flags; the caller's
+    /// hardtrim terms cover that.
+    pub fn any_effective(&self, paired: bool) -> bool {
+        ClipFlag::ALL
+            .iter()
+            .any(|&f| f.applies(paired) && self.value(f).is_some())
+    }
+}
+
+impl UserClips {
+    /// The value the user typed for `flag`, before any preset.
+    pub fn value(&self, flag: ClipFlag) -> Option<usize> {
+        match flag {
+            ClipFlag::ClipR1 => self.clip_r1,
+            ClipFlag::ClipR2 => self.clip_r2,
+            ClipFlag::ThreePrimeClipR1 => self.three_prime_clip_r1,
+            ClipFlag::ThreePrimeClipR2 => self.three_prime_clip_r2,
+        }
     }
 }
 
@@ -166,16 +239,13 @@ pub fn resolve(preset: Option<LibraryPreset>, user: UserClips) -> ResolvedClips 
 
     let clips = preset.clips();
     let mut overrides = Vec::new();
-    let mut pick = |flag: &'static str,
-                    user_value: Option<usize>,
-                    preset_value: usize,
-                    read_2: bool| match user_value {
+    let mut pick = |flag: ClipFlag, user_value: Option<usize>, preset_value: usize| match user_value
+    {
         Some(v) => {
             overrides.push(ClipOverride {
                 flag,
                 preset_value,
                 user_value: v,
-                read_2,
             });
             Some(v)
         }
@@ -184,19 +254,17 @@ pub fn resolve(preset: Option<LibraryPreset>, user: UserClips) -> ResolvedClips 
 
     ResolvedClips {
         preset: Some(preset),
-        clip_r1: pick("--clip_R1", user.clip_r1, clips.clip_r1, false),
-        clip_r2: pick("--clip_R2", user.clip_r2, clips.clip_r2, true),
+        clip_r1: pick(ClipFlag::ClipR1, user.clip_r1, clips.clip_r1),
+        clip_r2: pick(ClipFlag::ClipR2, user.clip_r2, clips.clip_r2),
         three_prime_clip_r1: pick(
-            "--three_prime_clip_R1",
+            ClipFlag::ThreePrimeClipR1,
             user.three_prime_clip_r1,
             clips.three_prime_clip_r1,
-            false,
         ),
         three_prime_clip_r2: pick(
-            "--three_prime_clip_R2",
+            ClipFlag::ThreePrimeClipR2,
             user.three_prime_clip_r2,
             clips.three_prime_clip_r2,
-            true,
         ),
         overrides,
     }
@@ -268,10 +336,9 @@ mod tests {
         assert_eq!(
             r.overrides,
             vec![ClipOverride {
-                flag: "--clip_R1",
+                flag: ClipFlag::ClipR1,
                 preset_value: 10,
                 user_value: 12,
-                read_2: false,
             }]
         );
     }
@@ -291,29 +358,95 @@ mod tests {
         assert!(r.overrides.is_empty());
     }
 
-    /// `read_2` is set at `pick`'s call sites rather than parsed out of the flag
-    /// name, so the name is available here as an independent oracle.
+    /// `read_2` is a match on the variant, not a parse of the name, so the name
+    /// serves here as an independent oracle.
     #[test]
-    fn every_override_knows_which_read_it_belongs_to() {
-        let r = resolve(
-            Some(LibraryPreset::Accel),
-            UserClips {
-                clip_r1: Some(1),
-                clip_r2: Some(2),
-                three_prime_clip_r1: Some(3),
-                three_prime_clip_r2: Some(4),
-            },
-        );
-        assert_eq!(r.overrides.len(), 4);
-        for o in &r.overrides {
+    fn every_clip_flag_knows_which_read_it_belongs_to() {
+        for f in ClipFlag::ALL {
             assert_eq!(
-                o.read_2,
-                o.flag.ends_with("_R2"),
+                f.read_2(),
+                f.name().ends_with("_R2"),
                 "{} has read_2 = {}",
-                o.flag,
-                o.read_2
+                f.name(),
+                f.read_2()
             );
         }
+    }
+
+    /// A fifth variant makes the match non-exhaustive, which forces a visit here.
+    /// Nothing forces it into `ALL`, whose length is a literal.
+    #[test]
+    fn all_holds_every_clip_flag_once() {
+        for f in ClipFlag::ALL {
+            match f {
+                ClipFlag::ClipR1
+                | ClipFlag::ClipR2
+                | ClipFlag::ThreePrimeClipR1
+                | ClipFlag::ThreePrimeClipR2 => {}
+            }
+        }
+        let mut names: Vec<&str> = ClipFlag::ALL.iter().map(|f| f.name()).collect();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), 4, "ALL must hold each flag exactly once");
+    }
+
+    /// These four strings reach the JSON report, so a typo is a silent output
+    /// change. The `_R2` oracle above passes with or without the leading dashes.
+    #[test]
+    fn clip_flag_names_are_the_command_line_spellings() {
+        assert_eq!(ClipFlag::ClipR1.name(), "--clip_R1");
+        assert_eq!(ClipFlag::ClipR2.name(), "--clip_R2");
+        assert_eq!(ClipFlag::ThreePrimeClipR1.name(), "--three_prime_clip_R1");
+        assert_eq!(ClipFlag::ThreePrimeClipR2.name(), "--three_prime_clip_R2");
+    }
+
+    /// #450 — a Read 2 value reaches no clip site on a single-end run.
+    #[test]
+    fn any_effective_discounts_read_2_on_single_end() {
+        let r2_only = resolve(
+            None,
+            UserClips {
+                clip_r2: Some(5),
+                ..UserClips::default()
+            },
+        );
+        assert!(!r2_only.any_effective(false));
+        assert!(r2_only.any_effective(true));
+
+        let tp_r2_only = resolve(
+            None,
+            UserClips {
+                three_prime_clip_r2: Some(7),
+                ..UserClips::default()
+            },
+        );
+        assert!(!tp_r2_only.any_effective(false));
+        assert!(tp_r2_only.any_effective(true));
+
+        // Read 1 counts on either shape, and a live R1 flag is not masked by an
+        // inert R2 one.
+        for user in [
+            UserClips {
+                clip_r1: Some(3),
+                ..UserClips::default()
+            },
+            UserClips {
+                three_prime_clip_r1: Some(3),
+                ..UserClips::default()
+            },
+            UserClips {
+                clip_r1: Some(3),
+                clip_r2: Some(5),
+                ..UserClips::default()
+            },
+        ] {
+            let r = resolve(None, user);
+            assert!(r.any_effective(false));
+            assert!(r.any_effective(true));
+        }
+
+        assert!(!resolve(None, UserClips::default()).any_effective(true));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,16 +388,13 @@ fn main() -> Result<()> {
         reject_bam_format_mismatch_in_pair(&cli.input, &input_formats, shape)?;
     }
 
-    // #408 — format-gated, so it cannot live in `Cli::validate()`; sited after the
-    // two structural pair checks above so those report their own defect first. The
-    // clip-flag list must match every `--rename`-driven `append_to_id` site
-    // (`trimmer.rs` clip_5/clip_3, `specialty.rs` hardtrim) — without one of them
-    // set, `--rename` appends nothing and there is nothing to lose.
-    // The clip list reads through `effective_clips()` so a `--library` preset
-    // (#440) counts here exactly as the four flags it stands in for would.
+    // #408 — refused only where an `append_to_id` site can fire: a clip flag for a read
+    // this run processes, or a hardtrim. Format-gated, so it cannot live in `validate()`.
     if cli.rename
         && matches!(cli.output_format, trim_galore::cli::OutputFormat::UBam)
-        && (cli.effective_clips().any_set() || cli.hardtrim5.is_some() || cli.hardtrim3.is_some())
+        && (cli.effective_clips().any_effective(cli.paired)
+            || cli.hardtrim5.is_some()
+            || cli.hardtrim3.is_some())
         && input_formats
             .iter()
             .any(|f| !matches!(f, InputFormat::UnalignedBam))
@@ -1127,10 +1124,14 @@ fn setup_trimming(cli: &Cli, input_file: &Path) -> SetupResult {
             preset.canonical_name(),
             clips.flag_summary(cli.paired)
         );
-        for o in clips.overrides.iter().filter(|o| cli.paired || !o.read_2) {
+        for o in clips
+            .overrides
+            .iter()
+            .filter(|o| o.flag.applies(cli.paired))
+        {
             eprintln!(
                 "{} {} was given on the command line and overrides the {} preset value {}",
-                o.flag,
+                o.flag.name(),
                 o.user_value,
                 preset.canonical_name(),
                 o.preset_value

--- a/src/report.rs
+++ b/src/report.rs
@@ -284,12 +284,12 @@ pub fn write_report_header<W: Write>(w: &mut W, config: &TrimConfig) -> std::io:
         for o in library
             .overrides
             .iter()
-            .filter(|o| config.paired || !o.read_2)
+            .filter(|o| o.flag.applies(config.paired))
         {
             writeln!(
                 w,
                 "{} {} was given on the command line and overrides the {} preset value {}",
-                o.flag,
+                o.flag.name(),
                 o.user_value,
                 preset.canonical_name(),
                 o.preset_value
@@ -895,7 +895,7 @@ pub fn write_json_report<W: Write>(
                 write!(
                     w,
                     "{{\"flag\": \"{}\", \"preset_value\": {}, \"user_value\": {}}}",
-                    json_escape_string(o.flag),
+                    json_escape_string(o.flag.name()),
                     o.preset_value,
                     o.user_value
                 )?;

--- a/tests/integration_inert_clip_flags.rs
+++ b/tests/integration_inert_clip_flags.rs
@@ -237,4 +237,54 @@ fn each_inert_flag_gets_its_own_line() {
     );
     assert!(err.contains("--clip_R2 5"), "got:\n{err}");
     assert!(err.contains("--three_prime_clip_R2 7"), "got:\n{err}");
+    // 5' before 3', so the pair reads in clipping order.
+    assert!(
+        err.find("--clip_R2 5") < err.find("--three_prime_clip_R2 7"),
+        "expected --clip_R2 before --three_prime_clip_R2:\n{err}"
+    );
+}
+
+/// All four at once, under a mode where all four are inert. The four-flag order
+/// is otherwise unexercised — every other case sets at most two.
+#[test]
+fn all_four_inert_flags_warn_in_clipping_order() {
+    let dir = tempdir("four_lines");
+    let (ok, err) = run(&[
+        "--hardtrim5",
+        "20",
+        "--clip_R1",
+        "3",
+        "--three_prime_clip_R1",
+        "4",
+        "--clip_R2",
+        "5",
+        "--three_prime_clip_R2",
+        "7",
+        "-o",
+        dir.to_str().unwrap(),
+        R1,
+    ]);
+    assert!(ok, "run failed:\n{err}");
+    assert_eq!(
+        err.lines().filter(|l| l.contains(INERT)).count(),
+        4,
+        "expected one warning line per inert flag, got:\n{err}"
+    );
+    let positions: Vec<Option<usize>> = [
+        "--clip_R1 3",
+        "--three_prime_clip_R1 4",
+        "--clip_R2 5",
+        "--three_prime_clip_R2 7",
+    ]
+    .iter()
+    .map(|f| err.find(f))
+    .collect();
+    assert!(
+        positions.iter().all(|p| p.is_some()),
+        "every flag must be named:\n{err}"
+    );
+    assert!(
+        positions.windows(2).all(|w| w[0] < w[1]),
+        "expected Read 1 5'/3' then Read 2 5'/3':\n{err}"
+    );
 }

--- a/tests/integration_ubam_out.rs
+++ b/tests/integration_ubam_out.rs
@@ -1226,6 +1226,173 @@ fn rename_into_ubam_refused_for_hardtrim3_fastq_input() {
     );
 }
 
+/// #450 — a Read 2 clip flag reaches no clip site on a single-end run, so nothing
+/// can be appended and there is nothing to lose. Both flags of the pair, since
+/// dropping either array entry would otherwise ship green.
+#[test]
+fn rename_into_ubam_accepted_for_inert_read_2_clip_flag() {
+    for (tag, flag, value) in [
+        ("clip_r2", "--clip_R2", "5"),
+        ("tp_clip_r2", "--three_prime_clip_R2", "7"),
+    ] {
+        // A directory per case: both runs would otherwise write sp_trimmed.bam.
+        let dir = fresh_tmpdir(&format!("tg_450_inert_{tag}"));
+        write_one_record(
+            &dir.join("sp.fastq"),
+            "@withspace 1:N:0:ACGTAC",
+            "ACGTACGTACGTACGTACGTACGTACGT",
+        );
+        let (ok, err) = run_in(
+            &dir,
+            &[
+                flag,
+                value,
+                "--rename",
+                "--output-format",
+                "ubam",
+                "sp.fastq",
+            ],
+        );
+        assert!(
+            ok,
+            "{flag} is inert on a single-end run, not a refusal:\n{err}"
+        );
+        assert!(
+            err.contains(&format!(
+                "{flag} {value} was given but is not used in this mode"
+            )),
+            "{flag} should still warn that it is being ignored:\n{err}"
+        );
+        assert!(
+            !err.contains("--rename is refused"),
+            "{flag} must not trigger the #408 refusal:\n{err}"
+        );
+        let bam = dir.join("sp_trimmed.bam");
+        assert!(
+            bam.exists(),
+            "{flag} run should have produced sp_trimmed.bam"
+        );
+        let tuples = bam_tuples(&bam);
+        let record = tuples.first().expect("no records");
+        let name = String::from_utf8_lossy(&record.0).to_string();
+        assert!(
+            !name.contains(":clip5:") && !name.contains(":clip3:"),
+            "nothing should have been appended under {flag}; got {name}"
+        );
+        // The whole premise: a Read 2 value reaches no clip site here, so the
+        // sequence keeps all 28 input bases.
+        assert_eq!(record.2.len(), 28, "{flag} must not have removed any bases");
+    }
+}
+
+/// #450 — the narrowing is about which read a flag names, not about relaxing the
+/// gate. Read 1 flags still refuse on either shape, Read 2 flags still refuse when
+/// the run has a Read 2, and a live Read 1 flag is not excused by an inert Read 2
+/// one beside it — that last row is the only one whose failure mode is #408's
+/// original silent annotation loss rather than an over-refusal.
+#[test]
+fn rename_into_ubam_still_refused_where_a_clip_can_apply() {
+    struct Case {
+        tag: &'static str,
+        args: &'static [&'static str],
+        paired: bool,
+    }
+    let cases = [
+        Case {
+            tag: "three_prime_clip_r1_se",
+            args: &["--three_prime_clip_R1", "3"],
+            paired: false,
+        },
+        Case {
+            tag: "clip_r2_paired",
+            args: &["--clip_R2", "5"],
+            paired: true,
+        },
+        Case {
+            tag: "tp_clip_r2_paired",
+            args: &["--three_prime_clip_R2", "7"],
+            paired: true,
+        },
+        Case {
+            tag: "r1_live_beside_inert_r2_se",
+            args: &["--clip_R1", "3", "--clip_R2", "5"],
+            paired: false,
+        },
+    ];
+    for case in cases {
+        let dir = fresh_tmpdir(&format!("tg_450_refused_{}", case.tag));
+        let mut argv: Vec<&str> = case.args.to_vec();
+        argv.extend_from_slice(&["--rename", "--output-format", "ubam"]);
+        let inputs: Vec<String> = if case.paired {
+            write_one_record(
+                &dir.join("r1.fastq"),
+                "@withspace 1:N:0:ACGTAC",
+                "ACGTACGTACGTACGTACGTACGTACGT",
+            );
+            write_one_record(
+                &dir.join("r2.fastq"),
+                "@withspace 2:N:0:ACGTAC",
+                "ACGTACGTACGTACGTACGTACGTACGT",
+            );
+            argv.extend_from_slice(&["--paired", "r1.fastq", "r2.fastq"]);
+            vec!["r1.fastq".to_string(), "r2.fastq".to_string()]
+        } else {
+            write_one_record(
+                &dir.join("sp.fastq"),
+                "@withspace 1:N:0:ACGTAC",
+                "ACGTACGTACGTACGTACGTACGTACGT",
+            );
+            argv.push("sp.fastq");
+            vec!["sp.fastq".to_string()]
+        };
+        let (ok, err) = run_in(&dir, &argv);
+        assert!(!ok, "{} must still exit non-zero", case.tag);
+        assert!(
+            err.contains("--rename is refused") && err.contains("--output-format ubam"),
+            "expected the #408 refusal for {}:\n{err}",
+            case.tag
+        );
+        // The whole listing, not one filename: the refusal precedes every writer,
+        // so the trimming reports must be absent too.
+        assert_eq!(
+            dir_listing(&dir),
+            inputs,
+            "{} was refused, so it must have written nothing",
+            case.tag
+        );
+    }
+}
+
+/// #450 — every preset supplies a Read 1 clip value, so no preset becomes
+/// acceptable on a single-end run. All five, not one representative.
+#[test]
+fn rename_into_ubam_refused_for_every_library_preset() {
+    for preset in ["emseq", "accel", "zymo", "scbs", "pbat"] {
+        let dir = fresh_tmpdir(&format!("tg_450_preset_{preset}"));
+        write_one_record(
+            &dir.join("sp.fastq"),
+            "@withspace 1:N:0:ACGTAC",
+            "ACGTACGTACGTACGTACGTACGTACGT",
+        );
+        let (ok, err) = run_in(
+            &dir,
+            &[
+                "--library",
+                preset,
+                "--rename",
+                "--output-format",
+                "ubam",
+                "sp.fastq",
+            ],
+        );
+        assert!(!ok, "--library {preset} must still be refused");
+        assert!(
+            err.contains("--rename is refused"),
+            "expected the #408 refusal for --library {preset}:\n{err}"
+        );
+    }
+}
+
 /// #408 — the guard sits behind `Cli::validate()`, so `--clump_only` keeps its
 /// own mode-specific message instead of being pre-empted by a mechanical one.
 #[test]


### PR DESCRIPTION
Closes #450.

A single-end `--rename --output-format ubam --clip_R2 5` run warned that `--clip_R2` was being ignored and then refused the run because `--clip_R2` was set. The #408 guard counted all four clip values, including a Read 2 flag that reaches no read on a single-end run. It now counts only flags that apply to the run's shape, so that run proceeds with the warning; every other refusal is unchanged. Along the way, "which read does a clip flag belong to" moves from six open-coded sites into one `ClipFlag` enum, which is what the duplication had already cost us once.

`--help` and both statements of the gate in `docs/guide/outputs.md` said "when a clipping flag is set", which this makes inaccurate, so all three are updated.

<details>
<summary>Implementation and verification detail (AI-assisted)</summary>

**Why the narrowing is safe.** The guard's own comment stated the criterion it meant to apply — the clip-flag list must match every `--rename`-driven `append_to_id` site, "without one of them set, `--rename` appends nothing and there is nothing to lose". `trim_read` picks the clip value by `is_r2`, and the three production call sites passing `true` (`trimmer.rs` `run_paired_end` and `run_paired_end_to_bam`, `parallel.rs` `classify_paired`) are all gated on `cli.paired`, so on a single-end run no Read 2 value is read and no append site can fire.

That absence is *categorical*, which is the boundary of the change. The guard stays conservative about the statistical case: `clip_5prime` returns `None` when a read is shorter than the clip, so even a live Read 1 flag appends nothing for some reads, and the refusal is deliberately whole-run rather than per-record because of it. It is also the principle `rename_without_clip_flag_is_accepted_into_ubam` already established.

**The fold-in.** `ClipFlag::applies(paired)` replaces four hand-written spellings of `paired || !read_2`: `flag_summary`'s skip, the inert-flag warning ladder, the #408 guard, and the override-line filters in `main.rs` and `report.rs`. `ClipOverride` carries a `ClipFlag` rather than a `&'static str` plus a separate bool, so a wrong read-ownership bool is unrepresentable rather than merely tested. Only the guard changes behaviour.

Each display site keeps its own emission order, because the two differ and are both user-visible (`flag_summary`: R1, R2, 3'R1, 3'R2; the ladder: R1, 3'R1, R2, 3'R2). `ClipFlag::ALL` is deliberately in neither order, so no display site can iterate it and still look correct.

**Verification.** 788 tests (7 new), `fmt` and `clippy --all-targets --release -D warnings` clean.

- A 27-cell base-vs-new differential over 102 artifacts (stderr plus both trimming reports) has exactly one differing cell — the #450 shape. Each cell asserts it emitted a warning, a preset banner or the refusal before comparing, so a cell cannot pass by comparing two identical error messages.
- Four mutations, each red at its target: counting Read 2 regardless of `paired` turns the two new "must run" rows red; dropping the `paired ||` narrowing turns the paired "must refuse" rows red; flipping `read_2()` for `ClipR2` or for `ThreePrimeClipR1` turns the ownership oracle red, the latter also turning the `--three_prime_clip_R1` row red. The first two fail disjoint test sets, which is what shows they are opposite mutations rather than one.
- All twelve rows of the refusal truth table now have a test. `--three_prime_clip_R1` had none before — `grep -c` in `integration_ubam_out.rs` returns 0 at the base commit and 1 now.

**Two things deliberately not fixed.** `--rrbs` reaches the same append site without setting a clip flag, because `setup_trimming` sets `clip_r2 = 2` after the guard runs — an under-refusal in the opposite direction, filed as #459. And `--clip_R1 0` still triggers the refusal though a zero value can never append.

**Not held by any test:** the guard's siting after the two structural pair checks in `main()`, which is what makes a mixed-format pair report its own defect rather than this refusal. `Validate vs Perl TrimGalore` is the job to watch here, since `Cli::validate()` is edited.

</details>
