### PR TITLE
ci(clump): enforce the clumpify drift band, and assert it stays armed (#439)

### DIFF
--- a/.github/clumpify-memory-baseline.tsv
+++ b/.github/clumpify-memory-baseline.tsv
@@ -3,43 +3,70 @@
 # The job gates on two things. The *promise* — measured peak <= the peak the
 # binary printed — is absolute and platform-independent. The *drift* band is
 # relative to the ratios below, because gating on the promise alone cannot see a
-# regression on Linux: at the expected ~0.85 ratio a work-channel-depth revert
+# regression on Linux: at the measured ~0.78 ratio a work-channel-depth revert
 # adds ~72-104 MiB and still lands under the printed prediction.
 #
-# Fail if a cell's peak/prediction rises more than 0.05 above its baseline, or
-# falls more than 0.10 below it. A depth revert is a 0.08-0.11 move, so it
+# Fail if a cell peak/prediction rises more than 0.05 above its baseline, or
+# falls more than 0.10 below it. A depth revert is a 0.078-0.11 move, so it
 # breaches the upper bound on any platform; a silent fallback to plain mode or a
 # fixture that stopped filling the bin pool is a multi-point drop.
 #
-# BOOTSTRAP: while this line is present the job records ratios and warns instead
-# of enforcing the band. Delete it once the values below are filled in from two
-# or three green runs on the runner. It is printed on every run so it cannot sit
-# here unnoticed.
+# A cell is banded only if it has >= 3 reps that predate the PR adding its row,
+# AND a false-red multiple >= 3x: a spurious red must need an excursion at least
+# three times the largest yet observed for that cell. Reps from the adding PR do
+# not count toward the bar, or a cell would certify itself. Cells under the bar
+# are measured and printed but not banded, and the BANDED list in ci.yml keeps a
+# deliberate omission distinguishable from a typo.
+#
+# On a lone red 5-7 points above baseline on unmodified code: re-run once. If it
+# clears it was spread, not drift. Do not widen the band on one reading.
 #
 # cell<TAB>baseline_peak_over_prediction
+1G_c4	0.777
+25bp_1G_c4	0.923
+multipair_c4	0.790
 #
-# Runner observations. Reps 1-2 measured identical code: the only difference
-# between 69d8f67 and 3f1a930 is this file's comment block, so they pool. Two
-# more reps are needed before these become the enforced baseline, because a pair
-# bounds a cell's spread without estimating it.
+# Baselines are the means of reps 1-4, half-up to 3 dp (1G_c4 3.108/4 = 0.7770;
+# 25bp_1G_c4 3.691/4 = 0.92275 -> 0.923; multipair_c4 3.160/4 = 0.7900). Rep 5 is
+# deliberately excluded from the centre: it is the run that first enforced these
+# bands, so it serves as their independent confirmation. Fold it in at the next
+# deliberate re-baseline.
 #
-#   cell            rep1     rep2     mean      macOS/arm64
-#   1G_c4           0.770    0.782    0.776     0.939
-#   1G_c4_fastqc    0.697    0.701    0.699     0.724
-#   25bp_1G_c4      0.941    0.924    0.9325    1.054-1.075
-#   multipair_c4    0.792    0.787    0.790     -
+#   cell            rep1   rep2   rep3   rep4   rep5    range   false red   miss
+#   1G_c4           0.770  0.782  0.785  0.771  0.785   0.015   6.7x        3.7x
+#   25bp_1G_c4      0.941  0.924  0.914  0.912  0.929   0.029   3.4x        1.9x
+#   multipair_c4    0.792  0.787  0.789  0.792  0.808   0.021   4.8x        2.7x
 #
-#   rep1  69d8f67  run 32065004600
-#   rep2  3f1a930  run 32065624366
+# 25bp_1G_c4 is banded at a 1.9x miss margin because a depth revert moves every
+# cell at once, so a miss needs every banded cell to miss: 1G_c4 carries that
+# direction at 3.7x. multipair_c4 looked like the carrier at 11.2x on four reps
+# and is 2.7x on five, which is why the redundancy argument names the widest
+# margin currently measured rather than a fixed cell.
 #
-# Record the commit for every rep. Reps whose binaries differ must not be pooled;
-# `git diff --quiet <rep1> <repN> -- src Cargo.lock` is the check, and a rep that
-# fails it is dropped in favour of another push.
+# Measured but NOT banded:
 #
-# The runner sits ~16 points below macOS at the gating cell, not the ~9 the #439
-# calibration estimated. Observed spread is 0.4-1.7 points.
+#   1G_c4_fastqc    0.697  0.701  0.707  0.745  0.701   0.048   2.1x        1.2x
+#     Widest of the six. A +0.05 band would trigger at 0.7625 against an observed
+#     max of 0.745 — 1.75 points of headroom on a 4.8-point range — so banding it
+#     would red on correct code. It stays promise-gated (peak <= prediction, at
+#     0.745 of 1.000). FastQC cost scales with --cores and the allocator holds the
+#     pool pages across the trim->FastQC boundary, so this cell is timing-
+#     sensitive in a way the pure-trim cells are not.
 #
-# 1G_c2 and 25bp_1G_c2 record from reps 3-4 onward and have no row yet: two reps
-# is below the bar above. 25bp_1G_c2 is #457's worst cell on macOS, where it
-# exceeds the budget; a Linux breach there needs a c4->c2 increment of +0.169,
-# 2.4x the +0.070 macOS shows.
+#   1G_c2           -      -      0.867  0.894  0.878   0.027   3.7x        2.1x
+#   25bp_1G_c2      -      -      1.031  1.026  1.043   0.017   5.9x        3.3x
+#     Both now clear the 3x multiple, but their third rep IS rep 5, which does not
+#     count toward the bar. Band them in the next pass, on an independent
+#     confirmation. 25bp_1G_c2 also tripled its range on that third draw (0.005 ->
+#     0.017), which is the signal to wait rather than to proceed: dispersion from
+#     two draws is biased low, not merely imprecise. That is how 1G_c4_fastqc
+#     looked tightest of the six on its first two reps.
+#     25bp_1G_c2 is #457: over the printed prediction, inside the budget, on
+#     Linux. Its value will move when sigma is refitted, needing a re-baseline.
+#
+# Reps: rep1 69d8f67 (run 32065004600), rep2 3f1a930 (32065624366),
+#       rep3 7d676b7 (32109372844), rep4 bc48bf0 (32110691552),
+#       rep5 7a218b0 (32113210868, the run that enforced these bands).
+# Every rep passes `git diff --quiet 69d8f67 <rep> -- src Cargo.lock`, so they
+# pool. Reps built from different sources must not be pooled into one mean; when
+# src/ moves, judge whether the change can reach the clump path before pooling.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,11 @@ jobs:
         run: |
           set -euo pipefail
           base=.github/clumpify-memory-baseline.tsv
+          # A missing file would leave every lookup empty and the band silently off.
+          test -f "$base" || { echo "::error::baseline file missing: $base"; exit 1; }
+          # Cells with a committed baseline. A label here without exactly one row
+          # means the drift band is not armed for it.
+          BANDED="1G_c4 25bp_1G_c4 multipair_c4"
           bootstrap=0
           if grep -q '^# BOOTSTRAP' "$base"; then
             bootstrap=1
@@ -351,6 +356,15 @@ jobs:
           Record the ratios below in $base and delete the BOOTSTRAP line."
           fi
           fail=0
+
+          # Assert before measuring so a broken baseline shows at the top of the log,
+          # but with fail=1 rather than exit so the ratios still print for repair.
+          if [ "$bootstrap" = 0 ]; then
+            for label in $BANDED; do
+              awk -v c="$label" '$1==c {n++} END{exit !(n==1)}' "$base" \
+                || { echo "::error::$label has no single baseline row in $base - the drift band is not armed for it"; fail=1; }
+            done
+          fi
 
           # $1 label  $2 gating(1|0)  $3.. trim_galore args
           measure () {


### PR DESCRIPTION
The `clumpify-memory` baseline file leaves BOOTSTRAP mode, so `peak/prediction` is now gated against a recorded band as well as against the prediction the binary prints. Gating on the printed prediction alone cannot see a work-channel-depth revert on Linux — it adds 72–104 MiB and still lands well under the prediction at the measured 0.78 ratio, which is why #439 accepted a committed baseline file in the first place.

Three cells are banded rather than all six, by a stated rule: **≥ 3 reps that predate this PR, and a false-red multiple ≥ 3×** — a spurious red must need an excursion at least three times the largest yet observed for that cell. Reps from the adding PR do not count toward the bar, or a cell would certify itself.

| cell | baseline | reps | range | false red needs | banded |
|---|---:|---:|---:|---:|---|
| `1G_c4` | 0.777 | 5 | 0.015 | 6.7× | yes |
| `25bp_1G_c4` | 0.923 | 5 | 0.029 | 3.4× | yes |
| `multipair_c4` | 0.790 | 5 | 0.021 | 4.8× | yes |
| `1G_c4_fastqc` | — | 5 | 0.048 | 2.1× | no — spread |
| `1G_c2` | — | 3 | 0.027 | 3.7× | not yet — see below |
| `25bp_1G_c2` | — | 3 | 0.017 | 5.9× | not yet — see below |

`1G_c4_fastqc` read 0.697 / 0.701 / 0.707 / 0.745 / 0.701 — the widest range of the six, having looked like the tightest on two reps. A ±0.05 band would trigger at 0.7625 against an observed max of 0.745, so banding it would go red on correct code. It stays gated on the printed prediction (0.745 of 1.000). Because a depth revert moves every cell at once, a miss needs every banded cell to miss, and `1G_c4` carries that direction at 3.7×.

The two `--cores 2` cells now clear the multiple, but only on a rep produced by this PR, and `25bp_1G_c2` tripled its range on that draw (0.005 → 0.017). Both wait for an independent confirmation — which is the rep-count bar doing its job rather than an oversight, and the file says so.

Deleting the `BOOTSTRAP` line also removes the warning that the band is off, so three silent routes to an inert band open at the same moment: a missing baseline file (the `grep` sits inside an `if`, so `set -e` does not catch it), a label typo, and a cell renamed in `ci.yml` but not in the TSV. An explicit `BANDED` list, a file-exists guard and an exactly-one-row assertion close all three, plus the duplicate-row case where `awk` would quietly coerce the first of two.

Verified against the committed clauses rather than a paraphrase of them: the band fires above **and** below with distinguishable messages (`+0.050` passes and `+0.051` fires, since the comparison is strict `>`), lever A's weakest form goes red on all three banded cells, and all five armed-check failure modes are caught — deleted row, typo'd label, renamed file, duplicate row, and a cell renamed in `ci.yml` only.

This PR's own run is the first time the band has ever been enforced; all three banded cells landed inside with 3.2–4.4 points of margin.

**Note for anyone touching `src/clump.rs`, `src/parallel.rs`'s channel depths or `src/fastqc.rs`'s thread resolution:** from this PR onward a clumpify memory regression fails CI. If a change legitimately moves peak RSS, move the baseline in the same PR and say why in the commit message.

Follows #452. Part of #439.