### PR TITLE
fix(cli): count the --rrbs auto-clip in the --rename uBAM guard (#459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 #### Changes
 
+- **`--rename --output-format ubam` is now refused on the `--rrbs` directional paired path**
+  ([#459](https://github.com/FelixKrueger/TrimGalore/issues/459)). That path auto-sets
+  `--clip_R2 2`, so the annotation was being appended and then dropped without a word.
+
 - **`--rename --output-format ubam` no longer refuses over a clip flag that applies to no read**
   ([#450](https://github.com/FelixKrueger/TrimGalore/issues/450)). A Read 2 clip flag on a single-end
   run is still warned about and ignored, but no longer blocks the run.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1228,6 +1228,12 @@ impl Cli {
         crate::library::resolve(self.library, self.user_clips())
     }
 
+    /// `--rrbs` auto-sets `--clip_R2 2` on the directional paired path, so a run
+    /// can clip Read 2 with no clip flag on the command line.
+    pub fn rrbs_sets_clip_r2(&self) -> bool {
+        self.rrbs && !self.non_directional && self.paired
+    }
+
     /// The values as typed. Only the inert-flag warning wants these directly, so
     /// that it cannot report a flag a preset supplied; anything needing the values
     /// in force goes through `effective_clips()`, which folds the preset in.
@@ -2587,6 +2593,33 @@ mod tests {
             "expected the missing-input error first, got: {err}"
         );
         assert!(!err.contains("--library"), "got: {err}");
+    }
+
+    /// #459 — each conjunct is load-bearing, so each is dropped in turn. The
+    /// `--rename` uBAM guard and `setup_trimming` both read this one predicate.
+    #[test]
+    fn rrbs_sets_clip_r2_only_on_the_directional_paired_path() {
+        let cli = Cli::parse_from(["trim_galore", "--rrbs", "--paired", R1, R2]);
+        assert!(cli.rrbs_sets_clip_r2());
+
+        // Drop --rrbs.
+        let cli = Cli::parse_from(["trim_galore", "--paired", R1, R2]);
+        assert!(!cli.rrbs_sets_clip_r2());
+
+        // Drop --paired.
+        let cli = Cli::parse_from(["trim_galore", "--rrbs", R1]);
+        assert!(!cli.rrbs_sets_clip_r2());
+
+        // Add --non_directional.
+        let cli = Cli::parse_from([
+            "trim_galore",
+            "--rrbs",
+            "--non_directional",
+            "--paired",
+            R1,
+            R2,
+        ]);
+        assert!(!cli.rrbs_sets_clip_r2());
     }
 
     /// A clip flag a mode cannot honour is a warning, never a refusal — unlike

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,11 +388,12 @@ fn main() -> Result<()> {
         reject_bam_format_mismatch_in_pair(&cli.input, &input_formats, shape)?;
     }
 
-    // #408 — refused only where an `append_to_id` site can fire: a clip flag for a read
-    // this run processes, or a hardtrim. Format-gated, so it cannot live in `validate()`.
+    // #408 — refused only where an `append_to_id` site can fire: a clip that applies to a
+    // read this run processes, or a hardtrim. Format-gated, so it cannot live in `validate()`.
     if cli.rename
         && matches!(cli.output_format, trim_galore::cli::OutputFormat::UBam)
         && (cli.effective_clips().any_effective(cli.paired)
+            || cli.rrbs_sets_clip_r2()
             || cli.hardtrim5.is_some()
             || cli.hardtrim3.is_some())
         && input_formats
@@ -1141,7 +1142,7 @@ fn setup_trimming(cli: &Cli, input_file: &Path) -> SetupResult {
 
     // RRBS: auto-set --clip_r2 2 for directional paired-end mode. A preset that
     // supplies clip_R2 counts as "already set", same as an explicit flag.
-    let clip_r2 = if cli.rrbs && !cli.non_directional && cli.paired && clips.clip_r2.is_none() {
+    let clip_r2 = if cli.rrbs_sets_clip_r2() && clips.clip_r2.is_none() {
         eprintln!(
             "Setting the option '--clip_r2 2' (to remove methylation bias from the start of Read 2)"
         );

--- a/tests/integration_ubam_out.rs
+++ b/tests/integration_ubam_out.rs
@@ -1363,6 +1363,96 @@ fn rename_into_ubam_still_refused_where_a_clip_can_apply() {
     }
 }
 
+/// #459 — `--rrbs` auto-sets `--clip_R2 2` on the directional paired path, so a run
+/// with no clip flag on the command line still clips Read 2 and still appends. The
+/// three shapes where the auto-clip does not fire must stay accepted.
+#[test]
+fn rename_into_ubam_accounts_for_the_rrbs_auto_clip() {
+    struct Case {
+        tag: &'static str,
+        args: &'static [&'static str],
+        paired: bool,
+        refused: bool,
+    }
+    let cases = [
+        Case {
+            tag: "rrbs_directional_paired",
+            args: &["--rrbs"],
+            paired: true,
+            refused: true,
+        },
+        // --non_directional skips the auto-clip, so nothing is appended.
+        Case {
+            tag: "rrbs_non_directional_paired",
+            args: &["--rrbs", "--non_directional"],
+            paired: true,
+            refused: false,
+        },
+        // The auto-clip is paired-only.
+        Case {
+            tag: "rrbs_single_end",
+            args: &["--rrbs"],
+            paired: false,
+            refused: false,
+        },
+    ];
+    for case in cases {
+        let dir = fresh_tmpdir(&format!("tg_459_{}", case.tag));
+        let mut argv: Vec<&str> = case.args.to_vec();
+        argv.extend_from_slice(&["--rename", "--output-format", "ubam"]);
+        let inputs: Vec<String> = if case.paired {
+            write_one_record(
+                &dir.join("r1.fastq"),
+                "@withspace 1:N:0:ACGTAC",
+                "ACGTACGTACGTACGTACGTACGTACGT",
+            );
+            write_one_record(
+                &dir.join("r2.fastq"),
+                "@withspace 2:N:0:ACGTAC",
+                "TTACGTACGTACGTACGTACGTACGTA",
+            );
+            argv.extend_from_slice(&["--paired", "r1.fastq", "r2.fastq"]);
+            vec!["r1.fastq".to_string(), "r2.fastq".to_string()]
+        } else {
+            write_one_record(
+                &dir.join("sp.fastq"),
+                "@withspace 1:N:0:ACGTAC",
+                "ACGTACGTACGTACGTACGTACGTACGT",
+            );
+            argv.push("sp.fastq");
+            vec!["sp.fastq".to_string()]
+        };
+        let (ok, err) = run_in(&dir, &argv);
+        if case.refused {
+            assert!(!ok, "{} must exit non-zero", case.tag);
+            assert!(
+                err.contains("--rename is refused"),
+                "expected the #408 refusal for {}:\n{err}",
+                case.tag
+            );
+            // The refusal precedes every writer, so nothing may be written — and it
+            // must also precede the auto-clip's own log line.
+            assert_eq!(
+                dir_listing(&dir),
+                inputs,
+                "{} was refused, so it must have written nothing",
+                case.tag
+            );
+        } else {
+            assert!(
+                ok,
+                "{} has no Read 2 clip to append, so it must run:\n{err}",
+                case.tag
+            );
+            assert!(
+                !err.contains("--rename is refused"),
+                "{} must not be refused:\n{err}",
+                case.tag
+            );
+        }
+    }
+}
+
 /// #450 — every preset supplies a Read 1 clip value, so no preset becomes
 /// acceptable on a single-end run. All five, not one representative.
 #[test]


### PR DESCRIPTION
Closes #459.

`--rrbs --paired --rename --output-format ubam` with no clip flag ran to completion and silently dropped the annotation. The #408 guard counted only the clip flags on the command line, but the directional paired path auto-sets `--clip_R2 2` *after* the guard runs — so a clip did apply, `--rename` did append `:clip5:` to Read 2, and the BAM QNAME kept only the first whitespace-delimited token. It is now refused, like every other shape where the annotation cannot survive.

<details>
<summary>Verification detail (AI-assisted)</summary>

**Observed, not derived.** #459 was written from reading the code path; both the issue and the review that found it flagged the final step as unverified. On a 40 bp pair with a description in the header, the output R2 record is **38 bases** with QNAME `readone` and no `:clip5:` anywhere — exit 0, no warning. After this change the same command exits 1 with the #408 refusal and writes nothing.

**One predicate, two consumers.** `Cli::rrbs_sets_clip_r2()` is now the single spelling of `rrbs && !non_directional && paired`; the guard and `setup_trimming` both read it. Open-coding it in the guard would have added a seventh site encoding when a Read 2 clip applies, which is the duplication #450's fold-in was reducing.

**The three shapes where the auto-clip does not fire stay accepted**, each a row in the new test table: `--non_directional` (skips the auto-clip), single-end (the auto-clip is paired-only), and FASTQ output (unaffected, and still logs the auto-clip).

**Mutations, in opposite directions.** Dropping the guard term loosens it and turns the should-refuse row red (1 failure); making the predicate ignore `--non_directional` tightens it and turns the should-run row plus the unit test red (2 failures). A mutation that loosens a condition cannot turn a should-succeed test red, so the pair opposing each other is what makes them meaningful.

798 tests (2 new), `fmt` and `clippy --all-targets --release -D warnings` clean. No file in the clumpify memory path is touched, so the peak-RSS baseline is undisturbed.

</details>
