### PR TITLE
feat(clump): print --clump_only's predicted peak, like --clumpify (#456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 #### Changes
 
+- **`--clump_only` now prints its predicted peak memory, like `--clumpify` does**
+  ([#456](https://github.com/FelixKrueger/TrimGalore/issues/456)). All four banners name the
+  peak and the `--memory` budget it was sized against.
+
 - **`--rename --output-format ubam` is now refused on the `--rrbs` directional paired path**
   ([#459](https://github.com/FelixKrueger/TrimGalore/issues/459)). That path auto-sets
   `--clip_R2 2`, so the annotation was being appended and then dropped without a word.

--- a/src/clump_only.rs
+++ b/src/clump_only.rs
@@ -287,11 +287,13 @@ pub fn clump_only_single(
     let output_path = naming::clumped_output_name(input, output_dir, basename, gzip_output);
 
     eprintln!(
-        "clump-only: reordering '{}' -> '{}' ({} bins × {} MiB each, gzip level {}{})",
+        "clump-only: reordering '{}' -> '{}' ({} bins × {} MiB each; predicted peak ≈ {} of {} MiB budget, gzip level {}{})",
         input.display(),
         output_path.display(),
         layout.n_bins,
         layout.bin_byte_budget / (1024 * 1024),
+        layout.predicted_peak_bytes() / (1024 * 1024),
+        memory_budget_bytes / (1024 * 1024),
         compression,
         if gzip_output { "" } else { ", --dont_gzip" },
     );
@@ -435,13 +437,15 @@ pub fn clump_only_paired(
         naming::clumped_paired_output_names(input_r1, input_r2, output_dir, basename, gzip_output);
 
     eprintln!(
-        "clump-only (paired): '{}' + '{}' -> '{}' + '{}' ({} bins × {} MiB each, gzip level {}{})",
+        "clump-only (paired): '{}' + '{}' -> '{}' + '{}' ({} bins × {} MiB each; predicted peak ≈ {} of {} MiB budget, gzip level {}{})",
         input_r1.display(),
         input_r2.display(),
         out_r1_path.display(),
         out_r2_path.display(),
         layout.n_bins,
         layout.bin_byte_budget / (1024 * 1024),
+        layout.predicted_peak_bytes() / (1024 * 1024),
+        memory_budget_bytes / (1024 * 1024),
         compression,
         if gzip_output { "" } else { ", --dont_gzip" },
     );
@@ -784,11 +788,13 @@ pub fn clump_only_single_to_bam(
     let output_path = naming::clumped_bam_output_name(input, output_dir, basename);
 
     eprintln!(
-        "clump-only (uBAM out): reordering '{}' -> '{}' ({} bins × {} MiB each, BGZF)",
+        "clump-only (uBAM out): reordering '{}' -> '{}' ({} bins × {} MiB each; predicted peak ≈ {} of {} MiB budget, BGZF)",
         input.display(),
         output_path.display(),
         layout.n_bins,
         layout.bin_byte_budget / (1024 * 1024),
+        layout.predicted_peak_bytes() / (1024 * 1024),
+        memory_budget_bytes / (1024 * 1024),
     );
 
     let mut reader = crate::format::open_sync_reader(input, preserve_tags)?;
@@ -1032,11 +1038,13 @@ pub fn clump_only_paired_to_bam_one_pair(
         format!("{} + {}", inputs[0].display(), inputs[1].display())
     };
     eprintln!(
-        "clump-only (uBAM out, paired): '{}' -> '{}' ({} bins × {} MiB each, BGZF)",
+        "clump-only (uBAM out, paired): '{}' -> '{}' ({} bins × {} MiB each; predicted peak ≈ {} of {} MiB budget, BGZF)",
         input_display,
         output_path.display(),
         layout.n_bins,
         layout.bin_byte_budget / (1024 * 1024),
+        layout.predicted_peak_bytes() / (1024 * 1024),
+        memory_budget_bytes / (1024 * 1024),
     );
 
     let mut writer = BamWriter::create(

--- a/tests/integration_clump_only.rs
+++ b/tests/integration_clump_only.rs
@@ -96,6 +96,40 @@ fn se_byte_identity_gzip() -> Result<()> {
     Ok(())
 }
 
+/// #456 — the memory visibility added for `--clumpify` under #439 must reach
+/// `--clump_only` too, which fails below the memory floor rather than falling back.
+/// Both figures are pinned by value: at the default `--memory 1G`, 1024 × 10/11
+/// truncates to 930, so the arithmetic is asserted and not just the label.
+#[test]
+fn banner_reports_the_predicted_peak() -> Result<()> {
+    let r1 = fixture("BS-seq_10K_R1.fastq.gz");
+    let r2 = fixture("BS-seq_10K_R2.fastq.gz");
+
+    for (tag, args) in [
+        ("se", vec!["--clump_only", "--cores", "2"]),
+        ("pe", vec!["--clump_only", "--paired", "--cores", "2"]),
+    ] {
+        let dir = tempdir(&format!("peak_{tag}"));
+        let mut cmd = Command::new(binary());
+        cmd.args(&args).args(["-o", dir.to_str().unwrap()]).arg(&r1);
+        if tag == "pe" {
+            cmd.arg(&r2);
+        }
+        let out = cmd.output()?;
+        let err = String::from_utf8_lossy(&out.stderr).to_string();
+        assert!(out.status.success(), "{tag} run failed:\n{err}");
+        assert!(
+            err.contains("clump-only"),
+            "{tag}: clump-only did not engage, so this proves nothing:\n{err}"
+        );
+        assert!(
+            err.contains("predicted peak ≈ 930 of 1024 MiB budget"),
+            "{tag}: banner must name the peak and the budget it came from:\n{err}"
+        );
+    }
+    Ok(())
+}
+
 // ── Byte-identity: SE (gzip in / plain out via --dont_gzip) ────────
 
 #[test]

--- a/tests/integration_clump_only_ubam.rs
+++ b/tests/integration_clump_only_ubam.rs
@@ -139,6 +139,39 @@ fn has_trim_galore_pg(path: &Path) -> bool {
 
 // ── SE positive path ──────────────────────────────────────────────
 
+/// #456 — the two uBAM-out banners carry the same peak/budget pair as the FASTQ
+/// ones. Covered here as well as in `integration_clump_only.rs` because deleting
+/// the figure from only these two would otherwise ship green.
+#[test]
+fn ubam_out_banners_report_the_predicted_peak() {
+    let r1 = fixture("BS-seq_10K_R1.fastq.gz");
+    let r2 = fixture("BS-seq_10K_R2.fastq.gz");
+
+    for (tag, paired) in [("se", false), ("pe", true)] {
+        let dir = fresh_tmpdir(&format!("peak_ubam_{tag}"));
+        let mut cmd = Command::new(binary());
+        cmd.args(["--clump_only", "--output-format", "ubam", "--cores", "2"]);
+        if paired {
+            cmd.arg("--paired");
+        }
+        cmd.args(["-o", dir.to_str().unwrap()]).arg(&r1);
+        if paired {
+            cmd.arg(&r2);
+        }
+        let out = cmd.output().expect("trim_galore failed to run");
+        let err = String::from_utf8_lossy(&out.stderr).to_string();
+        assert!(out.status.success(), "{tag} uBAM-out run failed:\n{err}");
+        assert!(
+            err.contains("clump-only (uBAM out"),
+            "{tag}: the uBAM-out banner did not print, so this proves nothing:\n{err}"
+        );
+        assert!(
+            err.contains("predicted peak ≈ 930 of 1024 MiB budget"),
+            "{tag}: uBAM-out banner must name the peak and its budget:\n{err}"
+        );
+    }
+}
+
 #[test]
 fn se_ubam_out_from_fastq_in() {
     let dir = fresh_tmpdir("se_fq_to_bam");


### PR DESCRIPTION
Closes #456.

`--clumpify` names its predicted peak and the budget it came from; `--clump_only` printed only its bin layout. That left the memory visibility added under #439 missing from the mode where it matters more — `--clump_only` fails below the memory floor rather than falling back to plain mode, so a user had no way to see how close they were before it did.

```
before: clump-only: reordering 'in.fq.gz' -> 'in_clumped.fq.gz' (16 bins × 26 MiB each, gzip level 1)
after:  clump-only: reordering 'in.fq.gz' -> 'in_clumped.fq.gz' (16 bins × 26 MiB each; predicted peak ≈ 930 of 1024 MiB budget, gzip level 1)
```

<details>
<summary>Detail (AI-assisted)</summary>

`ClumpLayout::predicted_peak_bytes()` and `memory_budget_bytes` were both already in scope at all four sites, so this is a format argument and no model work — as the issue predicted.

**All four banners are pinned separately.** Removing the figure from any one of them turns exactly one test red, verified by mutating each in turn:

| banner | test that goes red |
|---|---|
| `clump-only: reordering` | `banner_reports_the_predicted_peak` |
| `clump-only (paired)` | `banner_reports_the_predicted_peak` |
| `clump-only (uBAM out): reordering` | `ubam_out_banners_report_the_predicted_peak` |
| `clump-only (uBAM out, paired)` | `ubam_out_banners_report_the_predicted_peak` |

The two uBAM shapes are covered in `integration_clump_only_ubam.rs` rather than folded into one test, because a single test over one shape would let the other three regress green.

Both figures are asserted **by value** (`930 of 1024`), matching how the existing `--clumpify` assertion in `integration_preflight_tripwire.rs` pins the same arithmetic — at the default `--memory 1G`, 1024 × 10/11 truncates to 930, so a divisor change is caught where a unit label alone would not be.

`--clumpify`'s own banner is byte-unchanged. 798 tests (2 new), `fmt` and `clippy --all-targets --release -D warnings` clean.

</details>
