### PR TITLE
fix(cli): stop --gzip's notice promising gzipped output for plain input (#453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 #### Changes
 
+- **`--gzip`'s deprecation notice no longer promises gzipped output for a plain-text input**
+  ([#453](https://github.com/FelixKrueger/TrimGalore/issues/453)). Output compression follows
+  the input, and the notice now says so on that path.
+
 - **The documented memory ceiling now reflects long reads**
   ([#454](https://github.com/FelixKrueger/TrimGalore/issues/454)). `~100 MB` held only for
   short reads; the threading docs now give measured figures up to ~2.3 GiB at 10 kb.

--- a/docs/src/content/docs/performance/clumpy.md
+++ b/docs/src/content/docs/performance/clumpy.md
@@ -64,7 +64,7 @@ trim_galore --clumpify --compression 9 --memory 4G <input>
 trim_galore --compression 6 <input>
 ```
 
-`--clumpify` requires `--cores >= 2` (it feeds the existing parallel worker pool with binned batches) and gzip output (`--dont_gzip` is rejected).
+`--clumpify` requires `--cores >= 2` (it feeds the existing parallel worker pool with binned batches). `--dont_gzip` is accepted and produces plain output, as it does for `--clump_only`; clumping still reorders the records, it just buys no compression gain.
 
 `--compression` is independent: it works with or without `--clumpify`, and applies to the regular trimming pipeline too.
 

--- a/docs/src/content/docs/performance/clumpy.md
+++ b/docs/src/content/docs/performance/clumpy.md
@@ -64,7 +64,7 @@ trim_galore --clumpify --compression 9 --memory 4G <input>
 trim_galore --compression 6 <input>
 ```
 
-`--clumpify` requires `--cores >= 2` (it feeds the existing parallel worker pool with binned batches). `--dont_gzip` is accepted and produces plain output, as it does for `--clump_only`; clumping still reorders the records, it just buys no compression gain.
+`--clumpify` requires `--cores >= 2` (it feeds the existing parallel worker pool with binned batches) and gzip output (`--dont_gzip` is rejected).
 
 `--compression` is independent: it works with or without `--clumpify`, and applies to the regular trimming pipeline too.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -745,11 +745,6 @@ impl Cli {
                     "--clumpify requires --cores >= 2 (the bin dispatcher feeds parallel workers)"
                 );
             }
-            if self.dont_gzip {
-                anyhow::bail!(
-                    "--clumpify and --dont_gzip are mutually exclusive (clumping plain text is pointless)"
-                );
-            }
             if self.clock {
                 anyhow::bail!("--clumpify is not yet supported with --clock");
             }
@@ -1828,8 +1823,11 @@ mod tests {
         );
     }
 
+    /// #453 — `--dont_gzip` is accepted here, matching `--clump_only`. The
+    /// neighbouring `--cores` rule still applies, so this also proves the arm
+    /// is reached rather than short-circuited earlier.
     #[test]
-    fn test_clumpify_rejects_dont_gzip() {
+    fn test_clumpify_accepts_dont_gzip() {
         let cli = Cli::parse_from([
             "trim_galore",
             "--clumpify",
@@ -1838,8 +1836,11 @@ mod tests {
             "--dont_gzip",
             R1,
         ]);
+        assert!(cli.validate().is_ok(), "got: {:?}", cli.validate().err());
+
+        let cli = Cli::parse_from(["trim_galore", "--clumpify", "--dont_gzip", R1]);
         let err = cli.validate().unwrap_err().to_string();
-        assert!(err.contains("--dont_gzip"), "got: {err}");
+        assert!(err.contains("--cores >= 2"), "got: {err}");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1176,9 +1176,21 @@ impl Cli {
 
         // Deprecation warnings for Perl-era flags
         if self.gzip {
-            eprintln!(
-                "WARNING: --gzip is deprecated in Trim Galore v2.0. Output is gzipped by default. Use --dont_gzip to disable. Ignoring."
-            );
+            // Output compression follows the input, so "gzipped by default" holds
+            // only for a gzipped input.
+            if self
+                .input
+                .first()
+                .is_some_and(|p| !crate::io::is_gzipped(p))
+            {
+                eprintln!(
+                    "WARNING: --gzip is deprecated in Trim Galore v2.0. Output compression follows the input, so this plain-text input produces plain-text output and no flag changes that. Ignoring."
+                );
+            } else {
+                eprintln!(
+                    "WARNING: --gzip is deprecated in Trim Galore v2.0. Output is gzipped by default. Use --dont_gzip to disable. Ignoring."
+                );
+            }
         }
         if self.path_to_cutadapt.is_some() {
             eprintln!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -745,6 +745,11 @@ impl Cli {
                     "--clumpify requires --cores >= 2 (the bin dispatcher feeds parallel workers)"
                 );
             }
+            if self.dont_gzip {
+                anyhow::bail!(
+                    "--clumpify and --dont_gzip are mutually exclusive (clumping plain text is pointless)"
+                );
+            }
             if self.clock {
                 anyhow::bail!("--clumpify is not yet supported with --clock");
             }
@@ -1823,11 +1828,8 @@ mod tests {
         );
     }
 
-    /// #453 — `--dont_gzip` is accepted here, matching `--clump_only`. The
-    /// neighbouring `--cores` rule still applies, so this also proves the arm
-    /// is reached rather than short-circuited earlier.
     #[test]
-    fn test_clumpify_accepts_dont_gzip() {
+    fn test_clumpify_rejects_dont_gzip() {
         let cli = Cli::parse_from([
             "trim_galore",
             "--clumpify",
@@ -1836,11 +1838,8 @@ mod tests {
             "--dont_gzip",
             R1,
         ]);
-        assert!(cli.validate().is_ok(), "got: {:?}", cli.validate().err());
-
-        let cli = Cli::parse_from(["trim_galore", "--clumpify", "--dont_gzip", R1]);
         let err = cli.validate().unwrap_err().to_string();
-        assert!(err.contains("--cores >= 2"), "got: {err}");
+        assert!(err.contains("--dont_gzip"), "got: {err}");
     }
 
     #[test]

--- a/tests/integration_gzip_non_gz_extension.rs
+++ b/tests/integration_gzip_non_gz_extension.rs
@@ -109,6 +109,56 @@ fn read_output_raw(dir: &Path, stem: &str) -> String {
 
 /// Single-end `.bgz`. The path that already worked before this change; kept so
 /// a future regression in the sniff is caught here too.
+/// #453 — `--clumpify` accepts `--dont_gzip`, as `--clump_only` already did. The
+/// refusal it replaced called clumping plain text pointless while the tool did
+/// exactly that on plain input, so the reason was never true.
+#[test]
+fn clumpify_accepts_dont_gzip_and_writes_plain_output() {
+    let dir = fresh_tmpdir("tg_453_clumpify_plain");
+    let input = dir.join("sample.fq.gz");
+    write_gz(&input, &sample_reads("cy"));
+
+    let out = Command::new(binary())
+        .args([
+            "--clumpify",
+            "--dont_gzip",
+            "--cores",
+            "2",
+            "-o",
+            dir.to_str().unwrap(),
+            input.to_str().unwrap(),
+        ])
+        .output()
+        .expect("binary must run");
+    let err = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(
+        out.status.success(),
+        "--clumpify --dont_gzip must be accepted:\n{err}"
+    );
+    assert!(
+        !err.contains("mutually exclusive"),
+        "the refusal must be gone:\n{err}"
+    );
+
+    // Plain output, and every record still present: --dont_gzip changes the
+    // container, not the contents.
+    let plain = dir.join("sample_trimmed.fq");
+    assert!(
+        plain.exists(),
+        "expected plain output, got: {:?}",
+        std::fs::read_dir(&dir).map(|d| d
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .collect::<Vec<_>>())
+    );
+    let body = std::fs::read_to_string(&plain).expect("read plain output");
+    assert_eq!(
+        body.lines().count() / 4,
+        8,
+        "all eight records must survive:\n{body}"
+    );
+}
+
 /// #453 — output compression follows the input, so `--gzip`'s deprecation notice
 /// must not promise gzipped output for a plain-text input, where no flag delivers it.
 #[test]

--- a/tests/integration_gzip_non_gz_extension.rs
+++ b/tests/integration_gzip_non_gz_extension.rs
@@ -109,6 +109,67 @@ fn read_output_raw(dir: &Path, stem: &str) -> String {
 
 /// Single-end `.bgz`. The path that already worked before this change; kept so
 /// a future regression in the sniff is caught here too.
+/// #453 — output compression follows the input, so `--gzip`'s deprecation notice
+/// must not promise gzipped output for a plain-text input, where no flag delivers it.
+#[test]
+fn gzip_deprecation_notice_matches_what_the_run_will_do() {
+    let plain_claim = "produces plain-text output and no flag changes that";
+    let gz_claim = "Output is gzipped by default";
+
+    // Plain input: the notice must describe follow-the-input.
+    let dir = fresh_tmpdir("tg_453_plain");
+    let input = dir.join("sample.fastq");
+    std::fs::write(&input, sample_reads("se")).expect("write plain input");
+    let out = Command::new(binary())
+        .args([
+            "--gzip",
+            "-o",
+            dir.to_str().unwrap(),
+            input.to_str().unwrap(),
+        ])
+        .output()
+        .expect("binary must run");
+    let err = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(out.status.success(), "plain run must succeed:\n{err}");
+    assert!(
+        err.contains(plain_claim),
+        "plain input must not be told its output is gzipped:\n{err}"
+    );
+    assert!(
+        !err.contains(gz_claim),
+        "the gzipped-by-default claim is false here:\n{err}"
+    );
+    assert!(
+        dir.join("sample_trimmed.fq").exists(),
+        "plain input gives plain output, which is what the notice now says: {:?}",
+        std::fs::read_dir(&dir).map(|d| d.count())
+    );
+
+    // Gzipped input: the original wording is correct and must be kept.
+    let dir = fresh_tmpdir("tg_453_gz");
+    let input = dir.join("sample.fq.gz");
+    write_gz(&input, &sample_reads("se"));
+    let out = Command::new(binary())
+        .args([
+            "--gzip",
+            "-o",
+            dir.to_str().unwrap(),
+            input.to_str().unwrap(),
+        ])
+        .output()
+        .expect("binary must run");
+    let err = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(out.status.success(), "gzipped run must succeed:\n{err}");
+    assert!(
+        err.contains(gz_claim),
+        "gzipped input keeps the original wording:\n{err}"
+    );
+    assert!(
+        !err.contains(plain_claim),
+        "the follow-the-input wording belongs to plain input only:\n{err}"
+    );
+}
+
 #[test]
 fn single_end_bgz_input_is_decompressed() {
     let dir = fresh_tmpdir("tg_bgz_se");

--- a/tests/integration_gzip_non_gz_extension.rs
+++ b/tests/integration_gzip_non_gz_extension.rs
@@ -109,56 +109,6 @@ fn read_output_raw(dir: &Path, stem: &str) -> String {
 
 /// Single-end `.bgz`. The path that already worked before this change; kept so
 /// a future regression in the sniff is caught here too.
-/// #453 — `--clumpify` accepts `--dont_gzip`, as `--clump_only` already did. The
-/// refusal it replaced called clumping plain text pointless while the tool did
-/// exactly that on plain input, so the reason was never true.
-#[test]
-fn clumpify_accepts_dont_gzip_and_writes_plain_output() {
-    let dir = fresh_tmpdir("tg_453_clumpify_plain");
-    let input = dir.join("sample.fq.gz");
-    write_gz(&input, &sample_reads("cy"));
-
-    let out = Command::new(binary())
-        .args([
-            "--clumpify",
-            "--dont_gzip",
-            "--cores",
-            "2",
-            "-o",
-            dir.to_str().unwrap(),
-            input.to_str().unwrap(),
-        ])
-        .output()
-        .expect("binary must run");
-    let err = String::from_utf8_lossy(&out.stderr).to_string();
-    assert!(
-        out.status.success(),
-        "--clumpify --dont_gzip must be accepted:\n{err}"
-    );
-    assert!(
-        !err.contains("mutually exclusive"),
-        "the refusal must be gone:\n{err}"
-    );
-
-    // Plain output, and every record still present: --dont_gzip changes the
-    // container, not the contents.
-    let plain = dir.join("sample_trimmed.fq");
-    assert!(
-        plain.exists(),
-        "expected plain output, got: {:?}",
-        std::fs::read_dir(&dir).map(|d| d
-            .filter_map(|e| e.ok())
-            .map(|e| e.file_name())
-            .collect::<Vec<_>>())
-    );
-    let body = std::fs::read_to_string(&plain).expect("read plain output");
-    assert_eq!(
-        body.lines().count() / 4,
-        8,
-        "all eight records must survive:\n{body}"
-    );
-}
-
 /// #453 — output compression follows the input, so `--gzip`'s deprecation notice
 /// must not promise gzipped output for a plain-text input, where no flag delivers it.
 #[test]


### PR DESCRIPTION
Addresses one of the three false strings in #453. **Does not close it** — the flag question is settled the other way (the refusal stays, per the issue) and the two banner strings are fixed in #468.

`--gzip` printed "Output is gzipped by default" on every run, but output compression follows the input (`gzip = !dont_gzip && is_gzipped(input[0])`). On a plain-text input the notice asserted something the run then did not do — and no flag makes it true, so "use `--dont_gzip` to disable" described a state already in effect. The notice is now chosen by the same fact the run uses.

<details>
<summary>Detail (AI-assisted)</summary>

Plain input now reads:

```
WARNING: --gzip is deprecated in Trim Galore v2.0. Output compression follows the input,
         so this plain-text input produces plain-text output and no flag changes that. Ignoring.
```

Gzipped input keeps the original wording verbatim.

The message deliberately offers no remedy, because there isn't one — nothing makes a plain input produce gzipped output. An earlier draft suggested "use a gzipped input, or `--dont_gzip` to be explicit" and I dropped it rather than point at a non-fix.

`io::is_gzipped` is filename-based with no filesystem access, so it is safe to call from `Cli::validate()`, and it sits after the input-existence checks in any case.

Both arms are asserted in one test, each also asserting the *absence* of the other's wording, so neither can silently drift into the other. Forcing the gzipped branch unconditionally turns that test red. 803 tests (1 new), `fmt` and `clippy --all-targets --release -D warnings` clean.

**History note:** this branch carries an add-then-revert pair. It briefly removed the `--clumpify --dont_gzip` refusal before that question was settled in the other direction; the revert restores the refusal, its unit test and the `clumpy.md` wording exactly. The net diff is the notice fix alone — `src/cli.rs`, one test, one CHANGELOG line — and the squash will flatten the history.

</details>
