### PR TITLE
DO NOT MERGE — Validation 8: does the clumpify drift band catch a re-inlined work depth? (#439)

### DIFF
--- a/src/clump.rs
+++ b/src/clump.rs
@@ -187,7 +187,7 @@ pub struct ChannelDepths {
 pub fn channel_depths(clumpy: bool) -> ChannelDepths {
     if clumpy {
         ChannelDepths {
-            work: 1,
+            work: 2, // VALIDATION 8 form (a): helper edited
             result_per_core: 2,
         }
     } else {

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -114,7 +114,7 @@ pub fn run_paired_end_parallel(
 
     // Per-worker channels (round-robin distribution — no MPMC dependency needed)
     let depths = clump::channel_depths(clump_layout.is_some());
-    let queue_depth = depths.work;
+    let queue_depth = 2; // VALIDATION 8 form (b): literal re-inlined, helper bypassed
     let mut work_txs: Vec<mpsc::SyncSender<PairedWork>> = Vec::with_capacity(cores);
     let mut work_rxs: Vec<mpsc::Receiver<PairedWork>> = Vec::with_capacity(cores);
     for _ in 0..cores {
@@ -942,7 +942,7 @@ pub fn run_single_end_parallel(
 ) -> Result<TrimStats> {
     // A clumpy batch is a whole bin, so a shallower queue caps resident bins.
     let depths = clump::channel_depths(clump_layout.is_some());
-    let queue_depth = depths.work;
+    let queue_depth = 2; // VALIDATION 8 form (b): literal re-inlined, helper bypassed
     let mut work_txs: Vec<mpsc::SyncSender<SingleWork>> = Vec::with_capacity(cores);
     let mut work_rxs: Vec<mpsc::Receiver<SingleWork>> = Vec::with_capacity(cores);
     for _ in 0..cores {


### PR DESCRIPTION
**Do not merge. Do not review.** This branch carries a deliberate regression and exists only to verify the CI guard added in #462. It will be closed and deleted once both forms have been observed.

#439 accepted a committed baseline file — breaking the otherwise-good principle that the job should never restate a number the binary owns — on the argument that gating on `peak <= printed prediction` alone cannot catch a work-channel-depth revert on Linux. That argument has never been tested. This tests it.

**Form (b): the work depth re-inlined at both `parallel.rs` call sites**, bypassing `clump::channel_depths`. The full unit suite passes with it applied — **503/503**, including the 4c sum pin `channel_depths_sum_to_the_per_worker_coefficient`, because the helper is untouched. That is precisely why this form matters: it is the shape a future regression is most likely to take, and no test in the repo sees it.

Expected: `Clumpify peak RSS (#439)` reds on all three banded cells with `is >0.05 above baseline`.

Form (a) — editing the helper — follows as a second push. It should red the unit suite *and* the band.