### PR TITLE
fix(clump): report the encoding the clumping banners write, not the configured level (#453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@
   ([#456](https://github.com/FelixKrueger/TrimGalore/issues/456)). All four banners name the
   peak and the `--memory` budget it was sized against.
 
-- **`--clumpify` no longer reports gzip when it writes plain output**
-  ([#453](https://github.com/FelixKrueger/TrimGalore/issues/453)). Output encoding follows the
-  input's, so a plain input now prints `(plain output)` and a warning that the reordering gains
-  nothing without a compressor.
+- **The clumping banners report the encoding they write, not the configured level**
+  ([#453](https://github.com/FelixKrueger/TrimGalore/issues/453)). `--clumpify` on a plain input
+  prints `(plain output)` plus a warning that the reordering gains nothing without a compressor,
+  and `--clump_only --dont_gzip` no longer names a gzip level alongside the flag disabling it.
 
 - **`--rename --output-format ubam` is now refused on the `--rrbs` directional paired path**
   ([#459](https://github.com/FelixKrueger/TrimGalore/issues/459)). That path auto-sets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   ([#456](https://github.com/FelixKrueger/TrimGalore/issues/456)). All four banners name the
   peak and the `--memory` budget it was sized against.
 
+- **`--clumpify` no longer reports gzip when it writes plain output**
+  ([#453](https://github.com/FelixKrueger/TrimGalore/issues/453)). Output encoding follows the
+  input's, so a plain input now prints `(plain output)` and a warning that the reordering gains
+  nothing without a compressor.
+
 - **`--rename --output-format ubam` is now refused on the `--rrbs` directional paired path**
   ([#459](https://github.com/FelixKrueger/TrimGalore/issues/459)). That path auto-sets
   `--clip_R2 2`, so the annotation was being appended and then dropped without a word.

--- a/docs/src/content/docs/modes/clump-only.md
+++ b/docs/src/content/docs/modes/clump-only.md
@@ -75,7 +75,7 @@ Composes with:
 - `--memory <SIZE>` (bin-buffer sizing, e.g. `4G`)
 - `--cores <N>` — v1 is single-threaded internally, so this does not affect speed, but it does set the bin count (`max(16, 4 × cores)`) and therefore the memory floor below. Values 1–4 all give 16 bins; the floor only starts moving at `--cores 5`.
 - `--fastqc` — runs on the reordered output; fastqc-rust reads both FASTQ and BAM natively
-- `--dont_gzip` — FASTQ output only, produces `*_clumped.fq` (plain). Rejected with `--output-format ubam` (BAM is always BGZF-compressed).
+- `--dont_gzip` — FASTQ output only, produces `*_clumped.fq` (plain). Rejected with `--output-format ubam` (BAM is always BGZF-compressed). Supported here although `--clumpify` refuses it: reordering is the whole job in this mode, and clumped plain output still compresses better under whatever tool is applied next.
 - `--basename BASE` — output becomes `BASE_clumped.fq(.gz)` (SE FASTQ), `BASE_clumped_{1,2}.fq(.gz)` (PE FASTQ), or `BASE_clumped.bam` (uBAM)
 - `--output-format ubam` — produces uBAM output. Composes with all of the above except `--dont_gzip`.
 - `--preserve-tags TAG1,TAG2,…` — uBAM only. Aux tags round-trip through the reorder. A/Z/i/f scalars supported; B (array) and H (hex) rejected at BAM-read time.

--- a/src/clump_only.rs
+++ b/src/clump_only.rs
@@ -240,6 +240,17 @@ fn write_records_member<W: Write>(
     }
 }
 
+/// The encoding the run writes, for the startup banner. A plain input and
+/// `--dont_gzip` both land here, so the banner must not name a compression level
+/// it will not apply.
+fn banner_encoding(gzip_output: bool, compression: u32) -> String {
+    if gzip_output {
+        format!("gzip level {compression}")
+    } else {
+        "plain output".to_string()
+    }
+}
+
 /// Run `--clump_only` on a single-end FASTQ input.
 ///
 /// Byte-identity: every record R in the input file appears in the output
@@ -287,15 +298,14 @@ pub fn clump_only_single(
     let output_path = naming::clumped_output_name(input, output_dir, basename, gzip_output);
 
     eprintln!(
-        "clump-only: reordering '{}' -> '{}' ({} bins × {} MiB each; predicted peak ≈ {} of {} MiB budget, gzip level {}{})",
+        "clump-only: reordering '{}' -> '{}' ({} bins × {} MiB each; predicted peak ≈ {} of {} MiB budget, {})",
         input.display(),
         output_path.display(),
         layout.n_bins,
         layout.bin_byte_budget / (1024 * 1024),
         layout.predicted_peak_bytes() / (1024 * 1024),
         memory_budget_bytes / (1024 * 1024),
-        compression,
-        if gzip_output { "" } else { ", --dont_gzip" },
+        banner_encoding(gzip_output, compression),
     );
 
     let mut reader = FastqReader::open(input)
@@ -437,7 +447,7 @@ pub fn clump_only_paired(
         naming::clumped_paired_output_names(input_r1, input_r2, output_dir, basename, gzip_output);
 
     eprintln!(
-        "clump-only (paired): '{}' + '{}' -> '{}' + '{}' ({} bins × {} MiB each; predicted peak ≈ {} of {} MiB budget, gzip level {}{})",
+        "clump-only (paired): '{}' + '{}' -> '{}' + '{}' ({} bins × {} MiB each; predicted peak ≈ {} of {} MiB budget, {})",
         input_r1.display(),
         input_r2.display(),
         out_r1_path.display(),
@@ -446,8 +456,7 @@ pub fn clump_only_paired(
         layout.bin_byte_budget / (1024 * 1024),
         layout.predicted_peak_bytes() / (1024 * 1024),
         memory_budget_bytes / (1024 * 1024),
-        compression,
-        if gzip_output { "" } else { ", --dont_gzip" },
+        banner_encoding(gzip_output, compression),
     );
 
     let mut reader_r1 = FastqReader::open(input_r1)

--- a/src/io.rs
+++ b/src/io.rs
@@ -35,6 +35,13 @@ pub fn is_gzipped(path: &Path) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("gz"))
 }
 
+/// Whether the run writes gzipped output: the first input's encoding, unless
+/// `--dont_gzip`. Every message describing the output must read this rather than
+/// the configured compression level, or it can claim gzip over plain text.
+pub fn output_is_gzipped(dont_gzip: bool, first_input: &Path) -> bool {
+    !dont_gzip && is_gzipped(first_input)
+}
+
 /// Case-folded (ASCII lowercase) view of a path; the folding half of `collision_key`.
 fn norm_path(p: &Path) -> String {
     p.to_string_lossy().to_ascii_lowercase()
@@ -1623,6 +1630,15 @@ mod tests {
         assert_eq!(out, PathBuf::from("/data/sample.fq.gz_clumping_report.txt"));
         // Confirm it's NOT the trimming-report shape.
         assert_ne!(out, report_name(input, None));
+    }
+
+    #[test]
+    fn output_is_gzipped_follows_the_input_unless_dont_gzip() {
+        // The banner and the writers must not be able to disagree.
+        assert!(output_is_gzipped(false, Path::new("s.fastq.gz")));
+        assert!(!output_is_gzipped(false, Path::new("s.fastq")));
+        assert!(!output_is_gzipped(true, Path::new("s.fastq.gz")));
+        assert!(!output_is_gzipped(true, Path::new("s.fastq")));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,14 +205,28 @@ fn resolve_clump_layout(cli: &Cli) -> Result<Option<clump::ClumpLayout>> {
     }
     let layout = clump::resolve_layout(memory_bytes, &layout_inputs)?;
     // Naming the budget makes the ~9% margin visible arithmetic.
+    let gzipped = naming::output_is_gzipped(cli.dont_gzip, &cli.input[0]);
+    let encoding = if gzipped {
+        format!("gzip level {}", cli.compression)
+    } else {
+        "plain output".to_string()
+    };
     eprintln!(
-        "clumpify: {} bins × {} MiB; predicted peak ≈ {} of {} MiB budget (gzip level {})",
+        "clumpify: {} bins × {} MiB; predicted peak ≈ {} of {} MiB budget ({})",
         layout.n_bins,
         layout.bin_byte_budget / (1024 * 1024),
         layout.predicted_peak_bytes() / (1024 * 1024),
         memory_bytes / (1024 * 1024),
-        cli.compression,
+        encoding,
     );
+    // Clumping only pays off through a compressor, so say when there is none.
+    if !gzipped {
+        eprintln!(
+            "WARNING: the output is not compressed, so --clumpify's reordering gains \
+             nothing here — output encoding follows the input's. Supply gzipped input, \
+             or drop --clumpify to skip the memory reservation."
+        );
+    }
     Ok(Some(layout))
 }
 
@@ -421,7 +435,7 @@ fn main() -> Result<()> {
     // gzipped inputs in one invocation isn't a supported configuration.
     // See #245 for the parity rationale (Rust v2.1.0-beta.5 always gzipped
     // regardless of input, breaking pipelines that globbed `*.fq` no-gz).
-    let gzip = !cli.dont_gzip && naming::is_gzipped(&cli.input[0]);
+    let gzip = naming::output_is_gzipped(cli.dont_gzip, &cli.input[0]);
     let output_dir = cli.output_dir.as_deref();
 
     // Auto-create --output_dir if it doesn't exist. See io::ensure_output_dir

--- a/tests/integration_clump_only.rs
+++ b/tests/integration_clump_only.rs
@@ -130,6 +130,36 @@ fn banner_reports_the_predicted_peak() -> Result<()> {
     Ok(())
 }
 
+// ── Banner reports the encoding written, not the configured level (#453) ────────
+
+#[test]
+fn dont_gzip_banner_does_not_name_a_compression_level() {
+    let dir = tempdir("se_banner_plain");
+    let input = fixture("BS-seq_10K_R1.fastq.gz");
+
+    let out = Command::new(binary())
+        .args([
+            "--clump_only",
+            "--dont_gzip",
+            "--cores",
+            "2",
+            "-o",
+            dir.to_str().unwrap(),
+        ])
+        .arg(&input)
+        .output()
+        .expect("failed to run trim_galore");
+    assert!(out.status.success(), "--clump_only --dont_gzip failed");
+
+    // The run writes plain text, so naming a gzip level would be false — and the
+    // report already prints equal in/out byte counts beside it.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("MiB budget, plain output)") && !stderr.contains("gzip level"),
+        "--dont_gzip must not advertise a compression level:\n{stderr}"
+    );
+}
+
 // ── Byte-identity: SE (gzip in / plain out via --dont_gzip) ────────
 
 #[test]

--- a/tests/integration_preflight_tripwire.rs
+++ b/tests/integration_preflight_tripwire.rs
@@ -606,6 +606,20 @@ fn se_trim_clumpify() {
         "clumpify banner must pin both figures and their divisors:\n{}",
         out.stderr
     );
+
+    // This case's input is plain, so the output is plain: the banner must report the
+    // encoding it writes rather than the configured level, and the run must say the
+    // reordering buys nothing without a compressor.
+    assert!(
+        out.stderr.contains("MiB budget (plain output)") && !out.stderr.contains("gzip level"),
+        "a plain-output run must not advertise gzip:\n{}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.contains("WARNING: the output is not compressed"),
+        "clumping with no compressor must say so:\n{}",
+        out.stderr
+    );
 }
 
 #[test]


### PR DESCRIPTION
Settles the remaining half of #453 — the messaging. The flag question was decided separately and is not changed here: **`--clumpify --dont_gzip` stays refused, `--clump_only --dont_gzip` stays supported.**

**Two banners claimed a compression they were not applying.**

`--clumpify` on a plain input — output encoding follows the input's, so this run writes plain text:

```
clumpify: 16 bins × 22 MiB; predicted peak ≈ 930 of 1024 MiB budget (gzip level 1)   ← before
clumpify: 16 bins × 22 MiB; predicted peak ≈ 930 of 1024 MiB budget (plain output)   ← after
WARNING: the output is not compressed, so --clumpify's reordering gains nothing here — output
encoding follows the input's. Supply gzipped input, or drop --clumpify to skip the memory reservation.
```

`--clump_only --dont_gzip` — the level and the flag disabling it, side by side, while its own report printed `1926073 bytes -> 1926073 bytes` two lines later:

```
(16 bins × 26 MiB each; predicted peak ≈ 930 of 1024 MiB budget, gzip level 1, --dont_gzip)  ← before
(16 bins × 26 MiB each; predicted peak ≈ 930 of 1024 MiB budget, plain output)               ← after
```

The `--clumpify` case is a warning rather than a refusal because, unlike the flag combination, it is reachable without asking for it: the bin pool's reservation has been paid for output that differs from the input only in record order.

**Not cosmetic.** Peak-RSS measurements during #439 were taken against the `--clumpify` banner rather than the output filenames, and the readings had to be retracted once a plain-output run turned out to have been misread as gzipped.

**The structural half matters more than the strings.** `io::output_is_gzipped` is now the single source for "will this run write gzip", read by both the banner and the writers at `main.rs:424`; `clump_only::banner_encoding` does the same for the two `--clump_only` sites. Duplicating those decisions is what let the messages and the behaviour disagree.

**The gzipped banners are byte-unchanged**, so the `clumpify-memory` CI job's parse and the tripwire's `predicted peak ≈ 930 of 1024 MiB budget` assertion are untouched.

**Guards, each proven able to fail.** The existing `se_trim_clumpify` tripwire case turned out to run on a plain input already, so it had been exercising the false banner silently for as long as it existed; it now pins `(plain output)`, the absence of `gzip level`, and the warning. A new `dont_gzip_banner_does_not_name_a_compression_level` covers the `--clump_only` side. Reverting either banner to report the configured level turns the respective test red — checked, not assumed. Plus a unit test on `output_is_gzipped` across all four flag/extension combinations.

504 lib tests, all suites green, fmt and clippy clean, docs build clean.

`--clump_only --dont_gzip` is documented as deliberately supported in `modes/clump-only.md` — reordering is the whole job there, and clumped plain output still compresses better under whatever tool runs next — so the asymmetry with `--clumpify` reads as intentional rather than as an oversight to "fix".

Rebased over #464, keeping both `### Unreleased` bullets.