### PR TITLE
ci(clump): re-tune the clumpify drift band on 27 observations per cell (#439)

### DIFF
--- a/.github/clumpify-memory-baseline.tsv
+++ b/.github/clumpify-memory-baseline.tsv
@@ -3,70 +3,61 @@
 # The job gates on two things. The *promise* — measured peak <= the peak the
 # binary printed — is absolute and platform-independent. The *drift* band is
 # relative to the ratios below, because gating on the promise alone cannot see a
-# regression on Linux: at the measured ~0.78 ratio a work-channel-depth revert
-# adds ~72-104 MiB and still lands under the printed prediction.
+# regression on Linux: a work-channel-depth revert was measured at +0.126 to
+# +0.151 of prediction and every cell it moved still sat under the printed peak.
 #
-# Fail if a cell peak/prediction rises more than 0.05 above its baseline, or
-# falls more than 0.10 below it. A depth revert is a 0.078-0.11 move, so it
-# breaches the upper bound on any platform; a silent fallback to plain mode or a
-# fixture that stopped filling the bin pool is a multi-point drop.
+# Fail if a cell peak/prediction rises more than 0.09 above its baseline, or
+# falls more than 0.10 below it. A silent fallback to plain mode or a fixture
+# that stopped filling the bin pool is a multi-point drop.
 #
-# A cell is banded only if it has >= 3 reps that predate the PR adding its row,
-# AND a false-red multiple >= 3x: a spurious red must need an excursion at least
-# three times the largest yet observed for that cell. Reps from the adding PR do
-# not count toward the bar, or a cell would certify itself. Cells under the bar
-# are measured and printed but not banded, and the BANDED list in ci.yml keeps a
-# deliberate omission distinguishable from a typo.
+# Band a cell only when the width satisfies both sides:
 #
-# On a lone red 5-7 points above baseline on unmodified code: re-run once. If it
-# clears it was spread, not drift. Do not widen the band on one reading.
+#   width >= 3x the observed half-range      (so noise cannot fire it), and
+#   width <= the measured regression delta   (so the regression still fires it),
+#            minus a working margin
+#
+# The half-range must come from a double-digit sample. Two or four draws estimate
+# dispersion LOW by construction — they cannot land far apart as often as they
+# can land close — so a threshold set from a handful of reps is set too tight.
 #
 # cell<TAB>baseline_peak_over_prediction
-1G_c4	0.777
-25bp_1G_c4	0.923
-multipair_c4	0.790
+1G_c4	0.788
+25bp_1G_c4	0.914
 #
-# Baselines are the means of reps 1-4, half-up to 3 dp (1G_c4 3.108/4 = 0.7770;
-# 25bp_1G_c4 3.691/4 = 0.92275 -> 0.923; multipair_c4 3.160/4 = 0.7900). Rep 5 is
-# deliberately excluded from the centre: it is the run that first enforced these
-# bands, so it serves as their independent confirmation. Fold it in at the next
-# deliberate re-baseline.
+# Re-tuned 2026-08-18 from 27 observations per cell (31 job logs, excluding the
+# two runs carrying Validation 8`s deliberate regression). Baselines are means,
+# half-up to 3 dp: 1G_c4 21.2840/27 = 0.78830; 25bp_1G_c4 24.6720/27 = 0.91378.
 #
-#   cell            rep1   rep2   rep3   rep4   rep5    range   false red   miss
-#   1G_c4           0.770  0.782  0.785  0.771  0.785   0.015   6.7x        3.7x
-#   25bp_1G_c4      0.941  0.924  0.914  0.912  0.929   0.029   3.4x        1.9x
-#   multipair_c4    0.792  0.787  0.789  0.792  0.808   0.021   4.8x        2.7x
+#   cell            n   mean    min     max     range   at +0.09
+#   1G_c4           27  0.7883  0.770   0.825   0.055   3.3x half-range; lever A fires by 0.036
+#   25bp_1G_c4      27  0.9138  0.898   0.941   0.043   4.2x half-range; lever A fires by 0.038
 #
-# 25bp_1G_c4 is banded at a 1.9x miss margin because a depth revert moves every
-# cell at once, so a miss needs every banded cell to miss: 1G_c4 carries that
-# direction at 3.7x. multipair_c4 looked like the carrier at 11.2x on four reps
-# and is 2.7x on five, which is why the redundancy argument names the widest
-# margin currently measured rather than a fixed cell.
+# Measured but NOT banded, with the reason:
 #
-# Measured but NOT banded:
+#   multipair_c4    27  0.7987  0.771   0.852   0.081   1.2x at +0.09; needs +0.121 for 3x
+#     Widest range of the six. Its 0.852 maximum was observed while the other
+#     cells moved +0.012 and -0.019 — spread, not drift. Covering it at 3x would
+#     need a width close to the regression the band exists to catch, so it is
+#     recorded instead. A depth revert moves every cell, so either banded cell
+#     catches it.
 #
-#   1G_c4_fastqc    0.697  0.701  0.707  0.745  0.701   0.048   2.1x        1.2x
-#     Widest of the six. A +0.05 band would trigger at 0.7625 against an observed
-#     max of 0.745 — 1.75 points of headroom on a 4.8-point range — so banding it
-#     would red on correct code. It stays promise-gated (peak <= prediction, at
-#     0.745 of 1.000). FastQC cost scales with --cores and the allocator holds the
-#     pool pages across the trim->FastQC boundary, so this cell is timing-
-#     sensitive in a way the pure-trim cells are not.
+#   1G_c4_fastqc    27  0.7069  0.688   0.768   0.080   1.2x at +0.09
+#     Also too wide. Stays gated on the printed prediction, at 0.768 of 1.000.
+#     FastQC cost scales with --cores and the allocator holds the pool pages
+#     across the trim->FastQC boundary, so this cell is timing-sensitive in a way
+#     the pure-trim cells are not.
 #
-#   1G_c2           -      -      0.867  0.894  0.878   0.027   3.7x        2.1x
-#   25bp_1G_c2      -      -      1.031  1.026  1.043   0.017   5.9x        3.3x
-#     Both now clear the 3x multiple, but their third rep IS rep 5, which does not
-#     count toward the bar. Band them in the next pass, on an independent
-#     confirmation. 25bp_1G_c2 also tripled its range on that third draw (0.005 ->
-#     0.017), which is the signal to wait rather than to proceed: dispersion from
-#     two draws is biased low, not merely imprecise. That is how 1G_c4_fastqc
-#     looked tightest of the six on its first two reps.
+#   1G_c2           25  0.8789  0.860   0.894   0.034   2.9x at +0.09 — just under the bar
+#   25bp_1G_c2      25  1.0301  1.007   1.050   0.043   4.2x at +0.09 — eligible next pass
 #     25bp_1G_c2 is #457: over the printed prediction, inside the budget, on
-#     Linux. Its value will move when sigma is refitted, needing a re-baseline.
+#     Linux. Its value will move when sigma is refitted, needing a re-baseline,
+#     which is why it is not banded while that work is pending.
 #
-# Reps: rep1 69d8f67 (run 32065004600), rep2 3f1a930 (32065624366),
-#       rep3 7d676b7 (32109372844), rep4 bc48bf0 (32110691552),
-#       rep5 7a218b0 (32113210868, the run that enforced these bands).
-# Every rep passes `git diff --quiet 69d8f67 <rep> -- src Cargo.lock`, so they
-# pool. Reps built from different sources must not be pooled into one mean; when
-# src/ moves, judge whether the change can reach the clump path before pooling.
+# Diagnosing a red: if one cell rises alone, it is spread — re-run once, and if it
+# clears, leave the band alone. A depth revert moves every cell together by 12
+# points or more (measured), which is the signature to act on.
+#
+# When src/ moves, judge whether the change can reach the clump path before
+# pooling new observations with these; the proxy
+# `git diff --quiet <old> <new> -- src Cargo.lock` is deliberately conservative
+# and exists to force that judgement, not to make it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
           test -f "$base" || { echo "::error::baseline file missing: $base"; exit 1; }
           # Cells with a committed baseline. A label here without exactly one row
           # means the drift band is not armed for it.
-          BANDED="1G_c4 25bp_1G_c4 multipair_c4"
+          BANDED="1G_c4 25bp_1G_c4"
           bootstrap=0
           if grep -q '^# BOOTSTRAP' "$base"; then
             bootstrap=1
@@ -425,8 +425,8 @@ jobs:
             local want
             want=$(awk -v c="$label" '$1==c {print $2}' "$base" 2>/dev/null || true)
             if [ -n "$want" ] && [ "$bootstrap" = 0 ]; then
-              awk -v r="$ratio" -v w="$want" 'BEGIN{exit !(r > w + 0.05)}' \
-                && { echo "::error::$label: peak/pred $ratio is >0.05 above baseline $want"; fail=1; }
+              awk -v r="$ratio" -v w="$want" 'BEGIN{exit !(r > w + 0.09)}' \
+                && { echo "::error::$label: peak/pred $ratio is >0.09 above baseline $want"; fail=1; }
               awk -v r="$ratio" -v w="$want" 'BEGIN{exit !(r < w - 0.10)}' \
                 && { echo "::error::$label: peak/pred $ratio is >0.10 below baseline $want - fixture may have stopped filling the pool"; fail=1; }
             fi


### PR DESCRIPTION
The drift band added in #462 was calibrated from **four reps per cell**, and four draws estimate dispersion low by construction — they cannot land far apart as often as they can land close. The resulting `+0.05` width was narrower than the runner's real spread, and it false-fired on an unrelated PR: `multipair_c4` at 0.852 against a 0.840 trigger, moving alone while `1G_c4` went +0.012 and `25bp_1G_c4` −0.019. The re-run passed with no code change.

Recomputed from **27 observations per cell** (31 job logs, excluding Validation 8's two deliberately-regressed runs):

| cell | n | mean | min | max | range | width for 3× half-range | banded |
|---|---:|---:|---:|---:|---:|---:|---|
| `1G_c4` | 27 | 0.7883 | 0.770 | 0.825 | 0.055 | 0.083 | **yes, 0.788** |
| `25bp_1G_c4` | 27 | 0.9138 | 0.898 | 0.941 | 0.043 | 0.065 | **yes, 0.914** |
| `multipair_c4` | 27 | 0.7987 | 0.771 | 0.852 | 0.081 | 0.121 | no |
| `1G_c4_fastqc` | 27 | 0.7069 | 0.688 | 0.768 | 0.080 | 0.120 | no |
| `1G_c2` | 25 | 0.8789 | 0.860 | 0.894 | 0.034 | 0.051 | no |
| `25bp_1G_c2` | 25 | 1.0301 | 1.007 | 1.050 | 0.043 | 0.065 | no |

**No cell cleared the 3× bar at `+0.05`** — including all three that were banded on it — and `1G_c4` had already come within 0.002 of firing at 0.825.

**Widening is affordable because the regression was measured rather than predicted.** Validation 8 put a work-channel-depth revert at **+0.126 to +0.151** of prediction, where the original sizing assumed the predicted +0.078. At `+0.09` both remaining banded cells clear 3× (3.3× and 4.2×) and still red on that regression by 0.036 and 0.038.

`multipair_c4` is **unbanded**: covering its 0.081 range at 3× would need a width close to the regression the band exists to catch. It stays measured, and since a depth revert moves every cell together, either banded cell catches it — the same argument that already excluded `1G_c4_fastqc`.

**The rule is now two-sided**, which is the actual defect being fixed:

```
width >= 3x the observed half-range      (so noise cannot fire it), and
width <= the measured regression delta   (so the regression still fires it),
         minus a working margin
```

…with the half-range required to come from a double-digit sample. As originally written it constrained only the noise side, and was evaluated with the very estimate it was meant to guard against.

**Verified against the committed clauses, not a paraphrase:** all 54 observations of the two banded cells pass; both red at the measured lever-A deltas; the strict-`>` boundary holds (`+0.090` passes, `+0.091` fires); the lower bound is still live; unbanded cells are not checked; and the armed-check still catches a deleted row while correctly accepting a deliberately-unbanded cell that happens to have a row.

No CHANGELOG entry — CI-only, matching #452 and #462.

Part of #439 (closed; this corrects the guard it shipped).