### PR TITLE
ci(clump): measure `--memory 2G`/`--cores 4` instead of recording it as a blind spot (#458)

### DIFF
--- a/.github/clumpify-memory-baseline.tsv
+++ b/.github/clumpify-memory-baseline.tsv
@@ -47,6 +47,15 @@
 #     across the trim->FastQC boundary, so this cell is timing-sensitive in a way
 #     the pure-trim cells are not.
 #
+#   2G_c4            -       -      -       -       -   no observations yet
+#     The cell that carried #439's original breach (1.173 -> 1.014 -> 0.887 of
+#     budget across two fix phases). Recorded rather than gated: a 2 GiB pool needs
+#     ~2.3x this fixture to saturate, so its ratio reads low and cannot approach
+#     the printed prediction. That depression is expected — do not read it as
+#     headroom. Lever A still moves it ~+0.09 to +0.13, since B is 42.0 MiB here
+#     against 18.1 at 1G/c4, so it is a usable drift cell once it has a
+#     double-digit sample. See #458.
+#
 #   1G_c2           25  0.8789  0.860   0.894   0.034   2.9x at +0.09 — just under the bar
 #   25bp_1G_c2      25  1.0301  1.007   1.050   0.043   4.2x at +0.09 — eligible next pass
 #     25bp_1G_c2 is #457: over the printed prediction, inside the budget, on

--- a/.github/clumpify-memory-baseline.tsv
+++ b/.github/clumpify-memory-baseline.tsv
@@ -47,14 +47,18 @@
 #     across the trim->FastQC boundary, so this cell is timing-sensitive in a way
 #     the pure-trim cells are not.
 #
-#   2G_c4            -       -      -       -       -   no observations yet
+#   2G_c4            1  0.8540  0.854   0.854       -   one observation
 #     The cell that carried #439's original breach (1.173 -> 1.014 -> 0.887 of
-#     budget across two fix phases). Recorded rather than gated: a 2 GiB pool needs
-#     ~2.3x this fixture to saturate, so its ratio reads low and cannot approach
-#     the printed prediction. That depression is expected — do not read it as
-#     headroom. Lever A still moves it ~+0.09 to +0.13, since B is 42.0 MiB here
-#     against 18.1 at 1G/c4, so it is a usable drift cell once it has a
-#     double-digit sample. See #458.
+#     budget on macOS across two fix phases). First Linux reading: 1589 MiB peak,
+#     0.854 of the printed 1861 MiB, 0.776 of a 2048 MiB budget.
+#     Recorded rather than gated: a 2 GiB pool needs ~2.3x this fixture to
+#     saturate, so the cell cannot near its printed peak and gating it would prove
+#     little. Note it reads *higher* than 1G_c4, not lower — absolute peak more
+#     than doubles with the pool (1589 vs 731 MiB), so non-saturation caps how far
+#     it can rise without depressing it below the smaller-budget cells.
+#     Lever A moves it ~+0.09 to +0.13, since B is 42.0 MiB here against 18.1 at
+#     1G/c4, so it is a usable drift cell once it has a double-digit sample.
+#     See #458.
 #
 #   1G_c2           25  0.8789  0.860   0.894   0.034   2.9x at +0.09 — just under the bar
 #   25bp_1G_c2      25  1.0301  1.007   1.050   0.043   4.2x at +0.09 — eligible next pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,7 @@ jobs:
           # --cores 2 is too tight to gate; both cells record their ratio only.
           measure 1G_c2        0 --clumpify --paired --cores 2 --memory 1G "$F51R1" "$F51R2"
           measure 25bp_1G_c2   0 --clumpify --paired --cores 2 --memory 1G "$F25R1" "$F25R2"
-          # A 2 GiB pool needs ~2.3x this fixture to saturate, so the ratio reads low.
+          # A 2 GiB pool needs ~2.3x this fixture to saturate, so it cannot near its peak.
           measure 2G_c4        0 --clumpify --paired --cores 4 --memory 2G "$F51R1" "$F51R2"
 
           exit $fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,8 @@ jobs:
           # --cores 2 is too tight to gate; both cells record their ratio only.
           measure 1G_c2        0 --clumpify --paired --cores 2 --memory 1G "$F51R1" "$F51R2"
           measure 25bp_1G_c2   0 --clumpify --paired --cores 2 --memory 1G "$F25R1" "$F25R2"
+          # A 2 GiB pool needs ~2.3x this fixture to saturate, so the ratio reads low.
+          measure 2G_c4        0 --clumpify --paired --cores 4 --memory 2G "$F51R1" "$F51R2"
 
           exit $fail
 


### PR DESCRIPTION
Closes the blind spot #458 exists to record, rather than leaving it recorded.

`2G/c4` carried #439's original breach — 1.173 → 1.014 → 0.887 of budget across the two fix phases — and came out of that work with **neither a CI cell nor any continuing measurement**. #458 was filed so it would be rediscovered as a known item rather than as novel, and concluded "no action required".

**The reason it was dropped was a gating argument.** Its 672 MiB pool (16 × 42 MiB) needs ~2.3× the job's fixture to reach steady state, making it the least informative candidate per byte for a cell that must be able to fail the absolute promise. That reasoning is sound, and it does not transfer to a **recorded** cell: those only need to be reproducible, and this one reuses the existing `f51` fixture at no generation cost.

One correction to a guess I made before checking: `2G/c4` is not a weak drift detector. `B` = 16 × (2048 × 10/11 − 224) / 624 = **42.0 MiB**, against 18.1 MiB at `1G/c4`, so lever A moves its ratio **+0.090 to +0.130** — essentially the same proportional sensitivity as the cell the band is centred on.

**Non-gating and unbanded on first appearance**, as with every cell added since the band went live: its dispersion is unknown, and the two-sided rule needs a double-digit sample before a width can be chosen. The expected *low* ratio is documented in the baseline file so a future reader does not mistake the depression for headroom.

Cost: one more measured cell on an existing fixture, no new generation, no new dependency.