### PR TITLE
docs(threading): name the memory fixture's read length and the allocator's cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 #### Changes
 
+- **The threading docs name the memory fixture's read length**
+  ([nf-core/rnaseq#1903](https://github.com/nf-core/rnaseq/issues/1903)). The 84M-read Buckberry pair
+  is 65 bp, not the 150 bp the memory section claimed.
+
+- **The threading docs record the plain-path memory arriving in the next release**
+  ([#437](https://github.com/FelixKrueger/TrimGalore/issues/437)). Peak RSS moves from 74 to 146 MiB
+  at `--cores 8`, mostly `mimalloc` trading memory for ~30% wall-clock.
+
 - **`--gzip`'s deprecation notice no longer promises gzipped output for a plain-text input**
   ([#453](https://github.com/FelixKrueger/TrimGalore/issues/453)). Output compression follows
   the input, and the notice now says so on that path.

--- a/docs/src/content/docs/performance/threading.md
+++ b/docs/src/content/docs/performance/threading.md
@@ -49,7 +49,7 @@ Parallel efficiency at Buckberry scale: 100% (cores=1) → 72% (cores=8) → 34%
 
 ## Memory profile
 
-Peak resident set size on the 84M-read Buckberry fixture (Trim Galore v2.1.0-beta.7, measured via `/usr/bin/time -v`):
+Peak resident set size on the 84M-read paired-end Buckberry fixture (65 bp reads; Trim Galore v2.1.0-beta.7, measured via `/usr/bin/time -v`):
 
 | `--cores` | Peak RSS | Notes |
 |----------:|---------:|-------|
@@ -58,9 +58,11 @@ Peak resident set size on the 84M-read Buckberry fixture (Trim Galore v2.1.0-bet
 | 4 | 73.0 MB | |
 | 8 | 91.6 MB | |
 
-The c1 → c2 step is by far the largest (+55 MB) — that's the four infrastructure threads spinning up their I/O buffers. Past c2, each additional pair of workers adds ~7 MB on average; the bulk of which is the per-worker compression buffer. Memory growth is bounded and predictable, well-suited to cluster scheduling: on these 150 bp reads, even worst-case at the saturation point (`--cores 8`), the process stays under ~100 MB. That ceiling belongs to the read length rather than to the tool, as the long-read figures below show.
+The c1 → c2 step is by far the largest (+55 MB) — that's the four infrastructure threads spinning up their I/O buffers. Past c2, each additional pair of workers adds ~7 MB on average; the bulk of which is the per-worker compression buffer. Memory growth is bounded and predictable, well-suited to cluster scheduling: on these 65 bp reads, even worst-case at the saturation point (`--cores 8`), the process stays under ~100 MB. That ceiling belongs to the read length rather than to the tool, as the long-read figures below show.
 
-For context, mainstream multi-threaded FASTQ trimmers typically use a lot more RAM: Cutadapt 100–300 MB, fastp 100+ MB, BBDuk (JVM) 1–4 GB. On short reads Trim Galore v2 stays under 100 MB across all reasonable core counts — well below the noise floor of cluster scheduler memory allocation: at `--cores 8`, a 1M-read 50-bp fixture sits at ~28 MB and an 84M-read 150-bp fixture at ~92 MB.
+For context, mainstream multi-threaded FASTQ trimmers typically use a lot more RAM: Cutadapt 100–300 MB, fastp 100+ MB, BBDuk (JVM) 1–4 GB. On short reads Trim Galore v2 stays under 100 MB across all reasonable core counts — well below the noise floor of cluster scheduler memory allocation: at `--cores 8`, a 1M-read 50-bp fixture sits at ~28 MB and an 84M-read 65 bp fixture at ~92 MB.
+
+**The next release uses roughly twice this on the plain path.** Between v2.3.0 and current development, paired peak RSS on the fixture above moves from 60 to 98 MiB at `--cores 4`, and from 74 to 146 MiB at `--cores 8`. Most of that is `mimalloc` replacing the platform allocator, which buys ~30% wall-clock at `--cores 8` in exchange for retaining more pages. Budget from the larger figure.
 
 **Peak RSS scales with read length**, because the batch sizes are counts of records rather than of bytes, so a batch holds as many bytes as its reads happen to be. Measured in plain mode at `--cores 4` on 400 MB of input: ~75 MiB at 150 bp, ~245 MiB at 1 kb, ~800 MiB at 10 kb.
 


### PR DESCRIPTION
The memory section described the 84M-read Buckberry pair as 150 bp in two places. It is 65 bp, so its
~92 MB at `--cores 8` never described 150 bp data — and because the batch constants count records
rather than bytes, 150 bp input needs roughly 2.3× more. That mislabel is what let the figure be read
as a general short-read ceiling: nf-core/modules#11541 sized a 1 GB budget on it and
nf-core/rnaseq#1903 OOM-killed every sample. This also records the ~2× plain-path memory arriving with
`mimalloc` in the next release. Docs only.

<details>
<summary>Re-measurement behind these numbers (AI-assisted analysis)</summary>

Measured on dockyard-oxy-0 — the host the published table came from — on the same Buckberry pair,
`--paired`, gz in and out, `/usr/bin/time -v`, 3 reps per cell. Read length verified at 65 bp over
200k reads on both mates. Every run checked for exit status, worker-thread banner, and gzipped output;
the harness carries the `clumpify-memory` job's GNU-time capability probe and free-disk guard, the
latter with an impossible-threshold positive control.

| build | allocator | c4 | c8 |
|---|---|--:|--:|
| v2.1.0-beta.7 (the published table) | stock | 78.8 | 87.7 |
| v2.3.0 | stock | 60.7 | 74.0 |
| current dev | mimalloc | 97.6 | 146.0 |

beta.7 reproduces the published 73.0 / 91.6 MB within their run-to-run spread, so the table was sound
for the fixture it was measured on — only its description was wrong. v2.3.0 is lower than beta.7 and
much tighter, so nothing regressed across releases.

The v2.3.0 → dev rise is `mimalloc` (#437): 96% of the move at c8 and 61% at c4, isolated with two
one-variable builds. It buys ~28-30% wall-clock at c8 (1:07 → 0:52), which is why the trade is kept
and the cost documented rather than reverted.

One aside worth recording: #442's switch from a flat `reads.len() * 300` batch-buffer reservation to a
content-derived `estimated_record_bytes` sum **flips sign with the allocator** — it costs ~18 MiB at c4
under the platform allocator but saves ~15 MiB at c8 under `mimalloc`, whose size-class segregation
absorbs the per-batch variance that defeats a free list. With `mimalloc` kept, #442 is a small win and
needs no change; the two commits are complementary though neither mentions the other.

Caveat: all of the above is 65 bp on one host. Run-to-run spread reached ~31 MiB at c8 on beta.7, so
the published table's single-run, three-significant-figure precision claims more than it can support —
worth revisiting whenever the table is next refreshed.

</details>
