### PR TITLE
fix(clump): bound the per-record cost that size_of cannot see (#457)

### DIFF
--- a/.github/clumpify-memory-baseline.tsv
+++ b/.github/clumpify-memory-baseline.tsv
@@ -28,26 +28,46 @@
 # dispersion LOW by construction — they cannot land far apart as often as they
 # can land close — so a threshold set from a handful of reps is set too tight.
 #
-# BOOTSTRAP - the two rows below are PRE-REFIT (#457) and must not be trusted.
-# The refit changed sigma_16 23 -> 33 and k_16 64 -> 92, so every centre moves by
-# roughly -0.17 to -0.21. Record the ratios from this PR's own Linux run, replace
-# both rows, and delete this line. Predicted, for a sanity check only, NOT to be
-# committed as a baseline: 1G_c4 ~0.62, 25bp_1G_c4 ~0.71.
+# BOOTSTRAP - the centres below are POST-REFIT and measured, but n = 1 each, so
+# the band is not enforced yet.
 #
-# Deleting the BOOTSTRAP line needs BOTH sides of the width rule above, which is
-# two measurements and not one:
-#   1. new centres and half-ranges, from a double-digit sample per cell; and
+# Measured on run 32341837369 (PR #474, commit 467865a), the first Linux run after
+# the #457 refit took sigma_16 23 -> 33 and k_16 64 -> 92. They replace pre-refit
+# centres of 0.788 and 0.914; the whole set moved by -0.15 to -0.28.
+#
+# Deleting the BOOTSTRAP line needs BOTH sides of the width rule above, and only
+# the centre half is in hand:
+#   1. half-ranges from a double-digit sample per cell. These centres are single
+#      observations, and the rule above is explicit that few draws estimate
+#      dispersion low; the current +0.065 width was derived by scaling the
+#      pre-refit half-ranges by 1/1.435, which is an inference, not a measurement.
 #   2. the post-refit lever-A delta, by reverting `channel_depths(true).work` to 2
 #      once and recording the rise. The 0.126-0.151 figures came from doing exactly
 #      that; B-proportionality gives the delta's direction, not its size.
 #
-# cell<TAB>baseline_peak_over_prediction
-1G_c4	0.788
-25bp_1G_c4	0.914
+# The failure mode changed when these centres did: while they were pre-refit,
+# deleting this line redded the band on the next run and said so. Centred on
+# reality it would now pass on n = 1 instead, so this comment is the only thing
+# standing between a premature deletion and a band nobody has validated.
 #
-# Re-tuned 2026-08-18 from 27 observations per cell (31 job logs, excluding the
-# two runs carrying Validation 8`s deliberate regression). Baselines are means,
-# half-up to 3 dp: 1G_c4 21.2840/27 = 0.78830; 25bp_1G_c4 24.6720/27 = 0.91378.
+# Arming on one observation against an inferred width is what this file's own
+# history warns about: +0.09 exists because a tighter band false-fired on an
+# unrelated PR. The promise gate (peak <= printed prediction) is enforcing on
+# 1G_c4, 1G_c4_fastqc, 25bp_1G_c4 and 25bp_1G_c2 meanwhile, so no cell is
+# unguarded while the band is off.
+#
+# For the record, the other five cells on the same run: 1G_c4_fastqc 0.541,
+# multipair_c4 0.608, 1G_c2 0.648, 25bp_1G_c2 0.748, 2G_c4 0.608.
+#
+# cell<TAB>baseline_peak_over_prediction
+1G_c4	0.636
+25bp_1G_c4	0.683
+#
+# How the superseded pre-refit centres were derived, kept as the method to repeat
+# once a post-refit sample exists: re-tuned 2026-08-18 from 27 observations per
+# cell (31 job logs, excluding the two runs carrying Validation 8`s deliberate
+# regression), as means half-up to 3 dp — 1G_c4 21.2840/27 = 0.78830;
+# 25bp_1G_c4 24.6720/27 = 0.91378.
 #
 #   cell            n   mean    min     max     range   at the current +0.065
 #   1G_c4           27  0.7883  0.770   0.825   0.055   pre-refit; at +0.065 post-refit: 3.4x half-range, lever A fires by 0.023

--- a/.github/clumpify-memory-baseline.tsv
+++ b/.github/clumpify-memory-baseline.tsv
@@ -59,6 +59,25 @@
 # For the record, the other five cells on the same run: 1G_c4_fastqc 0.541,
 # multipair_c4 0.608, 1G_c2 0.648, 25bp_1G_c2 0.748, 2G_c4 0.608.
 #
+# Lever A measured post-refit on run 32344279194 (work 1 -> 2, against the means
+# of two #474 runs). Read this before arming anything:
+#
+#   1G_c4        +0.088   ok at 0.065, margin +0.023 - and exactly what
+#                         B-proportionality predicted
+#   25bp_1G_c4   +0.052   BELOW the 0.065 width: this cell CANNOT detect lever A.
+#                         Do not band it. Its window between a 0.045 noise bar and
+#                         a 0.052 signal is ~0.007, narrower than its dispersion
+#                         will be on a real sample.
+#   25bp_1G_c2   +0.059   same problem
+#   1G_c2        +0.067   margin +0.002, too thin to rely on
+#   1G_c4_fastqc +0.116 | the strongest movers now, because lever A scales with B
+#   2G_c4        +0.117 | and theirs are larger. Best band candidates, but each
+#   multipair_c4 +0.134 | needs a double-digit post-refit sample first.
+#
+# Why the 25 bp cells move least is unexplained: B depends on budget and cores,
+# not read length, so 1G_c4 and 25bp_1G_c4 have identical bins, and sigma is
+# larger at 25 bp - the extra bin should cost more there, not less.
+#
 # cell<TAB>baseline_peak_over_prediction
 1G_c4	0.636
 25bp_1G_c4	0.683

--- a/.github/clumpify-memory-baseline.tsv
+++ b/.github/clumpify-memory-baseline.tsv
@@ -6,9 +6,17 @@
 # regression on Linux: a work-channel-depth revert was measured at +0.126 to
 # +0.151 of prediction and every cell it moved still sat under the printed peak.
 #
-# Fail if a cell peak/prediction rises more than 0.09 above its baseline, or
-# falls more than 0.10 below it. A silent fallback to plain mode or a fixture
+# Fail if a cell peak/prediction rises more than 0.065 above its baseline, or
+# falls more than 0.072 below it. A silent fallback to plain mode or a fixture
 # that stopped filling the bin pool is a multi-point drop.
+#
+# The width narrowed from 0.09 with the #457 refit, and had to: lever A is one
+# extra whole bin per worker, so its size in ratio-of-prediction units is
+# proportional to B, and B fell by 1.435. The delta falls with it, 0.126 -> 0.088
+# and 0.128 -> 0.089, which at width 0.09 leaves a *negative* margin — the band
+# would read as armed while sitting wider than the regression it exists to catch.
+# The noise side pays for the narrowing: the half-ranges scale down by the same
+# 1.435, so 0.065 is still 3.4x and 4.3x them.
 #
 # Band a cell only when the width satisfies both sides:
 #
@@ -20,6 +28,19 @@
 # dispersion LOW by construction — they cannot land far apart as often as they
 # can land close — so a threshold set from a handful of reps is set too tight.
 #
+# BOOTSTRAP - the two rows below are PRE-REFIT (#457) and must not be trusted.
+# The refit changed sigma_16 23 -> 33 and k_16 64 -> 92, so every centre moves by
+# roughly -0.17 to -0.21. Record the ratios from this PR's own Linux run, replace
+# both rows, and delete this line. Predicted, for a sanity check only, NOT to be
+# committed as a baseline: 1G_c4 ~0.62, 25bp_1G_c4 ~0.71.
+#
+# Deleting the BOOTSTRAP line needs BOTH sides of the width rule above, which is
+# two measurements and not one:
+#   1. new centres and half-ranges, from a double-digit sample per cell; and
+#   2. the post-refit lever-A delta, by reverting `channel_depths(true).work` to 2
+#      once and recording the rise. The 0.126-0.151 figures came from doing exactly
+#      that; B-proportionality gives the delta's direction, not its size.
+#
 # cell<TAB>baseline_peak_over_prediction
 1G_c4	0.788
 25bp_1G_c4	0.914
@@ -28,20 +49,20 @@
 # two runs carrying Validation 8`s deliberate regression). Baselines are means,
 # half-up to 3 dp: 1G_c4 21.2840/27 = 0.78830; 25bp_1G_c4 24.6720/27 = 0.91378.
 #
-#   cell            n   mean    min     max     range   at +0.09
-#   1G_c4           27  0.7883  0.770   0.825   0.055   3.3x half-range; lever A fires by 0.036
-#   25bp_1G_c4      27  0.9138  0.898   0.941   0.043   4.2x half-range; lever A fires by 0.038
+#   cell            n   mean    min     max     range   at the current +0.065
+#   1G_c4           27  0.7883  0.770   0.825   0.055   pre-refit; at +0.065 post-refit: 3.4x half-range, lever A fires by 0.023
+#   25bp_1G_c4      27  0.9138  0.898   0.941   0.043   pre-refit; at +0.065 post-refit: 4.3x half-range, lever A fires by 0.024
 #
 # Measured but NOT banded, with the reason:
 #
-#   multipair_c4    27  0.7987  0.771   0.852   0.081   1.2x at +0.09; needs +0.121 for 3x
+#   multipair_c4    27  0.7987  0.771   0.852   0.081   pre-refit; post-refit half-range 0.028, so 1.1x at +0.065
 #     Widest range of the six. Its 0.852 maximum was observed while the other
 #     cells moved +0.012 and -0.019 — spread, not drift. Covering it at 3x would
 #     need a width close to the regression the band exists to catch, so it is
 #     recorded instead. A depth revert moves every cell, so either banded cell
 #     catches it.
 #
-#   1G_c4_fastqc    27  0.7069  0.688   0.768   0.080   1.2x at +0.09
+#   1G_c4_fastqc    27  0.7069  0.688   0.768   0.080   pre-refit; post-refit half-range 0.028, so 1.2x at +0.065
 #     Also too wide. Stays gated on the printed prediction, at 0.768 of 1.000.
 #     FastQC cost scales with --cores and the allocator holds the pool pages
 #     across the trim->FastQC boundary, so this cell is timing-sensitive in a way
@@ -56,19 +77,21 @@
 #     little. Note it reads *higher* than 1G_c4, not lower — absolute peak more
 #     than doubles with the pool (1589 vs 731 MiB), so non-saturation caps how far
 #     it can rise without depressing it below the smaller-budget cells.
-#     Lever A moves it ~+0.09 to +0.13, since B is 42.0 MiB here against 18.1 at
+#     Lever A moves it ~+0.06 to +0.09 post-refit (+0.09 to +0.13 before), since B is larger here than at
 #     1G/c4, so it is a usable drift cell once it has a double-digit sample.
 #     See #458.
 #
-#   1G_c2           25  0.8789  0.860   0.894   0.034   2.9x at +0.09 — just under the bar
-#   25bp_1G_c2      25  1.0301  1.007   1.050   0.043   4.2x at +0.09 — eligible next pass
-#     25bp_1G_c2 is #457: over the printed prediction, inside the budget, on
-#     Linux. Its value will move when sigma is refitted, needing a re-baseline,
-#     which is why it is not banded while that work is pending.
+#   1G_c2           25  0.8789  0.860   0.894   0.034   pre-refit; post-refit half-range 0.012, so ~5.5x at +0.065 — now clears the noise bar
+#   25bp_1G_c2      25  1.0301  1.007   1.050   0.043   pre-refit; post-refit half-range 0.015, so ~4.3x at +0.065
+#     25bp_1G_c2 was #457: over the printed prediction, inside the budget, on
+#     Linux. The refit lands the promise gate on it, so it is now gated at
+#     `peak <= prediction`; the drift band still needs a post-refit double-digit
+#     sample before it can be banded.
 #
 # Diagnosing a red: if one cell rises alone, it is spread — re-run once, and if it
-# clears, leave the band alone. A depth revert moves every cell together by 12
-# points or more (measured), which is the signature to act on.
+# clears, leave the band alone. A depth revert moves every cell together — by 12
+# points or more before the #457 refit, and ~8.4 after it, since the delta scales
+# with B — which is the signature to act on.
 #
 # When src/ moves, judge whether the change can reach the clump path before
 # pooling new observations with these; the proxy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,10 +425,10 @@ jobs:
             local want
             want=$(awk -v c="$label" '$1==c {print $2}' "$base" 2>/dev/null || true)
             if [ -n "$want" ] && [ "$bootstrap" = 0 ]; then
-              awk -v r="$ratio" -v w="$want" 'BEGIN{exit !(r > w + 0.09)}' \
-                && { echo "::error::$label: peak/pred $ratio is >0.09 above baseline $want"; fail=1; }
-              awk -v r="$ratio" -v w="$want" 'BEGIN{exit !(r < w - 0.10)}' \
-                && { echo "::error::$label: peak/pred $ratio is >0.10 below baseline $want - fixture may have stopped filling the pool"; fail=1; }
+              awk -v r="$ratio" -v w="$want" 'BEGIN{exit !(r > w + 0.065)}' \
+                && { echo "::error::$label: peak/pred $ratio is >0.065 above baseline $want"; fail=1; }
+              awk -v r="$ratio" -v w="$want" 'BEGIN{exit !(r < w - 0.072)}' \
+                && { echo "::error::$label: peak/pred $ratio is >0.072 below baseline $want - fixture may have stopped filling the pool"; fail=1; }
             fi
             rm -f "$out"/*.fq.gz
           }
@@ -438,15 +438,13 @@ jobs:
 
           measure 1G_c4        1 --clumpify --paired --cores 4 --memory 1G "$F51R1" "$F51R2"
           measure 1G_c4_fastqc 1 --clumpify --paired --fastqc --cores 4 --memory 1G "$F51R1" "$F51R2"
-          # 25 bp is above the prediction today: the per-bin coefficient is
-          # fitted per byte, not per record (#457). Recorded, not gated on the
-          # promise, until that refit lands.
-          measure 25bp_1G_c4   0 --clumpify --paired --cores 4 --memory 1G "$F25R1" "$F25R2"
+          measure 25bp_1G_c4   1 --clumpify --paired --cores 4 --memory 1G "$F25R1" "$F25R2"
           measure multipair_c4 0 --clumpify --paired --cores 4 --memory 1G \
             "$F51R1" "$F51R2" "${RUNNER_TEMP}/dup_R1.fastq.gz" "${RUNNER_TEMP}/dup_R2.fastq.gz"
-          # --cores 2 is too tight to gate; both cells record their ratio only.
+          # 1G_c2 stays recorded-only: its 0.034 range is the tightest of the six, so
+          # banding it adds no detection the two banded cells do not already give.
           measure 1G_c2        0 --clumpify --paired --cores 2 --memory 1G "$F51R1" "$F51R2"
-          measure 25bp_1G_c2   0 --clumpify --paired --cores 2 --memory 1G "$F25R1" "$F25R2"
+          measure 25bp_1G_c2   1 --clumpify --paired --cores 2 --memory 1G "$F25R1" "$F25R2"
           # A 2 GiB pool needs ~2.3x this fixture to saturate, so it cannot near its peak.
           measure 2G_c4        0 --clumpify --paired --cores 4 --memory 2G "$F51R1" "$F51R2"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 #### Changes
 
+- **`--clumpify` keeps peak memory inside the budget it prints on short reads too**
+  ([#457](https://github.com/FelixKrueger/TrimGalore/issues/457)). Part of the per-record cost is the
+  allocator's, so the bin-pool coefficients now bound it at 25 bp rather than modelling it: bins are
+  ~30% smaller at every budget, and `.fq.gz` output differs from earlier releases on identical input
+  (same records, different gzip member boundaries — the third such change this cycle, after
+  [#442](https://github.com/FelixKrueger/TrimGalore/issues/442) and
+  [#446](https://github.com/FelixKrueger/TrimGalore/issues/446)). The minimum budget rises with it, so
+  `--fastqc` above `--cores 23` now falls back to plain trimming at the default `--memory 1G`; see
+  [the memory section](https://trimgalore.com/performance/clumpy/#memory) for the new floors and the
+  `--memory` values that restore the old bin size.
+
 - **The threading docs no longer imply plain-path memory is too small to budget for**
   ([nf-core/rnaseq#1903](https://github.com/nf-core/rnaseq/issues/1903)). The figures are heap, and a
   cgroup scheduler also charges page cache, so the page now says to allocate with headroom.
@@ -73,10 +84,8 @@
   `--fastqc` runs now get smaller bins, and `.fq.gz` output differs from earlier releases on
   identical input (same records, different gzip member boundaries). The startup banner now
   names the budget alongside the prediction (`predicted peak ≈ 930 of 1024 MiB budget`) so the
-  ~9% headroom is visible. Very short reads are not yet covered: the per-bin coefficient is
-  fitted per byte rather than per record, so a 25 bp library packs more records into the same
-  bin bytes and can exceed the budget at `--cores 2`
-  ([#457](https://github.com/FelixKrueger/TrimGalore/issues/457)).
+  ~9% headroom is visible. Short reads are covered by
+  [#457](https://github.com/FelixKrueger/TrimGalore/issues/457) below.
 
 - **An output file is now published only if every byte it owes was written, including the
   gzip trailer** ([#434](https://github.com/FelixKrueger/TrimGalore/issues/434)). #428 made the

--- a/docs/src/content/docs/modes/clump-only.md
+++ b/docs/src/content/docs/modes/clump-only.md
@@ -82,7 +82,7 @@ Composes with:
 
 ## Memory
 
-`--memory` sizes the per-bin sort buffers, using the same formula as [`--clumpify`](/performance/clumpy/#memory) with `workers = 1`, since this mode is single-threaded. At `--cores 1`–`4` the floor is 277 MiB, rising to 454 MiB at `--cores 32`; requesting `--fastqc` adds 24 MiB per thread, capped at 16 threads.
+`--memory` sizes the per-bin sort buffers, using the same formula as [`--clumpify`](/performance/clumpy/#memory) with `workers = 1`, since this mode is single-threaded. At `--cores 1`–`4` the floor is 290 MiB, rising to 544 MiB at `--cores 32`; requesting `--fastqc` adds 24 MiB per thread, capped at 16 threads.
 
 **Below the floor, `--clump_only` fails rather than degrading.** This differs from `--clumpify`, which warns and falls back to plain trimming. The reason is that reordering is the entire job here: falling back would spend the full read-and-write cost to produce a file identical to the input, and exit successfully, so a pipeline checking only the exit code could not tell that the archival recompression it asked for had not happened.
 
@@ -91,8 +91,8 @@ The error names the budget to retry with:
 ```
 Error: --memory budget too small for --cores 16: after reserving 608 MiB for static
 overhead (allocator, gzip state, IO buffers, FastQC) and 9% margin, the derived bin
-budget is 309806 bytes — below the 1048576-byte per-bin floor. Increase --memory
-(try ≥ 775 MiB) or decrease --cores.
+budget is 215908 bytes — below the 1048576-byte per-bin floor. Increase --memory
+(try ≥ 821 MiB) or decrease --cores.
 ```
 
 Lowering `--cores` is the cheap fix here — it costs no speed, only coarser read grouping. At `--cores 1`–`4` there is nothing left to lower, so raising `--memory` is the only remedy.

--- a/docs/src/content/docs/performance/clumpy.md
+++ b/docs/src/content/docs/performance/clumpy.md
@@ -88,35 +88,52 @@ The minimizer computation uses 2-bit packed integer ops (one O(1) bitwise step p
 
 `--memory` (default `1G`) is a Trim Galore-wide memory budget.
 
-The clumpify dispatcher sizes the per-bin sort runs against it, using coefficients fitted to measured peak RSS on both macOS/arm64 and Linux/x86_64:
+The clumpify dispatcher sizes the per-bin sort runs against it. The coefficients bound measured peak RSS at the shortest calibrated read length rather than modelling it, because part of the per-record cost is the allocator's and no per-record constant is exact at every read length:
 
 $$
 \begin{aligned}
 n_{\text{bins}}          &= \max(16,\; 4 \times \text{cores}) \\[0.8em]
 \text{static}            &= 224\,\text{MiB} \;+\; 24\,\text{MiB} \times \min(\text{FastQC threads},\, 16) \\[0.8em]
 \text{usable}            &= \text{memory} \times \tfrac{10}{11} - \text{static} \\[0.8em]
-\text{bin\_byte\_budget} &= \frac{16 \times \text{usable}}{23 \times n_{\text{bins}} + 64 \times \text{workers}}
+\text{bin\_byte\_budget} &= \frac{16 \times \text{usable}}{33 \times n_{\text{bins}} + 92 \times \text{workers}}
 \end{aligned}
 $$
 
 Three terms need naming. **static** is the resident cost outside the bin pool — allocator, gzip state and I/O buffers — and the FastQC term is charged only when a report is requested, capped at 16 threads because scaling above that is unmeasured. The **10/11** factor holds back ~9% of the budget as headroom for run-to-run variation, which is why the predicted peak the binary prints is always a little under the `--memory` you gave it. **workers** is the number of threads that can hold a batch in flight: `--cores` on the trimming path, and 1 under [`--clump_only`](/modes/clump-only/), which is single-threaded.
 
-So with `--cores 8 --memory 1G` you get **32 bins × 9 MiB**; with `--cores 8 --memory 4G` you get 32 bins × 44 MiB. The binary prints those resolved values at startup.
+So with `--cores 8 --memory 1G` you get **32 bins × 6 MiB**; with `--cores 8 --memory 4G` you get 32 bins × 31 MiB. The binary prints those resolved values at startup.
 
 In theory, bigger budget → bigger per-gzip-member sort runs → better compression. In practice, increasing memory doesn't seem to make very much difference in our tests.
 
 :::caution[Savings figures predate the current sizing]
-The savings in the tables above were measured before the memory model was refitted in v2.4 ([#439](https://github.com/FelixKrueger/TrimGalore/issues/439)), which reduced bin sizes by 24–31% at budgets of 2 GiB and above. Figures at the default `--memory 1G` are unaffected; the RRBS row's `--memory 4G+` entry is the one most likely to have moved and is pending re-measurement.
+The savings in the tables above were measured before the memory model was refitted. The refit for [#457](https://github.com/FelixKrueger/TrimGalore/issues/457) reduces bin sizes by ~30% at **every** budget, including the default `--memory 1G`, so all of these figures are due for re-measurement. Whether smaller bins cost real savings has not been measured on a library with duplicates.
 :::
+
+#### Read length, and getting the bin size back
+
+The coefficients are set by the shortest read length they were calibrated at, 25 bp. Long reads therefore reserve more than they need, because the same per-record charge is spread over more bytes per record. Measured at 25 bp, a run peaks at 0.81–0.92 of its printed prediction; at 150 bp the model puts it near 0.61, which is an extrapolation rather than a measurement.
+
+Raise `--memory` to recover the bin size. The static reservation is a fixed part of the budget, so this is not a flat multiplier: **1G → 1363M** restores the previous bin size at `--cores 2` or `4`, and **2G → 2834M** at `--cores 8`.
+
+Reads shorter than 25 bp sit below the calibrated floor, and Trim Galore warns rather than silently extrapolating. Every input is checked, so a multi-pair run cannot hide a short pair behind a long first one:
+
+```
+WARNING: the shortest input read is 19 bp, below the 25 bp the --memory reservation was calibrated at,
+         so peak memory may exceed the predicted peak for this run. Raise --memory if the run is near its limit.
+```
+
+Header length is not part of the test: a longer header raises the per-record size and so makes a run safer, not riskier.
 
 #### Below-floor behaviour
 
-`--clumpify` needs a minimum budget that rises with `--cores`, because both the bin pool and the per-worker reservation scale with it. Over `--cores` 2–32 the floor runs from **281 MiB** to **590 MiB** without `--fastqc`, and from **334 MiB** to **1012 MiB** with it. Above `--cores 32` it keeps climbing — at `--cores 64` it is 933 MiB, or 1356 MiB with `--fastqc`, which is above the 1 GiB default.
+`--clumpify` needs a minimum budget that rises with `--cores`, because both the bin pool and the per-worker reservation scale with it. Over `--cores` 2–32 the floor runs from **296 MiB** to **740 MiB** without `--fastqc`, and from **349 MiB** to **1162 MiB** with it. Above `--cores 32` it keeps climbing — at `--cores 64` it is 1232 MiB, or 1655 MiB with `--fastqc`, both above the 1 GiB default.
+
+Because the floor rose, some configurations that clumped at the default `--memory 1G` no longer do. The one most likely to be hit is `--fastqc` at `--cores 24`–`33`, which used to clump at the default and now falls back to plain trimming; raise `--memory` to keep it. Without `--fastqc` the default carries `--cores` up to 50.
 
 If `--memory` is below the floor, Trim Galore prints a warning and falls back to plain mode:
 
 ```
-WARNING: --memory 100M is too small for --clumpify at --cores 6 (need ≥ 311 MiB).
+WARNING: --memory 100M is too small for --clumpify at --cores 6 (need ≥ 339 MiB).
          Falling back to plain mode (no read reordering). Increase --memory or
          drop --clumpify to silence this warning.
 ```

--- a/src/clump.rs
+++ b/src/clump.rs
@@ -170,13 +170,13 @@ impl ClumpLayout {
 }
 
 /// `16 × (σ·n_bins + k·cores)` — the resident multiple of one bin budget, with
-/// σ = 23/16 for the bin pool and k = 4 per worker.
+/// σ = 33/16 for the bin pool and k = 92/16 per worker.
 fn dyn_denominator(n_bins: usize, cores: usize) -> u64 {
-    23 * n_bins as u64 + 64 * cores as u64
+    33 * n_bins as u64 + 92 * cores as u64
 }
 
-/// Per-worker channel depths. `k` above charges for `work + 1 in hand +
-/// result_per_core`, so their sum is the constant and neither may move alone.
+/// Per-worker channel depths. `k` above charges for these slots plus the
+/// allocator's per-record cost, so a deeper queue raises peak beyond `k`.
 #[derive(Debug, Clone, Copy)]
 pub struct ChannelDepths {
     pub work: usize,
@@ -260,7 +260,7 @@ const STATIC_FASTQC_PER_THREAD_BYTES: u64 = 24 * 1024 * 1024;
 const FASTQC_CHARGED_THREAD_CAP: usize = 16;
 
 /// The budget is sized to `MARGIN_NUM / MARGIN_DEN` of `--memory`, leaving ~9%
-/// for run-to-run variation. Largest observed within-cell spread is 96 MiB.
+/// for run-to-run variation. Largest observed within-cell spread is 64 MiB.
 const MARGIN_NUM: u64 = 10;
 const MARGIN_DEN: u64 = 11;
 
@@ -270,21 +270,22 @@ const MARGIN_DEN: u64 = 11;
 /// The goal is **peak RSS ≤ memory_budget**. Resident memory is a fixed term
 /// plus a multiple of one bin budget `B`:
 ///
-/// 1. Reader's resident bins: `σ × n_bins × B`, text plus `Vec<FastqRecord>`
-///    spine, σ = 23/16.
+/// 1. Reader's resident bins: `σ × n_bins × B`, text plus the record spine and
+///    the allocator's per-record cost, σ = 33/16.
 /// 2. Per worker: `k × B` for the queued batch, the batch in hand, and the
-///    compressed output waiting on the result channel, k = 4.
+///    compressed output waiting on the result channel, k = 92/16.
 ///
 ///   n_bins          = max(16, 4 × bin_cores)
 ///   usable          = memory_budget × 10/11 − static reservation
-///   bin_byte_budget = 16 × usable / (23 × n_bins + 64 × workers)
+///   bin_byte_budget = 16 × usable / (33 × n_bins + 92 × workers)
 ///
-/// σ and k are fitted from a 10 M-pair paired-end matrix over `cores ∈ {2,3,4}`
-/// with `n_bins` pinned at 16, taking the worst of two reps per cell; `cores ∈
-/// {8,16}` were held out and predicted within 5%. Measured values are σ = 1.29
-/// (Linux) / 1.41 (macOS) and k = 3.71 / 3.99; the constants take the worse of
-/// each. The 10/11 factor is margin: the largest within-cell spread was 96 MiB.
-/// See `plans/08162026_clumpify-memory-accounting/phase2/CALIBRATION.md`.
+/// σ and k bound the measured breach at the shortest calibrated read length
+/// rather than modelling it: part of the per-record cost is the allocator's, and
+/// no per-record constant is exact at more than one read length. The floor is
+/// `r = 96.642` B, from a byte-equalised paired-end matrix over read lengths
+/// {25,36,51,100,150} × `cores ∈ {2,4}` plus held-out `cores ∈ {8,16}` cells,
+/// summarised by the worst rep per cell. Inputs below the floor are warned about,
+/// not covered. See `plans/08162026_clumpify-memory-accounting/phase4/PLAN.md`.
 ///
 /// If the derived budget falls below `MIN_BIN_BYTES`, bails — better to fail
 /// loudly than silently produce a degraded output.
@@ -349,6 +350,14 @@ pub fn parse_memory_size(s: &str) -> Result<u64> {
 }
 
 // ─── Bin buffers + sort ───────────────────────────────────────────────────
+
+/// A paired slot reserves two records and one key; the model's per-record term
+/// is built on this, so the struct and the constant may not drift apart.
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(
+    2 * std::mem::size_of::<FastqRecord>() + std::mem::size_of::<MinimizerKey>() == 148,
+    "paired slot is no longer 148 B; the clumpify per-record term is derived from it"
+);
 
 /// Estimate the raw FASTQ-text bytes a record will occupy on disk.
 /// Used by the dispatcher for per-bin byte-budget accounting.
@@ -554,29 +563,29 @@ mod tests {
     #[test]
     fn resolve_layout_default() {
         // 4 GiB + 2 cores: usable = 4 GiB×10/11 − 224 MiB, n_bins=16,
-        // denom = 23×16 + 64×2 = 496, so B = 16 × usable / 496 ≈ 113 MiB.
+        // denom = 33×16 + 92×2 = 712, so B = 16 × usable / 712 ≈ 79 MiB.
         let layout = resolve_layout(4 * 1024 * 1024 * 1024, &ins(2, false)).unwrap();
         assert_eq!(layout.n_bins, 16);
-        assert!(layout.bin_byte_budget >= 112 * 1024 * 1024);
-        assert!(layout.bin_byte_budget < 114 * 1024 * 1024);
+        assert!(layout.bin_byte_budget >= 78 * 1024 * 1024);
+        assert!(layout.bin_byte_budget < 80 * 1024 * 1024);
     }
 
     #[test]
     fn resolve_layout_scales_with_cores() {
-        // 4 GiB + 8 cores: n_bins=32, denom = 23×32 + 64×8 = 1248, B ≈ 45 MiB.
+        // 4 GiB + 8 cores: n_bins=32, denom = 33×32 + 92×8 = 1792, B ≈ 31 MiB.
         let layout = resolve_layout(4 * 1024 * 1024 * 1024, &ins(8, false)).unwrap();
         assert_eq!(layout.n_bins, 32);
-        assert!(layout.bin_byte_budget >= 44 * 1024 * 1024);
-        assert!(layout.bin_byte_budget < 46 * 1024 * 1024);
+        assert!(layout.bin_byte_budget >= 31 * 1024 * 1024);
+        assert!(layout.bin_byte_budget < 33 * 1024 * 1024);
     }
 
     #[test]
     fn resolve_layout_pins_the_default_cell() {
         // 1 GiB + 4 cores is the cell #439 is about, so the sizing arithmetic may
-        // not move it silently: 16 × (1 GiB×10/11 − 224 MiB) / 624.
+        // not move it silently: 16 × (1 GiB×10/11 − 224 MiB) / 896.
         let layout = resolve_layout(1024 * 1024 * 1024, &ins(4, false)).unwrap();
         assert_eq!(layout.n_bins, 16);
-        assert_eq!(layout.bin_byte_budget, 19_006_356);
+        assert_eq!(layout.bin_byte_budget, 13_236_569);
     }
 
     #[test]
@@ -588,7 +597,7 @@ mod tests {
         // observes FASTQC_CHARGED_THREAD_CAP.
         let gib = 1024 * 1024 * 1024u64;
         let cases: [(u64, LayoutInputs, usize); 6] = [
-            (gib, LayoutInputs::uniform(4, None), 19_006_356),
+            (gib, LayoutInputs::uniform(4, None), 13_236_569),
             (
                 gib,
                 LayoutInputs {
@@ -596,7 +605,7 @@ mod tests {
                     workers: 1,
                     fastqc_threads: None,
                 },
-                27_453_626,
+                19_128_978,
             ),
             (
                 gib,
@@ -605,7 +614,7 @@ mod tests {
                     workers: 4,
                     fastqc_threads: Some(16),
                 },
-                8_681_915,
+                6_046_334,
             ),
             (
                 gib,
@@ -614,10 +623,10 @@ mod tests {
                     workers: 4,
                     fastqc_threads: Some(17),
                 },
-                8_681_915,
+                6_046_334,
             ),
-            (gib, LayoutInputs::uniform(2, None), 23_911_222),
-            (4 * gib, LayoutInputs::uniform(32, None), 11_761_649),
+            (gib, LayoutInputs::uniform(2, None), 16_657_256),
+            (4 * gib, LayoutInputs::uniform(32, None), 8_191_148),
         ];
         for (budget, inputs, expected) in cases {
             let layout = resolve_layout(budget, &inputs).unwrap();
@@ -634,21 +643,20 @@ mod tests {
         // both sides move together. This pins the constant and the figure the
         // docs publish for --cores 2 in one assertion.
         let floor = clumpify_min_memory_bytes(&ins(2, false));
-        assert_eq!(floor.div_ceil(1024 * 1024), 281);
+        assert_eq!(floor.div_ceil(1024 * 1024), 296);
     }
 
     #[test]
-    fn channel_depths_sum_to_the_per_worker_coefficient() {
-        // k = 4 in dyn_denominator charges for the queued batch, the batch in
-        // hand, and the result slots. Raising either depth invalidates the fit.
+    fn channel_depths_are_pinned_to_the_calibrated_values() {
+        // k was measured at these depths, and charges the allocator's per-record
+        // cost on top of them, so a deeper queue raises peak above the charge.
         let clumpy = channel_depths(true);
-        assert_eq!(clumpy.work, 1);
-        assert_eq!(clumpy.result_per_core, 2);
         assert_eq!(
-            clumpy.work + 1 + clumpy.result_per_core,
-            4,
-            "channel depths must sum to k = 4 (64/16 in dyn_denominator); see \
-             plans/08162026_clumpify-memory-accounting/phase2/CALIBRATION.md"
+            (clumpy.work, clumpy.result_per_core),
+            (1, 2),
+            "k = 92/16 was calibrated at work=1, result_per_core=2; changing \
+             either invalidates it — see \
+             plans/08162026_clumpify-memory-accounting/phase4/PLAN.md"
         );
         assert_eq!(channel_depths(false).work, 2);
     }
@@ -667,7 +675,7 @@ mod tests {
             plain.bin_byte_budget
         );
         // The difference is the per-core reservation spread over the denominator.
-        let expected = (24u64 * 4 * 1024 * 1024 * 16 / 624) as usize;
+        let expected = (24u64 * 4 * 1024 * 1024 * 16 / 896) as usize;
         let delta = plain.bin_byte_budget - with_qc.bin_byte_budget;
         assert!(
             delta.abs_diff(expected) <= 1024,

--- a/src/clump_only.rs
+++ b/src/clump_only.rs
@@ -91,6 +91,8 @@ struct SingleBin {
     keys: Vec<MinimizerKey>,
     raw_bytes: usize,
     budget: usize,
+    /// Mean bytes per reserved slot over the last flushed cycle; 0 initially.
+    prev_mean_bytes: usize,
 }
 
 impl SingleBin {
@@ -104,7 +106,15 @@ impl SingleBin {
     fn push(&mut self, r: FastqRecord, key: MinimizerKey) {
         let bytes_this = estimated_record_bytes(&r);
         if self.keys.capacity() == 0 {
-            let predicted = self.budget.div_ceil(bytes_this.max(1)).max(1);
+            // See `parallel::PairedBin::push`: one short record after a flush
+            // would over-reserve the whole cycle.
+            let est = if self.prev_mean_bytes > 0 {
+                self.prev_mean_bytes
+            } else {
+                bytes_this
+            };
+            let predicted = self.budget.div_ceil(est.max(1)).max(1);
+            let predicted = predicted + predicted / 16 + 1;
             self.records.reserve_exact(predicted);
             self.keys.reserve_exact(predicted);
         }
@@ -118,6 +128,9 @@ impl SingleBin {
     }
 
     fn take(&mut self) -> (Vec<FastqRecord>, Vec<MinimizerKey>) {
+        if !self.keys.is_empty() {
+            self.prev_mean_bytes = self.raw_bytes / self.keys.len();
+        }
         let records = std::mem::take(&mut self.records);
         let keys = std::mem::take(&mut self.keys);
         self.raw_bytes = 0;
@@ -134,6 +147,8 @@ struct PairedBin {
     keys: Vec<MinimizerKey>,
     raw_bytes: usize,
     budget: usize,
+    /// Mean bytes per reserved slot over the last flushed cycle; 0 initially.
+    prev_mean_bytes: usize,
 }
 
 impl PairedBin {
@@ -147,7 +162,13 @@ impl PairedBin {
     fn push(&mut self, r1: FastqRecord, r2: FastqRecord, key: MinimizerKey) {
         let bytes_this = estimated_record_bytes(&r1) + estimated_record_bytes(&r2);
         if self.keys.capacity() == 0 {
-            let predicted = self.budget.div_ceil(bytes_this.max(1)).max(1);
+            let est = if self.prev_mean_bytes > 0 {
+                self.prev_mean_bytes
+            } else {
+                bytes_this
+            };
+            let predicted = self.budget.div_ceil(est.max(1)).max(1);
+            let predicted = predicted + predicted / 16 + 1;
             self.r1.reserve_exact(predicted);
             self.r2.reserve_exact(predicted);
             self.keys.reserve_exact(predicted);
@@ -163,6 +184,9 @@ impl PairedBin {
     }
 
     fn take(&mut self) -> (Vec<FastqRecord>, Vec<FastqRecord>, Vec<MinimizerKey>) {
+        if !self.keys.is_empty() {
+            self.prev_mean_bytes = self.raw_bytes / self.keys.len();
+        }
         let r1 = std::mem::take(&mut self.r1);
         let r2 = std::mem::take(&mut self.r2);
         let keys = std::mem::take(&mut self.keys);
@@ -1159,6 +1183,44 @@ mod tests {
     use super::*;
     use std::io::Read;
     use std::path::PathBuf;
+
+    fn sized_rec(seq_len: usize) -> FastqRecord {
+        FastqRecord {
+            id: "@r".to_string(),
+            seq: "A".repeat(seq_len),
+            qual: "I".repeat(seq_len),
+        }
+    }
+
+    /// These bins duplicate `parallel.rs`'s reservation rule, so they need the
+    /// same guard: a short record after a flush must not size the whole cycle.
+    #[test]
+    fn single_bin_reservation_follows_the_previous_cycle() {
+        let budget = 10_000;
+        let mut bin = SingleBin::with_budget(budget);
+        for i in 0..48 {
+            bin.push(sized_rec(100), i);
+        }
+        let mean = bin.raw_bytes / bin.keys.len();
+        bin.take();
+        bin.push(sized_rec(10), 0);
+        assert!(bin.keys.capacity() < budget.div_ceil(27));
+        assert!(bin.keys.capacity() >= budget.div_ceil(mean));
+    }
+
+    #[test]
+    fn paired_bin_reservation_follows_the_previous_cycle() {
+        let budget = 10_000;
+        let mut bin = PairedBin::with_budget(budget);
+        for i in 0..24 {
+            bin.push(sized_rec(100), sized_rec(100), i);
+        }
+        let mean = bin.raw_bytes / bin.keys.len();
+        bin.take();
+        bin.push(sized_rec(10), sized_rec(10), 0);
+        assert!(bin.keys.capacity() < budget.div_ceil(54));
+        assert!(bin.keys.capacity() >= budget.div_ceil(mean));
+    }
 
     /// Build a synthetic FASTQ file at `path` (gzip if extension ends `.gz`)
     /// from the given records.

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,43 @@ fn planned_hardtrim_outputs(
         .collect()
 }
 
+/// Shortest read length the sizing coefficients were calibrated at, as bytes
+/// per record: 25 bp with a 41-byte header. Below it the reservation is an
+/// extrapolation rather than a bound.
+/// Shortest read length the sizing coefficients were calibrated at. Header bytes
+/// raise the per-record size and so make a run safer, which is why the floor is
+/// a read length rather than a record size.
+const CLUMPIFY_CALIBRATED_FLOOR_BP: usize = 25;
+
+/// First record's read length, or `None` if the input cannot be peeked.
+/// Advisory only — the per-input sanity check reports real I/O errors later.
+fn peek_read_length(path: &std::path::Path) -> Option<usize> {
+    // Tags cannot change a read length, so none need preserving here.
+    let mut src = open_sync_reader(path, &[]).ok()?;
+    Some(src.next_record().ok()??.seq.len())
+}
+
+/// Warn when any input's reads are shorter than the calibrated floor. Checks
+/// every input, so a multi-pair run cannot hide a short pair behind a long first
+/// one. Emitted after the layout banner, so "the printed prediction" it mentions
+/// has already been printed.
+fn warn_below_clumpify_floor(cli: &Cli) {
+    let Some(shortest) = cli.input.iter().filter_map(|p| peek_read_length(p)).min() else {
+        return;
+    };
+    if shortest >= CLUMPIFY_CALIBRATED_FLOOR_BP {
+        return;
+    }
+    eprintln!(
+        "WARNING: the shortest input read is {shortest} bp, below the \
+         {CLUMPIFY_CALIBRATED_FLOOR_BP} bp the --memory reservation was calibrated at,"
+    );
+    eprintln!(
+        "         so peak memory may exceed the predicted peak for this run. Raise \
+         --memory if the run is near its limit."
+    );
+}
+
 /// Resolve `--memory` into a `(n_bins, bin_byte_budget)` layout when
 /// `--clumpify` is set, and emit a one-line startup notice with the
 /// resolved values. Returns `None` if clumpify is off — or if the budget
@@ -219,6 +256,7 @@ fn resolve_clump_layout(cli: &Cli) -> Result<Option<clump::ClumpLayout>> {
         memory_bytes / (1024 * 1024),
         encoding,
     );
+    warn_below_clumpify_floor(cli);
     // Clumping only pays off through a compressor, so say when there is none.
     if !gzipped {
         eprintln!(
@@ -601,6 +639,7 @@ fn main() -> Result<()> {
         return Ok(());
     }
     if cli.clump_only {
+        warn_below_clumpify_floor(&cli);
         // --clump_only: lossless reorder-only specialty mode. Feature #353.
         // v1: FASTQ in/out. v2: uBAM in/out via --output-format ubam.
         let memory_bytes =

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -881,6 +881,8 @@ struct PairedBin {
     keys: Vec<MinimizerKey>,
     raw_bytes: usize,
     budget: usize,
+    /// Mean bytes per reserved slot over the last flushed cycle; 0 initially.
+    prev_mean_bytes: usize,
 }
 
 impl PairedBin {
@@ -894,15 +896,25 @@ impl PairedBin {
     /// Push one R1/R2 pair into the bin.
     ///
     /// On the first push since the bin was last flushed (`take`d), we extrapolate
-    /// expected record count from this record's text size and the bin's budget,
-    /// then `reserve_exact` to avoid the doubling cascade. With 32 bins all growing
+    /// expected pair count from the previous cycle's mean pair size and the bin's
+    /// budget, then `reserve_exact` to avoid the doubling cascade. With 32 bins all growing
     /// at once on a memory-tight host, the transient old+new spine overlap during
     /// `Vec` doublings was inflating peak memory by ~40% (measured: 8 GiB
     /// configured budget → 11.5 GiB peak footprint on 16 GiB Mac).
     fn push(&mut self, r1: FastqRecord, r2: FastqRecord, key: MinimizerKey) {
         let bytes_this = estimated_record_bytes(&r1) + estimated_record_bytes(&r2);
         if self.keys.capacity() == 0 {
-            let predicted = self.budget.div_ceil(bytes_this).max(1);
+            // Sizing from one record over-reserves the whole cycle when that
+            // record is short, so prefer the previous cycle's mean.
+            let est = if self.prev_mean_bytes > 0 {
+                self.prev_mean_bytes
+            } else {
+                bytes_this
+            };
+            let predicted = self.budget.div_ceil(est.max(1)).max(1);
+            // A cycle whose records drift smaller overflows an exact
+            // reservation, and `Vec` then doubles; 6% headroom is the cheaper side.
+            let predicted = predicted + predicted / 16 + 1;
             self.r1.reserve_exact(predicted);
             self.r2.reserve_exact(predicted);
             self.keys.reserve_exact(predicted);
@@ -918,6 +930,9 @@ impl PairedBin {
     }
 
     fn take(&mut self) -> (Vec<FastqRecord>, Vec<FastqRecord>, Vec<MinimizerKey>) {
+        if !self.keys.is_empty() {
+            self.prev_mean_bytes = self.raw_bytes / self.keys.len();
+        }
         let r1 = std::mem::take(&mut self.r1);
         let r2 = std::mem::take(&mut self.r2);
         let keys = std::mem::take(&mut self.keys);
@@ -1271,6 +1286,8 @@ struct SingleBin {
     keys: Vec<MinimizerKey>,
     raw_bytes: usize,
     budget: usize,
+    /// Mean bytes per reserved slot over the last flushed cycle; 0 initially.
+    prev_mean_bytes: usize,
 }
 
 impl SingleBin {
@@ -1286,7 +1303,13 @@ impl SingleBin {
     fn push(&mut self, record: FastqRecord, key: MinimizerKey) {
         let bytes_this = estimated_record_bytes(&record);
         if self.keys.capacity() == 0 {
-            let predicted = self.budget.div_ceil(bytes_this).max(1);
+            let est = if self.prev_mean_bytes > 0 {
+                self.prev_mean_bytes
+            } else {
+                bytes_this
+            };
+            let predicted = self.budget.div_ceil(est.max(1)).max(1);
+            let predicted = predicted + predicted / 16 + 1;
             self.records.reserve_exact(predicted);
             self.keys.reserve_exact(predicted);
         }
@@ -1300,6 +1323,9 @@ impl SingleBin {
     }
 
     fn take(&mut self) -> (Vec<FastqRecord>, Vec<MinimizerKey>) {
+        if !self.keys.is_empty() {
+            self.prev_mean_bytes = self.raw_bytes / self.keys.len();
+        }
         let records = std::mem::take(&mut self.records);
         let keys = std::mem::take(&mut self.keys);
         self.raw_bytes = 0;
@@ -1319,6 +1345,70 @@ mod tests {
     /// `RecordSource` refactor. Cleaner than rewriting every call site.
     fn open_fq(path: &std::path::Path) -> Box<dyn RecordSource> {
         Box::new(FastqReader::open_threaded(path).expect("test fixture must open"))
+    }
+
+    fn rec(seq_len: usize) -> FastqRecord {
+        FastqRecord {
+            id: "@r".to_string(),
+            seq: "A".repeat(seq_len),
+            qual: "I".repeat(seq_len),
+        }
+    }
+
+    /// A short record arriving first after a flush must not size the whole cycle.
+    #[test]
+    fn bin_reservation_follows_the_previous_cycle_not_one_short_record() {
+        let budget = 10_000;
+        let mut bin = PairedBin::with_budget(budget);
+        // One cycle of 100 bp records: 207 B each, 414 B per pair.
+        for i in 0..24 {
+            bin.push(rec(100), rec(100), i);
+        }
+        let mean = bin.raw_bytes / bin.keys.len();
+        assert_eq!(mean, 414, "fixture arithmetic changed");
+        bin.take();
+
+        // A 10 bp pair is 54 B. Sizing from it would reserve budget/54 = 186
+        // slots; sizing from the previous cycle reserves budget/414 = 25.
+        bin.push(rec(10), rec(10), 0);
+        let from_short = budget.div_ceil(54);
+        let from_mean = budget.div_ceil(mean);
+        assert_eq!(from_short, 186, "fixture arithmetic changed");
+        assert!(
+            bin.keys.capacity() < from_short,
+            "reserved {} slots from a single short record, expected ~{from_mean}",
+            bin.keys.capacity()
+        );
+        // `reserve_exact` is documented as free to over-allocate, so bound the
+        // reservation rather than pinning it.
+        assert!(bin.keys.capacity() >= from_mean);
+        assert!(bin.keys.capacity() <= from_mean + from_mean / 16 + 1);
+    }
+
+    /// `SingleBin` carries the same rule, and had no test of its own.
+    #[test]
+    fn single_bin_reservation_follows_the_previous_cycle() {
+        let budget = 10_000;
+        let mut bin = SingleBin::with_budget(budget);
+        for i in 0..48 {
+            bin.push(rec(100), i);
+        }
+        let mean = bin.raw_bytes / bin.keys.len();
+        assert_eq!(mean, 207, "fixture arithmetic changed");
+        bin.take();
+        bin.push(rec(10), 0);
+        assert!(bin.keys.capacity() < budget.div_ceil(27));
+        assert!(bin.keys.capacity() >= budget.div_ceil(mean));
+    }
+
+    /// The first cycle has no history, so it still sizes from the first record.
+    #[test]
+    fn bin_reservation_falls_back_to_the_first_record_before_any_cycle() {
+        let mut bin = PairedBin::with_budget(10_000);
+        bin.push(rec(100), rec(100), 0);
+        let exact = 10_000usize.div_ceil(414);
+        assert!(bin.keys.capacity() >= exact);
+        assert!(bin.keys.capacity() <= exact + exact / 16 + 1);
     }
 
     fn fresh_tmpdir(slug: &str) -> PathBuf {

--- a/tests/integration_clumpify_floor_warning.rs
+++ b/tests/integration_clumpify_floor_warning.rs
@@ -1,0 +1,131 @@
+//! Binary-driven tests for the `--clumpify` calibrated-floor warning.
+//!
+//! The sizing coefficients are bounded at 25 bp, so shorter reads are an
+//! extrapolation and get a warning. Two things need holding: the warning fires
+//! below the floor, and it does *not* fire at it — the CI memory cells run a
+//! 25 bp fixture whose early records carry short headers, and an earlier
+//! record-size-based form of this check warned on every one of them.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_trim_galore"))
+}
+
+fn tempdir(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir().join(format!("tg_floor_warn_{tag}_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&d);
+    fs::create_dir_all(&d).unwrap();
+    d
+}
+
+/// One record with a deliberately terse header, so the record's *byte* size is
+/// far below the floor even when its read length is not.
+fn write_fastq(dir: &Path, name: &str, read_len: usize) -> PathBuf {
+    let p = dir.join(name);
+    let seq = "ACGT".repeat(read_len.div_ceil(4))[..read_len].to_string();
+    let qual = "I".repeat(read_len);
+    fs::write(&p, format!("@SRR1234567.1\n{seq}\n+\n{qual}\n")).unwrap();
+    p
+}
+
+fn stderr_of(args: &[&str]) -> String {
+    let out = Command::new(binary())
+        .args(args)
+        .output()
+        .expect("binary must run");
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+const NEEDLE: &str = "below the 25 bp the --memory reservation was calibrated at";
+
+#[test]
+fn warns_below_the_calibrated_floor() {
+    let d = tempdir("below");
+    let fq = write_fastq(&d, "short.fq", 19);
+    let err = stderr_of(&[
+        "--clumpify",
+        "--cores",
+        "2",
+        "--memory",
+        "1G",
+        "-o",
+        d.to_str().unwrap(),
+        fq.to_str().unwrap(),
+    ]);
+    assert!(
+        err.contains(NEEDLE) && err.contains("shortest input read is 19 bp"),
+        "expected the floor warning, got:\n{err}"
+    );
+}
+
+#[test]
+fn silent_at_the_calibrated_floor() {
+    let d = tempdir("at");
+    // 25 bp with a 13-byte header is 68 record bytes, well under the 97 that an
+    // earlier form of this check compared against.
+    let fq = write_fastq(&d, "at_floor.fq", 25);
+    let err = stderr_of(&[
+        "--clumpify",
+        "--cores",
+        "2",
+        "--memory",
+        "1G",
+        "-o",
+        d.to_str().unwrap(),
+        fq.to_str().unwrap(),
+    ]);
+    assert!(
+        !err.contains(NEEDLE),
+        "warned at the floor, not below it:\n{err}"
+    );
+}
+
+#[test]
+fn checks_every_input_not_just_the_first() {
+    let d = tempdir("multi");
+    let long = write_fastq(&d, "p1_R1.fq", 51);
+    let long2 = write_fastq(&d, "p1_R2.fq", 51);
+    let short = write_fastq(&d, "p2_R1.fq", 15);
+    let short2 = write_fastq(&d, "p2_R2.fq", 15);
+    let err = stderr_of(&[
+        "--clumpify",
+        "--paired",
+        "--cores",
+        "2",
+        "--memory",
+        "1G",
+        "-o",
+        d.to_str().unwrap(),
+        long.to_str().unwrap(),
+        long2.to_str().unwrap(),
+        short.to_str().unwrap(),
+        short2.to_str().unwrap(),
+    ]);
+    assert!(
+        err.contains("shortest input read is 15 bp"),
+        "a short second pair was hidden behind a long first pair:\n{err}"
+    );
+}
+
+#[test]
+fn clump_only_gets_the_warning_too() {
+    let d = tempdir("only");
+    let fq = write_fastq(&d, "short.fq", 19);
+    let err = stderr_of(&[
+        "--clump_only",
+        "--cores",
+        "2",
+        "--memory",
+        "1G",
+        "-o",
+        d.to_str().unwrap(),
+        fq.to_str().unwrap(),
+    ]);
+    assert!(
+        err.contains(NEEDLE),
+        "--clump_only never reaches resolve_clump_layout, so it needs its own call:\n{err}"
+    );
+}


### PR DESCRIPTION
`--clumpify` charged the bin pool per byte while part of its cost is per record, so short reads exceeded the memory peak the binary printed — 1.16–1.30 of prediction at 25 bp. The sizing coefficients now bound that breach at the shortest calibrated read length (`23·n_bins + 64·cores` → `33·n_bins + 92·cores`), which makes bins ~30% smaller at every budget, moves output bytes again (same records, different gzip member boundaries), and raises the minimum viable `--memory` — `--fastqc` above `--cores 23` now falls back to plain trimming at the default 1G. Worst rep of three per cell on darwin/arm64: 25 bp c8/2G 1.300 → 0.927, c2/1G 1.201 → 0.838, c4/1G 1.161 → 0.816. Both 25 bp CI cells now gate on `peak ≤ prediction`; the baseline is deliberately left in `BOOTSTRAP` because its committed centres are pre-refit, so **the first CI run here supplies the real ones**.

Closes #457.

<details>
<summary>Why the coefficient is a bound rather than a fit (AI-assisted analysis)</summary>

`size_of` accounts for 148 B of a paired slot and that part is exact — it is now pinned by a `const` assert. But a slot costs **245–270 B**: the three `String` allocations per record each carry ~20 B that neither `size_of` nor `estimated_record_bytes` can see. That excess is allocator-independent (libmalloc and mimalloc agree within 1–4 B/pair), page reuse means it does not accumulate across flush cycles, and it is *not* attenuated by bin occupancy. It also varies ~10% across read lengths, so **no per-record constant is exact at more than one read length** — which is why this bounds the measured breach instead of modelling it.

The scale factor is `(peak − static) / (prediction − static)`, which moves only 1.331–1.349 across a 173–260 MiB range of `static` — so it does not rest on the one term this design cannot identify. Both terms scale together because the calibration matrix holds only two `n_bins:cores` shapes and cannot separate them.

Also included:

- The reservation follows the previous flush cycle's mean rather than whichever record arrives first after it, so one short record cannot size a whole cycle. 6% headroom, because landing one slot short costs a full `Vec` doubling — ~half of cycles on variable-length input, and invisible to every fixture here because they are all fixed-length.
- Reads below the 25 bp calibration floor warn. The floor is a **read length, not a record size**: header bytes raise the per-record size and so make a run safer. Every input is checked, so a multi-pair run cannot hide a short pair behind a long first one.
- The drift band narrows `0.09` → `0.065`. Lever A is one extra whole bin per worker, so its magnitude in ratio-of-prediction units is proportional to `B` and falls with it; at `0.09` the band would have been *wider* than the regression it exists to catch.

**Outstanding, and needs CI rather than a laptop:** the Linux cells (rule is take the worse of the two), the post-refit lever-A delta measured rather than inferred, and an output-size measurement on a library with duplicates — the calibration fixture is 100% distinct sequences and cannot show a clumping gain or its loss, so no compression cost is claimed in either direction.

One thing to watch on the CI run: the c2 cell's relative within-cell spread roughly doubled post-change (2.3% → 4.98%). That is still inside the 5.55% the margin rule assumed, but that figure was derived pre-change. If Linux shows the same widening, the margin's input wants re-deriving from post-change data.
</details>
