### PR TITLE
fix(io): drop the local mem::forget now that gzp 2.0.3 disarms its own Drop (#434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 #### Changes
 
+- **The `--cores N` gzip teardown no longer leaks its compressor to avoid a panic**
+  ([#434](https://github.com/FelixKrueger/TrimGalore/issues/434)). Reporting a failed teardown on the
+  parallel path relied on a local `std::mem::forget`, which disarmed a double-teardown panic in
+  `gzp` at the cost of leaking a `Sender` pair and a `JoinHandle` and parking the compressor threads.
+  [gzp 2.0.3](https://github.com/sstadick/gzp/issues/68) fixes that upstream, so the workaround is
+  gone and the error propagates normally; the minimum `gzp` is now 2.0.3, because on 2.0.2 the
+  regression test panics rather than fails.
+
 - **`--clumpify` keeps peak memory inside the budget it prints on short reads too**
   ([#457](https://github.com/FelixKrueger/TrimGalore/issues/457)). Part of the per-record cost is the
   allocator's, so the bin-pool coefficients now bound it at 25 bp rather than modelling it: bins are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "gzp"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe9930717197e0ea50d8c8a1106a38b5bee0536ed4cbf4b93ba1a953f97d04"
+checksum = "d4db1c9484dd0efe5915d057891b2d3800271cd1e466dcdea80022038b86e510"
 dependencies = [
  "byteorder",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 flate2 = { version = "1.1", default-features = false, features = ["zlib-rs"] }
-gzp = { version = "2", default-features = false, features = ["deflate_rust"] }
+gzp = { version = "2.0.3", default-features = false, features = ["deflate_rust"] }
 anyhow = "1"
 memchr = "2"
 log = "0.4"

--- a/src/fastq.rs
+++ b/src/fastq.rs
@@ -647,51 +647,30 @@ impl Sink {
                 encoder.try_finish()?;
             }
             Sink::ParGz(mut w) => {
-                // Every fallible step is inside the closure so that ONE error
-                // path covers all of them. `?` straight out of this arm would
-                // drop `w` on the way, and dropping a `ParCompress` that has
-                // not been finished is the panic described below — which the
-                // flushes can reach just as easily as `finish` can.
-                let outcome = (|| -> Result<()> {
-                    // Same markers as the serial arm, same reason — see
-                    // `PRE_434_GZ_SYNC_FLUSHES`. `ParCompress::flush` is
-                    // `flush_last(false)`.
-                    for _ in 0..PRE_434_GZ_SYNC_FLUSHES {
-                        w.flush()?;
-                    }
-                    w.finish()?;
-                    Ok(())
-                })();
-                match outcome {
-                    Ok(()) => {}
-                    Err(e) => {
-                        // `ParCompress::finish` propagates a failed
-                        // `flush_last` with `?` BEFORE it takes its channels
-                        // and join handle, so all three are still `Some` here.
-                        // `ParCompress::drop` reads that as "never finished",
-                        // calls `finish()` again and `unwrap()`s the same
-                        // error (`gzp-2.0.2/src/par/compress.rs:398`) — turning
-                        // a reportable I/O failure into a panic on the way out
-                        // of this function. #434 is specifically about a failed
-                        // teardown being *reported* rather than swallowed, so
-                        // leaving that in place would half-undo it for
-                        // `--cores N`.
-                        //
-                        // Disarming means not running that `Drop`. What leaks
-                        // is a `Sender` pair and a `JoinHandle`; the compressor
-                        // threads then park on a channel that is never closed.
-                        // That is bounded by the process, which is on its way
-                        // to exiting with this error — every
-                        // `FastqWriter::finish` caller propagates it with `?`.
-                        // A panic in place of an error message is the worse
-                        // trade.
-                        //
-                        // The real fix belongs upstream in `gzp`: take the
-                        // fields before the `?`. Remove this when that lands.
-                        std::mem::forget(w);
-                        return Err(e);
-                    }
+                // `?` straight out of this arm drops `w` on the way, and a
+                // `ParCompress` dropped after a failed teardown used to call
+                // `finish()` a second time and `unwrap()` the same error —
+                // turning a reportable I/O failure into a panic, which is
+                // exactly what #434 set out to remove for `--cores N`. This
+                // arm carried a local `std::mem::forget(w)` to disarm that
+                // `Drop`, at the cost of leaking a `Sender` pair and a
+                // `JoinHandle`.
+                //
+                // gzp 2.0.3 fixes it upstream: every error path now goes
+                // through `ParCompress::recover_send_error`, which takes the
+                // channels and the join handle before it joins, so `Drop`
+                // sees them as `None` and does not retry. The workaround is
+                // therefore gone and `?` is used directly. The lower bound in
+                // Cargo.toml is 2.0.3 for this reason — on 2.0.2 the test
+                // below panics rather than fails.
+                //
+                // Same markers as the serial arm, same reason — see
+                // `PRE_434_GZ_SYNC_FLUSHES`. `ParCompress::flush` is
+                // `flush_last(false)`.
+                for _ in 0..PRE_434_GZ_SYNC_FLUSHES {
+                    w.flush()?;
                 }
+                w.finish()?;
             }
         }
         Ok(())
@@ -905,14 +884,18 @@ mod tests {
         // THE `--cores N` ARM, WHICH HAD NO TEST OF ITS OWN AND IS THE ONE THE
         // REVIEW OF #436 CAUGHT TWICE.
         //
-        // `ParCompress::finish` propagates a failed `flush_last` with `?`
-        // before taking its channels and join handle, so `ParCompress::drop`
-        // sees them still `Some`, calls `finish()` a second time and
-        // `unwrap()`s the same error at `gzp-2.0.2/src/par/compress.rs:398`.
-        // Without the `mem::forget` in `Sink::finish` this test does not fail
-        // — it PANICS, which is exactly the outcome #434 set out to remove.
-        // Running to completion is the real assertion here; `is_err()` is the
-        // weaker half.
+        // On gzp 2.0.2 `ParCompress::finish` propagated a failed `flush_last`
+        // with `?` before taking its channels and join handle, so
+        // `ParCompress::drop` saw them still `Some`, called `finish()` a
+        // second time and `unwrap()`ed the same error at
+        // `gzp-2.0.2/src/par/compress.rs:398` — this test PANICKED rather
+        // than failed, which is exactly the outcome #434 set out to remove.
+        // gzp 2.0.3 routes that path through `recover_send_error`, which
+        // takes all three before joining, so `Drop` no longer retries and the
+        // local `mem::forget` workaround this arm used to carry is gone.
+        // Running to completion is still the real assertion here; `is_err()`
+        // is the weaker half. Cargo.toml pins gzp >= 2.0.3 to keep it that
+        // way — verified by building against 2.0.2, where it panics.
         //
         // THE WINDOW IS NARROW AND THE OBVIOUS TEST MISSES IT. `ParCompress::
         // write`, on a send failure, takes the join handle itself so it can


### PR DESCRIPTION
Follow-up to #436, which I said in that thread I'd open: *"dropping the local `mem::forget` is a one-commit follow-up here and I'll open it"*. You answered that you were happy to carry the disarm until the upstream fix landed. **It landed on 2026-08-19 in gzp v2.0.3**, so here is the follow-up.

### What was there

`Sink::finish`'s `--cores N` arm carried a `std::mem::forget(w)` on the error path. gzp 2.0.2's `ParCompress::finish` propagated a failed `flush_last` with `?` *before* taking its channels and join handle, so `Drop` saw all three still `Some`, called `finish()` a second time and `unwrap()`ed the same error at `gzp-2.0.2/src/par/compress.rs:398`. That turned a reportable I/O failure into a panic — precisely what #434 set out to remove — so the arm disarmed `Drop` by leaking a `Sender` pair and a `JoinHandle`, leaving the compressor threads parked on a channel that never closed.

### What changed upstream

sstadick/gzp#68 → [v2.0.3](https://github.com/sstadick/gzp/blob/master/CHANGELOG.md). Error paths now route through `ParCompress::recover_send_error`, which takes the join handle and both senders *before* it joins, so `Drop` sees `None` and does not retry. (For the record: I opened sstadick/gzp#69 with a fix and tests; he preferred his own implementation in #70 and closed mine, which is the right call — his covers `write`/`flush`/`finish` and the scoped variant uniformly.)

### What this PR does

- Raises the `gzp` lower bound from `"2"` to `"2.0.3"` and updates `Cargo.lock`.
- Removes the `mem::forget` and the closure-plus-match that existed only to route around it; `?` is used directly.
- Rewrites the comments at both the call site and the regression test to describe the current state rather than the workaround.

**The version bound is load-bearing, not cosmetic.** On 2.0.2 the regression test `pargz_sink_finish_reports_a_failing_teardown_without_panicking` *panics* rather than fails, so a stale lockfile would reintroduce #434 without a red test to say so. That is why the floor moved rather than just the lock.

### Verification

I built and ran it all three ways rather than reasoning from the changelog:

| gzp | `mem::forget` | result |
|---|---|---|
| 2.0.2 | present | pass — previous behaviour |
| 2.0.2 | removed | **panics** at `gzp-2.0.2/src/par/compress.rs:398:27` |
| 2.0.3 | removed | pass |

The middle row is the one that matters: it confirms the test still has teeth and that 2.0.3 is what makes the removal safe.

`cargo test` **810 passed / 0 failed**. `cargo fmt --check` and `cargo clippy --all-targets` both clean.

*Disclosure: AI-assisted, and reviewed and verified by me before opening.*

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*